### PR TITLE
fix compile errors in srutils/sha256 on SunOS (SmartOS)

### DIFF
--- a/lib/srutils/sha256.c
+++ b/lib/srutils/sha256.c
@@ -36,6 +36,12 @@
 #include <assert.h>	/* assert() */
 #include "sha256.h"
 
+/* discover byte order on solaris */
+#if defined(__SVR4) || defined(__sun)
+       #include <sys/isa_defs.h>
+       #define BYTE_ORDER _BYTE_ORDER
+#endif
+
 /*
  * ASSERT NOTE:
  * Some sanity checking code is included using assert().  On my FreeBSD

--- a/lib/srutils/sha256.h
+++ b/lib/srutils/sha256.h
@@ -53,6 +53,12 @@ extern "C" {
 
 #endif /* SHA2_USE_INTTYPES_H */
 
+/* fix types for Sun Solaris */
+#if defined(__SVR4) || defined(__sun)
+    typedef uint8_t u_int8_t;
+    typedef uint32_t u_int32_t;
+    typedef uint64_t u_int64_t;
+#endif
 
 /*** SHA-256/384/512 Various Length Definitions ***********************/
 #define SHA256_BLOCK_LENGTH		64


### PR DESCRIPTION
This PR fixes missing types and endian defs in srutils/sha256 that prevent compilation on Solaris derivatives.

Specifically, this fixes the following errors when compiling:
```
CC (gcc) [L libsrutils.so.1.0]          sha256.o
In file included from sha256.c:37:0:
sha256.h:111:2: error: unknown type name 'u_int32_t'
sha256.h:112:2: error: unknown type name 'u_int64_t'
sha256.h:113:2: error: unknown type name 'u_int8_t'
sha256.h:116:2: error: unknown type name 'u_int64_t'
sha256.h:117:2: error: unknown type name 'u_int64_t'
sha256.h:118:2: error: unknown type name 'u_int8_t'
sha256.h:151:1: error: unknown type name 'u_int8_t'
sha256.h:152:19: error: unknown type name 'u_int8_t'
sha256.h:154:1: error: unknown type name 'u_int8_t'
sha256.h:157:1: error: unknown type name 'u_int8_t'
sha256.h:158:19: error: unknown type name 'u_int8_t'
sha256.h:160:1: error: unknown type name 'u_int8_t'
sha256.h:163:1: error: unknown type name 'u_int8_t'
sha256.h:164:19: error: unknown type name 'u_int8_t'
sha256.h:166:1: error: unknown type name 'u_int8_t'
sha256.c:89:2: error: #error Define BYTE_ORDER to be equal to either LITTLE_ENDIAN or BIG_ENDIAN
sha256.c:114:1: error: unknown type name 'u_int8_t'
sha256.c:115:1: error: unknown type name 'u_int32_t'
sha256.c:116:1: error: unknown type name 'u_int64_t'
```