### PR TITLE
usrloc - fix column types not initialized on update

### DIFF
--- a/modules/usrloc/ucontact.c
+++ b/modules/usrloc/ucontact.c
@@ -824,9 +824,9 @@ int db_update_ucontact_addr(ucontact_t* _c)
 	nr_cols2++;
 
 	keys2[nr_cols2] = &ruid_col;
+	vals2[nr_cols2].type = DB1_STR;
 	if(_c->ruid.len>0)
 	{
-		vals2[nr_cols2].type = DB1_STR;
 		vals2[nr_cols2].nul = 0;
 		vals2[nr_cols2].val.str_val = _c->ruid;
 	} else {
@@ -835,9 +835,9 @@ int db_update_ucontact_addr(ucontact_t* _c)
 	nr_cols2++;
 
 	keys2[nr_cols2] = &instance_col;
+	vals2[nr_cols2].type = DB1_STR;
 	if(_c->instance.len>0)
 	{
-		vals2[nr_cols2].type = DB1_STR;
 		vals2[nr_cols2].nul = 0;
 		vals2[nr_cols2].val.str_val = _c->instance;
 	} else {
@@ -1036,9 +1036,9 @@ int db_update_ucontact_ruid(ucontact_t* _c)
 	n2++;
 
 	keys2[n2] = &instance_col;
+	vals2[n2].type = DB1_STR;
 	if(_c->instance.len>0)
 	{
-		vals2[n2].type = DB1_STR;
 		vals2[n2].nul = 0;
 		vals2[n2].val.str_val = _c->instance;
 	} else {


### PR DESCRIPTION
some columns were not initialized on update leading to errors in update

ERROR: db_text [dbt_lib.c:464]: dbt_is_neq_type(): invalid datatype -1001432832
ERROR: db_text [dbt_base.c:560]: dbt_update(): incompatible types!
ERROR: db_text [dbt_base.c:599]: dbt_update(): failed to update the table!