### PR TITLE
registrar: make connection id available in $ulc()

### DIFF
--- a/modules/registrar/README
+++ b/modules/registrar/README
@@ -1068,6 +1068,7 @@ event_route[usrloc:contact-expired] {
      * ruid - record unique ID
      * reg-id - reg-id value
      * instance - instance value
+     * conid - TCP socket internal connection ID ($null if UDP)
 
    The pseudo-variable accepts positive index value to access a specific
    contact record.

--- a/modules/registrar/doc/registrar_admin.xml
+++ b/modules/registrar/doc/registrar_admin.xml
@@ -1455,6 +1455,10 @@ event_route[usrloc:contact-expired] {
 				<para><emphasis>instance</emphasis> - instance value
 				</para>
 				</listitem>	  
+				<listitem>
+				<para><emphasis>conid</emphasis> - TCP socket internal connection ID ($null if UDP)
+				</para>
+				</listitem>	  
 			</itemizedlist>
 			<para>
 				The pseudo-variable accepts positive index value to access

--- a/modules/registrar/regpv.c
+++ b/modules/registrar/regpv.c
@@ -269,6 +269,10 @@ int pv_get_ulc(struct sip_msg *msg,  pv_param_t *param,
 			if(c->instance.len>0)
 				return  pv_get_strval(msg, param, res, &c->instance);
 		break;
+		case 21: /* conid */
+			if (c->sock && (c->sock->proto == PROTO_TCP || c->sock->proto == PROTO_TLS || c->sock->proto == PROTO_WS || c->sock->proto == PROTO_WSS))
+				return pv_get_sintval(msg, param, res, c->tcpconn_id);
+		break;
 	}
 
 	return pv_get_null(msg, param, res);
@@ -363,6 +367,8 @@ int pv_parse_ulc_name(pv_spec_p sp, str *in)
 				rp->attr = 17;
 			else if(strncmp(pa.s, "regid", 5)==0)
 				rp->attr = 19;
+			else if(strncmp(pa.s, "conid", 5)==0)
+				rp->attr = 21;
 			else goto error;
 		break;
 		case 6: 
@@ -537,6 +543,10 @@ int pv_fetch_contacts(struct sip_msg* msg, char* table, char* uri,
 			memcpy(c0->instance.s, ptr->instance.s, ptr->instance.len);
 			c0->instance.len = ptr->instance.len;
 			p += c0->instance.len;
+		}
+		if (ptr->sock->proto == PROTO_TCP || ptr->sock->proto == PROTO_TLS || ptr->sock->proto == PROTO_WS || ptr->sock->proto == PROTO_WSS)
+		{
+			c0->tcpconn_id = ptr->tcpconn_id;
 		}
 
 		if(ptr0==NULL)


### PR DESCRIPTION
if an UA is registered using TCP (or TLS or WS(S)), make the internal
connection id avalilable in the $ulc(xxx=>conid) pv