### PR TITLE
registrar - additional features

### DIFF
--- a/modules/registrar/api.c
+++ b/modules/registrar/api.c
@@ -105,7 +105,7 @@ int regapi_registered(struct sip_msg *msg, char *table)
 		LM_ERR("usrloc domain [%s] not found\n", table);
 		return -1;
 	}
-	return registered(msg, d, NULL);
+	return registered(msg, d, NULL, 0);
 }
 
 /**

--- a/modules/registrar/lookup.c
+++ b/modules/registrar/lookup.c
@@ -664,16 +664,18 @@ int registered(struct sip_msg* _m, udomain_t* _d, str* _uri)
 		LM_DBG("searching with initial match flags (%d,%d)\n", match_flags, match_return_flags);
 		if(reg_xavp_cfg.s!=NULL) {
 
-			if( (vavp = xavp_get_child_with_ival(&reg_xavp_cfg, &match_flags_name)) != NULL
-					&& vavp->val.v.s.len > 0) {
-				match_flags = vavp->val.v.i;
-				LM_DBG("match flags set to %d\n", match_flags);
-			}
+			if(match_search_flags == 1) {
+				if( (vavp = xavp_get_child_with_ival(&reg_xavp_cfg, &match_flags_name)) != NULL
+						&& vavp->val.v.s.len > 0) {
+					match_flags = vavp->val.v.i;
+					LM_DBG("match flags set to %d\n", match_flags);
+				}
 
-			if( (vavp = xavp_get_child_with_ival(&reg_xavp_cfg, &match_return_flags_name)) != NULL
-					&& vavp->val.v.s.len > 0) {
-				match_return_flags = vavp->val.v.i;
-				LM_DBG("match return flags set to %d\n", match_return_flags);
+				if( (vavp = xavp_get_child_with_ival(&reg_xavp_cfg, &match_return_flags_name)) != NULL
+						&& vavp->val.v.s.len > 0) {
+					match_return_flags = vavp->val.v.i;
+					LM_DBG("match return flags set to %d\n", match_return_flags);
+				}
 			}
 
 			if((match_flags & 1)

--- a/modules/registrar/lookup.c
+++ b/modules/registrar/lookup.c
@@ -697,7 +697,7 @@ int registered(struct sip_msg* _m, udomain_t* _d, str* _uri, int match_flag)
 				continue;
 			if (match_contact.s && /* optionally enforce tighter matching w/ Contact */
 				match_contact.len > 0 &&
-				(match_contact.len != ptr->s.len || 
+				(match_contact.len != ptr->c.len || 
 				memcmp(match_contact.s, ptr->c.s, match_contact.len)))
 				continue;
 

--- a/modules/registrar/lookup.c
+++ b/modules/registrar/lookup.c
@@ -674,6 +674,13 @@ int registered(struct sip_msg* _m, udomain_t* _d, str* _uri)
 				continue;
 			ul.release_urecord(r);
 			ul.unlock_udomain(_d, &aor);
+			if(ptr->xavp!=NULL) {
+				xavp = xavp_clone_level_nodata(ptr->xavp);
+				if(xavp_add(xavp, NULL)<0) {
+					LM_ERR("error adding xavp for %.*s after successful match\n", aor.len, ZSW(aor.s));
+					return -1;
+				}
+			}
 			LM_DBG("'%.*s' found in usrloc\n", aor.len, ZSW(aor.s));
 			return 1;
 		}

