### PR TITLE
usrloc: change level of log

### DIFF
--- a/modules/usrloc/udomain.c
+++ b/modules/usrloc/udomain.c
@@ -310,7 +310,7 @@ static inline ucontact_info_t* dbrow2info(db_val_t *vals, str *contact, int rcon
 		}
 		ci.sock = grep_sock_info( &host, (unsigned short)port, proto);
 		if (ci.sock==0) {
-			LM_INFO("non-local socket <%s>...ignoring\n", p);
+			LM_DBG("non-local socket <%s>\n", p);
 		}
 	}
 


### PR DESCRIPTION

When a non local socket is found, the entry is not ignored and the message should be for debugging purpose only.