### PR TITLE
utils/kamctl: use $(basedir) as tmp dir on building instead of insecure /tmp

### DIFF
--- a/utils/kamctl/Makefile
+++ b/utils/kamctl/Makefile
@@ -25,63 +25,63 @@ install-bin: $(bin_prefix)/$(bin_dir)
 		cat kamctl | \
 		sed -e "s#/usr/local/sbin#$(bin_target)#g" | \
 		sed -e "s#/usr/local/lib/kamailio#$(lib_target)#g" | \
-		sed -e "s#/usr/local/etc/kamailio#$(cfg_target)#g"  >/tmp/kamctl
+		sed -e "s#/usr/local/etc/kamailio#$(cfg_target)#g"  >$(basedir)/kamctl
 		$(INSTALL_TOUCH) $(bin_prefix)/$(bin_dir)/kamctl
-		$(INSTALL_BIN) /tmp/kamctl $(bin_prefix)/$(bin_dir)
-		rm -fr /tmp/kamctl
+		$(INSTALL_BIN) $(basedir)/kamctl $(bin_prefix)/$(bin_dir)
+		rm -fr $(basedir)/kamctl
 		sed -e "s#/usr/local/sbin#$(bin_target)#g" \
-			< kamctl.base > /tmp/kamctl.base
+			< kamctl.base > $(basedir)/kamctl.base
 		mkdir -p $(modules_prefix)/$(lib_dir)/kamctl 
 		$(INSTALL_TOUCH) \
 			$(modules_prefix)/$(lib_dir)/kamctl
-		$(INSTALL_CFG) /tmp/kamctl.base \
+		$(INSTALL_CFG) $(basedir)/kamctl.base \
 			$(modules_prefix)/$(lib_dir)/kamctl/kamctl.base
-		rm -fr /tmp/kamctl.base
+		rm -fr $(basedir)/kamctl.base
 		sed -e "s#/usr/local#$(bin_target)#g" \
-			< kamctl.ctlbase > /tmp/kamctl.ctlbase
-		$(INSTALL_CFG) /tmp/kamctl.ctlbase \
+			< kamctl.ctlbase > $(basedir)/kamctl.ctlbase
+		$(INSTALL_CFG) $(basedir)/kamctl.ctlbase \
 			$(modules_prefix)/$(lib_dir)/kamctl/kamctl.ctlbase
-		rm -fr /tmp/kamctl.ctlbase
+		rm -fr $(basedir)/kamctl.ctlbase
 		sed -e "s#/usr/local#$(bin_target)#g" \
-			< kamctl.fifo > /tmp/kamctl.fifo
-		$(INSTALL_CFG) /tmp/kamctl.fifo \
+			< kamctl.fifo > $(basedir)/kamctl.fifo
+		$(INSTALL_CFG) $(basedir)/kamctl.fifo \
 			$(modules_prefix)/$(lib_dir)/kamctl/kamctl.fifo
-		rm -fr /tmp/kamctl.fifo
+		rm -fr $(basedir)/kamctl.fifo
 		sed -e "s#/usr/local#$(bin_target)#g" \
-			< kamctl.ser > /tmp/kamctl.ser
-		$(INSTALL_CFG) /tmp/kamctl.ser \
+			< kamctl.ser > $(basedir)/kamctl.ser
+		$(INSTALL_CFG) $(basedir)/kamctl.ser \
 			$(modules_prefix)/$(lib_dir)/kamctl/kamctl.ser
-		rm -fr /tmp/kamctl.ser
+		rm -fr $(basedir)/kamctl.ser
 		sed -e "s#/usr/local#$(bin_target)#g" \
-			< kamctl.ser_mi > /tmp/kamctl.ser_mi
-		$(INSTALL_CFG) /tmp/kamctl.ser_mi \
+			< kamctl.ser_mi > $(basedir)/kamctl.ser_mi
+		$(INSTALL_CFG) $(basedir)/kamctl.ser_mi \
 			$(modules_prefix)/$(lib_dir)/kamctl/kamctl.ser_mi
