### PR TITLE
pv: Fixed assigning $null to $vn(name) pvs

### DIFF
--- a/modules/pv/pv_core.c
+++ b/modules/pv/pv_core.c
@@ -1968,8 +1968,13 @@ int pv_set_scriptvar(struct sip_msg* msg, pv_param_t *param,
 	}
 	if((val==NULL) || (val->flags&PV_VAL_NULL))
 	{
-		avp_val.n = 0;
-		set_var_value((script_var_t*)param->pvn.u.dname, &avp_val, 0);
+		if(((script_var_t*)param->pvn.u.dname)->v.flags&VAR_TYPE_NULL)
+		{
+			set_var_value((script_var_t*)param->pvn.u.dname, NULL, 0);
+		} else {
+			avp_val.n = 0;
+			set_var_value((script_var_t*)param->pvn.u.dname, &avp_val, 0);
+		}
 		return 0;
 	}
 	flags = 0;


### PR DESCRIPTION
Pass NULL as value to set_var_value when assigning a NULL or PV_VAL_NULL value to a pv with the VAR_TYPE_NULL flag set.

Previously assigning $null didn't work as expected:

`$vn(foo) = $null` would result in `$vn(foo)` being assigned `0` (this can be verified by either logging the value or testing with an if statement).