### PR TITLE
dispatcher: fix ds_is_from_list usage after commit 121cb0f4

### DIFF
--- a/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/modules/dispatcher/doc/dispatcher_admin.xml
@@ -1141,7 +1141,7 @@ if(ds_list_exist("10")) {
 			This function can be used from ANY_ROUTE.
 		</para>
 		<example>
-		<title><function>ds_mark_dst</function> usage</title>
+		<title><function>ds_is_from_list</function> usage</title>
 		<programlisting format="linespecific">
 ...
 if(ds_is_from_list()) {
@@ -1150,7 +1150,10 @@ if(ds_is_from_list()) {
 if(ds_is_from_list("10")) {
     ...
 }
-if(ds_is_from_list("10", "sip:127.0.0.1:5080", "3")) {
+if(ds_is_from_list("10", "3")) {
+    ...
+}
+if(ds_is_from_list("10", "3", "sip:127.0.0.1:5080")) {
     ...
 }
 ...


### PR DESCRIPTION
Needed update for the dispatcher module Readme + fix function name in the description
The function description became inaccurate after commit:

Author: Daniel-Constantin Mierla <miconda@gmail.com>
Committer: Daniel-Constantin Mierla <miconda@gmail.com>
Date:   Mon Sep  8 17:13:12 2014 +0200

dispatcher: swap the order between uri and mode parameters in the new ds_is_from_list(...)

- allow to have ds_is_from_list() only with group id and mode, uri is
  the last parameter, still optional
- patch provided by Luis Azedo <luis.azedo@factorlusitano.com>