-		rm -fr /tmp/kamctl.ser_mi
+		rm -fr $(basedir)/kamctl.ser_mi
 		sed -e "s#/usr/local#$(bin_target)#g" \
-			< kamctl.unixsock > /tmp/kamctl.unixsock
-		$(INSTALL_CFG) /tmp/kamctl.unixsock \
+			< kamctl.unixsock > $(basedir)/kamctl.unixsock
+		$(INSTALL_CFG) $(basedir)/kamctl.unixsock \
 			$(modules_prefix)/$(lib_dir)/kamctl/kamctl.unixsock
-		rm -fr /tmp/kamctl.unixsock
+		rm -fr $(basedir)/kamctl.unixsock
 		sed -e "s#/usr/local#$(bin_target)#g" \
-			< kamctl.sqlbase > /tmp/kamctl.sqlbase
-		$(INSTALL_CFG) /tmp/kamctl.sqlbase \
+			< kamctl.sqlbase > $(basedir)/kamctl.sqlbase
+		$(INSTALL_CFG) $(basedir)/kamctl.sqlbase \
 			$(modules_prefix)/$(lib_dir)/kamctl/kamctl.sqlbase
-		rm -fr /tmp/kamctl.sqlbase
+		rm -fr $(basedir)/kamctl.sqlbase
 		# install db setup base script
 		sed -e "s#/usr/local/sbin#$(bin_target)#g" \
 			-e "s#/usr/local/etc/kamailio#$(cfg_target)#g" \
 			-e "s#/usr/local/share/kamailio#$(data_target)#g" \
-			< kamdbctl.base > /tmp/kamdbctl.base
-		$(INSTALL_CFG) /tmp/kamdbctl.base \
+			< kamdbctl.base > $(basedir)/kamdbctl.base
+		$(INSTALL_CFG) $(basedir)/kamdbctl.base \
 			$(modules_prefix)/$(lib_dir)/kamctl/kamdbctl.base
-		rm -fr /tmp/kamdbctl.base
+		rm -fr $(basedir)/kamdbctl.base
 		cat kamdbctl | \
 		sed -e "s#/usr/local/sbin#$(bin_target)#g" | \
 		sed -e "s#/usr/local/lib/kamailio#$(lib_target)#g" | \
-		sed -e "s#/usr/local/etc/kamailio#$(cfg_target)#g"  >/tmp/kamdbctl
+		sed -e "s#/usr/local/etc/kamailio#$(cfg_target)#g"  >$(basedir)/kamdbctl
 		$(INSTALL_TOUCH) $(bin_prefix)/$(bin_dir)/kamdbctl
-		$(INSTALL_BIN) /tmp/kamdbctl $(bin_prefix)/$(bin_dir)
-		rm -fr /tmp/kamdbctl
+		$(INSTALL_BIN) $(basedir)/kamdbctl $(bin_prefix)/$(bin_dir)
+		rm -fr $(basedir)/kamdbctl
 
 install-man: $(man_prefix)/$(man_dir)/man8 $(man_prefix)/$(man_dir)/man5
 		sed -e "s#/etc/$(NAME)/$(NAME)\.cfg#$(cfg_target)$(NAME).cfg#g" \
@@ -105,15 +105,15 @@ install-modules: $(bin_prefix)/$(bin_dir)
 		if [ "$(MYSQLON)" = "yes" ]; then \
 			mkdir -p $(modules_prefix)/$(lib_dir)/kamctl ; \
 			sed -e "s#/usr/local/sbin#$(bin_target)#g" \
-				< kamctl.mysql > /tmp/kamctl.mysql ; \
-			$(INSTALL_CFG) /tmp/kamctl.mysql \
+				< kamctl.mysql > $(basedir)/kamctl.mysql ; \
+			$(INSTALL_CFG) $(basedir)/kamctl.mysql \
 				$(modules_prefix)/$(lib_dir)/kamctl/kamctl.mysql ; \
