### PR TITLE
Add option to disable delete queries in usrloc module.

### DIFF
--- a/modules/usrloc/ucontact.c
+++ b/modules/usrloc/ucontact.c
@@ -1431,6 +1431,10 @@ int db_update_ucontact(ucontact_t* _c)
  */
 int db_delete_ucontact_addr(ucontact_t* _c)
 {
+	if (ul_db_disable_delete) {
+		return 0;
+	}
+
 	char* dom;
 	db_key_t keys[4];
 	db_val_t vals[4];
@@ -1522,6 +1526,10 @@ int db_delete_ucontact_addr(ucontact_t* _c)
  */
 int db_delete_ucontact_ruid(ucontact_t* _c)
 {
+	if (ul_db_disable_delete) {
+		return 0;
+	}
+
 	db_key_t keys[1];
 	db_val_t vals[1];
 	int n;
@@ -1699,6 +1707,10 @@ int update_ucontact(struct urecord* _r, ucontact_t* _c, ucontact_info_t* _ci)
  */
 int uldb_delete_attrs(str* _dname, str *_user, str *_domain, str *_ruid)
 {
+	if (ul_db_disable_delete) {
+		return 0;
+	}
+
 	char tname_buf[64];
 	str tname;
 	db_key_t keys[3];
@@ -1764,6 +1776,10 @@ int uldb_delete_attrs(str* _dname, str *_user, str *_domain, str *_ruid)
  */
 int uldb_delete_attrs_ruid(str* _dname, str *_ruid)
 {
+	if (ul_db_disable_delete) {
+		return 0;
+	}
+
 	char tname_buf[64];
 	str tname;
 	db_key_t keys[1];

--- a/modules/usrloc/udomain.c
+++ b/modules/usrloc/udomain.c
@@ -866,6 +866,10 @@ done:
  */
 int db_timer_udomain(udomain_t* _d)
 {
+    if (ul_db_disable_delete) {
+        return 0;
+    }
+
 	db_key_t keys[2];
 	db_op_t  ops[2];
 	db_val_t vals[2];

--- a/modules/usrloc/ul_mod.c
+++ b/modules/usrloc/ul_mod.c
@@ -109,6 +109,7 @@ int ul_db_update_as_insert = 0;
 int ul_timer_procs = 0;
 int ul_db_check_update = 0;
 int ul_keepalive_timeout = 0;
+int ul_db_disable_delete = 0;
 
 int ul_db_ops_ruid = 1;
 int ul_expires_type = 0;
@@ -229,6 +230,7 @@ static param_export_t params[] = {
 	{"expires_type",        PARAM_INT, &ul_expires_type},
 	{"db_raw_fetch_type",   PARAM_INT, &ul_db_raw_fetch_type},
 	{"db_insert_null",      PARAM_INT, &ul_db_insert_null},
+	{"db_disable_delete",	PARAM_INT, &ul_db_disable_delete},
 	{0, 0, 0}
 };
 

--- a/modules/usrloc/ul_mod.h
+++ b/modules/usrloc/ul_mod.h
@@ -83,6 +83,7 @@ extern int ul_fetch_rows;
 extern int ul_hash_size;
 extern int ul_db_update_as_insert;
 extern int ul_db_check_update;
+extern int ul_db_disable_delete;
 extern int ul_keepalive_timeout;
 extern int handle_lost_tcp;
 extern int close_expired_tcp;

--- a/modules/usrloc/urecord.c
+++ b/modules/usrloc/urecord.c
@@ -469,6 +469,10 @@ void timer_urecord(urecord_t* _r)
  */
 int db_delete_urecord(urecord_t* _r)
 {
+	if (ul_db_disable_delete) {
+		return 0;
+	}
+
 	db_key_t keys[2];
 	db_val_t vals[2];
 	char* dom;
@@ -510,6 +514,10 @@ int db_delete_urecord(urecord_t* _r)
  */
 int db_delete_urecord_by_ruid(str *_table, str *_ruid)
 {
+	if (ul_db_disable_delete) {
+		return 0;
+	}
+
 	db_key_t keys[1];
 	db_val_t vals[1];
 


### PR DESCRIPTION
This adds a parameter to allow users to disable the delete queries in the usrloc module.  This is mainly for problems due to the differences between how a relational DB and Cassandra work.  If the schema for Cassandra is created in certain ways a delete query isn't required to keep the data clean.