### PR TITLE
Allow domain_attrs 'type' field to be a mysql BIGINT

### DIFF
--- a/modules/domain/domain.c
+++ b/modules/domain/domain.c
@@ -362,7 +362,8 @@ int reload_tables ( void )
 	}
 
 	if ((VAL_NULL(ROW_VALUES(row) + 2) == 1) ||
-	    (VAL_TYPE(ROW_VALUES(row) + 2) != DB1_INT)) {
+	    ((VAL_TYPE(ROW_VALUES(row) + 2) != DB1_INT) &&
+	    (VAL_TYPE(ROW_VALUES(row) + 2) != DB1_BIGINT))) {
 	    LM_ERR("type at row <%u> is null or not int\n", i);
 	    goto err;
 	}


### PR DESCRIPTION
Allow 'type' field in domain_attrs to be a DB1_BIGINT as well as a
DB1_INT. If you are using a view with 'type' as a calculated field on
a 64 bit machine, then mysql will return the type of 'type' to be a bigint,
not an int (and no amount of CASTing or CONVERTing will fix it).