### PR TITLE
dialplan: skip check subexpressions on expressions with pvs

### DIFF
--- a/modules/dialplan/dp_db.c
+++ b/modules/dialplan/dp_db.c
@@ -494,8 +494,10 @@ dpl_node_t * build_rule(db_val_t * values)
 	LM_DBG("building rule for [%d:%.*s/%.*s/%.*s]\n", matchop,
 			match_exp.len, ZSW(match_exp.s), subst_exp.len, ZSW(subst_exp.s),
 			repl_exp.len, ZSW(repl_exp.s));
-	if (repl_comp && (cap_cnt < repl_comp->max_pmatch) && 
-			(repl_comp->max_pmatch != 0)) {
+	if (!(tflags&(DP_TFLAGS_PV_SUBST|DP_TFLAGS_PV_MATCH)) &&
+		repl_comp && (cap_cnt < repl_comp->max_pmatch) &&
+		(repl_comp->max_pmatch != 0))
+	{
 		LM_ERR("repl_exp %.*s refers to %d sub-expressions, but "
 				"subst_exp %.*s has only %d\n",
 				repl_exp.len, repl_exp.s, repl_comp->max_pmatch,

--- a/modules/dialplan/dp_repl.c
+++ b/modules/dialplan/dp_repl.c
@@ -188,7 +188,13 @@ int rule_translate(sip_msg_t *msg, str string, dpl_node_t * rule,
 	}
 
 	if(rule->tflags&DP_TFLAGS_PV_SUBST) {
-		subst_comp = dpl_dynamic_pcre(msg, &rule->subst_exp, NULL);
+		subst_comp = dpl_dynamic_pcre(msg, &rule->subst_exp, &cap_cnt);
+		if (cap_cnt > MAX_REPLACE_WITH) {
+			LM_ERR("subst expression %.*s has too many sub-expressions\n",
+				rule->subst_exp.len, rule->subst_exp.s);
+			if(subst_comp) pcre_free(subst_comp);
+			return -1;
+		}
 	} else {
 		subst_comp = rule->subst_comp;
 	}


### PR DESCRIPTION
subexpressions should not be checked when the expression has private variables

output of the error
```
 0(10175) DEBUG: dialplan [dp_db.c:496]: build_rule(): building rule for [2:^(00|\+)([1-9][0-9]+)$/^(00|\+)([1-9][0-9]+)$/\2]
 0(10175) DEBUG: dialplan [dp_db.c:533]: build_rule(): attrs are: ''
 0(10175) DEBUG: dialplan [dp_db.c:580]: add_rule2hash(): new dpl_id 1
 0(10175) DEBUG: dialplan [dp_db.c:593]: add_rule2hash(): new index , len 0
 0(10175) DEBUG: dialplan [dp_db.c:629]: add_rule2hash(): added the rule id 1 index 0 pr 1 next (nil) to the index with 0 len
 0(10175) DEBUG: dialplan [dp_repl.c:146]: repl_exp_parse(): replacement expression is [\1]
 0(10175) DEBUG: dialplan [dp_db.c:102]: dpl_check_pv(): parsing [^$avp(s:caller_cc)$avp(s:caller_ac)([1-9][0-9]+)$]
 0(10175) DEBUG: <core> [pvapi.c:419]: pv_spec_lookup(): PV <$avp(s:caller_cc)> is not in cache
 0(10175) DEBUG: <core> [usr_avp.c:882]: parse_avp_ident(): Parsing 's:caller_cc'
 0(10175) DEBUG: <core> [pvapi.c:293]: pv_cache_add(): pvar [$avp(s:caller_cc)] added in cache
 0(10175) DEBUG: dialplan [dp_db.c:124]: dpl_check_pv(): string [^$avp(s:caller_cc)$avp(s:caller_ac)([1-9][0-9]+)$] has variables
 0(10175) DEBUG: dialplan [dp_db.c:496]: build_rule(): building rule for [2:^$avp(s:caller_cc)$avp(s:caller_ac)([1-9][0-9]+)$/^$avp(s:caller_cc)$avp(s:caller_ac)([1-9][0-9]+)$/\1]
 0(10175) ERROR: dialplan [dp_db.c:502]: build_rule(): repl_exp \1 refers to 1 sub-expressions, but subst_exp ^$avp(s:caller_cc)$avp(s:caller_ac)([1-9][0-9]+)$ has only 0
 0(10175) DEBUG: dialplan [dp_db.c:685]: destroy_rule(): destroying rule with priority 1
```