### PR TITLE
Possible hash_entry,hash_id duplicate due to bad loading of dialogs at startup

### DIFF
--- a/modules/dialog/dlg_db_handler.c
+++ b/modules/dialog/dlg_db_handler.c
@@ -366,7 +366,7 @@ static int load_dialog_info_from_db(int dlg_hash_size, int fetch_num_rows)
 			next_id = d_table->entries[dlg->h_entry].next_id;
 
 			d_table->entries[dlg->h_entry].next_id =
-				(next_id < dlg->h_id) ? (dlg->h_id+1) : next_id;
+				(next_id <= dlg->h_id) ? (dlg->h_id+1) : next_id;
 
 			GET_STR_VALUE(to_tag, values, 6, 1, 1);
 


### PR DESCRIPTION
At startup, assume d_table->entries[5].next_id is initialized at 25 (see function init_dlg_table in dlg_hash.c) and assume you have only one dialog in the database with hash_entry=5 and hash_id=25. Since the condition next_id < dlg->h_id is false (because next_id == dlg->h_id == 25), the next available hash_id for a future dialog that matches this entry will be 25. Therefore, there will be duplicated (hash_entry,hash_id) which will cause errors when the dialog is inserted in the database.