### PR TITLE
mem: TLSF memory summary and sums implementation

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -668,6 +668,9 @@ endif
 else ifeq ($(MEMMNG), 2)
 #	use tlsf malloc
 	C_DEFS+= -DTLSF_MALLOC=1
+ifeq 	($(MEMDBG), 1)
+		C_DEFS+= -DDBG_TLSF_MALLOC
+endif
 else
 #	use f_malloc
 	C_DEFS+= -DF_MALLOC

--- a/mem/mem.h
+++ b/mem/mem.h
@@ -49,6 +49,14 @@
 	#elif defined(DBG_QM_MALLOC)
 		#define DBG_F_MALLOC
 	#endif
+#elif defined TLSF_MALLOC
+	#ifdef DBG_TLSF_MALLOC
+		#ifndef DBG_QM_MALLOC
+			#define DBG_QM_MALLOC
+		#endif
+	#elif defined(DBG_QM_MALLOC)
+		#define DBG_TLSF_MALLOC
+	#endif
 #endif
 
 #ifdef PKG_MALLOC
@@ -77,6 +85,13 @@
 #			define pkg_free(p)   fm_free(mem_block, (p), _SRC_LOC_,  \
 				_SRC_FUNCTION_, _SRC_LINE_)
 #			define pkg_realloc(p, s) fm_realloc(mem_block, (p), (s), \
+					_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_)
+#		elif defined TLSF_MALLOC
+#			define pkg_malloc(s) tlsf_malloc(mem_block, (s), _SRC_LOC_, \
+				_SRC_FUNCTION_, _SRC_LINE_)
+#			define pkg_free(p)   tlsf_free(mem_block, (p), _SRC_LOC_,  \
+				_SRC_FUNCTION_, _SRC_LINE_)
+#			define pkg_realloc(p, s) tlsf_realloc(mem_block, (p), (s), \
 					_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_)
 #		else
 #			define pkg_malloc(s) qm_malloc(mem_block, (s),_SRC_LOC_, \
@@ -116,10 +131,10 @@
 #		define pkg_available()  0
 #		define pkg_sums()  0
 #	elif defined TLSF_MALLOC
-#		define pkg_status()  ((void) 0)
+#		define pkg_status()  tlsf_status(mem_block)
 #		define pkg_info(mi)  tlsf_meminfo(mem_block, (mi))
-#		define pkg_available()  ((void) 0)
-#		define pkg_sums()  ((void) 0)
+#		define pkg_available()  tlsf_available(mem_block)
+#		define pkg_sums()  tlsf_sums(mem_block)
 #	else
 #		define pkg_status()    qm_status(mem_block)
 #		define pkg_info(mi)    qm_info(mem_block, mi)

--- a/mem/q_malloc.c
+++ b/mem/q_malloc.c
@@ -23,7 +23,7 @@
  */
 
 
-#if !defined(q_malloc) && !(defined F_MALLOC)
+#if !defined(q_malloc) && !(defined F_MALLOC) && !defined(TLSF_MALLOC)
 #define q_malloc
 
 #include <stdlib.h>

--- a/mem/q_malloc.h
+++ b/mem/q_malloc.h
@@ -22,7 +22,7 @@
  * \ingroup mem
  */
 
-#if !defined(q_malloc_h) && !defined(F_MALLOC)
+#if !defined(q_malloc_h) && !defined(F_MALLOC) && !defined(TLSF_MALLOC)
 #define q_malloc_h
 
 #include "meminfo.h"

--- a/mem/shm_mem.h
+++ b/mem/shm_mem.h
@@ -57,6 +57,14 @@
 	#elif defined(DBG_QM_MALLOC)
 		#define DBG_F_MALLOC
 	#endif
+#elif defined TLSF_MALLOC
+	#ifdef DBG_TLSF_MALLOC
+		#ifndef DBG_QM_MALLOC
+			#define DBG_QM_MALLOC
+		#endif
+	#elif defined(DBG_QM_MALLOC)
+		#define DBG_TLSF_MALLOC
+	#endif
 #endif
 
 
@@ -149,9 +157,9 @@
 #	define MY_MALLOC tlsf_malloc
 #	define MY_FREE tlsf_free
 #	define MY_REALLOC tlsf_realloc
-#	define MY_STATUS(...) ((void) 0)
+#	define MY_STATUS tlsf_status
 #	define MY_MEMINFO	tlsf_meminfo
-#	define MY_SUMS(...) ((void) 0)
+#	define MY_SUMS tlsf_sums
 #	define shm_malloc_init(mem, bytes, type) tlsf_create_with_pool((void*) mem, bytes)
 #	define shm_malloc_destroy(b) do{}while(0)
 #	define shm_available() tlsf_available(shm_block)

--- a/mem/tlsf.h
+++ b/mem/tlsf.h
@@ -40,10 +40,18 @@ pool_t tlsf_add_pool(tlsf_t tlsf, void* mem, size_t bytes);
 void tlsf_remove_pool(tlsf_t tlsf, pool_t pool);
 
 /* malloc/memalign/realloc/free replacements. */
+#ifdef DBG_TLSF_MALLOC
+void* tlsf_malloc(tlsf_t tlsf, size_t size,
+		const char *file, const char *function, unsigned long line);
+void* tlsf_realloc(tlsf_t tlsf, void* ptr, size_t size,
+		const char *file, const char *function, unsigned long line);
+void tlsf_free(tlsf_t tlsf, void* ptr,
+		const char *file, const char *function, unsigned long line);
+#else
 void* tlsf_malloc(tlsf_t tlsf, size_t bytes);
-void* tlsf_memalign(tlsf_t tlsf, size_t align, size_t bytes);
 void* tlsf_realloc(tlsf_t tlsf, void* ptr, size_t size);
 void tlsf_free(tlsf_t tlsf, void* ptr);
+#endif
 
 /* Returns internal block size, not original request size */
 size_t tlsf_block_size(void* ptr);
@@ -64,6 +72,8 @@ int tlsf_check(tlsf_t tlsf);
 int tlsf_check_pool(pool_t pool);
 
 void tlsf_meminfo(tlsf_t pool, struct mem_info *info);
+void tlsf_status(tlsf_t pool);
+void tlsf_sums(tlsf_t pool);
 size_t tlsf_available(tlsf_t pool);
 
 #if defined(__cplusplus)


### PR DESCRIPTION
TLSF now has a debug mode, that will dump every memory block when xxx_status()
is called, and a summary of still allocated blocks when xxx_sums() is called.

configure build with

    make MEMDBG=1 MEMMNG=2 cfg

to enable maximum debuging informations (source location of mallocs and frees)