### PR TITLE
debugger module: add per module facility logging + add a debug SIP message config function

### DIFF
--- a/dprint.c
+++ b/dprint.c
@@ -103,12 +103,15 @@ int log_facility_fixup(void *handle, str *gname, str *name, void **val)
  */
 
 /* value for unset local log level  */
-#define UNSET_LOCAL_DEBUG_LEVEL	-255
+#define UNSET_LOCAL_DEBUG_LEVEL	    -255
+#define UNSET_LOCAL_DEBUG_FACILITY  -255
 
 /* the local debug log level */
 static int _local_debug_level = UNSET_LOCAL_DEBUG_LEVEL;
+static int _local_debug_facility = UNSET_LOCAL_DEBUG_FACILITY;
 /* callback to get per module debug level */
 static get_module_debug_level_f _module_debug_level = NULL;
+static get_module_debug_facility_f _module_debug_facility = NULL;
 
 /**
  * @brief set callback function for per module debug level
@@ -118,12 +121,17 @@ void set_module_debug_level_cb(get_module_debug_level_f f)
 	_module_debug_level = f;
 }
 
+void set_module_debug_facility_cb(get_module_debug_facility_f f)
+{
+	_module_debug_facility = f;
+}
+
 /**
  * @brief return the log level - the local one if it set,
  *   otherwise the global value
  */
 int get_debug_level(char *mname, int mnlen) {
-	int mlevel = L_DBG;
+	int mlevel;
 	/*important -- no LOGs inside, because it will loop */
 	if(unlikely(_module_debug_level!=NULL && mnlen>0)) {
 		if(_module_debug_level(mname, mnlen, &mlevel)==0) {
@@ -133,6 +141,23 @@ int get_debug_level(char *mname, int mnlen) {
 	return (_local_debug_level != UNSET_LOCAL_DEBUG_LEVEL) ?
 				_local_debug_level : cfg_get(core, core_cfg, debug);
 }
+
+/**
+ * @brief return the log facility - the local one if it set,
+ *   otherwise the global value
+ */
+int get_debug_facility(char *mname, int mnlen) {
+	int mfacility;
+	/*important -- no LOGs inside, because it will loop */
+	if(unlikely(_module_debug_facility!=NULL && mnlen>0)) {
+		if(_module_debug_facility(mname, mnlen, &mfacility)==0) {
+			return mfacility;
+		}
+	}
+	return (_local_debug_facility != UNSET_LOCAL_DEBUG_FACILITY) ?
+				_local_debug_facility : cfg_get(core, core_cfg, log_facility);
+}
+
 
 /**
  * @brief set the local debug log level
@@ -148,6 +173,22 @@ void set_local_debug_level(int level)
 void reset_local_debug_level(void)
 {
 	_local_debug_level = UNSET_LOCAL_DEBUG_LEVEL;
+}
+
+/**
+ * @brief set the local debug log facility
+ */
+void set_local_debug_facility(int facility)
+{
+	_local_debug_facility = facility;
+}
+
+/**
+ * @brief reset the local debug log facility
+ */
+void reset_local_debug_facility(void)
+{
+	_local_debug_facility = UNSET_LOCAL_DEBUG_FACILITY;
 }
 
 typedef struct log_level_color {

--- a/dprint.h
+++ b/dprint.h
@@ -130,10 +130,15 @@ struct log_level_info {
 
 /** @brief per process debug level handling */
 int get_debug_level(char *mname, int mnlen);
+int get_debug_facility(char *mname, int mnlen);
 void set_local_debug_level(int level);
+void set_local_debug_facility(int facility);
 void reset_local_debug_level(void);
+void reset_local_debug_facility(void);
 typedef int (*get_module_debug_level_f)(char *mname, int mnlen, int *mlevel);
+typedef int (*get_module_debug_facility_f)(char *mname, int mnlen, int *mfacility);
 void set_module_debug_level_cb(get_module_debug_level_f f);
+void set_module_debug_facility_cb(get_module_debug_facility_f f);
 
 #define is_printable(level) (get_debug_level(LOG_MNAME, LOG_MNAME_LEN)>=(level))
 extern struct log_level_info log_level_info[];
@@ -141,7 +146,7 @@ extern char *log_name;
 
 #ifndef NO_SIG_DEBUG
 /** @brief protection against "simultaneous" printing from signal handlers */
-extern volatile int dprint_crit; 
+extern volatile int dprint_crit;
 #endif
 
 int str2facility(char *s);
@@ -210,7 +215,7 @@ void log_prefix_init(void);
 							syslog(LOG2SYSLOG_LEVEL(level) | \
 								   (((facility) != DEFAULT_FACILITY) ? \
 									(facility) : \
-									cfg_get(core, core_cfg, log_facility)), \
+								    get_debug_facility(LOG_MNAME, LOG_MNAME_LEN)), \
 									"%s: %s" fmt, \
 									(lname)?(lname):LOG_LEVEL2NAME(level),\
 									(prefix), __VA_ARGS__); \
@@ -227,13 +232,13 @@ void log_prefix_init(void);
 								syslog(LOG2SYSLOG_LEVEL(L_ALERT) | \
 									   (((facility) != DEFAULT_FACILITY) ? \
 										(facility) : \
-										cfg_get(core, core_cfg, log_facility)),\
+								        get_debug_facility(LOG_MNAME, LOG_MNAME_LEN)), \
 									   "%s" fmt, (prefix), __VA_ARGS__); \
 							else \
 								syslog(LOG2SYSLOG_LEVEL(L_DBG) | \
 									   (((facility) != DEFAULT_FACILITY) ? \
 										(facility) : \
-										cfg_get(core, core_cfg, log_facility)),\
+								        get_debug_facility(LOG_MNAME, LOG_MNAME_LEN)), \
 									   "%s" fmt, (prefix), __VA_ARGS__); \
 						} \
 					} \
