### PR TITLE
presence_dialoginfo: rfc4235 in dummy dialog

### DIFF
--- a/modules/presence_dialoginfo/notify_body.c
+++ b/modules/presence_dialoginfo/notify_body.c
@@ -68,7 +68,7 @@ void free_xml_body(char* body)
 }
 
 #define DIALOGINFO_EMPTY_BODY "<dialog-info>\
-<dialog direction=\"recipient\">\
+<dialog id=\"615293b33c62dec073e05d9421e9f48b\" direction=\"recipient\">\
 <state>terminated</state>\
 </dialog>\
 </dialog-info>"


### PR DESCRIPTION
according to rfc4235 the id element is mandatory.
granstream phones are affected by this.