### PR TITLE
integrate TLSF for pkg mem

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -102,6 +102,7 @@ EXTRAVERSION = -pre0
 # memory manager switcher
 # 0 - f_malloc (fast malloc)
 # 1 - q_malloc (quick malloc)
+# 2 - tlsf_malloc (O(1) malloc and free)
 MEMMNG ?= 0
 # memory debugger switcher
 # 0 - off (no-debug mode)
@@ -501,6 +502,8 @@ data_target = $(prefix)/$(data_dir)
 #		(not true anymore, q_malloc performs approx. the same)
 # -DF_MALLOC
 #		an even faster malloc, not recommended for debugging
+# -DTLSF_MALLOC=1
+#       an implemetation of the "two levels segregation fit" malloc algorithm
 # -DDL_MALLOC
 #		a malloc implementation based on Doug Lea's dl_malloc
 # -DSF_MALLOC 
@@ -662,6 +665,9 @@ ifeq 	($(MEMDBG), 1)
 		C_DEFS+= -DDBG_QM_MALLOC
 endif
 	C_DEFS+= -DMEM_JOIN_FREE
+else ifeq ($(MEMMNG), 2)
+#	use tlsf malloc
+	C_DEFS+= -DTLSF_MALLOC=1
 else
 #	use f_malloc
 	C_DEFS+= -DF_MALLOC

--- a/mem/mem.c
+++ b/mem/mem.c
@@ -51,6 +51,8 @@
 		struct fm_block* mem_block = 0;
 	#elif defined DL_MALLOC
 		/* don't need this */
+	#elif defined TLSF_MALLOC
+		tlsf_t mem_block = 0;
 	#else
 		struct qm_block* mem_block = 0;
 	#endif
@@ -75,6 +77,8 @@ int init_pkg_mallocs(void)
 			mem_block=fm_malloc_init(mem_pool, pkg_mem_size, MEM_TYPE_PKG);
 	#elif DL_MALLOC
 		/* don't need this */
+	#elif TLSF_MALLOC
+		mem_block = tlsf_create_with_pool(mem_pool, pkg_mem_size);
 	#else
 		if (mem_pool)
 			mem_block=qm_malloc_init(mem_pool, pkg_mem_size, MEM_TYPE_PKG);

--- a/mem/mem.h
+++ b/mem/mem.h
@@ -57,6 +57,9 @@
 		extern struct fm_block* mem_block;
 #	elif defined DL_MALLOC
 #		include "dl_malloc.h"
+#	elif defined TLSF_MALLOC
+#		include "tlsf.h"
+		extern tlsf_t mem_block;
 #   else
 #		include "q_malloc.h"
 		extern struct qm_block* mem_block;
@@ -92,6 +95,10 @@
 #			define pkg_malloc(s) dlmalloc((s))
 #			define pkg_realloc(p, s) dlrealloc((p), (s))
 #			define pkg_free(p)   dlfree((p))
+#		elif defined TLSF_MALLOC
+#			define pkg_malloc(s) tlsf_malloc(mem_block, (s))
+#			define pkg_realloc(p, s) tlsf_realloc(mem_block, (p), (s))
+#			define pkg_free(p)   tlsf_free(mem_block, (p))
 #		else
 #			define pkg_malloc(s) qm_malloc(mem_block, (s))
 #			define pkg_realloc(p, s) qm_realloc(mem_block, (p), (s))
@@ -108,6 +115,11 @@
 #		define pkg_info(mi)  0
 #		define pkg_available()  0
 #		define pkg_sums()  0
+#	elif defined TLSF_MALLOC
+#		define pkg_status()  ((void) 0)
+#		define pkg_info(mi)  tlsf_meminfo(mem_block, (mi))
+#		define pkg_available()  ((void) 0)
+#		define pkg_sums()  ((void) 0)
 #	else
 #		define pkg_status()    qm_status(mem_block)
 #		define pkg_info(mi)    qm_info(mem_block, mi)


### PR DESCRIPTION
following patches add TLSF support for pkg memory, and easier TLSF selection at compile time