### PR TITLE
auth: use correct parameter for pv_auth_check checks

### DIFF
--- a/modules/auth/auth_mod.c
+++ b/modules/auth/auth_mod.c
@@ -755,7 +755,7 @@ static int pv_auth_check(sip_msg_t *msg, char *realm,
 		ret = pv_authenticate(msg, &srealm, &spasswd, vflags, HDR_PROXYAUTH_T,
 					&msg->first_line.u.request.method);
 
-	if(ret==AUTH_OK && (vflags&AUTH_CHECK_ID_F)) {
+	if(ret==AUTH_OK && (vchecks&AUTH_CHECK_ID_F)) {
 		hdr = (msg->proxy_auth==0)?msg->authorization:msg->proxy_auth;
 		srealm = ((auth_body_t*)(hdr->parsed))->digest.username.user;
 


### PR DESCRIPTION
The pv_auth_check has a flags and a checks parameter but the flags
parameter is used for both. This means that if flags has the 1-bit set
it will enable both HA1-passwords and from/to URI checks and setting the
1-bit in the checks parameter does not do anything.

This fixes the parameters so that the checks parameter is used for the
to/from URI checks.