@@ -298,7 +303,7 @@ void log_prefix_init(void);
 							syslog(LOG2SYSLOG_LEVEL(__llevel) |\
 							   (((facility) != DEFAULT_FACILITY) ? \
 								(facility) : \
-								cfg_get(core, core_cfg, log_facility)), \
+								get_debug_facility(LOG_MNAME, LOG_MNAME_LEN)), \
 								"%.*s%s: %s" fmt,\
 								log_prefix_val->len, log_prefix_val->s, \
 								(lname)?(lname):LOG_LEVEL2NAME(__llevel),\
@@ -307,7 +312,7 @@ void log_prefix_init(void);
 							syslog(LOG2SYSLOG_LEVEL(__llevel) |\
 							   (((facility) != DEFAULT_FACILITY) ? \
 								(facility) : \
-								cfg_get(core, core_cfg, log_facility)), \
+								get_debug_facility(LOG_MNAME, LOG_MNAME_LEN)), \
 								"%s: %s" fmt,\
 								(lname)?(lname):LOG_LEVEL2NAME(__llevel),\
 								(prefix) , ## args); \

--- a/dprint.h
+++ b/dprint.h
@@ -98,6 +98,9 @@
 #define L_INFO   	2
 #define L_DBG    	3
 #define L_MAX    	3
+#define L_OFFSET   42 /* needs to be added and then substracted
+                        because L_WARN may be confused with NULL pointer
+                        (e.g. fixup_dbg_sip_msg) */
 
 /** @brief This is the facility value used to indicate that the caller of the macro
  * did not override the facility. Value 0 (the defaul) is LOG_KERN on Linux

--- a/modules/debugger/debugger_api.h
+++ b/modules/debugger/debugger_api.h
@@ -35,7 +35,9 @@ int dbg_init_rpc(void);
 
 int dbg_init_mod_levels(int _dbg_mod_hash_size);
 int dbg_set_mod_debug_level(char *mname, int mnlen, int *mlevel);
+int dbg_set_mod_debug_facility(char *mname, int mnlen, int *mfacility);
 void dbg_enable_mod_levels(void);
+void dbg_enable_mod_facilities(void);
 
 int dbg_init_pvcache(void);
 void dbg_enable_log_assign(void);

--- a/modules/debugger/debugger_config.c
+++ b/modules/debugger/debugger_config.c
@@ -32,6 +32,7 @@
 
 struct cfg_group_dbg	default_dbg_cfg = {
 	0, /* level_mode */
+	0, /* facility_mode */
 	0  /* hash_size */
 };
 