-			rm -fr /tmp/kamctl.mysql ; \
+			rm -fr $(basedir)/kamctl.mysql ; \
 			sed -e "s#/usr/local/share/kamailio#$(data_target)#g" \
-			< kamdbctl.mysql > /tmp/kamdbctl.mysql ; \
+			< kamdbctl.mysql > $(basedir)/kamdbctl.mysql ; \
 			$(INSTALL_TOUCH) $(modules_prefix)/$(lib_dir)/kamctl/kamdbctl.mysql ; \
-			$(INSTALL_CFG) /tmp/kamdbctl.mysql $(modules_prefix)/$(lib_dir)/kamctl/ ; \
-			rm -fr /tmp/kamdbctl.mysql ; \
+			$(INSTALL_CFG) $(basedir)/kamdbctl.mysql $(modules_prefix)/$(lib_dir)/kamctl/ ; \
+			rm -fr $(basedir)/kamdbctl.mysql ; \
 			mkdir -p $(data_prefix)/$(data_dir)/mysql ; \
 			for FILE in $(wildcard mysql/*) ; do \
 				if [ -f $$FILE ] ; then \
@@ -128,15 +128,15 @@ install-modules: $(bin_prefix)/$(bin_dir)
 		if [ "$(PGSQLON)" = "yes" ]; then \
 			mkdir -p $(modules_prefix)/$(lib_dir)/kamctl ; \
 			sed -e "s#/usr/local/sbin#$(bin_target)#g" \
-				< kamctl.pgsql > /tmp/kamctl.pgsql ; \
-			$(INSTALL_CFG) /tmp/kamctl.pgsql \
+				< kamctl.pgsql > $(basedir)/kamctl.pgsql ; \
+			$(INSTALL_CFG) $(basedir)/kamctl.pgsql \
 				$(modules_prefix)/$(lib_dir)/kamctl/kamctl.pgsql ; \
-			rm -fr /tmp/kamctl.pgsql ; \
+			rm -fr $(basedir)/kamctl.pgsql ; \
 			sed -e "s#/usr/local/share/kamailio#$(data_target)#g" \
-				< kamdbctl.pgsql > /tmp/kamdbctl.pgsql ; \
+				< kamdbctl.pgsql > $(basedir)/kamdbctl.pgsql ; \
 			$(INSTALL_TOUCH) $(modules_prefix)/$(lib_dir)/kamctl/kamdbctl.pgsql ; \
-			$(INSTALL_CFG) /tmp/kamdbctl.pgsql $(modules_prefix)/$(lib_dir)/kamctl/ ; \
-			rm -fr /tmp/kamdbctl.pgsql ; \
+			$(INSTALL_CFG) $(basedir)/kamdbctl.pgsql $(modules_prefix)/$(lib_dir)/kamctl/ ; \
+			rm -fr $(basedir)/kamdbctl.pgsql ; \
 			mkdir -p $(data_prefix)/$(data_dir)/postgres ; \
 			for FILE in $(wildcard postgres/*) ; do \
 				if [ -f $$FILE ] ; then \
@@ -151,20 +151,20 @@ install-modules: $(bin_prefix)/$(bin_dir)
 		if [ "$(ORACLEON)" = "yes" ]; then \
 			mkdir -p $(modules_prefix)/$(lib_dir)/kamctl ; \
 			sed -e "s#/usr/local/sbin#$(bin_target)#g" \
-				< kamctl.oracle > /tmp/kamctl.oracle ; \
-			$(INSTALL_CFG) /tmp/kamctl.oracle \
+				< kamctl.oracle > $(basedir)/kamctl.oracle ; \
+			$(INSTALL_CFG) $(basedir)/kamctl.oracle \
 				$(modules_prefix)/$(lib_dir)/kamctl/kamctl.oracle ; \
-			rm -fr /tmp/kamctl.oracle ; \
+			rm -fr $(basedir)/kamctl.oracle ; \
 			sed -e "s#/usr/local/share/kamailio#$(data_target)#g" \
-			< kamdbctl.oracle > /tmp/kamdbctl.oracle ; \
+			< kamdbctl.oracle > $(basedir)/kamdbctl.oracle ; \
 			$(INSTALL_TOUCH) $(modules_prefix)/$(lib_dir)/kamctl/kamdbctl.oracle ; \
-			$(INSTALL_CFG) /tmp/kamdbctl.oracle $(modules_prefix)/$(lib_dir)/kamctl/ ; \
-			rm -fr /tmp/kamdbctl.oracle ; \
+			$(INSTALL_CFG) $(basedir)/kamdbctl.oracle $(modules_prefix)/$(lib_dir)/kamctl/ ; \
+			rm -fr $(basedir)/kamdbctl.oracle ; \
 			sed -e "s#/usr/local/share/kamailio#$(data_target)#g" \
-			< kamdbfunc.oracle > /tmp/kamdbfunc.oracle ; \
+			< kamdbfunc.oracle > $(basedir)/kamdbfunc.oracle ; \
 			$(INSTALL_TOUCH) $(modules_prefix)/$(lib_dir)/kamctl/kamdbfunc.oracle ; \
-			$(INSTALL_CFG) /tmp/kamdbfunc.oracle $(modules_prefix)/$(lib_dir)/kamctl/ ; \
-			rm -fr /tmp/kamdbfunc.oracle ; \
+			$(INSTALL_CFG) $(basedir)/kamdbfunc.oracle $(modules_prefix)/$(lib_dir)/kamctl/ ; \
+			rm -fr $(basedir)/kamdbfunc.oracle ; \
 			mkdir -p $(data_prefix)/$(data_dir)/oracle ; \
 			for FILE in $(wildcard oracle/*) ; do \
 				if [ -f $$FILE ] ; then \
@@ -199,15 +199,15 @@ install-modules: $(bin_prefix)/$(bin_dir)
 		if [ "$(BERKELEYDBON)" = "yes" ]; then \
 			mkdir -p $(modules_prefix)/$(lib_dir)/kamctl ; \
 			sed -e "s#/usr/local/share/kamailio/#$(data_target)#g" \
-				< kamctl.db_berkeley > /tmp/kamctl.db_berkeley ; \
-			$(INSTALL_CFG) /tmp/kamctl.db_berkeley \
+				< kamctl.db_berkeley > $(basedir)/kamctl.db_berkeley ; \
+			$(INSTALL_CFG) $(basedir)/kamctl.db_berkeley \
 				$(modules_prefix)/$(lib_dir)/kamctl/kamctl.db_berkeley ; \
-			rm -fr /tmp/kamctl.db_berkeley ; \
+			rm -fr $(basedir)/kamctl.db_berkeley ; \
 			sed -e "s#/usr/local/share/kamailio#$(data_target)#g" \
-				< kamdbctl.db_berkeley > /tmp/kamdbctl.db_berkeley ; \
+				< kamdbctl.db_berkeley > $(basedir)/kamdbctl.db_berkeley ; \
 			$(INSTALL_TOUCH) $(modules_prefix)/$(lib_dir)/kamctl/kamdbctl.db_berkeley ; \
-			$(INSTALL_CFG) /tmp/kamdbctl.db_berkeley $(modules_prefix)/$(lib_dir)/kamctl/ ; \
-			rm -fr /tmp/kamdbctl.db_berkeley ; \
+			$(INSTALL_CFG) $(basedir)/kamdbctl.db_berkeley $(modules_prefix)/$(lib_dir)/kamctl/ ; \
+			rm -fr $(basedir)/kamdbctl.db_berkeley ; \
 			mkdir -p $(data_prefix)/$(data_dir)/db_berkeley/kamailio ; \
 			for FILE in $(wildcard db_berkeley/kamailio/*) ; do \
 				if [ -f $$FILE ] ; then \
@@ -224,15 +224,15 @@ install-modules: $(bin_prefix)/$(bin_dir)
 		if [ "$(DBTEXTON)" = "yes" ]; then \
 			mkdir -p $(modules_prefix)/$(lib_dir)/kamctl ; \
 			sed -e "s#/usr/local/share/kamailio/#$(data_target)#g" \
-				< kamctl.dbtext > /tmp/kamctl.dbtext ; \
-			$(INSTALL_CFG) /tmp/kamctl.dbtext \
+				< kamctl.dbtext > $(basedir)/kamctl.dbtext ; \
+			$(INSTALL_CFG) $(basedir)/kamctl.dbtext \
 				$(modules_prefix)/$(lib_dir)/kamctl/kamctl.dbtext ; \
-			rm -fr /tmp/kamctl.dbtext ; \
+			rm -fr $(basedir)/kamctl.dbtext ; \
 			sed -e "s#/usr/local/share/kamailio#$(data_target)#g" \
-				< kamdbctl.dbtext > /tmp/kamdbctl.dbtext ; \
+				< kamdbctl.dbtext > $(basedir)/kamdbctl.dbtext ; \
 			$(INSTALL_TOUCH) $(modules_prefix)/$(lib_dir)/kamctl/kamdbctl.dbtext ; \
-			$(INSTALL_CFG) /tmp/kamdbctl.dbtext $(modules_prefix)/$(lib_dir)/kamctl/ ; \
-			rm -fr /tmp/kamdbctl.dbtext ; \
+			$(INSTALL_CFG) $(basedir)/kamdbctl.dbtext $(modules_prefix)/$(lib_dir)/kamctl/ ; \
+			rm -fr $(basedir)/kamdbctl.dbtext ; \
 			mkdir -p $(modules_prefix)/$(lib_dir)/kamctl/dbtextdb ; \
 			$(INSTALL_TOUCH) $(modules_prefix)/$(lib_dir)/kamctl/dbtextdb/dbtextdb.py ; \
 			$(INSTALL_BIN) dbtextdb/dbtextdb.py $(modules_prefix)/$(lib_dir)/kamctl/dbtextdb/ ; \
@@ -250,15 +250,15 @@ install-modules: $(bin_prefix)/$(bin_dir)
 		if [ "$(SQLITEON)" = "yes" ]; then \
 			mkdir -p $(modules_prefix)/$(lib_dir)/kamctl ; \
 			sed -e "s#/usr/local/sbin#$(bin_target)#g" \
-				< kamctl.sqlite > /tmp/kamctl.sqlite ; \
-			$(INSTALL_CFG) /tmp/kamctl.sqlite \
+				< kamctl.sqlite > $(basedir)/kamctl.sqlite ; \
+			$(INSTALL_CFG) $(basedir)/kamctl.sqlite \
 				$(modules_prefix)/$(lib_dir)/kamctl/kamctl.sqlite ; \
-			rm -fr /tmp/kamctl.sqlite ; \
+			rm -fr $(basedir)/kamctl.sqlite ; \
 			sed -e "s#/usr/local/share/kamailio#$(data_target)#g" \
-				< kamdbctl.sqlite > /tmp/kamdbctl.sqlite ; \
+				< kamdbctl.sqlite > $(basedir)/kamdbctl.sqlite ; \
 			$(INSTALL_TOUCH) $(modules_prefix)/$(lib_dir)/kamctl/kamdbctl.sqlite ; \
-			$(INSTALL_CFG) /tmp/kamdbctl.sqlite $(modules_prefix)/$(lib_dir)/kamctl/ ; \
-			rm -fr /tmp/kamdbctl.sqlite ; \
+			$(INSTALL_CFG) $(basedir)/kamdbctl.sqlite $(modules_prefix)/$(lib_dir)/kamctl/ ; \
+			rm -fr $(basedir)/kamdbctl.sqlite ; \
 			mkdir -p $(data_prefix)/$(data_dir)/db_sqlite ; \
 			for FILE in $(wildcard db_sqlite/*) ; do \
 				if [ -f $$FILE ] ; then \


### PR DESCRIPTION
Reported by: Helmut Grohne <helmut@subdivi.de> See #48
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775681