### PR TITLE
pkg/kamailio: Initial Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c
+compiler:
+  - gcc
+  - clang
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y gdebi-core
+  - sudo pkg/kamailio/deb/build_deps.sh precise $TRAVIS_BUILD_DIR
+script: ./pkg/kamailio/deb/build_travis.sh
+notifications:
+  irc:
+    channels:
+      - "chat.freenode.net#Kamailio"
+    on_success: change
+    on_failure: always
+  email:
+    - sr-dev@lists.sip-router.org

--- a/pkg/kamailio/deb/build_deps.sh
+++ b/pkg/kamailio/deb/build_deps.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# build_deps script for travis CI
+# installs the build_deps packages needed to build Kamailio
+# environment based on Ubuntu 12.04 LTS (precise)
+#
+DIST=${1:-precise}
+BASE_DIR=${2:-$(pwd)}
+CONTROL_FILE="${BASE_DIR}/pkg/kamailio/deb/${DIST}/control"
+if ! [ -f "${CONTROL_FILE}" ]; then
+	echo "Error: No ${CONTROL_FILE} found"
+	exit 1
+fi
+
+BUILD_DEPS=$(/usr/bin/gdebi --quiet --non-interactive \
+	--option=APT::Install-Recommends=false \
+	--apt-line ${CONTROL_FILE})
+if [ -z "${BUILD_DEPS}" ]; then
+	echo "Error: no build deps packages resolved"
+	exit 2
+fi
+
+apt-get install -y $BUILD_DEPS

--- a/pkg/kamailio/deb/build_travis.sh
+++ b/pkg/kamailio/deb/build_travis.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# build script for travis CI
+# environment based on Ubuntu 12.04 LTS (precise)
+#
+export JAVA_HOME="/usr/lib/jvm/java-gcj"
+EXCLUDED_MODULES=""
+EXTRA_EXCLUDED_MODULES="bdb dbtext oracle pa iptrtpproxy mi_xmlrpc dnssec kazoo cnxcc"
+PACKAGE_GROUPS="mysql postgres berkeley unixodbc radius presence ldap xml perl utils lua memcached \
+	snmpstats carrierroute xmpp cpl redis python geoip\
+	sqlite json mono ims sctp java \
+	purple tls outbound websocket autheph"
+echo "make cfg"
+make FLAVOUR=kamailio cfg \
+	skip_modules="${EXCLUDED_MODULES} ${EXTRA_EXCLUDED_MODULES}" \
+	group_include="kstandard"
+echo "make all"
+make all
+echo "make groups"
+for grp in ${PACKAGE_GROUPS}; do
+	make every-module group_include="k${grp}"
+done


### PR DESCRIPTION
Initial configuration that integrates Travis CI infrastructure for Kamailio project

[![Build Status](https://travis-ci.org/kamailio/kamailio.svg?branch=vseva%2Ftravis)](https://travis-ci.org/kamailio/kamailio)
- gcc and clang builds
- notifications by email and IRC
- environment based on Ubuntu 12.04 LTS(precise)

TODO
- configure basic testing after built
- build with valgrind
- ...

https://travis-ci.org/kamailio/kamailio
