### PR TITLE
presence: add $subs pv for subscription access

### DIFF
--- a/modules/presence/doc/presence_admin.xml
+++ b/modules/presence/doc/presence_admin.xml
@@ -1130,6 +1130,40 @@ pres_update_watchers("sip:test@kamailio.org", "presence");
 </section>
 
 <section>
+	<title>Pseudo Variables</title>
+		
+		<section>
+			<title><varname>$subs(attr)</varname></title>
+			<para>
+				Access the attributes of handled subscription. 
+				It must be used after a call of
+				<quote>handle_subscription())</quote>.
+			</para>
+			<para>
+			The <quote>attr</quote> can be:
+			</para>
+			<itemizedlist>
+				<listitem>
+				<para><emphasis>uri</emphasis> - subscription presentity uri
+				</para>
+				</listitem>	  
+			</itemizedlist>
+
+			<example>
+			<title><function moreinfo="none">$subs(name)</function> usage</title>
+<programlisting format="linespecific">
+...
+if(handle_subscription())
+{
+  xlog("presentity=$subs(uri)\n");
+}
+...
+				 </programlisting>
+			</example>
+		</section>
+</section>
+
+<section>
 	<title>Installation</title>
 	<para>
 	The module requires 3 tables in the &kamailio; database: "presentity",

--- a/modules/presence/presence.c
+++ b/modules/presence/presence.c
@@ -228,6 +228,11 @@ static mi_export_t mi_cmds[] = {
 	{  0,                0,                     0,  0,  0}
 };
 
+static pv_export_t pres_mod_pvs[] = {
+	{{"subs", (sizeof("subs")-1)}, PVT_OTHER, pv_get_subscription, 0, pv_parse_subscription_name, 0, 0, 0},
+	{ {0, 0}, 0, 0, 0, 0, 0, 0, 0 }
+};
+
 /** module exports */
 struct module_exports exports= {
 	"presence",			/* module name */
@@ -236,7 +241,7 @@ struct module_exports exports= {
 	params,				/* exported parameters */
 	0,					/* exported statistics */
 	mi_cmds,   			/* exported MI functions */
-	0,					/* exported pseudo-variables */
+	pres_mod_pvs,		/* exported pseudo-variables */
 	0,					/* extra processes */
 	mod_init,			/* module initialization function */
 	0,   				/* response handling function */

--- a/modules/presence/presence.h
+++ b/modules/presence/presence.h
@@ -102,4 +102,7 @@ int pres_auth_status(struct sip_msg* msg, str watcher_uri, str presentity_uri);
 typedef int (*sip_uri_match_f) (str* s1, str* s2);
 extern sip_uri_match_f presence_sip_uri_match;
 
+int pv_get_subscription(struct sip_msg *msg, pv_param_t *param,	pv_value_t *res);
+int pv_parse_subscription_name(pv_spec_p sp, str *in);
+
 #endif /* PA_MOD_H */


### PR DESCRIPTION
after handle_subscribe there is no safe way in script to obtain the presently
because re-subscription RURI is ip of kamailio and To-Uri may not contain
the presently.

$subs(uri) will allow access to this value

added as a pv to allow extension to get more properties from subscription