--- a/modules/registrar/lookup.c
+++ b/modules/registrar/lookup.c
@@ -657,7 +657,7 @@ int registered(struct sip_msg* _m, udomain_t* _d, str* _uri, int match_flag)
 	}
 
 	if (res == 0) {
-		LM_DBG("searching with initial match flags (%d,%d)\n", match_flags, reg_match_flag);
+		LM_DBG("searching with match flags (%d,%d)\n", match_flag, reg_match_flag_param);
 		if(reg_xavp_cfg.s!=NULL) {
 
 			if((match_flag & 1)

--- a/modules/registrar/lookup.c
+++ b/modules/registrar/lookup.c
@@ -686,18 +686,20 @@ int registered(struct sip_msg* _m, udomain_t* _d, str* _uri, int match_flag)
 		for (ptr = r->contacts; ptr; ptr = ptr->next) {
 			if(!VALID_CONTACT(ptr, act_time)) continue;
 			if (match_callid.s && /* optionally enforce tighter matching w/ Call-ID */
-				memcmp(match_callid.s,ptr->callid.s,match_callid.len))
+				match_callid.len > 0 &&
+				(match_callid.len != ptr->callid.len || 
+				memcmp(match_callid.s, ptr->callid.s, match_callid.len)))
 				continue;
 			if (match_received.s && /* optionally enforce tighter matching w/ ip:port */
-				memcmp(match_received.s,ptr->received.s,match_received.len))
+				match_received.len > 0 &&
+				(match_received.len != ptr->received.len || 
+				memcmp(match_received.s, ptr->received.s, match_received.len)))
 				continue;
 			if (match_contact.s && /* optionally enforce tighter matching w/ Contact */
-				memcmp(match_contact.s,ptr->c.s,match_contact.len))
+				match_contact.len > 0 &&
+				(match_contact.len != ptr->s.len || 
+				memcmp(match_contact.s, ptr->c.s, match_contact.len)))
 				continue;
-
-			ul.release_urecord(r);
-			ul.unlock_udomain(_d, &aor);
-			LM_DBG("'%.*s' found in usrloc\n", aor.len, ZSW(aor.s));
 
 			if(ptr->xavp!=NULL && reg_match_flag_param == 1) {
 				sr_xavp_t *xavp = xavp_clone_level_nodata(ptr->xavp);
@@ -706,6 +708,10 @@ int registered(struct sip_msg* _m, udomain_t* _d, str* _uri, int match_flag)
 					xavp_destroy_list(&xavp);
 				}
 			}
+
+			ul.release_urecord(r);
+			ul.unlock_udomain(_d, &aor);
+			LM_DBG("'%.*s' found in usrloc\n", aor.len, ZSW(aor.s));
 
 			return 1;
 		}

--- a/modules/registrar/lookup.c
+++ b/modules/registrar/lookup.c
@@ -633,6 +633,7 @@ int registered(struct sip_msg* _m, udomain_t* _d, str* _uri, int match_flag)
 	str match_callid = {0,0};
 	str match_received = {0,0};
 	str match_contact = {0,0};