@@ -39,8 +40,11 @@ void *dbg_cfg = &default_dbg_cfg;
 
 cfg_def_t dbg_cfg_def[] = {
 	{"mod_level_mode", CFG_VAR_INT|CFG_ATOMIC, 0, 1,
-		dbg_level_mode_fixup, 0,
+		dbg_mode_fixup, 0,
 		"Enable or disable per module log level (0 - disabled, 1 - enabled)"},
+	{"mod_facility_mode", CFG_VAR_INT|CFG_ATOMIC, 0, 1,
+		dbg_mode_fixup, 0,
+		"Enable or disable per module log facility (0 - disabled, 1 - enabled)"},
 	{"mod_hash_size", CFG_VAR_INT|CFG_READONLY, 0, 0,
 		0, 0,
 		"power of two as size of internal hash table to store levels per module"},

--- a/modules/debugger/debugger_config.h
+++ b/modules/debugger/debugger_config.h
@@ -34,6 +34,7 @@
 
 struct cfg_group_dbg {
 	unsigned int mod_level_mode;
+	unsigned int mod_facility_mode;
 	unsigned int mod_hash_size;
 };
 
@@ -41,6 +42,6 @@ extern struct cfg_group_dbg	default_dbg_cfg;
 extern void	*dbg_cfg;
 extern cfg_def_t dbg_cfg_def[];
 
-extern int dbg_level_mode_fixup(void *temp_handle,
+extern int dbg_mode_fixup(void *temp_handle,
 	str *group_name, str *var_name, void **value);
 #endif

--- a/modules/debugger/debugger_mod.c
+++ b/modules/debugger/debugger_mod.c
@@ -34,13 +34,14 @@
 #include "../../parser/parse_param.h"
 #include "../../shm_init.h"
 #include "../../script_cb.h"
+#include "../../msg_translator.h"
 
 #include "debugger_api.h"
 #include "debugger_config.h"
 
 MODULE_VERSION
 
-static int  mod_init(void);
+static int mod_init(void);
 static int child_init(int rank);
 static void mod_destroy(void);
 
@@ -51,6 +52,12 @@ static int dbg_mod_facility_param(modparam_t type, void *val);
 
 static int fixup_dbg_pv_dump(void** param, int param_no);
 static int w_dbg_dump(struct sip_msg* msg, char* mask, char* level);
+
+static struct action *dbg_fixup_get_action(void **param, int param_no);
+static int fixup_dbg_sip_msg(void** param, int param_no);
+static int w_dbg_sip_msg(struct sip_msg* msg, char *level, char *facility);
+
+extern char* dump_lump_list(struct lump *list, int s_offset, char *s_buf);
 
 /* parameters */
 extern int _dbg_cfgtrace;
@@ -64,6 +71,7 @@ extern int _dbg_step_usleep;
 extern int _dbg_step_loops;
 extern int _dbg_reset_msgid;
 
+static int _dbg_sip_msg_cline;
 static char * _dbg_cfgtrace_facility_str = 0;
 static int _dbg_log_assign = 0;
 
@@ -76,6 +84,12 @@ static cmd_export_t cmds[]={
 		fixup_dbg_pv_dump, 0, ANY_ROUTE},
 	{"dbg_pv_dump", (cmd_function)w_dbg_dump, 2,
 		fixup_dbg_pv_dump, 0, ANY_ROUTE},
+    {"dbg_sip_msg", (cmd_function)w_dbg_sip_msg, 0,
+        fixup_dbg_sip_msg, 0, REQUEST_ROUTE},
+    {"dbg_sip_msg", (cmd_function)w_dbg_sip_msg, 1,
+        fixup_dbg_sip_msg, 0, REQUEST_ROUTE},
+    {"dbg_sip_msg", (cmd_function)w_dbg_sip_msg, 2,
+        fixup_dbg_sip_msg, 0, REQUEST_ROUTE},
 	{0, 0, 0, 0, 0, 0}
 };
 
@@ -370,6 +384,161 @@ static int dbg_mod_facility_param(modparam_t type, void *val)
 		return -1;
 	}
 	return 0;
-
 }
 
