### PR TITLE
Makefile: use distclean as shortcut of maintainer-clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -920,10 +920,10 @@ clean: clean-libs
 clean-extra-names:
 	@rm -f $(filter-out $(MAIN_NAME), sip-router ser kamailio)
 
-# proper/distclean a.s.o modules, utils and libs too
+# proper/distclean-old a.s.o modules, utils and libs too
 
 proper: clean-extra-names proper-modules proper-utils proper-libs
-distclean: distclean-modules distclean-utils distclean-libs
+distclean-old: distclean-modules distclean-utils distclean-libs
 realclean: realclean-modules realclean-utils realclean-libs
 maintainer-clean: maintainer-clean-modules maintainer-clean-utils \
  maintainer-clean-libs
@@ -936,7 +936,7 @@ clean-all: clean
 maintainer-clean: modules=$(modules_all)
 
 # on make proper clean also the build config (w/o module list)
-proper realclean distclean maintainer-clean: clean_cfg
+proper realclean distclean-old maintainer-clean: clean_cfg
 
 # on maintainer clean, remove also the configured module list
 maintainer-clean: clean_modules_cfg clean_makefile_vars
@@ -959,7 +959,7 @@ clean_modules_cfg clean-modules-cfg:
 
 # clean everything generated - shortcut on maintainer-clean
 .PHONY: pure
-pure: maintainer-clean
+pure distclean: maintainer-clean
 
 .PHONY: install_initd_debian install-initd-debian
 install_initd_debian install-initd-debian:

--- a/Makefile.targets
+++ b/Makefile.targets
@@ -10,7 +10,7 @@ ifeq (,$(strip $(modules_dirs)))
 include $(COREPATH)/Makefile.dirs
 endif
 
-clean_targets:=	clean proper distclean realclean maintainer-clean local-clean \
+clean_targets:=	clean proper distclean-old realclean maintainer-clean local-clean \
 				clean-all proper-all distclean-all realclean-all \
 				clean_cfg clean-cfg clean_modules_cfg clean-modules-cfg \
 				clean-modules proper-modules realclean-modules \
@@ -19,7 +19,8 @@ clean_targets:=	clean proper distclean realclean maintainer-clean local-clean \
 				maintaner-clean-utils \
 				clean-libs proper-libs realclean-libs distclean-libs \
 				maintainer-clean-libs \
-				clean-tmp clean_doxygen clean-extra-names
+				clean-tmp clean_doxygen clean-extra-names \
+				pure distclean
 doc_targets:=	README man install-doc install-man install-ser-man \
 		install-every-module-doc install-every-module-man \
 		$(foreach m,$(modules_dirs),$(m)-doc $(m)-readme $(m)-man) \


### PR DESCRIPTION
Fixes: #167
Nowadays people expect distclean to be the rule to do the cleaning