+	r_xavp_t *vavp = NULL;
 
 	if(_uri!=NULL)
 	{

--- a/modules/registrar/lookup.c
+++ b/modules/registrar/lookup.c
@@ -633,7 +633,7 @@ int registered(struct sip_msg* _m, udomain_t* _d, str* _uri, int match_flag)
 	str match_callid = {0,0};
 	str match_received = {0,0};
 	str match_contact = {0,0};
-	r_xavp_t *vavp = NULL;
+	sr_xavp_t *vavp = NULL;
 
 	if(_uri!=NULL)
 	{

--- a/modules/registrar/lookup.h
+++ b/modules/registrar/lookup.h
@@ -68,7 +68,7 @@ int lookup_branches(sip_msg_t *msg, udomain_t *d);
  * it is similar to lookup but registered neither rewrites
  * the Request-URI nor appends branches
  */
-int registered(struct sip_msg* _m, udomain_t* _d, str* _uri);
+int registered(struct sip_msg* _m, udomain_t* _d, str* _uri, int match_flag);
 
 
 #endif /* LOOKUP_H */

--- a/modules/registrar/reg_mod.c
+++ b/modules/registrar/reg_mod.c
@@ -126,10 +126,16 @@ int reg_outbound_mode = 0;
 int reg_regid_mode = 0;
 int reg_flow_timer = 0;
 
-/* Populate this AVP if testing for specific registration instance. */
+/* Populate these AVPs if testing for specific registration instance. */
 char *reg_callid_avp_param = 0;
 unsigned short reg_callid_avp_type = 0;
 int_str reg_callid_avp_name;
+char *reg_received_avp_param = 0;
+unsigned short reg_received_avp_type = 0;
+int_str reg_received_avp_name;
+char *reg_contact_avp_param = 0;
+unsigned short reg_contact_avp_type = 0;
+int_str reg_contact_avp_name;
 
 char* rcv_avp_param = 0;
 unsigned short rcv_avp_type = 0;
@@ -226,6 +232,8 @@ static param_export_t params[] = {
 	{"received_param",     PARAM_STR, &rcv_param           					},
 	{"received_avp",       PARAM_STRING, &rcv_avp_param       					},
 	{"reg_callid_avp",     PARAM_STRING, &reg_callid_avp_param					},
+	{"reg_received_avp",     PARAM_STRING, &reg_received_avp_param					},
+	{"reg_contact_avp",     PARAM_STRING, &reg_contact_avp_param					},
 	{"max_contacts",       INT_PARAM, &default_registrar_cfg.max_contacts			},
 	{"retry_after",        INT_PARAM, &default_registrar_cfg.retry_after			},
 	{"sock_flag",          INT_PARAM, &sock_flag           					},
@@ -335,18 +343,54 @@ static int mod_init(void)
 		s.s = reg_callid_avp_param; s.len = strlen(s.s);
 		if (pv_parse_spec(&s, &avp_spec)==0
 			|| avp_spec.type!=PVT_AVP) {
-			LM_ERR("malformed or non AVP %s AVP definition\n", reg_callid_avp_param);
+			LM_ERR("malformed or non AVP %s AVP definition - reg_callid_avp\n", reg_callid_avp_param);
 			return -1;
 		}
 
 		if(pv_get_avp_name(0, &avp_spec.pvp, &reg_callid_avp_name, &reg_callid_avp_type)!=0)
 		{
-			LM_ERR("[%s]- invalid AVP definition\n", reg_callid_avp_param);
+			LM_ERR("[%s]- invalid AVP definition - reg_callid_avp\n", reg_callid_avp_param);
 			return -1;
 		}
 	} else {
 		reg_callid_avp_name.n = 0;
 		reg_callid_avp_type = 0;
+	}
+
+	if (reg_received_avp_param && *reg_received_avp_param) {
+		s.s = reg_received_avp_param; s.len = strlen(s.s);
+		if (pv_parse_spec(&s, &avp_spec)==0
+			|| avp_spec.type!=PVT_AVP) {
+			LM_ERR("malformed or non AVP %s AVP definition - reg_received_avp\n", reg_received_avp_param);
+			return -1;
+		}
+
+		if(pv_get_avp_name(0, &avp_spec.pvp, &reg_received_avp_name, &reg_received_avp_type)!=0)
+		{
+			LM_ERR("[%s]- invalid AVP definition - reg_received_avp\n", reg_received_avp_param);
+			return -1;
+		}
+	} else {
+		reg_received_avp_name.n = 0;
+		reg_received_avp_type = 0;
+	}
+
+	if (reg_contact_avp_param && *reg_contact_avp_param) {
+		s.s = reg_contact_avp_param; s.len = strlen(s.s);
+		if (pv_parse_spec(&s, &avp_spec)==0
+			|| avp_spec.type!=PVT_AVP) {
+			LM_ERR("malformed or non AVP %s AVP definition - reg_contact_avp\n", reg_contact_avp_param);
+			return -1;
+		}
+
+		if(pv_get_avp_name(0, &avp_spec.pvp, &reg_contact_avp_name, &reg_contact_avp_type)!=0)
+		{
+			LM_ERR("[%s]- invalid AVP definition - reg_contact_avp\n", reg_contact_avp_param);
+			return -1;
+		}
+	} else {
+		reg_contact_avp_name.n = 0;
+		reg_contact_avp_type = 0;
 	}
 
 	bind_usrloc = (bind_usrloc_t)find_export("ul_bind_usrloc", 1, 0);

--- a/modules/registrar/reg_mod.c
+++ b/modules/registrar/reg_mod.c
@@ -128,6 +128,7 @@ int reg_flow_timer = 0;
 
 int reg_match_flags_param = 0;
 int reg_match_return_flags_param = 0;
+int reg_match_search_flags_param = 0;
 str match_return_flags_name = str_init("match_return_flags");
 str match_flags_name = str_init("match_flags");
 str match_callid_name = str_init("match_callid");
@@ -245,6 +246,7 @@ static param_export_t params[] = {
 	{"flow_timer",         INT_PARAM, &reg_flow_timer					},
 	{"match_flags",        INT_PARAM, &reg_match_flags_param			},
 	{"match_return_flags", INT_PARAM, &reg_match_return_flags_param		},
+	{"match_search_flags", INT_PARAM, &reg_match_search_flags_param		},
 	{0, 0, 0}
 };
 

--- a/modules/registrar/reg_mod.h
+++ b/modules/registrar/reg_mod.h
@@ -88,6 +88,10 @@ extern unsigned short rcv_avp_type;
 extern int_str rcv_avp_name;
 extern unsigned short reg_callid_avp_type;
 extern int_str reg_callid_avp_name;
+extern unsigned short reg_received_avp_type;
+extern int_str reg_received_avp_name;
+extern unsigned short reg_contact_avp_type;
+extern int_str reg_contact_avp_name;
 
 extern str rcv_param;
 extern int method_filtering;

--- a/modules/registrar/reg_mod.h
+++ b/modules/registrar/reg_mod.h
@@ -86,12 +86,15 @@ extern float def_q;
 
 extern unsigned short rcv_avp_type;
 extern int_str rcv_avp_name;
-extern unsigned short reg_callid_avp_type;
-extern int_str reg_callid_avp_name;
-extern unsigned short reg_received_avp_type;
-extern int_str reg_received_avp_name;
-extern unsigned short reg_contact_avp_type;
-extern int_str reg_contact_avp_name;
+
+extern int reg_match_flags_param;
+extern int reg_match_return_flags_param;
+extern str match_flags_name;
+extern str match_return_flags_name;
+extern str match_callid_name;
+extern str match_received_name;
+extern str match_contact_name;
+
 
 extern str rcv_param;
 extern int method_filtering;

--- a/modules/registrar/reg_mod.h
+++ b/modules/registrar/reg_mod.h
@@ -89,6 +89,7 @@ extern int_str rcv_avp_name;
 
 extern int reg_match_flags_param;
 extern int reg_match_return_flags_param;
+extern int reg_match_search_flags_param;
 extern str match_flags_name;
 extern str match_return_flags_name;
 extern str match_callid_name;

--- a/modules/registrar/reg_mod.h
+++ b/modules/registrar/reg_mod.h
@@ -87,11 +87,7 @@ extern float def_q;
 extern unsigned short rcv_avp_type;
 extern int_str rcv_avp_name;
 
-extern int reg_match_flags_param;
-extern int reg_match_return_flags_param;
-extern int reg_match_search_flags_param;
-extern str match_flags_name;
-extern str match_return_flags_name;
+extern int reg_match_flag_param;
 extern str match_callid_name;
 extern str match_received_name;
 extern str match_contact_name;

--- a/modules/registrar/regpv.c
+++ b/modules/registrar/regpv.c
@@ -37,9 +37,14 @@
 #include "../../action.h"
 #include "../../lib/kcore/faked_msg.h"
 #include "../usrloc/usrloc.h"
+#include "../../pvapi.h"
+#include "../../xavp.h"
 #include "reg_mod.h"
 #include "common.h"
 #include "regpv.h"
+
+#define REGPV_FIELD_DELIM ", "
+#define REGPV_FIELD_DELIM_LEN (sizeof(REGPV_FIELD_DELIM) - 1)
 
 typedef struct _regpv_profile {
 	str pname;

--- a/modules/registrar/regpv.c
+++ b/modules/registrar/regpv.c
@@ -55,6 +55,7 @@ typedef struct _regpv_profile {
 typedef struct _regpv_name {
 	regpv_profile_t *rp;
 	int attr;
+	pv_xavp_name_t* xname;
 } regpv_name_t;
 
 static regpv_profile_t *_regpv_profile_list = NULL;
@@ -112,6 +113,9 @@ static void regpv_free_profile(regpv_profile_t *rpp)
 	ptr = rpp->contacts;
 	while(ptr)
 	{
+		if(ptr->xavp) {
+			xavp_destroy_list(&ptr->xavp);
+		}
 		ptr0 = ptr;
 		ptr = ptr->next;
 		pkg_free(ptr0);
@@ -152,6 +156,285 @@ void regpv_free_profiles(void)
 	}
 	_regpv_profile_list = 0;
 }
+
+char* regpv_xavp_fill_ni(str *in, pv_xavp_name_t *xname)
+{
+	char *p;
+	str idx;
+	int n;
+
+	if(in->s==NULL || in->len<=0 || xname==NULL)
+		return NULL;
+	p = in->s;
+
+	/* eat ws */
+	while(p<in->s+in->len && (*p==' ' || *p=='\t' || *p=='\n' || *p=='\r'))
+		p++;
+	if(p>in->s+in->len || *p=='\0')
+		goto error;
+	xname->name.s = p;
+	while(p < in->s + in->len)
+	{
+		if(*p=='=' || *p==' ' || *p=='\t' || *p=='\n' || *p=='\r' || *p=='[')
+			break;
+		p++;
+	}
+	xname->name.len = p - xname->name.s;
+	if(p>in->s+in->len || *p=='\0')
+		return p;
+	/* eat ws */
+	while(p<in->s+in->len && (*p==' ' || *p=='\t' || *p=='\n' || *p=='\r'))
+		p++;
+	if(p>in->s+in->len || *p=='\0')
+		return p;
+
+	if(*p!='[')
+		return p;
+	/* there is index */
+	p++;
+	idx.s = p;
+	n = 0;
+	while(p<in->s+in->len && *p!='\0')
+	{
+		if(*p==']')
+		{
+			if(n==0)
+				break;
+			n--;
+		}
+		if(*p == '[')
+			n++;
+		p++;
+	}
+	if(p>in->s+in->len || *p=='\0')
+		goto error;
+
+	if(p==idx.s)
+	{
+		LM_ERR("xavp [\"%.*s\"] does not get empty index param\n",
+				in->len, in->s);
+		goto error;
+	}
+	idx.len = p - idx.s;
+	if(pv_parse_index(&xname->index, &idx)!=0)
+	{
+		LM_ERR("idx \"%.*s\" has an invalid index param [%.*s]\n",
+					in->len, in->s, idx.len, idx.s);
+		goto error;
+	}
+	xname->index.type = PVT_EXTRA;
+	p++;
+	return p;
+error:
+	return NULL;
+}
+
+int regpv_parse_xavp_name(pv_spec_p sp, str *in)
+{
+	pv_xavp_name_t *xname=NULL;
+	char *p;
+	str s;
+
+	if(in->s==NULL || in->len<=0)
+		return -1;
+
+	xname = (pv_xavp_name_t*)shm_malloc(sizeof(pv_xavp_name_t));
+	if(xname==NULL)
+		return -1;
+
+	memset(xname, 0, sizeof(pv_xavp_name_t));
+
+	s = *in;
+
+	p = regpv_xavp_fill_ni(&s, xname);
+	if(p==NULL) {
+		goto error;
+	}
+
+	if(*p!='=') {
+		goto done;
+	}
+	p++;
+	if(*p!='>') {
+		goto error;
+	}
+	p++;
+
+	s.len = in->len - (int)(p - in->s);
+	s.s = p;
+	LM_INFO("xavp sublist [%.*s] - key [%.*s]\n", xname->name.len,
+			xname->name.s, s.len, s.s);
+
+	xname->next = (pv_xavp_name_t*)pkg_malloc(sizeof(pv_xavp_name_t));
+	if(xname->next==NULL) {
+		goto error;
+	}
+
+	memset(xname->next, 0, sizeof(pv_xavp_name_t));
+
+	p = regpv_xavp_fill_ni(&s, xname->next);
+	if(p==NULL) {
+		goto error;
+	}
+
+done:
+	sp->pvp.pvn.u.dname = (void*)xname;
+	sp->pvp.pvn.type = PV_NAME_PVAR;
+	return 0;
+
+error:
+	if(xname!=NULL) {
+		pkg_free(xname);
+	}
+	return -1;
+}
+
+int regpv_xavp_get_value(struct sip_msg *msg, pv_param_t *param,
+		pv_value_t *res, sr_xavp_t *avp)
+{
+	static char _pv_xavp_buf[128];
+	str s;
+
+	switch(avp->val.type) {
+		case SR_XTYPE_NULL:
+			return pv_get_null(msg, param, res);
+		break;
+		case SR_XTYPE_INT:
+			return pv_get_sintval(msg, param, res, avp->val.v.i);
+		break;
+		case SR_XTYPE_STR:
+			return pv_get_strval(msg, param, res, &avp->val.v.s);
+		break;
+		case SR_XTYPE_TIME:
+			if(snprintf(_pv_xavp_buf, 128, "%lu", (long unsigned)avp->val.v.t)<0)
+				return pv_get_null(msg, param, res);
+		break;
+		case SR_XTYPE_LONG:
+			if(snprintf(_pv_xavp_buf, 128, "%ld", (long unsigned)avp->val.v.l)<0)
+				return pv_get_null(msg, param, res);
+		break;
+		case SR_XTYPE_LLONG:
+			if(snprintf(_pv_xavp_buf, 128, "%lld", avp->val.v.ll)<0)
+				return pv_get_null(msg, param, res);
+		break;
+		case SR_XTYPE_XAVP:
+			if(snprintf(_pv_xavp_buf, 128, "<<xavp:%p>>", avp->val.v.xavp)<0)
+				return pv_get_null(msg, param, res);
+		break;
+		case SR_XTYPE_DATA:
+			if(snprintf(_pv_xavp_buf, 128, "<<data:%p>>", avp->val.v.data)<0)
+				return pv_get_null(msg, param, res);
+		break;
+		default:
+			return pv_get_null(msg, param, res);
+	}
+	s.s = _pv_xavp_buf;
+	s.len = strlen(_pv_xavp_buf);
+	return pv_get_strval(msg, param, res, &s);
+}
+
+int regpv_get_xavp_from_start(struct sip_msg *msg, pv_param_t *param,
+		pv_value_t *res, sr_xavp_t **start)
+{
+	pv_xavp_name_t *xname=NULL;
+	sr_xavp_t *avp=NULL;
+	int idxf = 0;
+	int idx = 0;
+	int count;
+	char *p, *p_ini;
+	int p_size;
+
+	if(param==NULL)
+	{
+		LM_ERR("bad parameters\n");
+		return -1;
+	}
+	xname = ((regpv_name_t*)param->pvn.u.dname)->xname;
+
+	if(xname->index.type==PVT_EXTRA)
+	{
+		/* get the index */
+		if(pv_get_spec_index(msg, &xname->index.pvp, &idx, &idxf)!=0)
+		{
+			LM_ERR("invalid index\n");
+			return -1;
+		}
+	}
+	/* fix the index */
+	if(idx<0)
+	{
+		count = xavp_count(&xname->name, start);
+		idx = count + idx;
+	}
+	avp = xavp_get_by_index(&xname->name, idx, start);
+	if(avp==NULL) {
+		LM_DBG("GET XAVP AVP = NULL\n");
+		return pv_get_null(msg, param, res);
+	}
+	if(xname->next==NULL) {
+		LM_DBG("GET XAVP XNAME NEXT = NULL\n");
+		return regpv_xavp_get_value(msg, param, res, avp);
+	}
+
+	idx = 0;
+	idxf = 0;
+	if(xname->next->index.type==PVT_EXTRA)
+	{
+		/* get the index */
+		if(pv_get_spec_index(msg, &xname->next->index.pvp, &idx, &idxf)!=0)
+		{
+			LM_ERR("invalid index\n");
+			return -1;
+		}
+	}
+	/* fix the index */
+	if(idx<0)
+	{
+		count = xavp_count(&xname->next->name, &avp->val.v.xavp);
+		idx = count + idx;
+	}
+	avp = xavp_get_by_index(&xname->next->name, idx, &avp->val.v.xavp);
+	if(avp==NULL) {
+		LM_DBG("GET XAVP AVP BY INDEX = NULL\n");
+		return pv_get_null(msg, param, res);
+	}
+	/* get all values of second key */
+	if(idxf==PV_IDX_ALL)
+	{
+		p_ini = pv_get_buffer();
+		p = p_ini;
+		p_size = pv_get_buffer_size();
+		do {
+			if(p!=p_ini)
+			{
+				if(p-p_ini+REGPV_FIELD_DELIM_LEN+1>p_size)
+				{
+					LM_ERR("local buffer length exceeded\n");
+					return pv_get_null(msg, param, res);
+				}
+				memcpy(p, REGPV_FIELD_DELIM, REGPV_FIELD_DELIM_LEN);
+				p += REGPV_FIELD_DELIM_LEN;
+			}
+			if(regpv_xavp_get_value(msg, param, res, avp)<0)
+			{
+				LM_ERR("can get value\n");
+				return pv_get_null(msg, param, res);
+			}
+			if(p-p_ini+res->rs.len+1>p_size)
+			{
+				LM_ERR("local buffer length exceeded!\n");
+				return pv_get_null(msg, param, res);
+			}
+			memcpy(p, res->rs.s, res->rs.len);
+			p += res->rs.len;
+		} while ((avp=xavp_get_next(avp))!=0);
+		res->rs.s = p_ini;
+		res->rs.len = p - p_ini;
+		return 0;
+	}
+	return regpv_xavp_get_value(msg, param, res, avp);
+}
+
 
 int pv_get_ulc(struct sip_msg *msg,  pv_param_t *param,
 		pv_value_t *res)
@@ -194,7 +477,7 @@ int pv_get_ulc(struct sip_msg *msg,  pv_param_t *param,
 	/* get contact */
 	i = 0;
 	c = rpp->contacts;
-	while(rpp)
+	while(c)
 	{
 		if(i == idx)
 			break;
@@ -271,6 +554,10 @@ int pv_get_ulc(struct sip_msg *msg,  pv_param_t *param,
 			if(c->instance.len>0)
 				return  pv_get_strval(msg, param, res, &c->instance);
 		break;
+		case 21: /* xavp */
+			if(c->xavp)
+				return regpv_get_xavp_from_start(msg, param, res, &c->xavp);
+		break;
 	}
 
 	return pv_get_null(msg, param, res);
@@ -334,6 +621,15 @@ int pv_parse_ulc_name(pv_spec_p sp, str *in)
 	}
 	memset(rp, 0, sizeof(regpv_name_t));
 	rp->rp = rpp;
+
+	if(strstr(pa.s, "=>")) {
+		regpv_parse_xavp_name(sp, &pa);
+		pv_xavp_name_t* xname = (pv_xavp_name_t*)sp->pvp.pvn.u.dname;
+		LM_DBG("ulc parse xavp name [%.*s] \n", xname->name.len, xname->name.s);
+		rp->xname = xname;
+		rp->attr = 21;
+		goto done;
+	}
 
 	switch(pa.len)
 	{
@@ -404,6 +700,7 @@ int pv_parse_ulc_name(pv_spec_p sp, str *in)
 		default:
 			goto error;
 	}
+done:
 	sp->pvp.pvn.u.dname = (void*)rp;
 	sp->pvp.pvn.type = PV_NAME_PVAR;
 
@@ -540,6 +837,10 @@ int pv_fetch_contacts(struct sip_msg* msg, char* table, char* uri,
 			c0->instance.len = ptr->instance.len;
 			p += c0->instance.len;
 		}
+		if(ptr->xavp != NULL)
+		{
+			c0->xavp = xavp_clone_level_nodata(ptr->xavp);
+		}		
 
 		if(ptr0==NULL)
 		{
@@ -681,6 +982,10 @@ void reg_ul_expired_contact(ucontact_t* ptr, int type, void* param)
 		c0->instance.len = ptr->instance.len;
 		p += c0->instance.len;
 	}
+	if(ptr->xavp != NULL)
+	{
+		c0->xavp = xavp_clone_level_nodata(ptr->xavp);
+	}		
 
 	rpp->contacts = c0;
 	rpp->nrc = 1;

--- a/modules/registrar/regpv.c
+++ b/modules/registrar/regpv.c
@@ -731,8 +731,6 @@ int pv_fetch_contacts(struct sip_msg* msg, char* table, char* uri,
 	int ilen;
 	int n;
 	char *p;
-	int match_return_flags = reg_match_return_flags_param;
-	sr_xavp_t *vavp=NULL;
 
 	rpp = regpv_get_profile((str*)profile);
 	if(rpp==0)
@@ -776,15 +774,6 @@ int pv_fetch_contacts(struct sip_msg* msg, char* table, char* uri,
 		LM_DBG("'%.*s' Not found in usrloc\n", aor.len, ZSW(aor.s));
 		ul.unlock_udomain((udomain_t*)table, &aor);
 		return -1;
-	}
-
-	if(match_search_flags == 1) {
-		if(reg_xavp_cfg.s!=NULL) {
-			if( (vavp = xavp_get_child_with_ival(&reg_xavp_cfg, &match_return_flags_name)) != NULL) {
-				match_return_flags = vavp->val.v.i;
-				LM_INFO("match return flags set to %d\n", match_return_flags);
-			}
-		}
 	}
 
 	ptr = r->contacts;
@@ -853,9 +842,8 @@ int pv_fetch_contacts(struct sip_msg* msg, char* table, char* uri,
 			c0->instance.len = ptr->instance.len;
 			p += c0->instance.len;
 		}
-		if(ptr->xavp != NULL && match_return_flags == 1)
+		if(ptr->xavp != NULL && reg_match_flag_param == 1)
 		{
-			LM_DBG("adding contact xavp \n");
 			c0->xavp = xavp_clone_level_nodata(ptr->xavp);
 		}
 		if(ptr0==NULL)
@@ -998,7 +986,7 @@ void reg_ul_expired_contact(ucontact_t* ptr, int type, void* param)
 		c0->instance.len = ptr->instance.len;
 		p += c0->instance.len;
 	}
-	if(ptr->xavp != NULL)
+	if(ptr->xavp != NULL && reg_match_flag_param == 1)
 	{
 		c0->xavp = xavp_clone_level_nodata(ptr->xavp);
 	}		

--- a/modules/registrar/regpv.c
+++ b/modules/registrar/regpv.c
@@ -778,10 +778,12 @@ int pv_fetch_contacts(struct sip_msg* msg, char* table, char* uri,
 		return -1;
 	}
 
-	if(reg_xavp_cfg.s!=NULL) {
-		if( (vavp = xavp_get_child_with_ival(&reg_xavp_cfg, &match_return_flags_name)) != NULL) {
-			match_return_flags = vavp->val.v.i;
-			LM_INFO("match return flags set to %d\n", match_return_flags);
+	if(match_search_flags == 1) {
+		if(reg_xavp_cfg.s!=NULL) {
+			if( (vavp = xavp_get_child_with_ival(&reg_xavp_cfg, &match_return_flags_name)) != NULL) {
+				match_return_flags = vavp->val.v.i;
+				LM_INFO("match return flags set to %d\n", match_return_flags);
+			}
 		}
 	}
 


### PR DESCRIPTION
- add xavp when registered returns success
- add reg_received_avp param for strict matching the contact
- add reg_contact_avp param for strict matching the contact
- add xavp to reg_fetch_contacts

modparam("usrloc", "xavp_contact", "ulattrs")
modparam("registrar", "reg_received_avp", "$avp(chk_origin)")
modparam("registrar", "reg_contact_avp", "$avp(chk_contact)")

using xavp with registered
   $avp(chk_origin) = $su;
   $avp(chk_contact) = $(ct{nameaddr.uri});
   if (registered("location","$fu")) {
       xlog("L_INFO", "$ci|log| checking $fu - $xavp(ulattrs=>account_id)");
  }

using xavp with reg_fetch_contacts
  if(reg_fetch_contacts("location", "$fu", "caller")) {
         xlog("L_INFO", "$ci|log| checking $fu - $(ulc(caller=>ulattrs=>account_id))");
   }
