### PR TITLE
Add domain to connection test query so it works with Cassandra

### DIFF
--- a/modules/usrloc/udomain.c
+++ b/modules/usrloc/udomain.c
@@ -901,8 +901,13 @@ int db_timer_udomain(udomain_t* _d)
  */
 int testdb_udomain(db1_con_t* con, udomain_t* d)
 {
-	db_key_t key[2], col[2];
-	db_val_t val[2];
+	int num_cols = 1;
+	if (use_domain) {
+		num_cols = 2;
+	}
+
+	db_key_t key[num_cols], col[num_cols];
+	db_val_t val[num_cols];
 	db1_res_t* res = NULL;
 
 	if (ul_dbf.use_table(con, d->name) < 0) {
@@ -910,21 +915,25 @@ int testdb_udomain(db1_con_t* con, udomain_t* d)
 		return -1;
 	}
 
+	// Set up the user column
 	key[0] = &user_col;
-	key[1] = &domain_col;
-
 	col[0] = &user_col;
-	col[1] = &domain_col;
 
 	VAL_TYPE(&val[0]) = DB1_STRING;
 	VAL_NULL(&val[0]) = 0;
 	VAL_STRING(&val[0]) = "dummy_user";
 
-	VAL_TYPE(&val[1]) = DB1_STRING;
-	VAL_NULL(&val[1]) = 0;
-	VAL_STRING(&val[1]) = "dummy_domain";
+	// Set up the domain column if needed
+	if (use_domain) {
+		key[1] = &domain_col;
+		col[1] = &domain_col;
 
-	if (ul_dbf.query( con, key, 0, val, col, 2, 2, 0, &res) < 0) {
+		VAL_TYPE(&val[1]) = DB1_STRING;
+		VAL_NULL(&val[1]) = 0;
+		VAL_STRING(&val[1]) = "dummy_domain";
+	}
+
+	if (ul_dbf.query( con, key, 0, val, col, num_cols, num_cols, 0, &res) < 0) {
 		LM_ERR("failure in db_query\n");
 		return -1;
 	}

--- a/modules/usrloc/udomain.c
+++ b/modules/usrloc/udomain.c
@@ -901,8 +901,8 @@ int db_timer_udomain(udomain_t* _d)
  */
 int testdb_udomain(db1_con_t* con, udomain_t* d)
 {
-	db_key_t key[1], col[1];
-	db_val_t val[1];
+	db_key_t key[2], col[2];
+	db_val_t val[2];
 	db1_res_t* res = NULL;
 
 	if (ul_dbf.use_table(con, d->name) < 0) {
@@ -911,13 +911,20 @@ int testdb_udomain(db1_con_t* con, udomain_t* d)
 	}
 
 	key[0] = &user_col;
+	key[1] = &domain_col;
 
 	col[0] = &user_col;
-	VAL_TYPE(val) = DB1_STRING;
-	VAL_NULL(val) = 0;
-	VAL_STRING(val) = "dummy_user";
-	
-	if (ul_dbf.query( con, key, 0, val, col, 1, 1, 0, &res) < 0) {
+	col[1] = &domain_col;
+
+	VAL_TYPE(&val[0]) = DB1_STRING;
+	VAL_NULL(&val[0]) = 0;
+	VAL_STRING(&val[0]) = "dummy_user";
+
+	VAL_TYPE(&val[1]) = DB1_STRING;
+	VAL_NULL(&val[1]) = 0;
+	VAL_STRING(&val[1]) = "dummy_domain";
+
+	if (ul_dbf.query( con, key, 0, val, col, 2, 2, 0, &res) < 0) {
 		LM_ERR("failure in db_query\n");
 		return -1;
 	}


### PR DESCRIPTION
This adds the 'domain' column to the testdb_udomain db connection test in the usrloc module.  When using Cassandra 2 as the database module (a module I'm working on that I will be submitting a PR for once it's stable) doing a query by only username can cause issues if you create your Cassandra partition key as username and domain.

This shouldn't affect the query functionality in general as it's only doing a query to test the connection to the database.