### PR TITLE
presence - match sip uris using alternative function

### DIFF
--- a/modules/presence/README
+++ b/modules/presence/README
@@ -45,22 +45,26 @@ Juha Heinanen
               3.10. to_tag_pref (str)
               3.11. expires_offset (int)
               3.12. max_expires (int)
-              3.13. server_address (str)
-              3.14. subs_db_mode (int)
-              3.15. publ_cache (int)
-              3.16. subs_htable_size (int)
-              3.17. pres_htable_size (int)
-              3.18. send_fast_notify (int)
-              3.19. enable_sphere_check (int)
-              3.20. timeout_rm_subs (int)
-              3.21. fetch_rows (integer)
-              3.22. db_table_lock_type (integer)
-              3.23. local_log_level (int)
-              3.24. subs_remove_match (int)
+              3.13. min_expires (int)
+              3.14. min_expires_action (int)
+              3.15. server_address (str)
+              3.16. subs_db_mode (int)
+              3.17. publ_cache (int)
+              3.18. subs_htable_size (int)
+              3.19. pres_htable_size (int)
+              3.20. send_fast_notify (int)
+              3.21. enable_sphere_check (int)
+              3.22. timeout_rm_subs (int)
+              3.23. fetch_rows (integer)
+              3.24. db_table_lock_type (integer)
+              3.25. local_log_level (int)
+              3.26. subs_remove_match (int)
+              3.27. xavp_cfg (str)
+              3.28. retrieve_order (int)
 
         4. Functions
 
