### PR TITLE
registrar : add lookup_to_dset optional uri param as in lookup

### DIFF
--- a/modules/registrar/lookup.c
+++ b/modules/registrar/lookup.c
@@ -399,22 +399,24 @@ int lookup_helper(struct sip_msg* _m, udomain_t* _d, str* _uri, int _mode)
 				path_dst.len = 0;
 			}
 
-			/* The same as for the first contact applies for branches 
-			 * regarding path vs. received. */
-			LM_DBG("instance is %.*s\n",
-			       ptr->instance.len, ptr->instance.s);
-			if (append_branch(_m, &ptr->c,
-					  path_dst.len?&path_dst:&ptr->received,
-					  path_dst.len?&path_str:0, ptr->q, ptr->cflags,
-					  ptr->sock,
-					  ptr->instance.len?&(ptr->instance):0,
-				          ptr->instance.len?ptr->reg_id:0,
-					  &ptr->ruid, &ptr->user_agent)
-			    == -1) {
-				LM_ERR("failed to append a branch\n");
-				/* Also give a chance to the next branches*/
-				continue;
-			}
+            if(_mode == 0) {
+                /* The same as for the first contact applies for branches
+                 * regarding path vs. received. */
+                LM_DBG("instance is %.*s\n",
+                       ptr->instance.len, ptr->instance.s);
+                if (append_branch(_m, &ptr->c,
+                          path_dst.len?&path_dst:&ptr->received,
+                          path_dst.len?&path_str:0, ptr->q, ptr->cflags,
+                          ptr->sock,
+                          ptr->instance.len?&(ptr->instance):0,
+                              ptr->instance.len?ptr->reg_id:0,
+                          &ptr->ruid, &ptr->user_agent)
+                    == -1) {
+                    LM_ERR("failed to append a branch\n");
+                    /* Also give a chance to the next branches*/
+                    continue;
+                }
+            }
 			if(ptr->xavp!=NULL) {
 				xavp = xavp_clone_level_nodata(ptr->xavp);
 				if(xavp_insert(xavp, nr_branches, NULL)<0) {

--- a/modules/registrar/lookup.c
+++ b/modules/registrar/lookup.c
@@ -93,7 +93,7 @@ int lookup(struct sip_msg* _m, udomain_t* _d, str* _uri) {
  * Lookup a contact in usrloc and add the records to the dset structure
  */
 int lookup_to_dset(struct sip_msg* _m, udomain_t* _d, str* _uri) {
-     return lookup_helper(_m, _d, _uri, 1);
+    return lookup_helper(_m, _d, _uri, (_uri==NULL?1:2));
 }
 
 /*! \brief
@@ -399,7 +399,7 @@ int lookup_helper(struct sip_msg* _m, udomain_t* _d, str* _uri, int _mode)
 				path_dst.len = 0;
 			}
 
-            if(_mode == 0) {
+            if(_mode != 2) {
                 /* The same as for the first contact applies for branches
                  * regarding path vs. received. */
                 LM_DBG("instance is %.*s\n",

--- a/modules/registrar/reg_mod.c
+++ b/modules/registrar/reg_mod.c
@@ -185,6 +185,8 @@ static cmd_export_t cmds[] = {
 			REQUEST_ROUTE | FAILURE_ROUTE },
 	{"lookup_to_dset",  (cmd_function)w_lookup_to_dset,  1,  domain_uri_fixup, 0,
 			REQUEST_ROUTE | FAILURE_ROUTE },
+    {"lookup_to_dset",  (cmd_function)w_lookup_to_dset,  2,  domain_uri_fixup, 0,
+        REQUEST_ROUTE | FAILURE_ROUTE },
 	{"registered",   (cmd_function)w_registered,  1,  domain_uri_fixup, 0,
 			REQUEST_ROUTE | FAILURE_ROUTE },
 	{"registered",   (cmd_function)w_registered,  2,  domain_uri_fixup, 0,


### PR DESCRIPTION
lookup function has an optional uri param for looking up based on that param.
lookup_to_dset is used if we don't want to overwritte the Request-URI but there is no option to lookup based on a uri.

during tests i noticed that the append_branch was being called when i did a lookup_to_dset("location", "$fu") and kamailio exited because of that.

i made the append_branch to depend on the _mode ( 0 = lookup ) which seemed to fixed.
