### PR TITLE
presence : min_expires

### DIFF
--- a/modules/presence/presence.c
+++ b/modules/presence/presence.c
@@ -139,6 +139,7 @@ char prefix='a';
 int startup_time=0;
 str db_url = {0, 0};
 int expires_offset = 0;
+int min_expires= 0;
 int max_expires= 3600;
 int shtable_size= 9;
 shtable_t subs_htable= NULL;
@@ -195,6 +196,7 @@ static param_export_t params[]={
 	{ "to_tag_pref",            PARAM_STRING, &to_tag_pref },
 	{ "expires_offset",         INT_PARAM, &expires_offset },
 	{ "max_expires",            INT_PARAM, &max_expires },
+	{ "min_expires",            INT_PARAM, &min_expires },
 	{ "server_address",         PARAM_STR, &server_address},
 	{ "subs_htable_size",       INT_PARAM, &shtable_size},
 	{ "pres_htable_size",       INT_PARAM, &phtable_size},
@@ -273,6 +275,12 @@ static int mod_init(void)
 
 	if(max_expires<= 0)
 		max_expires = 3600;
+
+	if(min_expires < 0)
+		min_expires = 0;
+
+	if(min_expires > max_expires)
+		min_expires = max_expires;
 
 	if(server_address.s== NULL)
 		LM_DBG("server_address parameter not set in configuration file\n");

--- a/modules/presence/presence.h
+++ b/modules/presence/presence.h
@@ -76,6 +76,7 @@ extern int startup_time;
 extern char *to_tag_pref;
 extern int expires_offset;
 extern str server_address;
+extern int min_expires;
 extern int max_expires;
 extern int subs_dbmode;
 extern int publ_cache_enabled;

--- a/modules/presence/subscribe.c
+++ b/modules/presence/subscribe.c
@@ -863,7 +863,7 @@ int handle_subscribe(struct sip_msg* msg, str watcher_user, str watcher_domain)
 		ev_param= ev_param->next;
 	}
 	
-	if(extract_sdialog_info(&subs, msg, max_expires, &to_tag_gen,
+	if(extract_sdialog_info(&subs, msg, min_expires, max_expires, &to_tag_gen,
 				server_address, watcher_user, watcher_domain)< 0)
 	{
 		LM_ERR("failed to extract dialog information\n");
@@ -1088,9 +1088,9 @@ error:
 }
 
 
-int extract_sdialog_info(subs_t* subs,struct sip_msg* msg, int mexp,
-		int* to_tag_gen, str scontact, str watcher_user,
-		str watcher_domain)
+int extract_sdialog_info(subs_t* subs,struct sip_msg* msg, int miexp,
+		int mexp, int* to_tag_gen, str scontact,
+		str watcher_user, str watcher_domain)
 {
 	str rec_route= {0, 0};
 	int rt  = 0;
@@ -1119,7 +1119,8 @@ int extract_sdialog_info(subs_t* subs,struct sip_msg* msg, int mexp,
 	}
 	if(lexpire > mexp)
 		lexpire = mexp;
-
+	if (lexpire && miexp && lexpire < miexp)
+                lexpire = miexp;
 	subs->expires = lexpire;
 
 	if( msg->to==NULL || msg->to->body.s==NULL)

--- a/modules/presence/subscribe.h
+++ b/modules/presence/subscribe.h
@@ -113,10 +113,10 @@ void update_db_subs_timer(db1_con_t *db,db_func_t dbf, shtable_t hash_table,
 typedef void (*update_db_subs_t)(db1_con_t * ,db_func_t ,shtable_t ,int ,int ,
 		handle_expired_func_t);
 
-int extract_sdialog_info(subs_t* subs,struct sip_msg* msg, int max_expire,
+int extract_sdialog_info(subs_t* subs,struct sip_msg* msg, int min_expire, int max_expire,
 		int* to_tag_gen, str scontact, str watcher_user, str watcher_domain);
 typedef int (*extract_sdialog_info_t)(subs_t* subs, struct sip_msg* msg,
-		int max_expire, int* to_tag_gen, str scontact, str watcher_user,
+		int min_expire, int max_expire, int* to_tag_gen, str scontact, str watcher_user,
 		str watcher_domain);
 void delete_subs(str* pres_uri, str* ev_name, str* to_tag, str* from_tag, str* callid);
 


### PR DESCRIPTION
some UAs send very low expires values for subscriptions flooding the server with subscribe/notify messages

this pr allows a minimum expire value for subscriptions.