+static int fixup_dbg_sip_msg(void** param, int param_no)
+{
+    int facility;
+    int level;
+    struct action *dbg_sip_msg_action;
+
+    switch(param_no)
+    {
+        case 2:
+            facility = str2facility((char*)*(param));
+            if (facility == -1) {
+                LM_ERR("invalid log facility configured");
+                return E_UNSPEC;
+            }
+
+                         *param = (void*)(long)facility;    
+        break;
+        case 1:
+            switch(((char*)(*param))[2])
+            {
+                /* add L_OFFSET because L_WARN is consdered null pointer */
+                case 'A': level = L_ALERT + L_OFFSET; break;
+                case 'B': level = L_BUG + L_OFFSET; break;
+                case 'C': level = L_CRIT2 + L_OFFSET; break;
+                case 'E': level = L_ERR + L_OFFSET; break;
+                case 'W': level = L_WARN + L_OFFSET; break;
+                case 'N': level = L_NOTICE + L_OFFSET; break;
+                case 'I': level = L_INFO + L_OFFSET; break;
+                case 'D': level = L_DBG + L_OFFSET; break;
+                default:
+                    LM_ERR("unknown log level\n");
+                    return E_UNSPEC;
+            }
+
+            *param = (void*)(long)level;
+        break;
+    }
+
+    /* save the config line where this config function was called */
+    dbg_sip_msg_action = dbg_fixup_get_action(param, param_no);
+    _dbg_sip_msg_cline = dbg_sip_msg_action->cline;
+
+     return 0;
+}
+
+/**
+  * dump current SIP message and a diff lump list
+  * part of the code taken from msg_apply_changes_f
+  */
+static int w_dbg_sip_msg(struct sip_msg* msg, char *level, char *facility)
+{
+    int ilevel = cfg_get(core, core_cfg, debug);
+    int ifacility= cfg_get(core, core_cfg, log_facility);
+    int flag = FLAG_MSG_LUMPS_ONLY; // copy lumps only, not the whole message
+    unsigned int new_buf_offs=0, orig_offs = 0;
+    char *hdr_lumps = NULL;
+    char *bdy_lumps = NULL;
+    const char *start_txt = "------------------------- START OF SIP message debug --------------------------\n";
+    const char *hdr_txt =   "------------------------------ SIP header diffs -------------------------------\n";
+    const char *bdy_txt =   "------------------------------- SIP body diffs --------------------------------\n";
+    const char *end_txt =   "-------------------------- END OF SIP message debug ---------------------------\n\n";
+    struct dest_info send_info;
+    str obuf;
+
+    if (level != NULL) {
+        /* substract L_OFFSET previously added */
+        ilevel = (int)(long)level - L_OFFSET;
+    }
+
+    if (facility != NULL) {
+        ifacility = (int)(long)facility;
+    }
+
+    /* msg_apply_changes_f code needed to get the current msg */
+    init_dest_info(&send_info);
+    send_info.proto = PROTO_UDP;
+    if(msg->first_line.type == SIP_REPLY) {
+        obuf.s = generate_res_buf_from_sip_res(msg,
+                (unsigned int*)&obuf.len, BUILD_NO_VIA1_UPDATE);
+    } else {
+        obuf.s = build_req_buf_from_sip_req(msg,
+                (unsigned int*)&obuf.len, &send_info,
+                BUILD_NO_PATH|BUILD_NO_LOCAL_VIA|BUILD_NO_VIA1_UPDATE);
+    }
+
+    if(obuf.s == NULL)
+    {
+        LM_ERR("couldn't update msg buffer content\n");
+        return -1;
+    }
+
+    if(obuf.len >= BUF_SIZE)
+    {
+        LM_ERR("new buffer overflow (%d)\n", obuf.len);
+        pkg_free(obuf.s);
+        return -1;
+    }
+
+    /* skip original uri */
+    if (msg->new_uri.s){
+        orig_offs=msg->first_line.u.request.uri.s - msg->buf;
+        orig_offs=msg->first_line.u.request.uri.len;
+    }
+
+    /* alloc private mem and copy lumps */
+    hdr_lumps = pkg_malloc(BUF_SIZE);
+    bdy_lumps = pkg_malloc(BUF_SIZE);
+
+    new_buf_offs = 0;
+    process_lumps(msg, msg->add_rm, hdr_lumps, &new_buf_offs, &orig_offs, &send_info, flag);
+
+    new_buf_offs = 0;
+    process_lumps(msg, msg->body_lumps, bdy_lumps, &new_buf_offs, &orig_offs, &send_info, flag);
+
+    /* do the print */
+    if (hdr_lumps != NULL && bdy_lumps != NULL) {
+        LOG_FC(ifacility, ilevel, "CONFIG LINE %d\n%s%.*s%s%s%s%s%s",
+            _dbg_sip_msg_cline,
+            start_txt,
+            obuf.len, obuf.s,
+            hdr_txt, hdr_lumps,
+            bdy_txt, bdy_lumps,
+            end_txt);
+    } else if (hdr_lumps != NULL) {
+        LOG_FC(ifacility, ilevel, "CONFIG LINE %d\n%s%.*s%s%s%s",
+            _dbg_sip_msg_cline,
+            start_txt,
+            obuf.len, obuf.s,
+            hdr_txt, hdr_lumps,
+            end_txt);
+    } else if (bdy_lumps != NULL) {
+        LOG_FC(ifacility, ilevel, "CONFIG LINE %d\n%s%.*s%s%s%s",
+            _dbg_sip_msg_cline,
+            start_txt,
+            obuf.len, obuf.s,
+            bdy_txt, bdy_lumps,
+            end_txt);
+    } else {
+        LOG_FC(ifacility, ilevel, "CONFIG LINE %d\n%s%.*s%s",
+            _dbg_sip_msg_cline,
+            start_txt,
+            obuf.len, obuf.s,
+            end_txt);
+    }
+
+    /* free lumps */
+    if (hdr_lumps) {
+        pkg_free(hdr_lumps);
+    }
+
+    if (bdy_lumps) {
+        pkg_free(bdy_lumps);
+    }
+
+    return 1;
+}

