### PR TITLE
set defaults of fifo and ctl to /var/run/kamailio

### DIFF
--- a/etc/kamailio-basic.cfg
+++ b/etc/kamailio-basic.cfg
@@ -191,7 +191,7 @@ loadmodule "debugger.so"
 
 
 # ----- mi_fifo params -----
-modparam("mi_fifo", "fifo_name", "/tmp/kamailio_fifo")
+modparam("mi_fifo", "fifo_name", "/var/run/kamailio/kamailio_fifo")
 
 # ----- ctl params -----
 modparam("ctl", "binrpc", "unix:/var/run/kamailio/kamailio_ctl")

--- a/etc/kamailio-basic.cfg
+++ b/etc/kamailio-basic.cfg
@@ -193,6 +193,8 @@ loadmodule "debugger.so"
 # ----- mi_fifo params -----
 modparam("mi_fifo", "fifo_name", "/tmp/kamailio_fifo")
 
+# ----- ctl params -----
+modparam("ctl", "binrpc", "unix:/var/run/kamailio/kamailio_ctl")
 
 # ----- tm params -----
 # auto-discard branches from previous serial forking leg

--- a/etc/kamailio-oob.cfg
+++ b/etc/kamailio-oob.cfg
@@ -315,7 +315,7 @@ loadmodule "xhttp_pi.so"
 
 
 # ----- mi_fifo params -----
-modparam("mi_fifo", "fifo_name", "/tmp/kamailio_fifo")
+modparam("mi_fifo", "fifo_name", "/var/run/kamailio/kamailio_fifo")
 
 # ----- ctl params -----
 modparam("ctl", "binrpc", "unix:/var/run/kamailio/kamailio_ctl")

--- a/etc/kamailio-oob.cfg
+++ b/etc/kamailio-oob.cfg
@@ -317,6 +317,8 @@ loadmodule "xhttp_pi.so"
 # ----- mi_fifo params -----
 modparam("mi_fifo", "fifo_name", "/tmp/kamailio_fifo")
 
+# ----- ctl params -----
+modparam("ctl", "binrpc", "unix:/var/run/kamailio/kamailio_ctl")
 
 # ----- tm params -----
 # auto-discard branches from previous serial forking leg

--- a/etc/kamailio.cfg
+++ b/etc/kamailio.cfg
@@ -290,6 +290,8 @@ loadmodule "debugger.so"
 # ----- mi_fifo params -----
 modparam("mi_fifo", "fifo_name", "/tmp/kamailio_fifo")
 
+# ----- ctl params -----
+modparam("ctl", "binrpc", "unix:/var/run/kamailio/kamailio_ctl")
 
 # ----- tm params -----
 # auto-discard branches from previous serial forking leg

--- a/etc/kamailio.cfg
+++ b/etc/kamailio.cfg
@@ -288,7 +288,7 @@ loadmodule "debugger.so"
 
 
 # ----- mi_fifo params -----
-modparam("mi_fifo", "fifo_name", "/tmp/kamailio_fifo")
+modparam("mi_fifo", "fifo_name", "/var/run/kamailio/kamailio_fifo")
 
 # ----- ctl params -----
 modparam("ctl", "binrpc", "unix:/var/run/kamailio/kamailio_ctl")

--- a/modules/ctl/ctl_defaults.h
+++ b/modules/ctl/ctl_defaults.h
@@ -4,10 +4,10 @@
 /*listen by default on: */
 #ifdef SRNAME
 /* this is used when compiling sercmd tool */
-#define DEFAULT_CTL_SOCKET  "unixs:/tmp/" SRNAME "_ctl"
+#define DEFAULT_CTL_SOCKET  "unixs:" RUN_DIR "/" SRNAME "/" SRNAME "_ctl"
 #else
 /* this is used when compiling sip server */
-#define DEFAULT_CTL_SOCKET  "unixs:/tmp/" NAME "_ctl"
+#define DEFAULT_CTL_SOCKET  "unixs:" RUN_DIR "/" NAME "_ctl"
 #endif
 /* port used by default for tcp/udp if no port is explicitely specified */
 #define DEFAULT_CTL_PORT 2049

--- a/utils/kamctl/kamctl.fifo
+++ b/utils/kamctl/kamctl.fifo
@@ -25,7 +25,7 @@ fi
 #
 if [ -z "$FIFOPATH" ]; then
 	if [ -z "$OSER_FIFO" ]; then
-		FIFOPATH=/tmp/kamailio_fifo
+		FIFOPATH=/var/run/kamailio/kamailio_fifo
 	else
 		FIFOPATH=$OSER_FIFO
 	fi

--- a/utils/kamctl/kamctlrc
+++ b/utils/kamctl/kamctlrc
@@ -124,7 +124,7 @@
 # CTLENGINE="FIFO"
 
 ## path to FIFO file
-# FIFOPATH="/tmp/kamailio_fifo"
+# FIFOPATH="/var/run/kamailio/kamailio_fifo"
 
 ## check ACL names; default on (1); off (0)
 # VERIFY_ACL=1
@@ -142,7 +142,7 @@
 
 ## Kamailio START Options
 ## PID file path - default is: /var/run/kamailio.pid
-# PID_FILE=/var/run/kamailio.pid
+# PID_FILE=/var/run/kamailio/kamailio.pid
 
 ## Extra start options - default is: not set
 # example: start Kamailio with 64MB share memory: STARTOPTIONS="-m 64"


### PR DESCRIPTION
Following #48 and #80