### PR TITLE
core: add support for per-TCP connection lifetime

### DIFF
--- a/core_cmd.c
+++ b/core_cmd.c
@@ -757,7 +757,7 @@ static void core_tcp_list(rpc_t* rpc, void* c)
 	char* state;
 	char* type;
 	struct tcp_connection* con;
-	int i, len, timeout;
+	int i, len, timeout, lifetime;
 
 	if (tcp_disable) {
 		rpc->fault(c, 500, "tcp support disabled");
@@ -789,6 +789,7 @@ static void core_tcp_list(rpc_t* rpc, void* c)
 				BUG("failed to convert destination ip");
 			dst_ip[len] = 0;
 			timeout = TICKS_TO_S(con->timeout - get_ticks_raw());
+			lifetime = TICKS_TO_S(con->lifetime);
 			switch(con->state) {
 				case S_CONN_ERROR:
 					state = "CONN_ERROR";
@@ -814,11 +815,12 @@ static void core_tcp_list(rpc_t* rpc, void* c)
 				default:
 					state = "UNKNOWN";
 			}
-			rpc->struct_add(handle, "dssddsdsd",
+			rpc->struct_add(handle, "dssdddsdsd",
 					"id", con->id,
 					"type", type,
 					"state", state,
 					"timeout", timeout,
+					"lifetime", lifetime,
 					"ref_count", con->refcnt,
 					"src_ip", src_ip,
 					"src_port", con->rcv.src_port,

--- a/tcp_conn.h
+++ b/tcp_conn.h
@@ -204,6 +204,7 @@ struct tcp_connection{
 	void* extra_data; /* extra data associated to the connection, 0 for tcp*/
 	struct timer_ln timer;
 	ticks_t timeout;/* connection timeout, after this it will be removed*/
+	ticks_t lifetime;/* connection lifetime */
 	unsigned id_hash; /* hash index in the id_hash */
 	struct tcp_connection* id_next; /* next, prev in id hash table */
 	struct tcp_connection* id_prev;

--- a/tcp_main.c
+++ b/tcp_main.c
@@ -998,6 +998,7 @@ struct tcp_connection* tcpconn_new(int sock, union sockaddr_union* su,
 		c->type=PROTO_TCP;
 		c->rcv.proto=PROTO_TCP;
 		c->timeout=get_ticks_raw()+cfg_get(tcp, tcp_cfg, con_lifetime);
+		c->lifetime = cfg_get(tcp, tcp_cfg, con_lifetime);
 	}
 	
 	return c;
@@ -3280,7 +3281,7 @@ inline static int handle_tcp_child(struct tcp_child* tcp_c, int fd_i)
 			}
 			/* update the timeout*/
 			t=get_ticks_raw();
-			con_lifetime=cfg_get(tcp, tcp_cfg, con_lifetime);
+			con_lifetime=tcpconn->lifetime;
 			tcpconn->timeout=t+con_lifetime;
 			crt_timeout=con_lifetime;
 #ifdef TCP_ASYNC


### PR DESCRIPTION
A per-TCP connection `lifetime` parameter is needed, to add a new functionnality in the tcpops module: the ability to dynamically modify the connection lifetime on a connection (e.g. raise the lifetime of a successfully authenticated connection).

This requires modifications in the core:
  - adding a new field in the `tcp_connection` structure
  - changing the way the `timeout` value is updated, using this new `lifetime` member instead of the core conf
