### PR TITLE
Improve for correct working with all RADIUS AV pairs

### DIFF
--- a/modules/auth_radius/sterman.c
+++ b/modules/auth_radius/sterman.c
@@ -44,6 +44,9 @@
 #include <string.h>
 
 
+
+
+
 /* Array for extra attribute values */
 static str val_arr[MAX_EXTRA];
 
@@ -70,77 +73,87 @@ static str val_arr[MAX_EXTRA];
 static inline int extract_avp(VALUE_PAIR* vp, unsigned short *flags,
 			      int_str *name, int_str *value)
 {
-	static str names, values;
-	unsigned int r;
-	char *p;
-	char *end;
+	char *p, *q, *r;
 
-	/* empty? */
-	if (vp->lvalue==0 || vp->strvalue==0)
-		goto error;
+	LM_DBG("vp->name '%.*s'\n",(int)strlen(vp->name),vp->name);
+	LM_DBG("vp->attribute '%d'\n",vp->attribute);
+	LM_DBG("vp->type '%d'\n",vp->type);
+	LM_DBG("vp->lvalue '%d'\n",vp->lvalue);
+	if (vp->type == PW_TYPE_STRING) 
+		LM_DBG("vp->strvalue '%.*s'\n",(int)strlen(vp->strvalue),vp->strvalue);
 
-	p = vp->strvalue;
-	end = vp->strvalue + vp->lvalue;
-
-	LM_DBG("string is <%.*s>\n", (int)(long)(end-p), p);
-
-	/* get name */
-	if (*p!='#') {
-		/* name AVP */
-		*flags |= AVP_NAME_STR;
-		names.s = p;
-	} else {
-		names.s = ++p;
-	}
-
-	names.len = 0;
-	while( p<end && *p!=':' && *p!='#')
-		p++;
-	if (names.s==p || p==end) {
-		LM_ERR("empty AVP name\n");
-		goto error;
-	}
-	names.len = p - names.s;
-	LM_DBG("AVP name is <%.*s>\n", names.len, names.s);
-
-	/* get value */
-	if (*p!='#') {
-		/* string value */
-		*flags |= AVP_VAL_STR;
-	}
-	values.s = ++p;
-	values.len = end-values.s;
-	if (values.len==0) {
-		LM_ERR("empty AVP value\n");
-		goto error;
-	}
-	LM_DBG("AVP val is <%.*s>\n", values.len, values.s);
-
-	if ( !((*flags)&AVP_NAME_STR) ) {
-		/* convert name to id*/
-		if (str2int(&names,&r)!=0 ) {
-			LM_ERR("invalid AVP ID '%.*s'\n", names.len,names.s);
-			goto error;
+	if ( vp->attribute == attrs[A_SIP_AVP].v && vp->type == PW_TYPE_STRING ) {
+		errno = 0;
+		p = strchr(vp->strvalue,'#');
+		q = strchr(vp->strvalue,':');
+		r = strrchr(vp->strvalue,'#');
+		if ( p != NULL && p == r && p == vp->strvalue && q != NULL ) {
+			// int name and str value
+			*flags |= AVP_VAL_STR;
+			p++;
+			name->n = strtol(p,&q,10);
+			q++;
+			value->s.len = strlen(q);
+			value->s.s = malloc(value->s.len + 1);
+			strcpy (value->s.s,q);
+		} else if ( p != NULL && p == r && q == NULL ) {
+			// str name and int value
+			*flags |= AVP_NAME_STR;
+			name->s.len = p - vp->strvalue;
+			name->s.s = malloc(name->s.len + 1);
+			strncpy(name->s.s,vp->strvalue,name->s.len);
+			name->s.s[name->s.len] = '\0';
+			p++;
+			value->n = strtol(p,&r,10);
+		} else if ( p != NULL && p != r && q == NULL ) {
+			// int name and int vale
+			p++;
+			name->n = strtol(p,&q,10);
+			r++;
+			value->n = strtol(r,&q,10);
+		} else if ( p == NULL && q != NULL ) {
+			// str name and str value
+			*flags |= AVP_VAL_STR|AVP_NAME_STR;
+			name->s.len = q - vp->strvalue;
+			name->s.s = malloc(name->s.len + 1);
+			strncpy(name->s.s,vp->strvalue,name->s.len);
+			name->s.s[name->s.len] = '\0';
+			q++;
+			value->s.len = strlen(q);
+			value->s.s = malloc(value->s.len + 1);
+			strcpy (value->s.s,q);
+		} else // error - unknown
+			return 0;
+	    if ( errno != 0 ) {
+			perror("strtol");
+			return 0;
 		}
-		name->n = (int)r;
+	} else if (vp->type == PW_TYPE_STRING) {
+			*flags |= AVP_VAL_STR|AVP_NAME_STR;
+			if (!(p = strchr(vp->strvalue,'='))) {
+				if (!(p = strchr(vp->strvalue,':'))) {
+					if (!(p = strchr(vp->strvalue,'#'))) {
+						p = vp->strvalue;
+					} else p++;
+				} else p++;
+			} else p++;
+			value->s.len = vp->lvalue - (p - vp->strvalue);
+			value->s.s = malloc(value->s.len + 1);
+			strcpy (value->s.s, p);
+			name->s.len = strlen(vp->name); 
+			name->s.s = malloc(name->s.len + 1);
+			strcpy(name->s.s,vp->name);
+	} else if ((vp->type == PW_TYPE_INTEGER) || (vp->type == PW_TYPE_IPADDR) || (vp->type == PW_TYPE_DATE)) {
+			*flags |= AVP_NAME_STR;
+			value->n = vp->lvalue;
+			name->s.len = strlen(vp->name); 
+			name->s.s = malloc(name->s.len+1);
+			strcpy(name->s.s,vp->name);
 	} else {
-		name->s = names;
+			LM_ERR("Unknown AVP type '%d'!\n",vp->type);
+			return 0;
 	}
-
-	if ( !((*flags)&AVP_VAL_STR) ) {
-		/* convert value to integer */
-		if (str2int(&values,&r)!=0 ) {
-			LM_ERR("invalid AVP numrical value '%.*s'\n", values.len,values.s);
-			goto error;
-		}
-		value->n = (int)r;
-	} else {
-		value->s = values;
-	}
-
-	return 0;
-error:
-	return -1;
+	return 1;
 }
 
 
@@ -153,27 +166,30 @@ static int generate_avps(VALUE_PAIR* received)
 	unsigned short flags;
 	VALUE_PAIR *vp;
 
-	vp = received;
-
-	LM_DBG("getting SIP AVPs from avpair %d\n",	attrs[A_SIP_AVP].v);
-
-	for( ; (vp=rc_avpair_get(vp,attrs[A_SIP_AVP].v,0)) ; vp=vp->next) {
+	LM_DBG("getting AVPs from RADIUS Reply");
+	for( vp = received; vp; vp=vp->next) {
 		flags = 0;
-		if (extract_avp( vp, &flags, &name, &val)!=0 )
+		if (!extract_avp( vp, &flags, &name, &val)){
+			LM_DBG("error while extracting AVP '%.*s'\n",(int)strlen(vp->name),vp->name);
 			continue;
+		}
 		if (add_avp( flags, name, val) < 0) {
 			LM_ERR("unable to create a new AVP\n");
 		} else {
-			LM_DBG("AVP '%.*s'/%d='%.*s'/%d has been added\n",
-				(flags&AVP_NAME_STR)?name.s.len:4,
-				(flags&AVP_NAME_STR)?name.s.s:"null",
-				(flags&AVP_NAME_STR)?0:name.n,
-				(flags&AVP_VAL_STR)?val.s.len:4,
-				(flags&AVP_VAL_STR)?val.s.s:"null",
-				(flags&AVP_VAL_STR)?0:val.n );
+			if (flags&PV_VAL_STR) {
+				LM_DBG("Added AVP name '%.*s'='%.*s'\n",(int)strlen(name.s.s),name.s.s,(int)strlen(val.s.s),val.s.s);
+			} else  if (flags&PV_VAL_INT) {
+				LM_DBG("Added AVP name '%.*s'=%d\n",(int)strlen(name.s.s),name.s.s,val.n);
+			} else
+				LM_DBG("AVP '%.*s'/%d='%.*s'/%d has been added\n",
+					(flags&AVP_NAME_STR)?name.s.len:4,
+					(flags&AVP_NAME_STR)?name.s.s:"null",
+					(flags&AVP_NAME_STR)?0:name.n,
+					(flags&AVP_VAL_STR)?val.s.len:4,
+					(flags&AVP_VAL_STR)?val.s.s:"null",
+					(flags&AVP_VAL_STR)?0:val.n );
 		}
 	}
-
 	return 0;
 }
 

--- a/modules/misc_radius/functions.c
+++ b/modules/misc_radius/functions.c
@@ -31,6 +31,8 @@
 #include "misc_radius.h"
 #include "extra.h"
 
+#define A_SIP_AVP_attr		225
+
 /* Array for extra attribute values */
 static str val_arr[MAX_EXTRA];
 
@@ -38,73 +40,87 @@ static str val_arr[MAX_EXTRA];
 static inline int extract_avp(VALUE_PAIR* vp, unsigned short *flags,
 		int_str *name, int_str *value)
 {
-	static str names, values;
-	unsigned int r;
-	char *p;
-	char *end;
+	char *p, *q, *r;
 
-	/* empty? */
-	if (vp->lvalue==0 || vp->strvalue==0)
-		goto error;
+	LM_DBG("vp->name '%.*s'\n",(int)strlen(vp->name),vp->name);
+	LM_DBG("vp->attribute '%d'\n",vp->attribute);
+	LM_DBG("vp->type '%d'\n",vp->type);
+	LM_DBG("vp->lvalue '%d'\n",vp->lvalue);
+	if (vp->type == PW_TYPE_STRING) 
+		LM_DBG("vp->strvalue '%.*s'\n",(int)strlen(vp->strvalue),vp->strvalue);
 
-	p = vp->strvalue;
-	end = vp->strvalue + vp->lvalue;
-
-	/* get name */
-	if (*p!='#') {
-		/* name AVP */
-		*flags |= AVP_NAME_STR;
-		names.s = p;
-	} else {
-		names.s = ++p;
-	}
-
-	names.len = 0;
-	while( p<end && *p!=':' && *p!='#')
-		p++;
-	if (names.s==p || p==end) {
-		LM_ERR("empty AVP name\n");
-		goto error;
-	}
-	names.len = p - names.s;
-
-	/* get value */
-	if (*p!='#') {
-		/* string value */
-		*flags |= AVP_VAL_STR;
-	}
-	values.s = ++p;
-	values.len = end-values.s;
-	if (values.len==0) {
-		LM_ERR("empty AVP value\n");
-		goto error;
-	}
-
-	if ( !((*flags)&AVP_NAME_STR) ) {
-		/* convert name to id*/
-		if (str2int(&names,&r)!=0 ) {
-			LM_ERR("invalid AVP ID '%.*s'\n", names.len,names.s);
-			goto error;
+	if ( vp->attribute == A_SIP_AVP_attr && vp->type == PW_TYPE_STRING ) {
+		errno = 0;
+		p = strchr(vp->strvalue,'#');
+		q = strchr(vp->strvalue,':');
+		r = strrchr(vp->strvalue,'#');
+		if ( p != NULL && p == r && p == vp->strvalue && q != NULL ) {
+			// int name and str value
+			*flags |= AVP_VAL_STR;
+			p++;
+			name->n = strtol(p,&q,10);
+			q++;
+			value->s.len = strlen(q);
+			value->s.s = malloc(value->s.len + 1);
+			strcpy (value->s.s,q);
+		} else if ( p != NULL && p == r && q == NULL ) {
+			// str name and int value
+			*flags |= AVP_NAME_STR;
+			name->s.len = p - vp->strvalue;
+			name->s.s = malloc(name->s.len + 1);
+			strncpy(name->s.s,vp->strvalue,name->s.len);
+			name->s.s[name->s.len] = '\0';
+			p++;
+			value->n = strtol(p,&r,10);
+		} else if ( p != NULL && p != r && q == NULL ) {
+			// int name and int vale
+			p++;
+			name->n = strtol(p,&q,10);
+			r++;
+			value->n = strtol(r,&q,10);
+		} else if ( p == NULL && q != NULL ) {
+			// str name and str value
+			*flags |= AVP_VAL_STR|AVP_NAME_STR;
+			name->s.len = q - vp->strvalue;
+			name->s.s = malloc(name->s.len + 1);
+			strncpy(name->s.s,vp->strvalue,name->s.len);
+			name->s.s[name->s.len] = '\0';
+			q++;
+			value->s.len = strlen(q);
+			value->s.s = malloc(value->s.len + 1);
+			strcpy (value->s.s,q);
+		} else // error
+			return 0;
+	    if ( errno != 0 ) {
+			perror("strtol");
+			return 0;
 		}
-		name->n = (int)r;
+	} else if (vp->type == PW_TYPE_STRING) {
+			*flags |= AVP_VAL_STR|AVP_NAME_STR;
+			if (!(p = strchr(vp->strvalue,'='))) {
+				if (!(p = strchr(vp->strvalue,':'))) {
+					if (!(p = strchr(vp->strvalue,'#'))) {
+						p = vp->strvalue;
+					} else p++;
+				} else p++;
+			} else p++;
+			value->s.len = vp->lvalue - (p - vp->strvalue);
+			value->s.s = malloc(value->s.len + 1);
+			strcpy (value->s.s, p);
+			name->s.len = strlen(vp->name); 
+			name->s.s = malloc(name->s.len + 1);
+			strcpy(name->s.s,vp->name);
+	} else if ((vp->type == PW_TYPE_INTEGER) || (vp->type == PW_TYPE_IPADDR) || (vp->type == PW_TYPE_DATE)) {
+			*flags |= AVP_NAME_STR;
+			value->n = vp->lvalue;
+			name->s.len = strlen(vp->name); 
+			name->s.s = malloc(name->s.len+1);
+			strcpy(name->s.s,vp->name);
 	} else {
-		name->s = names;
+			LM_ERR("Unknown AVP type '%d'!\n",vp->type);
+			return 0;
 	}
-
-	if ( !((*flags)&AVP_VAL_STR) ) {
-		/* convert value to integer */
-		if (str2int(&values,&r)!=0 ) {
-			LM_ERR("invalid AVP numrical value '%.*s'\n", values.len,values.s);
-			goto error;
-		}
-		value->n = (int)r;
-	} else {
-		value->s = values;
-	}
-
-	return 0;
-error:
-	return -1;
+	return 1;
 }
 
 static void generate_avps_rad(VALUE_PAIR* received)
@@ -113,52 +129,31 @@ static void generate_avps_rad(VALUE_PAIR* received)
 	unsigned short flags;
 	VALUE_PAIR *vp;
 
-	vp = received;
-
-	for( ; vp ; vp=vp->next) {
-		flags = AVP_NAME_STR;
-		switch(vp->type)
-		{
-			case PW_TYPE_STRING:
-				flags |= AVP_VAL_STR;
-				name.s.len = strlen(vp->name);
-				val.s.len = strlen(vp->strvalue);
-				name.s.s = vp->name;
-				val.s.s = vp->strvalue;
-				if (add_avp( flags, name, val ) < 0) {
-					LM_ERR("unable to create a new AVP\n");
-				} else {
-					LM_DBG("AVP '%.*s'/%d='%.*s'/%d has been added\n",
-							(flags&AVP_NAME_STR)?name.s.len:4,
-							(flags&AVP_NAME_STR)?name.s.s:"null",
-							(flags&AVP_NAME_STR)?0:name.n,
-							(flags&AVP_VAL_STR)?val.s.len:4,
-							(flags&AVP_VAL_STR)?val.s.s:"null",
-							(flags&AVP_VAL_STR)?0:val.n );
-				}
-				continue;
-			case PW_TYPE_INTEGER:
-				name.s.len = strlen(vp->name);
-				name.s.s = vp->name;
-				val.n = vp->lvalue;
-				if (add_avp( flags, name, val ) < 0) {
-					LM_ERR("unable to create a new AVP\n");
-				} else {
-					LM_DBG("AVP '%.*s'/%d='%.*s'/%d has been added\n",
-							(flags&AVP_NAME_STR)?name.s.len:4,
-							(flags&AVP_NAME_STR)?name.s.s:"null",
-							(flags&AVP_NAME_STR)?0:name.n,
-							(flags&AVP_VAL_STR)?val.s.len:4,
-							(flags&AVP_VAL_STR)?val.s.s:"null",
-							(flags&AVP_VAL_STR)?0:val.n );
-				}
-				continue;
-			default:
-				LM_ERR("skip attribute type %d (non-string)", vp->type);
-				continue;
+	LM_DBG("getting AVPs from RADIUS Reply");
+	for( vp = received; vp; vp=vp->next) {
+		flags = 0;
+		if (!extract_avp( vp, &flags, &name, &val)){
+			LM_DBG("error while extracting AVP '%.*s'\n",(int)strlen(vp->name),vp->name);
+			continue;
 		}
-		return;
+		if (add_avp( flags, name, val) < 0) {
+			LM_ERR("unable to create a new AVP\n");
+		} else {
+			if (flags&PV_VAL_STR) {
+				LM_DBG("Added AVP name '%.*s'='%.*s'\n",(int)strlen(name.s.s),name.s.s,(int)strlen(val.s.s),val.s.s);
+			} else  if (flags&PV_VAL_INT) {
+				LM_DBG("Added AVP name '%.*s'=%d\n",(int)strlen(name.s.s),name.s.s,val.n);
+			} else
+				LM_DBG("AVP '%.*s'/%d='%.*s'/%d has been added\n",
+					(flags&AVP_NAME_STR)?name.s.len:4,
+					(flags&AVP_NAME_STR)?name.s.s:"null",
+					(flags&AVP_NAME_STR)?0:name.n,
+					(flags&AVP_VAL_STR)?val.s.len:4,
+					(flags&AVP_VAL_STR)?val.s.s:"null",
+					(flags&AVP_VAL_STR)?0:val.n );
+		}
 	}
+	return;
 }
 
 
@@ -169,16 +164,22 @@ static void generate_avps(struct attr *attrs, VALUE_PAIR* received)
 	unsigned short flags;
 	VALUE_PAIR *vp;
 
-	vp = received;
-
-	for( ; (vp=rc_avpair_get(vp,attrs[SA_SIP_AVP].v,0)) ; vp=vp->next) {
+	LM_DBG("getting AVPs from RADIUS Reply");
+	for( vp = received; vp; vp=vp->next) {
 		flags = 0;
-		if (extract_avp( vp, &flags, &name, &val)!=0 )
+		if (!extract_avp( vp, &flags, &name, &val)){
+			LM_DBG("error while extracting AVP '%.*s'\n",(int)strlen(vp->name),vp->name);
 			continue;
+		}
 		if (add_avp( flags, name, val) < 0) {
 			LM_ERR("unable to create a new AVP\n");
 		} else {
-			LM_DBG("AVP '%.*s'/%d='%.*s'/%d has been added\n",
+			if (flags&PV_VAL_STR) {
+				LM_DBG("Added AVP name '%.*s'='%.*s'\n",(int)strlen(name.s.s),name.s.s,(int)strlen(val.s.s),val.s.s);
+			} else  if (flags&PV_VAL_INT) {
+				LM_DBG("Added AVP name '%.*s'=%d\n",(int)strlen(name.s.s),name.s.s,val.n);
+			} else
+				LM_DBG("AVP '%.*s'/%d='%.*s'/%d has been added\n",
 					(flags&AVP_NAME_STR)?name.s.len:4,
 					(flags&AVP_NAME_STR)?name.s.s:"null",
 					(flags&AVP_NAME_STR)?0:name.n,
@@ -187,7 +188,6 @@ static void generate_avps(struct attr *attrs, VALUE_PAIR* received)
 					(flags&AVP_VAL_STR)?0:val.n );
 		}
 	}
-
 	return;
 }
 

--- a/modules/misc_radius/functions.c
+++ b/modules/misc_radius/functions.c
@@ -54,20 +54,26 @@ static inline int extract_avp(VALUE_PAIR* vp, unsigned short *flags,
 		p = strchr(vp->strvalue,'#');
 		q = strchr(vp->strvalue,':');
 		r = strrchr(vp->strvalue,'#');
-		if ( p != NULL && p == r && p == vp->strvalue && q != NULL ) {
+		if ( p == vp->strvalue && q != NULL ) {
 			// int name and str value
 			*flags |= AVP_VAL_STR;
 			p++;
 			name->n = strtol(p,&q,10);
 			q++;
 			value->s.len = strlen(q);
-			value->s.s = malloc(value->s.len + 1);
+			if (!(value->s.s = pkg_malloc(value->s.len + 1))) {
+				*flags = 0;
+				return 0;
+			}
 			strcpy (value->s.s,q);
-		} else if ( p != NULL && p == r && q == NULL ) {
+		} else if ( p != NULL && p == r && p > vp->strvalue && q == NULL ) {
 			// str name and int value
 			*flags |= AVP_NAME_STR;
 			name->s.len = p - vp->strvalue;
-			name->s.s = malloc(name->s.len + 1);
+			if (!(name->s.s = pkg_malloc(name->s.len + 1))) {
+				*flags = 0;
+				return 0;
+			}
 			strncpy(name->s.s,vp->strvalue,name->s.len);
 			name->s.s[name->s.len] = '\0';
 			p++;
@@ -78,21 +84,33 @@ static inline int extract_avp(VALUE_PAIR* vp, unsigned short *flags,
 			name->n = strtol(p,&q,10);
 			r++;
 			value->n = strtol(r,&q,10);
-		} else if ( p == NULL && q != NULL ) {
+		} else if ( (p == NULL || p > q) && q != NULL ) {
 			// str name and str value
 			*flags |= AVP_VAL_STR|AVP_NAME_STR;
 			name->s.len = q - vp->strvalue;
-			name->s.s = malloc(name->s.len + 1);
+			if (!(name->s.s = pkg_malloc(name->s.len + 1))) {
+				*flags = 0;
+				return 0;
+			}
 			strncpy(name->s.s,vp->strvalue,name->s.len);
 			name->s.s[name->s.len] = '\0';
 			q++;
 			value->s.len = strlen(q);
-			value->s.s = malloc(value->s.len + 1);
+			if (!(value->s.s = pkg_malloc(value->s.len + 1))) {
+				pkg_free(name->s.s);
+				*flags = 0;
+				return 0;
+			}
 			strcpy (value->s.s,q);
-		} else // error
+		} else // error - unknown
 			return 0;
 	    if ( errno != 0 ) {
 			perror("strtol");
+			if (*flags&AVP_NAME_STR)
+				pkg_free(name->s.s);
+			if (*flags&AVP_VAL_STR)
+				pkg_free(value->s.s);
+			*flags = 0;
 			return 0;
 		}
 	} else if (vp->type == PW_TYPE_STRING) {
@@ -105,16 +123,26 @@ static inline int extract_avp(VALUE_PAIR* vp, unsigned short *flags,
 				} else p++;
 			} else p++;
 			value->s.len = vp->lvalue - (p - vp->strvalue);
-			value->s.s = malloc(value->s.len + 1);
+			if (!(value->s.s = pkg_malloc(value->s.len + 1))) {
+				*flags = 0;
+				return 0;
+			}
 			strcpy (value->s.s, p);
 			name->s.len = strlen(vp->name); 
-			name->s.s = malloc(name->s.len + 1);
+			if (!(name->s.s = pkg_malloc(name->s.len + 1))) {
+				pkg_free(value->s.s);
+				*flags = 0;
+				return 0;
+			}
 			strcpy(name->s.s,vp->name);
 	} else if ((vp->type == PW_TYPE_INTEGER) || (vp->type == PW_TYPE_IPADDR) || (vp->type == PW_TYPE_DATE)) {
 			*flags |= AVP_NAME_STR;
 			value->n = vp->lvalue;
 			name->s.len = strlen(vp->name); 
-			name->s.s = malloc(name->s.len+1);
+			if (!(name->s.s = pkg_malloc(name->s.len+1))) {
+				*flags = 0;
+				return 0;
+			}
 			strcpy(name->s.s,vp->name);
 	} else {
 			LM_ERR("Unknown AVP type '%d'!\n",vp->type);
@@ -123,40 +151,6 @@ static inline int extract_avp(VALUE_PAIR* vp, unsigned short *flags,
 	return 1;
 }
 
-static void generate_avps_rad(VALUE_PAIR* received)
-{
-	int_str name, val;
-	unsigned short flags;
-	VALUE_PAIR *vp;
-
-	LM_DBG("getting AVPs from RADIUS Reply");
-	for( vp = received; vp; vp=vp->next) {
-		flags = 0;
-		if (!extract_avp( vp, &flags, &name, &val)){
-			LM_DBG("error while extracting AVP '%.*s'\n",(int)strlen(vp->name),vp->name);
-			continue;
-		}
-		if (add_avp( flags, name, val) < 0) {
-			LM_ERR("unable to create a new AVP\n");
-		} else {
-			if (flags&PV_VAL_STR) {
-				LM_DBG("Added AVP name '%.*s'='%.*s'\n",(int)strlen(name.s.s),name.s.s,(int)strlen(val.s.s),val.s.s);
-			} else  if (flags&PV_VAL_INT) {
-				LM_DBG("Added AVP name '%.*s'=%d\n",(int)strlen(name.s.s),name.s.s,val.n);
-			} else
-				LM_DBG("AVP '%.*s'/%d='%.*s'/%d has been added\n",
-					(flags&AVP_NAME_STR)?name.s.len:4,
-					(flags&AVP_NAME_STR)?name.s.s:"null",
-					(flags&AVP_NAME_STR)?0:name.n,
-					(flags&AVP_VAL_STR)?val.s.len:4,
-					(flags&AVP_VAL_STR)?val.s.s:"null",
-					(flags&AVP_VAL_STR)?0:val.n );
-		}
-	}
-	return;
-}
-
-
 /* Generate AVPs from Radius reply items */
 static void generate_avps(struct attr *attrs, VALUE_PAIR* received)
 {
@@ -164,15 +158,15 @@ static void generate_avps(struct attr *attrs, VALUE_PAIR* received)
 	unsigned short flags;
 	VALUE_PAIR *vp;
 
-	LM_DBG("getting AVPs from RADIUS Reply");
+	LM_DBG("getting AVPs from RADIUS Reply\n");
 	for( vp = received; vp; vp=vp->next) {
 		flags = 0;
 		if (!extract_avp( vp, &flags, &name, &val)){
-			LM_DBG("error while extracting AVP '%.*s'\n",(int)strlen(vp->name),vp->name);
+			LM_ERR("error while extracting AVP '%.*s'\n",(int)strlen(vp->name),vp->name);
 			continue;
 		}
 		if (add_avp( flags, name, val) < 0) {
-			LM_ERR("unable to create a new AVP\n");
+			LM_ERR("error while creating a new AVP\n");
 		} else {
 			if (flags&PV_VAL_STR) {
 				LM_DBG("Added AVP name '%.*s'='%.*s'\n",(int)strlen(name.s.s),name.s.s,(int)strlen(val.s.s),val.s.s);
@@ -187,9 +181,51 @@ static void generate_avps(struct attr *attrs, VALUE_PAIR* received)
 					(flags&AVP_VAL_STR)?val.s.s:"null",
 					(flags&AVP_VAL_STR)?0:val.n );
 		}
+		if (flags&AVP_NAME_STR) 
+			pkg_free(name.s.s);
+		if (flags&AVP_VAL_STR) 
+			pkg_free(val.s.s);
 	}
 	return;
 }
+
+static void generate_avps_rad(VALUE_PAIR* received)
+{
+	int_str name, val;
+	unsigned short flags;
+	VALUE_PAIR *vp;
+
+	LM_DBG("getting AVPs from RADIUS Reply\n");
+	for( vp = received; vp; vp=vp->next) {
+		flags = 0;
+		if (!extract_avp( vp, &flags, &name, &val)){
+			LM_ERR("error while extracting AVP '%.*s'\n",(int)strlen(vp->name),vp->name);
+			continue;
+		}
+		if (add_avp( flags, name, val) < 0) {
+			LM_ERR("error while creating a new AVP\n");
+		} else {
+			if (flags&PV_VAL_STR) {
+				LM_DBG("Added AVP name '%.*s'='%.*s'\n",(int)strlen(name.s.s),name.s.s,(int)strlen(val.s.s),val.s.s);
+			} else  if (flags&PV_VAL_INT) {
+				LM_DBG("Added AVP name '%.*s'=%d\n",(int)strlen(name.s.s),name.s.s,val.n);
+			} else
+				LM_DBG("AVP '%.*s'/%d='%.*s'/%d has been added\n",
+					(flags&AVP_NAME_STR)?name.s.len:4,
+					(flags&AVP_NAME_STR)?name.s.s:"null",
+					(flags&AVP_NAME_STR)?0:name.n,
+					(flags&AVP_VAL_STR)?val.s.len:4,
+					(flags&AVP_VAL_STR)?val.s.s:"null",
+					(flags&AVP_VAL_STR)?0:val.n );
+		}
+		if (flags&AVP_NAME_STR) 
+			pkg_free(name.s.s);
+		if (flags&AVP_VAL_STR) 
+			pkg_free(val.s.s);
+	}
+	return;
+}
+
 
 /* Macro to add extra attribute */
 #define ADD_EXTRA_AVPAIR(_attrs, _attr, _val, _len)	\

--- a/modules/peering/verify.c
+++ b/modules/peering/verify.c
@@ -40,8 +40,11 @@
 #include "../../lib/kcore/cmpapi.h"
 #include "../../parser/parse_uri.h"
 #include "../../parser/parse_from.h"
+#include "../../pvar.h"
 #include "peering.h"
 
+#include <stdlib.h>
+#include <string.h>
 
 /*
  * Extract name and value of an AVP from VALUE_PAIR
@@ -49,76 +52,87 @@
 static inline int extract_avp(VALUE_PAIR* vp, unsigned short *flags,
 			      int_str *name, int_str *value)
 {
-    static str names, values;
-    unsigned int r;
-    char *p;
-    char *end;
+	char *p, *q, *r;
 
-    /* empty? */
-    if (vp->lvalue==0 || vp->strvalue==0)
-        goto error;
+	LM_DBG("vp->name '%.*s'\n",(int)strlen(vp->name),vp->name);
+	LM_DBG("vp->attribute '%d'\n",vp->attribute);
+	LM_DBG("vp->type '%d'\n",vp->type);
+	LM_DBG("vp->lvalue '%d'\n",vp->lvalue);
+	if (vp->type == PW_TYPE_STRING) 
+		LM_DBG("vp->strvalue '%.*s'\n",(int)strlen(vp->strvalue),vp->strvalue);
 
-    p = vp->strvalue;
-    end = vp->strvalue + vp->lvalue;
-
-    /* get name */
-    if (*p!='#') {
-	/* name AVP */
-	*flags |= AVP_NAME_STR;
-	names.s = p;
-    } else {
-	names.s = ++p;
-    }
-
-    names.len = 0;
-    while( p<end && *p!=':' && *p!='#')
-	p++;
-    if (names.s==p || p==end) {
-	LM_ERR("empty AVP name\n");
-	goto error;
-    }
-    names.len = p - names.s;
-    LM_DBG("AVP name is <%.*s>\n", names.len, names.s);
-
-    /* get value */
-    if (*p!='#') {
-	/* string value */
-	*flags |= AVP_VAL_STR;
-    }
-    values.s = ++p;
-    values.len = end-values.s;
-    if (values.len==0) {
-	LM_ERR("Empty AVP value\n");
-	goto error;
-    }
-    LM_DBG("AVP val is <%.*s>\n", values.len, values.s);
-
-    if ( !((*flags)&AVP_NAME_STR) ) {
-	/* convert name to id*/
-	if (str2int(&names,&r)!=0 ) {
-	    LM_ERR("invalid AVP ID '%.*s'\n", names.len,names.s);
-	    goto error;
+	if ( vp->attribute == attrs[A_SIP_AVP].v && vp->type == PW_TYPE_STRING ) {
+		errno = 0;
+		p = strchr(vp->strvalue,'#');
+		q = strchr(vp->strvalue,':');
+		r = strrchr(vp->strvalue,'#');
+		if ( p != NULL && p == r && p == vp->strvalue && q != NULL ) {
+			// int name and str value
+			*flags |= AVP_VAL_STR;
+			p++;
+			name->n = strtol(p,&q,10);
+			q++;
+			value->s.len = strlen(q);
+			value->s.s = malloc(value->s.len + 1);
+			strcpy (value->s.s,q);
+		} else if ( p != NULL && p == r && q == NULL ) {
+			// str name and int value
+			*flags |= AVP_NAME_STR;
+			name->s.len = p - vp->strvalue;
+			name->s.s = malloc(name->s.len + 1);
+			strncpy(name->s.s,vp->strvalue,name->s.len);
+			name->s.s[name->s.len] = '\0';
+			p++;
+			value->n = strtol(p,&r,10);
+		} else if ( p != NULL && p != r && q == NULL ) {
+			// int name and int vale
+			p++;
+			name->n = strtol(p,&q,10);
+			r++;
+			value->n = strtol(r,&q,10);
+		} else if ( p == NULL && q != NULL ) {
+			// str name and str value
+			*flags |= AVP_VAL_STR|AVP_NAME_STR;
+			name->s.len = q - vp->strvalue;
+			name->s.s = malloc(name->s.len + 1);
+			strncpy(name->s.s,vp->strvalue,name->s.len);
+			name->s.s[name->s.len] = '\0';
+			q++;
+			value->s.len = strlen(q);
+			value->s.s = malloc(value->s.len + 1);
+			strcpy (value->s.s,q);
+		} else // error - unknown
+			return 0;
+	    if ( errno != 0 ) {
+			perror("strtol");
+			return 0;
+		}
+	} else if (vp->type == PW_TYPE_STRING) {
+			*flags |= AVP_VAL_STR|AVP_NAME_STR;
+			if (!(p = strchr(vp->strvalue,'='))) {
+				if (!(p = strchr(vp->strvalue,':'))) {
+					if (!(p = strchr(vp->strvalue,'#'))) {
+						p = vp->strvalue;
+					} else p++;
+				} else p++;
+			} else p++;
+			value->s.len = vp->lvalue - (p - vp->strvalue);
+			value->s.s = malloc(value->s.len + 1);
+			strcpy (value->s.s, p);
+			name->s.len = strlen(vp->name); 
+			name->s.s = malloc(name->s.len + 1);
+			strcpy(name->s.s,vp->name);
+	} else if ((vp->type == PW_TYPE_INTEGER) || (vp->type == PW_TYPE_IPADDR) || (vp->type == PW_TYPE_DATE)) {
+			*flags |= AVP_NAME_STR;
+			value->n = vp->lvalue;
+			name->s.len = strlen(vp->name); 
+			name->s.s = malloc(name->s.len+1);
+			strcpy(name->s.s,vp->name);
+	} else {
+			LM_ERR("Unknown AVP type '%d'!\n",vp->type);
+			return 0;
 	}
-	name->n = (int)r;
-    } else {
-	name->s = names;
-    }
-
-    if ( !((*flags)&AVP_VAL_STR) ) {
-	/* convert value to integer */
-	if (str2int(&values,&r)!=0 ) {
-	    LM_ERR("invalid AVP numerical value '%.*s'\n",
-		   values.len,values.s);
-	    goto error;
-	}
-	value->n = (int)r;
-    } else {
-	value->s = values;
-    }
-
-    return 0;
-error:
-    return -1;
+	return 1;
 }
 
 
@@ -127,32 +141,35 @@ error:
  */
 static int generate_avps(VALUE_PAIR* received)
 {
-    int_str name, val;
-    unsigned short flags;
-    VALUE_PAIR *vp;
+   	int_str name, val;
+	unsigned short flags;
+	VALUE_PAIR *vp;
 
-    vp = received;
-
-    LM_DBG("getting SIP AVPs from avpair %d\n",	attrs[A_SIP_AVP].v);
-
-    for(; (vp=rc_avpair_get(vp,attrs[A_SIP_AVP].v,0)); vp=vp->next) {
-	flags = 0;
-	if (extract_avp(vp, &flags, &name, &val) != 0)
-	    continue;
-	if (add_avp( flags, name, val) < 0) {
-	    LM_ERR("unable to add a new AVP\n");
-	} else {
-	    LM_DBG("AVP '%.*s'/%d='%.*s'/%d has been added\n",
-		   (flags&AVP_NAME_STR)?name.s.len:4,
-		   (flags&AVP_NAME_STR)?name.s.s:"null",
-		   (flags&AVP_NAME_STR)?0:name.n,
-		   (flags&AVP_VAL_STR)?val.s.len:4,
-		   (flags&AVP_VAL_STR)?val.s.s:"null",
-		   (flags&AVP_VAL_STR)?0:val.n );
+	LM_DBG("getting AVPs from RADIUS Reply");
+	for( vp = received; vp; vp=vp->next) {
+		flags = 0;
+		if (!extract_avp( vp, &flags, &name, &val)){
+			LM_DBG("error while extracting AVP '%.*s'\n",(int)strlen(vp->name),vp->name);
+			continue;
+		}
+		if (add_avp( flags, name, val) < 0) {
+			LM_ERR("unable to create a new AVP\n");
+		} else {
+			if (flags&PV_VAL_STR) {
+				LM_DBG("Added AVP name '%.*s'='%.*s'\n",(int)strlen(name.s.s),name.s.s,(int)strlen(val.s.s),val.s.s);
+			} else  if (flags&PV_VAL_INT) {
+				LM_DBG("Added AVP name '%.*s'=%d\n",(int)strlen(name.s.s),name.s.s,val.n);
+			} else
+				LM_DBG("AVP '%.*s'/%d='%.*s'/%d has been added\n",
+					(flags&AVP_NAME_STR)?name.s.len:4,
+					(flags&AVP_NAME_STR)?name.s.s:"null",
+					(flags&AVP_NAME_STR)?0:name.n,
+					(flags&AVP_VAL_STR)?val.s.len:4,
+					(flags&AVP_VAL_STR)?val.s.s:"null",
+					(flags&AVP_VAL_STR)?0:val.n );
+		}
 	}
-    }
-    
-    return 0;
+	return 0;
 }
 
 

--- a/modules/peering/verify.c
+++ b/modules/peering/verify.c
@@ -66,20 +66,26 @@ static inline int extract_avp(VALUE_PAIR* vp, unsigned short *flags,
 		p = strchr(vp->strvalue,'#');
 		q = strchr(vp->strvalue,':');
 		r = strrchr(vp->strvalue,'#');
-		if ( p != NULL && p == r && p == vp->strvalue && q != NULL ) {
+		if ( p == vp->strvalue && q != NULL ) {
 			// int name and str value
 			*flags |= AVP_VAL_STR;
 			p++;
 			name->n = strtol(p,&q,10);
 			q++;
 			value->s.len = strlen(q);
-			value->s.s = malloc(value->s.len + 1);
+			if (!(value->s.s = pkg_malloc(value->s.len + 1))) {
+				*flags = 0;
+				return 0;
+			}
 			strcpy (value->s.s,q);
-		} else if ( p != NULL && p == r && q == NULL ) {
+		} else if ( p != NULL && p == r && p > vp->strvalue && q == NULL ) {
 			// str name and int value
 			*flags |= AVP_NAME_STR;
 			name->s.len = p - vp->strvalue;
-			name->s.s = malloc(name->s.len + 1);
+			if (!(name->s.s = pkg_malloc(name->s.len + 1))) {
+				*flags = 0;
+				return 0;
+			}
 			strncpy(name->s.s,vp->strvalue,name->s.len);
 			name->s.s[name->s.len] = '\0';
 			p++;
@@ -90,21 +96,33 @@ static inline int extract_avp(VALUE_PAIR* vp, unsigned short *flags,
 			name->n = strtol(p,&q,10);
 			r++;
 			value->n = strtol(r,&q,10);
-		} else if ( p == NULL && q != NULL ) {
+		} else if ( (p == NULL || p > q) && q != NULL ) {
 			// str name and str value
 			*flags |= AVP_VAL_STR|AVP_NAME_STR;
 			name->s.len = q - vp->strvalue;
-			name->s.s = malloc(name->s.len + 1);
+			if (!(name->s.s = pkg_malloc(name->s.len + 1))) {
+				*flags = 0;
+				return 0;
+			}
 			strncpy(name->s.s,vp->strvalue,name->s.len);
 			name->s.s[name->s.len] = '\0';
 			q++;
 			value->s.len = strlen(q);
-			value->s.s = malloc(value->s.len + 1);
+			if (!(value->s.s = pkg_malloc(value->s.len + 1))) {
+				pkg_free(name->s.s);
+				*flags = 0;
+				return 0;
+			}
 			strcpy (value->s.s,q);
 		} else // error - unknown
 			return 0;
 	    if ( errno != 0 ) {
 			perror("strtol");
+			if (*flags&AVP_NAME_STR) 
+				pkg_free(name->s.s);
+			if (*flags&AVP_VAL_STR) 
+				pkg_free(value->s.s);
+			*flags = 0;
 			return 0;
 		}
 	} else if (vp->type == PW_TYPE_STRING) {
@@ -117,16 +135,26 @@ static inline int extract_avp(VALUE_PAIR* vp, unsigned short *flags,
 				} else p++;
 			} else p++;
 			value->s.len = vp->lvalue - (p - vp->strvalue);
-			value->s.s = malloc(value->s.len + 1);
+			if (!(value->s.s = pkg_malloc(value->s.len + 1))) {
+				*flags = 0;
+				return 0;
+			}
 			strcpy (value->s.s, p);
 			name->s.len = strlen(vp->name); 
-			name->s.s = malloc(name->s.len + 1);
+			if (!(name->s.s = pkg_malloc(name->s.len + 1))) {
+				pkg_free(value->s.s);
+				*flags = 0;
+				return 0;
+			}
 			strcpy(name->s.s,vp->name);
 	} else if ((vp->type == PW_TYPE_INTEGER) || (vp->type == PW_TYPE_IPADDR) || (vp->type == PW_TYPE_DATE)) {
 			*flags |= AVP_NAME_STR;
 			value->n = vp->lvalue;
 			name->s.len = strlen(vp->name); 
-			name->s.s = malloc(name->s.len+1);
+			if (!(name->s.s = pkg_malloc(name->s.len+1))) {
+				*flags = 0;
+				return 0;
+			}
 			strcpy(name->s.s,vp->name);
 	} else {
 			LM_ERR("Unknown AVP type '%d'!\n",vp->type);
@@ -141,19 +169,19 @@ static inline int extract_avp(VALUE_PAIR* vp, unsigned short *flags,
  */
 static int generate_avps(VALUE_PAIR* received)
 {
-   	int_str name, val;
+	int_str name, val;
 	unsigned short flags;
 	VALUE_PAIR *vp;
 
-	LM_DBG("getting AVPs from RADIUS Reply");
+	LM_DBG("getting AVPs from RADIUS Reply\n");
 	for( vp = received; vp; vp=vp->next) {
 		flags = 0;
 		if (!extract_avp( vp, &flags, &name, &val)){
-			LM_DBG("error while extracting AVP '%.*s'\n",(int)strlen(vp->name),vp->name);
+			LM_ERR("error while extracting AVP '%.*s'\n",(int)strlen(vp->name),vp->name);
 			continue;
 		}
 		if (add_avp( flags, name, val) < 0) {
-			LM_ERR("unable to create a new AVP\n");
+			LM_ERR("error while creating a new AVP\n");
 		} else {
 			if (flags&PV_VAL_STR) {
 				LM_DBG("Added AVP name '%.*s'='%.*s'\n",(int)strlen(name.s.s),name.s.s,(int)strlen(val.s.s),val.s.s);
@@ -168,10 +196,13 @@ static int generate_avps(VALUE_PAIR* received)
 					(flags&AVP_VAL_STR)?val.s.s:"null",
 					(flags&AVP_VAL_STR)?0:val.n );
 		}
+		if (flags&AVP_NAME_STR) 
+			pkg_free(name.s.s);
+		if (flags&AVP_VAL_STR) 
+			pkg_free(val.s.s);
 	}
 	return 0;
 }
-
 
 /* 
  * Send Radius request to verify destination and generate AVPs from


### PR DESCRIPTION
In this pull request I`d correct work with retrieved from RADIUS AV pairs for modules auth_radius, misc_radius and peering. Now this modules correctly put to $avp() all retrieved params:
- integer name and integer value
- integer name and string value
- string name and integer value
- string name and string value

All above said and for SIP-AVP params too.