### PR TITLE
app_lua: Fix memory leak in sr.modf

### DIFF
--- a/modules/app_lua/app_lua_sr.c
+++ b/modules/app_lua/app_lua_sr.c
@@ -265,6 +265,11 @@ static int lua_sr_modf (lua_State *L)
 		}
 	}
 	pkg_free(act);
+	for(i=0; i<MAX_ACTIONS; i++)
+	{
+		if(argv[i]!=NULL) pkg_free(argv[i]);
+		argv[i] = 0;
+	}
 	lua_pushinteger(L, ret);
 	return 1;
 


### PR DESCRIPTION
- Free pkg memory allocated to store cloned function parameters