### PR TITLE
fix race condition in tls module when checking available memory limits

### DIFF
--- a/mem/shm_mem.c
+++ b/mem/shm_mem.c
@@ -254,5 +254,13 @@ void shm_mem_destroy(void)
 #endif
 }
 
+inline unsigned long safe_shm_available()
+{
+	unsigned long ret;
+	shm_lock();
+	ret = shm_available();
+	shm_unlock();
+	return ret;
+}
 
 #endif

--- a/mem/shm_mem.h
+++ b/mem/shm_mem.h
@@ -312,6 +312,11 @@ do{\
 
 #endif /* ! SHM_SAFE_MALLOC */
 
+/* multi-process safe version of shm_available()
+ */
+inline unsigned long safe_shm_available();
+
+
 #endif /* shm_mem_h */
 
 #endif /* SHM_MEM */

--- a/modules/tls/tls_server.c
+++ b/modules/tls/tls_server.c
@@ -59,10 +59,10 @@ int tls_run_event_routes(struct tcp_connection *c);
 /* low memory treshold for openssl bug #1491 workaround */
 #define LOW_MEM_NEW_CONNECTION_TEST() \
 	(cfg_get(tls, tls_cfg, low_mem_threshold1) && \
-	  (shm_available() < cfg_get(tls, tls_cfg, low_mem_threshold1)))
+	  (safe_shm_available() < cfg_get(tls, tls_cfg, low_mem_threshold1)))
 #define LOW_MEM_CONNECTED_TEST() \
 	(cfg_get(tls, tls_cfg, low_mem_threshold2) && \
-	  (shm_available() <  cfg_get(tls, tls_cfg, low_mem_threshold2)))
+	  (safe_shm_available() <  cfg_get(tls, tls_cfg, low_mem_threshold2)))
 
 #define TLS_RD_MBUF_SZ	65536
 #define TLS_WR_MBUF_SZ	65536


### PR DESCRIPTION
Under high load, the value returned by `shm_available()` can be total garbage, because it is not multiprocess safe. In the tls module, it makes the tests against the `low_mem_thresholdX` limits randomly return false positives, with errors such as:
```
ERROR: tls [tls_server.c:273]: tls_fix_connection(): tls: ssl bug #1491 workaround: not enough memory for safe operation: 88
```
although there is plenty of free shm memory.
 
This patch solves the issue by adding a safe version of the function.