### PR TITLE
quoted words reserved by mysql

### DIFF
--- a/utils/kamctl/mysql/registrar-create.sql
+++ b/utils/kamctl/mysql/registrar-create.sql
@@ -22,7 +22,7 @@ CREATE TABLE aliases (
     server_id INT(11) DEFAULT 0 NOT NULL,
     connection_id INT(11) DEFAULT 0 NOT NULL,
     keepalive INT(11) DEFAULT 0 NOT NULL,
-    partition INT(11) DEFAULT 0 NOT NULL,
+    `partition` INT(11) DEFAULT 0 NOT NULL,
     CONSTRAINT ruid_idx UNIQUE (ruid)
 );
 

--- a/utils/kamctl/mysql/usrloc-create.sql
+++ b/utils/kamctl/mysql/usrloc-create.sql
@@ -22,7 +22,7 @@ CREATE TABLE location (
     server_id INT(11) DEFAULT 0 NOT NULL,
     connection_id INT(11) DEFAULT 0 NOT NULL,
     keepalive INT(11) DEFAULT 0 NOT NULL,
-    partition INT(11) DEFAULT 0 NOT NULL,
+    `partition` INT(11) DEFAULT 0 NOT NULL,
     CONSTRAINT ruid_idx UNIQUE (ruid)
 );
 


### PR DESCRIPTION
Word **partition** is reserved by mysql. During the database creation this error appears:
```
ERROR 1064 (42000) at line 2: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'partition INT(11) DEFAULT 0 NOT NULL,
    CONSTRAINT ruid_idx UNIQUE (ruid)
)' at line 24
ERROR: Creating core tables failed at registrar!
```