--- a/modules/debugger/doc/debugger_admin.xml
+++ b/modules/debugger/doc/debugger_admin.xml
@@ -531,8 +531,69 @@ dbg_pv_dump(30, "L_DBG");
 	    </example>
 	</section>
 
+ 	<section id="dbg.f.dbg_sip_msg">
+	    <title>
+		<function moreinfo="none">dbg_sip_msg([log_level], [facility])</function>
+	    </title>
+	    <para>
+            Prints how the sip message <emphasis>would look</emphasis> like if it <emphasis>would be sent</emphasis> out
+            at that point in the config(i.e. if the current lump lists would
+            have been applied at that point in the config).
+
+            It also prints a diff list for both header and body of sip msg
+            which contain the lump lists content. The lumps deleted are printed
+            with "-" sign whereas the lumps added have no sign. The config line
+            where the function has been called is also printed.
+	    </para>
+	    <para>
+            NOTE that dbg_sip_msg function does not modify the initially received SIP message.
+            Just displays how it WOULD look like if it were to send it at that point.
+	    </para>
+		<para>
+			NOTE that the lump lists are usually applied only once, just before sending, to spare message reparse processing.
+            All the changes present in lump list are applied on the <emphasis>initially received</emphasis> SIP message.
+            One can force the lump application using msg_apply_changes() function from textopsx module.
+	    </para>
+		<para>
+	    </para>
+		<example>
+		<title><function>dbg_sip_msg</function> usage</title>
+		<programlisting format="linespecific">
+...
+    dbg_sip_msg();
+    dbg_sip_msg("L_ERR");
+    dbg_sip_msg("L_ERR", "LOG_LOCAL0");
+...
+        </programlisting>
+
+		<para>Output when dbg_sip_msg("L_ERR") is called after <emphasis>append_hf("P-Hint: My hint\r\n"); remove_hf("Contact");</emphasis></para>
+		<programlisting format="linespecific">
+ERROR: debugger [debugger_mod.c:467]: w_dbg_sip_msg(): CONFIG LINE 338
+------------------------- START OF SIP message debug --------------------------
+OPTIONS sip:nobody@127.0.0.1 SIP/2.0
+Via: SIP/2.0/UDP 127.0.1.1:56872;branch=z9hG4bK.6d7c487a;rport;alias
+From: sip:sipsak@127.0.1.1:56872;tag=188b7433
+To: sip:nobody@127.0.0.1
+Call-ID: 411792435@127.0.1.1
+CSeq: 1 OPTIONS
+Content-Length: 0
+Max-Forwards: 70
+User-Agent: sipsak 0.9.6
+Accept: text/plain
+P-Hint: My hintt
+
+------------------------------ SIP header diffs -------------------------------
+- Contact: sip:sipsak@127.0.1.1:56872
+P-Hint: My hint
+------------------------------- SIP body diffs --------------------------------
+-------------------------- END OF SIP message debug ---------------------------
+        </programlisting>
+	    </example>
     </section>
-	
+
+    </section>
+
+
 	<section>
 		<title>Exported RPC Functions</title>
 

