### PR TITLE
modules/nathelper: don't include enclosing brackets in contact uri in set_contact_alias

### DIFF
--- a/modules/nathelper/nathelper.c
+++ b/modules/nathelper/nathelper.c
@@ -921,8 +921,8 @@ set_contact_alias_f(struct sip_msg* msg, char* str1, char* str2)
 		pkg_free(buf);
 		return -1;
 	}
-	c->uri.s = buf;
-	c->uri.len = len;
+	c->uri.s = buf + br;
+	c->uri.len = len -2*br;
 
 	return 1;
 }


### PR DESCRIPTION
nathelper function set_contact_alias add brackets around contact's uri if the original one hadn't. This results in an invalid sip uri in the contact structure, which cause problems to other modules' functions when they try to parse the contact uri (e.g. save_pending() from ims_registrar_usrloc). This simple patch fix the issue simply mving the uri's boundaries.