### PR TITLE
Add kamailio-evapi-modules

### DIFF
--- a/pkg/kamailio/deb/debian/control
+++ b/pkg/kamailio/deb/debian/control
@@ -157,6 +157,18 @@ Description: Json parser and jsonrpc modules for Kamailio
  This package provides json parser for Kamailio's configuration file
  and the JSON-RPC client over netstrings.
 
+Package: kamailio-evapi-modules
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: kamailio (= ${binary:Version}),
+         libev-dev,
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: The EVAPI module can be used to create an event message flow from
+ Kamailio to any application that can connect to a TCP socket. The remote
+ application can also issue messages received by Kamailio.
+
 Package: kamailio-memcached-modules
 Architecture: linux-any
 Multi-Arch: same

--- a/pkg/kamailio/deb/debian/rules
+++ b/pkg/kamailio/deb/debian/rules
@@ -39,7 +39,8 @@ PACKAGE_GROUPS=mysql postgres berkeley unixodbc radius presence \
 			   ldap xml perl utils lua memcached \
 			   snmpstats carrierroute xmpp cpl redis python geoip\
 			   sqlite json mono ims sctp java \
-			   purple tls outbound websocket autheph dnssec kazoo cnxcc
+			   purple tls outbound websocket autheph dnssec kazoo \
+			   cnxcc evapi
 
 # module groups to be packaged onto kamailio-extra-modules
 EXTRA_GROUPS=gzcompress uuid ev jansson

--- a/pkg/kamailio/deb/jessie/control
+++ b/pkg/kamailio/deb/jessie/control
@@ -156,6 +156,18 @@ Description: Json parser and jsonrpc modules for Kamailio
  This package provides json parser for Kamailio's configuration file
  and the JSON-RPC client over netstrings.
 
+Package: kamailio-evapi-modules
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: kamailio (= ${binary:Version}),
+         libev-dev,
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: The EVAPI module can be used to create an event message flow from
+ Kamailio to any application that can connect to a TCP socket. The remote
+ application can also issue messages received by Kamailio.
+
 Package: kamailio-memcached-modules
 Architecture: linux-any
 Multi-Arch: same

--- a/pkg/kamailio/deb/jessie/rules
+++ b/pkg/kamailio/deb/jessie/rules
@@ -39,7 +39,8 @@ PACKAGE_GROUPS=mysql postgres berkeley unixodbc radius presence \
 			   ldap xml perl utils lua memcached \
 			   snmpstats carrierroute xmpp cpl redis python geoip\
 			   sqlite json mono ims sctp java \
-			   purple tls outbound websocket autheph dnssec kazoo cnxcc
+			   purple tls outbound websocket autheph dnssec kazoo\
+			   cnxcc evapi
 
 # module groups to be packaged onto kamailio-extra-modules
 EXTRA_GROUPS=gzcompress uuid ev jansson


### PR DESCRIPTION
Hi, 

These changes create the kamailio-evapi-modules in debian wheezy + debian jessie. Before we don't have this module in the deb list. 

Could you check if I did all ok? It works in jessie but I want to know If I did 100% compliant

Regards.