--- a/modules/debugger/doc/debugger_admin.xml
+++ b/modules/debugger/doc/debugger_admin.xml
@@ -19,8 +19,9 @@
 	<para>
 		This module provides an interactive config file debugger. It can print
 		a trace of config script execution for a SIP message to log and set
-		breakpoints on every script action, allowing step-by-step execution of 
-		the routing and response scripts.
+		breakpoints on every script action, allowing step-by-step execution of
+		the routing and response scripts. Moreover, this module allows setting
+		static and dynamic module specific debug settings.
 	</para>
 	<para>
 		Debugging can be done from local or remote host via RPC interface (e.g.,
@@ -247,8 +248,11 @@ modparam("debugger", "step_loops", 100)
 	    <title><varname>mod_hash_size</varname> (int)</title>
 	    <para>
 		Used to compute power of two as size of internal hash table to store levels
-		per module (e.g., if its set to 4, internal hash table has 16 slots). This
-		parameter is accesible readonly via the Kamailio config framework.
+		per module (e.g., if its set to 4, internal hash table has 16 slots). One
+		must set it's value grater than 0 such that memory to be allocated
+		to save the module specific debug levels or facility configured by 
+		<varname>mod_level</varname> or <varname>mod_facility</varname>.
+		This parameter is accesible readonly via the Kamailio config framework.
 	    </para>
 	    <para>
 		<emphasis>
@@ -303,6 +307,52 @@ modparam("debugger", "mod_level", "core=3")
 modparam("debugger", "mod_level", "tm=3")
 ...
 </programlisting>
+	    </example>
+	</section>
+
+	<section id="dbg.p.mod_facility_mode">
+	    <title><varname>mod_facility_mode</varname> (int)</title>
+	    <para>
+			Enable or disable per module log facility (0 - disabled, 1 - enabled).
+			This parameter is tunable via the Kamailio config framework. To use
+			per module log facility you also have to set <varname>mod_hash_size</varname>.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>0</quote>.
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>mod_facility_mode</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("debugger", "mod_facility_mode", 1)
+...
+        </programlisting>
+	    </example>
+	</section>
+
+	<section id="dbg.p.mod_facility">
+	    <title><varname>mod_facility</varname> (str)</title>
+	    <para>
+		Specify module log facility - the value must be in the format:
+		modulename=facility. The parameter can be set many times. For core
+		log facility, use module name 'core'. You also must enable
+		<varname>mod_facility_mode</varname> and <varname>mod_hash_size</varname>.
+	    </para>
+        <para>
+        NOTE: See the <emphasis>syslog()</emphasis> library call for facility names (http://linux.die.net/man/3/syslog).
+        The most used facilities are LOG_LOCAL[0-7].
+        </para>
+
+	    <example>
+		<title>Set <varname>mod_facility</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("debugger", "mod_facility", "core=LOG_LOCAL0")
+modparam("debugger", "mod_facility", "debugger=LOG_LOCAL1")
+...
+        </programlisting>
 	    </example>
 	</section>
 

--- a/msg_translator.h
+++ b/msg_translator.h
@@ -31,6 +31,10 @@
 #ifndef  _MSG_TRANSLATOR_H
 #define _MSG_TRANSLATOR_H
 
+/* flags used for process_lumps flag parameter */
+#define FLAG_MSG_LUMPS_ONLY     0   /* copy just the lumps */
+#define FLAG_MSG_ALL            1   /* copy all the msg */
+
 #define MY_HF_SEP ": "
 #define MY_HF_SEP_LEN 2
 
@@ -163,4 +167,17 @@ int build_sip_msg_from_buf(struct sip_msg *msg, char *buf, int len,
 
 /* returns a copy in private memory of the boundary in a multipart body */
 int get_boundary(struct sip_msg* msg, str* boundary);
+
+
+/* process the lumps of a sip msg
+ * flags =  => add also the existing header to new_buf
+ * flags =  => add only the lumps (unapplied info) to new_buf
+ **/
+void process_lumps( struct sip_msg* msg,
+                    struct lump* lumps,
+                    char* new_buf,
+                    unsigned int* new_buf_offs,
+                    unsigned int* orig_offs,
+                    struct dest_info* send_info,
+                    int flag);
 #endif


### PR DESCRIPTION
Added 2 new params to the debugger module such as the per module facility logging is now possible. Added a new config function which prints how the SIP message looks like if it would have to be sent out at that line in the config (prints the message with the applied lumps but does _not_ apply the lumps as msg_apply changes() function).