### PR TITLE
htable: Add missing ht_slot_unlock in ht_cell_value_add

### DIFF
--- a/modules/htable/ht_api.c
+++ b/modules/htable/ht_api.c
@@ -672,7 +672,10 @@ ht_cell_t* ht_cell_value_add(ht_t *ht, str *name, int val, int mode,
 	}
 	/* add val if htable has an integer init value */
 	if(ht->flags!=PV_VAL_INT)
+	{
+		if(mode) ht_slot_unlock(ht, idx);
 		return NULL;
+	}
 	isval.n = ht->initval.n + val;
 	it = ht_cell_new(name, 0, &isval, hid);
 	if(it == NULL)


### PR DESCRIPTION
Adds a missing call to ht_slot_unlock when the init value is not an integer. This would cause processes to block on ht_slot_lock leading to a deadlock.