### PR TITLE
add pv module as call_control dependence in documentation

### DIFF
--- a/modules/call_control/README
+++ b/modules/call_control/README
@@ -10,7 +10,7 @@ Dan Pascu
 
    <dan@ag-projects.com>
 
-   Copyright © 2005-2008 Dan Pascu
+   Copyright (c) 2005-2008 Dan Pascu
      __________________________________________________________________
 
    Table of Contents
@@ -151,6 +151,7 @@ Chapter 1. Admin Guide
 4.1. Kamailio Modules
 
    The following modules must be loaded before this module:
+     * pv module
      * dialog module
 
 4.2. External Libraries or Applications

--- a/modules/call_control/doc/call_control_admin.xml
+++ b/modules/call_control/doc/call_control_admin.xml
@@ -139,7 +139,12 @@
         <itemizedlist>
           <listitem>
             <para>
-              <emphasis>dialog</emphasis> module 
+              <emphasis>pv</emphasis> module
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <emphasis>dialog</emphasis> module
             </para>
           </listitem>
         </itemizedlist>


### PR DESCRIPTION
As @oej noticed in #37 pv is missing in the list of module dependences 