-              4.1. handle_publish(char* sender_uri)
+              4.1. handle_publish([sender_uri])
               4.2. handle_subscribe([watcher_uri])
               4.3. pres_auth_status(watcher_uri, presentity_uri)
               4.4. pres_refresh_watchers(uri, event, type[, file_uri,
@@ -113,23 +117,27 @@ Juha Heinanen
    1.10. Set to_tag_pref parameter
    1.11. Set expires_offset parameter
    1.12. Set max_expires parameter
-   1.13. Set server_address parameter
-   1.14. Set subs_db_mode parameter
-   1.15. Set publ_cache parameter
-   1.16. Set subs_htable_size parameter
-   1.17. Set pres_htable_size parameter
-   1.18. Set send_fast_notify parameter
-   1.19. Set enable_sphere_check parameter
-   1.20. Set timeout_rm_subs parameter
-   1.21. Set fetch_rows parameter
-   1.22. Set db_table_lock_type parameter
-   1.23. Set local_log_level parameter
-   1.24. Set subs_remove_match parameter
-   1.25. handle_publish usage
-   1.26. handle_subscribe usage
-   1.27. pres_auth_status usage
-   1.28. pres_refresh_watchers usage
-   1.29. pres_update_watchers usage
+   1.13. Set min_expires parameter
+   1.14. Set min_expires parameter
+   1.15. Set server_address parameter
+   1.16. Set subs_db_mode parameter
+   1.17. Set publ_cache parameter
+   1.18. Set subs_htable_size parameter
+   1.19. Set pres_htable_size parameter
+   1.20. Set send_fast_notify parameter
+   1.21. Set enable_sphere_check parameter
+   1.22. Set timeout_rm_subs parameter
+   1.23. Set fetch_rows parameter
+   1.24. Set db_table_lock_type parameter
+   1.25. Set local_log_level parameter
+   1.26. Set subs_remove_match parameter
+   1.27. Set xavp_cfg parameter
+   1.28. Set retrieve_order parameter
+   1.29. handle_publish usage
+   1.30. handle_subscribe usage
+   1.31. pres_auth_status usage
+   1.32. pres_refresh_watchers usage
+   1.33. pres_update_watchers usage
    2.1. presence_api_t structure
 
 Chapter 1. Admin Guide
@@ -156,22 +164,26 @@ Chapter 1. Admin Guide
         3.10. to_tag_pref (str)
         3.11. expires_offset (int)
         3.12. max_expires (int)
-        3.13. server_address (str)
-        3.14. subs_db_mode (int)
-        3.15. publ_cache (int)
-        3.16. subs_htable_size (int)
-        3.17. pres_htable_size (int)
-        3.18. send_fast_notify (int)
-        3.19. enable_sphere_check (int)
-        3.20. timeout_rm_subs (int)
-        3.21. fetch_rows (integer)
-        3.22. db_table_lock_type (integer)
-        3.23. local_log_level (int)
-        3.24. subs_remove_match (int)
+        3.13. min_expires (int)
+        3.14. min_expires_action (int)
+        3.15. server_address (str)
+        3.16. subs_db_mode (int)
+        3.17. publ_cache (int)
+        3.18. subs_htable_size (int)
+        3.19. pres_htable_size (int)
+        3.20. send_fast_notify (int)
+        3.21. enable_sphere_check (int)
+        3.22. timeout_rm_subs (int)
+        3.23. fetch_rows (integer)
+        3.24. db_table_lock_type (integer)
+        3.25. local_log_level (int)
+        3.26. subs_remove_match (int)
+        3.27. xavp_cfg (str)
+        3.28. retrieve_order (int)
 
    4. Functions
 
-        4.1. handle_publish(char* sender_uri)
+        4.1. handle_publish([sender_uri])
         4.2. handle_subscribe([watcher_uri])
         4.3. pres_auth_status(watcher_uri, presentity_uri)
         4.4. pres_refresh_watchers(uri, event, type[, file_uri, filename])
@@ -245,18 +257,22 @@ Chapter 1. Admin Guide
    3.10. to_tag_pref (str)
    3.11. expires_offset (int)
    3.12. max_expires (int)
-   3.13. server_address (str)
-   3.14. subs_db_mode (int)
-   3.15. publ_cache (int)
-   3.16. subs_htable_size (int)
-   3.17. pres_htable_size (int)
-   3.18. send_fast_notify (int)
-   3.19. enable_sphere_check (int)
-   3.20. timeout_rm_subs (int)
-   3.21. fetch_rows (integer)
-   3.22. db_table_lock_type (integer)
-   3.23. local_log_level (int)
-   3.24. subs_remove_match (int)
+   3.13. min_expires (int)
+   3.14. min_expires_action (int)
+   3.15. server_address (str)
+   3.16. subs_db_mode (int)
+   3.17. publ_cache (int)
+   3.18. subs_htable_size (int)
+   3.19. pres_htable_size (int)
+   3.20. send_fast_notify (int)
+   3.21. enable_sphere_check (int)
+   3.22. timeout_rm_subs (int)
+   3.23. fetch_rows (integer)
+   3.24. db_table_lock_type (integer)
+   3.25. local_log_level (int)
+   3.26. subs_remove_match (int)
+   3.27. xavp_cfg (str)
+   3.28. retrieve_order (int)
 
 3.1. db_url(str)
 
@@ -414,8 +430,8 @@ modparam("presence", "expires_offset", 10)
 
 3.12. max_expires (int)
 
-   The the maximum admissible expires value for PUBLISH/SUBSCRIBE message
-   (in seconds).
+   The maximum admissible expires value for PUBLISH/SUBSCRIBE message (in
+   seconds).
 
    Default value is "3600".
 
@@ -424,18 +440,49 @@ modparam("presence", "expires_offset", 10)
 modparam("presence", "max_expires", 3600)
 ...
 
-3.13. server_address (str)
+3.13. min_expires (int)
+
+   The minimum admissible expires value for PUBLISH/SUBSCRIBE message (in
+   seconds).
+
+   If > 0 then min_expires_action parameter determines the response.
+
+   Default value is "0".
+
+   Example 1.13. Set min_expires parameter
+            ...
+            modparam("presence", "min_expires", 1800)
+            ...
+
+3.14. min_expires_action (int)
+
+   The action to take when UA sends a expires value less then min_expires.
+
+   Possible Values
+     * 1 : RFC Compliant, returns "423 Interval Too Brief"
+     * 2 : forces the min_expires value in the subscription
+
+   If > 0 then min_expires_action parameter determines the response.
+
+   Default value is "1".
+
+   Example 1.14. Set min_expires parameter
+            ...
+            modparam("presence", "min_expires", 1800)
+            ...
+
+3.15. server_address (str)
 
    The presence server address which will become the value of Contact
    header filed for 200 OK replies to SUBSCRIBE and PUBLISH and in NOTIFY
    messages.
 
-   Example 1.13. Set server_address parameter
+   Example 1.15. Set server_address parameter
 ...
 modparam("presence", "server_address", "sip:10.10.10.10:5060")
 ...
 
-3.14. subs_db_mode (int)
+3.16. subs_db_mode (int)
 
    The presence module can utilize database for persistent subscription
    storage. If you use database, your subscriptions will survive machine
@@ -469,12 +516,12 @@ modparam("presence", "server_address", "sip:10.10.10.10:5060")
 
    Default value is 2 (Write-Back scheme).
 
-   Example 1.14. Set subs_db_mode parameter
+   Example 1.16. Set subs_db_mode parameter
 ...
 modparam("presence", "subs_db_mode", 1)
 ...
 
-3.15. publ_cache (int)
+3.17. publ_cache (int)
 
    To improve performance, the presence module holds by default a publish
    cache that says if a certain publication exists in database. This is
@@ -490,12 +537,12 @@ modparam("presence", "subs_db_mode", 1)
 
    Default value is "1".
 
-   Example 1.15. Set publ_cache parameter
+   Example 1.17. Set publ_cache parameter
 ...
 modparam("presence", "publ_cache", 0)
 ...
 
-3.16. subs_htable_size (int)
+3.18. subs_htable_size (int)
 
    The size of the in-memory hash table to store subscription dialogs.
    This parameter will be used as the power of 2 when computing table
@@ -503,24 +550,24 @@ modparam("presence", "publ_cache", 0)
 
    Default value is "9 (512)".
 
-   Example 1.16. Set subs_htable_size parameter
+   Example 1.18. Set subs_htable_size parameter
 ...
 modparam("presence", "subs_htable_size", 11)
 ...
 
-3.17. pres_htable_size (int)
+3.19. pres_htable_size (int)
 
    The size of the in-memory hash table to store publish records. This
    parameter will be used as the power of 2 when computing table size.
 
    Default value is "9 (512)".
 
-   Example 1.17. Set pres_htable_size parameter
+   Example 1.19. Set pres_htable_size parameter
 ...
 modparam("presence", "pres_htable_size", 11)
 ...
 
-3.18. send_fast_notify (int)
+3.20. send_fast_notify (int)
 
    This parameter enables or disables the sending of an initial empty
    NOTIFY after a SUBSCRIBE/reSUBSCRIBE. This caused problems for MWI
@@ -530,12 +577,12 @@ modparam("presence", "pres_htable_size", 11)
 
    Default value is "1 ".
 
-   Example 1.18. Set send_fast_notify parameter
+   Example 1.20. Set send_fast_notify parameter
 ...
 modparam("presence", "send_fast_notify", 0)
 ...
 
-3.19. enable_sphere_check (int)
+3.21. enable_sphere_check (int)
 
    This parameter is a flag that should be set if permission rules include
    sphere checking. The sphere information is expected to be present in
@@ -545,12 +592,12 @@ modparam("presence", "send_fast_notify", 0)
 
    Default value is "0 ".
 
-   Example 1.19. Set enable_sphere_check parameter
+   Example 1.21. Set enable_sphere_check parameter
 ...
 modparam("presence", "enable_sphere_check", 1)
 ...
 
-3.20. timeout_rm_subs (int)
+3.22. timeout_rm_subs (int)
 
    This parameter is a flag that should be set if subscriptions should be
    removed from the active_watchers when a NOTIFY times out. RFC3265
@@ -560,23 +607,23 @@ modparam("presence", "enable_sphere_check", 1)
 
    Default value is "1".
 
-   Example 1.20. Set timeout_rm_subs parameter
+   Example 1.22. Set timeout_rm_subs parameter
 ...
 modparam("presence", "timeout_rm_subs", 0)
 ...
 
-3.21. fetch_rows (integer)
+3.23. fetch_rows (integer)
 
    Number of rows to be loaded in one step from database.
 
    Default value is 500.
 
-   Example 1.21. Set fetch_rows parameter
+   Example 1.23. Set fetch_rows parameter
 ...
 modparam("presence", "fetch_rows", 1000)
 ...
 
-3.22. db_table_lock_type (integer)
+3.24. db_table_lock_type (integer)
 
    Enable (=1) or disable (=0) the Locks for table during an transaction.
    Locking only the "current" table causes problems with a MySQL-Databases
@@ -589,23 +636,23 @@ modparam("presence", "fetch_rows", 1000)
 
    Default value is 1 (Write Lock for the Tables).
 
-   Example 1.22. Set db_table_lock_type parameter
+   Example 1.24. Set db_table_lock_type parameter
 ...
 modparam("presence", "db_table_lock_type", 0)
 ...
 
-3.23. local_log_level (int)
+3.25. local_log_level (int)
 
    Control log level for some debug messages inside the module.
 
    Default value is 2 (L_INFO).
 
-   Example 1.23. Set local_log_level parameter
+   Example 1.25. Set local_log_level parameter
 ...
 modparam("presence", "local_log_level", 3)
 ...
 
-3.24. subs_remove_match (int)
+3.26. subs_remove_match (int)
 
    Control how to match the subscriptions to remove from memory. If set to
    0, then the match is done on To-Tag (local generated), if set to 1,
@@ -614,20 +661,57 @@ modparam("presence", "local_log_level", 3)
 
    Default value is 0.
 
-   Example 1.24. Set subs_remove_match parameter
+   Example 1.26. Set subs_remove_match parameter
 ...
 modparam("presence", "subs_remove_match", 1)
 ...
 
+3.27. xavp_cfg (str)
+
+   The name of the xavp to be used to specify attributes for internal
+   processing of presence module.
+
+   Inner attributes inside xavp can be:
+     * priority - integer value to set the priority of the presence
+       document (higher value, higher priority). It can set the order of
+       the aggregated presence documents sent by NOTIFY (first the
+       document with higher priority). If xavp_cfg parameter is set but
+       this attribute is not in the avp, the priority of the presence
+       document is based on timestamp, so newer documents have higher
+       priority.
+
+   Default value is empty (not set).
+
+   Example 1.27. Set xavp_cfg parameter
+...
+modparam("presence", "xavp_cfg", "pres")
+...
+if(is_method("PUBLISH")) {
+    $xavp(pres=>priority) = 100;
+}
+...
+
+3.28. retrieve_order (int)
+
+   If set to 0, presentity records are retrieve by received_time order. if
+   set to 1, presentity records are retrieve by priority order.
+
+   Default value is 0.
+
+   Example 1.28. Set retrieve_order parameter
+...
+modparam("presence", "retrieve_order", 1)
+...
+
 4. Functions
 
-   4.1. handle_publish(char* sender_uri)
+   4.1. handle_publish([sender_uri])
    4.2. handle_subscribe([watcher_uri])
    4.3. pres_auth_status(watcher_uri, presentity_uri)
    4.4. pres_refresh_watchers(uri, event, type[, file_uri, filename])
    4.5. pres_update_watchers(uri, event)
 
-4.1. handle_publish(char* sender_uri)
+4.1. handle_publish([sender_uri])
 
    Handles PUBLISH requests by storing and updating published information
    in memory cache and database, then calls functions to send NOTIFY
@@ -647,7 +731,7 @@ modparam("presence", "subs_remove_match", 1)
 
    The module sends an appropriate stateless reply in all cases.
 
-   Example 1.25. handle_publish usage
+   Example 1.29. handle_publish usage
 ...
         if(is_method("PUBLISH"))
         {
@@ -678,7 +762,7 @@ modparam("presence", "subs_remove_match", 1)
 
    The module sends an appropriate stateless reply in all cases.
 
-   Example 1.26. handle_subscribe usage
+   Example 1.30. handle_subscribe usage
 ...
 if(method=="SUBSCRIBE")
     handle_subscribe();
@@ -695,7 +779,7 @@ if(method=="SUBSCRIBE")
 
    This function can be used from REQUEST_ROUTE.
 
-   Example 1.27. pres_auth_status usage
+   Example 1.31. pres_auth_status usage
 ...
 if (method=="MESSAGE") {
     pres_auth_status("$fu", $ru");
@@ -731,7 +815,7 @@ if (method=="MESSAGE") {
 
    This function can be used from ANY_ROUTE.
 
-   Example 1.28. pres_refresh_watchers usage
+   Example 1.32. pres_refresh_watchers usage
 ...
 pres_refresh_watchers("sip:test@kamailio.org", "presence", 1);
 ...
@@ -749,7 +833,7 @@ pres_refresh_watchers("sip:test@kamailio.org", "presence", 1);
 
    This function can be used from ANY_ROUTE.
 
-   Example 1.29. pres_update_watchers usage
+   Example 1.33. pres_update_watchers usage
 ...
 pres_update_watchers("sip:test@kamailio.org", "presence");
 ...

--- a/modules/presence/doc/presence_admin.xml
+++ b/modules/presence/doc/presence_admin.xml
@@ -699,6 +699,35 @@ modparam("presence", "subs_remove_match", 1)
 	    </example>
 	</section>
 
+<section id="presence.p.sip_uri_match">
+    <title><varname>sip_uri_match</varname> (int)</title>
+    <para>
+        The mode used when comparing uris.
+    </para>
+    <para>
+        <itemizedlist>
+            <title>Possible Values</title>
+            <listitem>
+                <para> 0 : case sensitive</para>
+            </listitem>
+            <listitem>
+                <para> 1 : case insensitive</para>
+            </listitem>
+        </itemizedlist>
+    </para>
+    <para>
+        <emphasis>Default value is <quote>0</quote>.</emphasis>
+    </para>
+    <example>
+        <title>Set <varname>sip_uri_match</varname> parameter</title>
+        <programlisting format="linespecific">
+            ...
+            modparam("presence", "sip_uri_match", 1)
+            ...
+        </programlisting>
+    </example>
+</section>
+
 </section>
 
 <section>

--- a/modules/presence/doc/presence_admin.xml
+++ b/modules/presence/doc/presence_admin.xml
@@ -698,6 +698,63 @@ modparam("presence", "subs_remove_match", 1)
 </programlisting>
 	    </example>
 	</section>
+	<section id="presence.p.xavp_cfg">
+    <title><varname>xavp_cfg</varname> (str)</title>
+    <para>
+		The name of the xavp to be used to specify attributes for internal
+		processing of presence module.
+    </para>
+    <para>
+		Inner attributes inside xavp can be:
+    </para>
+    <itemizedlist>
+        <listitem>
+			<para><emphasis>priority</emphasis> - integer value to set the
+			priority of the presence document (higher value, higher priority).
+			It can set the order of the aggregated presence documents sent by
+			NOTIFY (first the document with higher priority). If xavp_cfg
+			parameter is set but this attribute is not in the avp,
+			the priority of the presence document is based on timestamp,
+			so newer documents have higher priority.</para>
+        </listitem>
+     </itemizedlist>
+    <para>
+        Default value is <emphasis>empty</emphasis> (not set).
+    </para>
+    <example>
+        <title>Set <varname>xavp_cfg</varname> parameter</title>
+        <programlisting format="linespecific">
+...
+modparam("presence", "xavp_cfg", "pres")
+...
+if(is_method("PUBLISH")) {
+    $xavp(pres=>priority) = 100;
+}
+...
+</programlisting>
+    </example>
+	</section>
+
+	<section id="presence.p.retrieve_order">
+	    <title><varname>retrieve_order</varname> (int)</title>
+	    <para>
+		If set to 0, presentity records are retrieve by received_time order.
+		if set to 1, presentity records are retrieve by priority order.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is 0.
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>retrieve_order</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("presence", "retrieve_order", 1)
+...
+</programlisting>
+	    </example>
+	</section>
 
 <section id="presence.p.sip_uri_match">
     <title><varname>sip_uri_match</varname> (int)</title>

--- a/modules/presence/doc/presence_admin.xml
+++ b/modules/presence/doc/presence_admin.xml
@@ -81,7 +81,7 @@
 	
 	<section>
 	<title>Parameters</title>
-	<section>
+	<section id="presence.p.db_url">
 		<title><varname>db_url</varname>(str)</title>
 		<para>
 		The database url.
@@ -103,7 +103,7 @@ modparam("presence", "db_url",
 </programlisting>
 		</example>
 	</section>
-	<section>
+	<section id="presence.p.presentity_table">
 		<title><varname>presentity_table</varname>(str)</title>
 		<para>
 		The name of the db table where PUBLISH presence information is stored.
@@ -121,7 +121,7 @@ modparam("presence", "presentity_table", "presentity")
 </programlisting>
 		</example>
 	</section>
-	<section>
+	<section id="presence.p.active_watchers_table">
 		<title><varname>active_watchers_table</varname>(str)</title>
 		<para>
 		The name of the db table where active subscription information is stored. 
@@ -139,7 +139,7 @@ modparam("presence", "active_watchers_table", "active_watchers")
 </programlisting>
 		</example>
 	</section>
-	<section>
+	<section id="presence.p.watchers_table">
 		<title><varname>watchers_table</varname>(str)</title>
 		<para>
 		The name of the db table where subscription states are stored.
@@ -157,7 +157,7 @@ modparam("presence", "watchers_table", "watchers")
 </programlisting>
 		</example>
 	</section>
-	<section>
+	<section id="presence.p.clean_period">
 		<title><varname>clean_period</varname> (int)</title>
 		<para>
 		The period in seconds between checks if there are expired messages stored in database.
@@ -175,7 +175,7 @@ modparam("presence", "clean_period", 100)
 </programlisting>
 		</example>
 	</section>
-	<section>
+	<section id="presence.p.db_update_period">
 		<title><varname>db_update_period</varname> (int)</title>
 		<para>
 		The period at which to synchronize cached subscriber info with the
@@ -195,7 +195,7 @@ modparam("presence", "db_update_period", 100)
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.p.waitn_time">
 		<title><varname>waitn_time</varname> (int)</title>
 		<para>
 		The maximum time period that NOTIFY requests will
@@ -221,7 +221,7 @@ modparam("presence", "waitn_time", 10)
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.p.notifier_poll_rate">
 		<title><varname>notifier_poll_rate</varname> (int)</title>
 		<para>
 		The number of times per second that the notifier processes
@@ -247,7 +247,7 @@ modparam("presence", "notifier_poll_rate", 20)
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.p.notifier_processes">
 		<title><varname>notifier_processes</varname> (int)</title>
 		<para>
 		The number of notifier processes that should be started.
@@ -278,7 +278,7 @@ modparam("presence", "notifier_processes", 2)
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.p.to_tag_pref">
 		<title><varname>to_tag_pref</varname> (str)</title>
 		<para>
 		The prefix used when generating to_tag when sending replies for
@@ -298,7 +298,7 @@ modparam("presence", "to_tag_pref", 'pres')
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.p.expires_offset">
 		<title><varname>expires_offset</varname> (int)</title>
 		<para>
 		The value in seconds that should be subtracted from the expires value when
@@ -319,7 +319,7 @@ modparam("presence", "expires_offset", 10)
 		</example>
 
 </section>
-       <section>
+       <section id="presence.p.max_expires">
                <title><varname>max_expires</varname> (int)</title>
                <para>
                The maximum admissible expires value for PUBLISH/SUBSCRIBE
@@ -339,7 +339,7 @@ modparam("presence", "max_expires", 3600)
 	</example>
 </section>
 
-<section>
+<section id="presence.p.min_expires">
     <title><varname>min_expires</varname> (int)</title>
     <para>
         The minimum admissible expires value for PUBLISH/SUBSCRIBE
@@ -362,7 +362,7 @@ modparam("presence", "max_expires", 3600)
     </example>
 </section>
 
-<section>
+<section id="presence.p.min_expires_action">
     <title><varname>min_expires_action</varname> (int)</title>
     <para>
         The action to take when UA sends a expires value less then min_expires.
@@ -394,7 +394,7 @@ modparam("presence", "max_expires", 3600)
     </example>
 </section>
 
-<section>
+<section id="presence.p.server_address">
 		<title><varname>server_address</varname> (str)</title>
 		<para>
 		The presence server address which will become the value of Contact header filed 
@@ -410,7 +410,7 @@ modparam("presence", "server_address", "sip:10.10.10.10:5060")
 		</example>
 	</section>
 
-<section>
+<section id="presence.p.subs_db_mode">
 		<title><varname>subs_db_mode</varname> (int)</title>
 		<para>
 		The presence module can utilize database for persistent subscription storage.
@@ -475,7 +475,7 @@ modparam("presence", "subs_db_mode", 1)
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.p.publ_cache">
 		<title><varname>publ_cache</varname> (int)</title>
 		<para>
 		To improve performance, the presence module holds by default a
@@ -505,7 +505,7 @@ modparam("presence", "publ_cache", 0)
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.p.subs_htable_size">
 		<title><varname>subs_htable_size</varname> (int)</title>
 		<para>
 		The size of the in-memory hash table to store subscription dialogs.
@@ -525,7 +525,7 @@ modparam("presence", "subs_htable_size", 11)
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.p.pres_htable_size">
 		<title><varname>pres_htable_size</varname> (int)</title>
 		<para>
         	The size of the in-memory hash table to store publish records.
@@ -544,7 +544,7 @@ modparam("presence", "pres_htable_size", 11)
 	</programlisting>
 		</example>
 	</section>
-	<section>
+	<section id="presence.p.send_fast_notify">
 		<title><varname>send_fast_notify</varname> (int)</title>
 		<para>
 		This parameter enables or disables the sending of an initial empty NOTIFY after a SUBSCRIBE/reSUBSCRIBE. 
@@ -565,7 +565,7 @@ modparam("presence", "send_fast_notify", 0)
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.p.enable_sphere_check">
 		<title><varname>enable_sphere_check</varname> (int)</title>
 		<para>
 		This parameter is a flag that should be set if permission rules include
@@ -589,7 +589,7 @@ modparam("presence", "enable_sphere_check", 1)
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.p.timeout_rm_subs">
 		<title><varname>timeout_rm_subs</varname> (int)</title>
 		<para>
 		This parameter is a flag that should be set if subscriptions should be
@@ -611,7 +611,7 @@ modparam("presence", "timeout_rm_subs", 0)
 	</programlisting>
 		</example>
 	</section>
-	<section>
+	<section id="presence.p.fetch_rows">
 	    <title><varname>fetch_rows</varname> (integer)</title>
 	    <para>
 		Number of rows to be loaded in one step from database.
@@ -630,7 +630,7 @@ modparam("presence", "fetch_rows", 1000)
 </programlisting>
 	    </example>
 	</section>
-	<section>
+	<section id="presence.p.db_table_lock_type">
 	    <title><varname>db_table_lock_type</varname> (integer)</title>
 	    <para>
 		Enable (=1) or disable (=0) the Locks for table during an
@@ -732,9 +732,9 @@ modparam("presence", "subs_remove_match", 1)
 
 <section>
 	<title>Functions</title>
-	<section>
+	<section id="presence.f.handle_publish">
 		<title>
-		<function moreinfo="none">handle_publish(char* sender_uri)</function>
+		<function moreinfo="none">handle_publish([sender_uri])</function>
 		</title>
 		<para>
 		Handles PUBLISH requests by storing and updating 
@@ -789,7 +789,7 @@ modparam("presence", "subs_remove_match", 1)
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.f.handle_subscribe">
 		<title>
 		<function moreinfo="none">handle_subscribe([watcher_uri])</function>
 		</title>
@@ -838,7 +838,7 @@ if(method=="SUBSCRIBE")
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.f.pres_auth_status">
 		<title>
 		<function moreinfo="none">pres_auth_status(watcher_uri, presentity_uri)</function>
 		</title>
@@ -873,7 +873,7 @@ if (method=="MESSAGE") {
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.f.pres_refresh_watchers">
 		<title>
 		<function moreinfo="none">pres_refresh_watchers(uri, event, type[, file_uri, filename])</function>
 		</title>
@@ -933,7 +933,7 @@ pres_refresh_watchers("sip:test@kamailio.org", "presence", 1);
 		</example>
 	</section>
 
-	<section>
+	<section id="presence.f.pres_update_whatchers">
 		<title>
 		<function moreinfo="none">pres_update_watchers(uri, event)</function>
 		</title>

--- a/modules/presence/hash.c
+++ b/modules/presence/hash.c
@@ -501,7 +501,7 @@ int insert_phtable(str* pres_uri, int event, char* sphere)
 	pres_entry_t* p= NULL;
 	int size;
 
-	hash_code= core_hash(pres_uri, NULL, phtable_size);
+	hash_code= core_case_hash(pres_uri, NULL, phtable_size);
 
 	lock_get(&pres_htable[hash_code].lock);
 	
@@ -559,7 +559,7 @@ int delete_phtable(str* pres_uri, int event)
 	unsigned int hash_code;
 	pres_entry_t* p= NULL, *prev_p= NULL;
 
-	hash_code= core_hash(pres_uri, NULL, phtable_size);
+	hash_code= core_case_hash(pres_uri, NULL, phtable_size);
 
 	lock_get(&pres_htable[hash_code].lock);
 	
@@ -616,7 +616,7 @@ int update_phtable(presentity_t* presentity, str pres_uri, str body)
 	}
 
 	/* search for record in hash table */
-	hash_code= core_hash(&pres_uri, NULL, phtable_size);
+	hash_code= core_case_hash(&pres_uri, NULL, phtable_size);
 	
 	lock_get(&pres_htable[hash_code].lock);
 

--- a/modules/presence/hash.c
+++ b/modules/presence/hash.c
@@ -380,7 +380,7 @@ int update_shtable(shtable_t htable,unsigned int hash_code,
 		subs->version = ++s->version;
 	}
 	
-	if(strncmp(s->contact.s, subs->contact.s, subs->contact.len))
+	if(presence_sip_uri_match(&s->contact, &subs->contact))
 	{
 		shm_free(s->contact.s);
 		s->contact.s= (char*)shm_malloc(subs->contact.len* sizeof(char));
@@ -488,7 +488,7 @@ pres_entry_t* search_phtable(str* pres_uri,int event, unsigned int hash_code)
 	while(p)
 	{
 		if(p->event== event && p->pres_uri.len== pres_uri->len &&
-				strncmp(p->pres_uri.s, pres_uri->s, pres_uri->len)== 0 )
+				presence_sip_uri_match(&p->pres_uri, pres_uri)== 0 )
 			return p;
 		p= p->next;
 	}

--- a/modules/presence/notify.c
+++ b/modules/presence/notify.c
@@ -391,7 +391,7 @@ str* get_wi_notify_body(subs_t* subs, subs_t* watcher_subs)
 
 			if(s->event== subs->event->wipeer &&
 				s->pres_uri.len== subs->pres_uri.len &&
-				strncmp(s->pres_uri.s, subs->pres_uri.s,subs->pres_uri.len)== 0)
+				presence_sip_uri_match(&s->pres_uri, &subs->pres_uri)== 0)
 			{
 				if(add_watcher_list(s, watchers)< 0)
 				{
@@ -704,7 +704,7 @@ str* get_p_notify_body(str pres_uri, pres_ev_t* event, str* etag,
 				sender.len= strlen(sender.s);
 			
 				if(sender.len== contact->len &&
-						strncmp(sender.s, contact->s, sender.len)== 0)
+						presence_sip_uri_match(&sender, contact)== 0)
 				{
 					notify_body= build_empty_bla_body(pres_uri);
 					pa_dbf.free_result(pa_db, result);
@@ -1212,9 +1212,9 @@ subs_t* get_subs_dialog(str* pres_uri, pres_ev_t* event, str* sender)
 			if((!(s->status== ACTIVE_STATUS &&
 		    s->reason.len== 0 &&
 				s->event== event && s->pres_uri.len== pres_uri->len &&
-				strncmp(s->pres_uri.s, pres_uri->s, pres_uri->len)== 0)) || 
+				presence_sip_uri_match(&s->pres_uri, pres_uri)== 0)) || 
 				(sender && sender->len== s->contact.len && 
-				strncmp(sender->s, s->contact.s, sender->len)== 0))
+				presence_sip_uri_match(sender, &s->contact)== 0))
 				continue;
 
 			s_new= mem_copy_subs(s, PKG_MEM_TYPE);
@@ -1888,7 +1888,7 @@ int watcher_found_in_list(watcher_t * watchers, str wuri)
 
 	while(w)
 	{
-		if(w->uri.len == wuri.len && strncmp(w->uri.s, wuri.s, wuri.len)== 0)
+		if(w->uri.len == wuri.len && presence_sip_uri_match(&w->uri, &wuri)== 0)
 			return 1;
 		w= w->next;
 	}

--- a/modules/presence/notify.c
+++ b/modules/presence/notify.c
@@ -375,7 +375,7 @@ str* get_wi_notify_body(subs_t* subs, subs_t* watcher_subs)
 			goto error;
 		}
 	} else {
-		hash_code= core_hash(&subs->pres_uri, &subs->event->wipeer->name,
+		hash_code= core_case_hash(&subs->pres_uri, &subs->event->wipeer->name,
 				shtable_size);
 		lock_get(&subs_htable[hash_code].lock);
 		s= subs_htable[hash_code].entries;
@@ -612,7 +612,7 @@ str* get_p_notify_body(str pres_uri, pres_ev_t* event, str* etag,
 	if( publ_cache_enabled )
 	{
 		/* search in hash table if any record exists */
-		hash_code= core_hash(&pres_uri, NULL, phtable_size);
+		hash_code= core_case_hash(&pres_uri, NULL, phtable_size);
 		if(search_phtable(&pres_uri, event->evp->type, hash_code)== NULL)
 		{
 			LM_DBG("No record exists in hash_table\n");
@@ -1191,7 +1191,7 @@ subs_t* get_subs_dialog(str* pres_uri, pres_ev_t* event, str* sender)
 			goto error;
 		}
 	}else {
-		hash_code= core_hash(pres_uri, &event->name, shtable_size);
+		hash_code= core_case_hash(pres_uri, &event->name, shtable_size);
 		
 		lock_get(&subs_htable[hash_code].lock);
 
@@ -1653,7 +1653,7 @@ int notify(subs_t* subs, subs_t * watcher_subs,str* n_body,int force_null_body)
 	if(subs->expires!= 0 && subs->status != TERMINATED_STATUS)
 	{
 		unsigned int hash_code;
-		hash_code= core_hash(&subs->pres_uri, &subs->event->name, shtable_size);
+		hash_code= core_case_hash(&subs->pres_uri, &subs->event->name, shtable_size);
 
 		/* if subscriptions are held also in memory, update the subscription hashtable */
 		if(subs_dbmode != DB_ONLY)
@@ -2265,7 +2265,7 @@ int set_wipeer_subs_updated(str *pres_uri, pres_ev_t *event, int full)
 		update_vals[n_update_cols].type = DB1_INT;
 		update_vals[n_update_cols].nul = 0;
 		update_vals[n_update_cols].val.int_val =
-			core_hash(&callid, &from_tag, 0) % (pres_waitn_time *
+			core_case_hash(&callid, &from_tag, 0) % (pres_waitn_time *
  			 pres_notifier_poll_rate * pres_notifier_processes);
 		n_update_cols++;
 
@@ -2326,7 +2326,7 @@ int set_updated(subs_t *sub)
 	update_vals[0].type = DB1_INT;
 	update_vals[0].nul = 0;
 	update_vals[0].val.int_val =
-		core_hash(&sub->callid, &sub->from_tag, 0) %
+		core_case_hash(&sub->callid, &sub->from_tag, 0) %
 			(pres_waitn_time * pres_notifier_poll_rate
 						* pres_notifier_processes);
 

--- a/modules/presence/presence.c
+++ b/modules/presence/presence.c
@@ -1024,7 +1024,7 @@ int update_watchers_status(str pres_uri, pres_ev_t* ev, str* rules_doc)
 	}
 
 	LM_DBG("found %d record-uri in watchers_table\n", result->n);
-	hash_code= core_hash(&pres_uri, &ev->name, shtable_size);
+	hash_code= core_case_hash(&pres_uri, &ev->name, shtable_size);
 	subs.db_flag= hash_code;
 
 	/*must do a copy as sphere_check requires database queries */
@@ -1445,7 +1445,7 @@ static int update_pw_dialogs_dbonlymode(subs_t* subs, subs_t** subs_array)
 					* pres_notifier_processes));
 	} else {
 		db_vals[n_update_cols].val.int_val = 
-			core_hash(&subs->callid, &subs->from_tag, 0) %
+			core_case_hash(&subs->callid, &subs->from_tag, 0) %
 				  (pres_waitn_time * pres_notifier_poll_rate
 					* pres_notifier_processes);
 	}

--- a/modules/presence/presence.h
+++ b/modules/presence/presence.h
@@ -101,4 +101,7 @@ extern db_locking_t db_table_lock;
 int update_watchers_status(str pres_uri, pres_ev_t* ev, str* rules_doc);
 int pres_auth_status(struct sip_msg* msg, str watcher_uri, str presentity_uri);
 
+typedef int (*sip_uri_match_f) (str* s1, str* s2);
+extern sip_uri_match_f presence_sip_uri_match;
+
 #endif /* PA_MOD_H */

--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -1033,7 +1033,7 @@ char* get_sphere(str* pres_uri)
 	if ( publ_cache_enabled )
 	{
 		/* search in hash table*/
-		hash_code= core_hash(pres_uri, NULL, phtable_size);
+		hash_code= core_case_hash(pres_uri, NULL, phtable_size);
 
 		lock_get(&pres_htable[hash_code].lock);
 

--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -519,7 +519,7 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity, str* body,
 			if(presentity->sender)
 			{
 				if(!(presentity->sender->len == sender.len && 
-				strncmp(presentity->sender->s, sender.s, sender.len)== 0))
+				presence_sip_uri_match(presentity->sender, &sender)== 0))
 					 bla_update_publish= 0;
 			}
 after_dialog_check:

--- a/modules/presence/subscribe.c
+++ b/modules/presence/subscribe.c
@@ -468,7 +468,7 @@ void delete_subs(str* pres_uri, str* ev_name, str* to_tag,
 	/* delete record from hash table also if not in dbonly mode */
 	if(subs_dbmode != DB_ONLY)
 	{
-		unsigned int hash_code= core_hash(pres_uri, ev_name, shtable_size);
+		unsigned int hash_code= core_case_hash(pres_uri, ev_name, shtable_size);
 		if(delete_shtable(subs_htable, hash_code, &subs) < 0) {
 			LM_ERR("Failed to delete subscription from memory"
 					" [slot: %u ev: %.*s pu: %.*s ci: %.*s ft: %.*s tt: %.*s]\n",
@@ -491,7 +491,7 @@ int update_subscription_notifier(struct sip_msg* msg, subs_t* subs,
 	*sent_reply= 0;
 
 	/* Set the notifier/update fields for the subscription */
-	subs->updated = core_hash(&subs->callid, &subs->from_tag, 0) %
+	subs->updated = core_case_hash(&subs->callid, &subs->from_tag, 0) %
 				(pres_waitn_time * pres_notifier_poll_rate
 					* pres_notifier_processes);
 	if (subs->event->type & WINFO_TYPE)
@@ -611,7 +611,7 @@ int update_subscription(struct sip_msg* msg, subs_t* subs, int to_tag_gen,
 		/* if subscriptions are stored in memory, update them */
 		if(subs_dbmode != DB_ONLY)
 		{
-			hash_code= core_hash(&subs->pres_uri, &subs->event->name, shtable_size);
+			hash_code= core_case_hash(&subs->pres_uri, &subs->event->name, shtable_size);
 			if(update_shtable(subs_htable, hash_code, subs, REMOTE_TYPE)< 0)
 			{
 				LM_ERR("failed to update subscription in memory\n");
@@ -638,7 +638,7 @@ int update_subscription(struct sip_msg* msg, subs_t* subs, int to_tag_gen,
 			{
 				LM_DBG("inserting in shtable\n");
 				subs->db_flag = (subs_dbmode==WRITE_THROUGH)?WTHROUGHDB_FLAG:INSERTDB_FLAG;
-				hash_code= core_hash(&subs->pres_uri, &subs->event->name, shtable_size);
+				hash_code= core_case_hash(&subs->pres_uri, &subs->event->name, shtable_size);
 				subs->version = 0;
 				if(insert_shtable(subs_htable,hash_code,subs)< 0)
 				{
@@ -1372,7 +1372,7 @@ int get_stored_info(struct sip_msg* msg, subs_t* subs, int* reply_code,
 	else
 		pres_uri = subs->pres_uri;
 
-	hash_code= core_hash(&pres_uri, &subs->event->name, shtable_size);
+	hash_code= core_case_hash(&pres_uri, &subs->event->name, shtable_size);
 	lock_get(&subs_htable[hash_code].lock);
 	s= search_shtable(subs_htable, subs->callid, subs->to_tag,
 		subs->from_tag, hash_code);
@@ -2481,7 +2481,7 @@ int restore_db_subs(void)
 			s.sockinfo_str.s=(char*)row_vals[sockinfo_col].val.string_val;
 			s.sockinfo_str.len= strlen(s.sockinfo_str.s);
 			s.db_flag = (subs_dbmode==WRITE_THROUGH)?WTHROUGHDB_FLAG:NO_UPDATEDB_FLAG;
-			hash_code= core_hash(&s.pres_uri, &s.event->name, shtable_size);
+			hash_code= core_case_hash(&s.pres_uri, &s.event->name, shtable_size);
 			if(insert_shtable(subs_htable, hash_code, &s)< 0)
 			{
 				LM_ERR("adding new record in hash table\n");


### PR DESCRIPTION
added param sip_uri_match
0 - case sensitive (default)
1 - case insensitive

can be extended to a more compliant version, (sensitive user, insensitive domain). 
the parameter sets the function to call to match uris.
