### PR TITLE
enum: fix buffer overflow and increase maximum number length

### DIFF
--- a/modules/enum/enum.c
+++ b/modules/enum/enum.c
@@ -34,7 +34,7 @@
  * based on the user part of the current Request-URI. These functions
  * assume that the Request URI user part consists of an international
  * phone number of the form +decimal-digits, where the number of digits is
- * at least 2 and at most 15. Out of this number enum_query forms a domain
+ * at least 2 and at most 32. Out of this number enum_query forms a domain
  * name, where the digits are in reverse order and separated by dots
  * followed by domain suffix that by default is "e164.arpa.". For example,
  * if the user part is +35831234567, the domain name will be
@@ -1005,7 +1005,7 @@ int enum_pv_query_3(struct sip_msg* _msg, char* _sp, char* _suffix,
 	struct naptr_rdata* naptr;
 	str pattern, replacement, result, new_result;
 	str *suffix, *service;
-	char string[17];
+	char string[MAX_NUM_LEN];
 	pv_spec_t *sp;
 	pv_value_t pv_val;
 

--- a/modules/enum/enum.h
+++ b/modules/enum/enum.h
@@ -35,7 +35,7 @@
 
 
 #define MAX_DOMAIN_SIZE 256
-#define MAX_NUM_LEN 22
+#define MAX_NUM_LEN 33
 #define MAX_COMPONENT_SIZE (MAX_NUM_LEN * 2)  /* separator, apex, ... This simplifies checks */
 
 


### PR DESCRIPTION
* Fix for buffer overflow in enum_pv_query_3 for char string[17] where the boundary checks for it in is_e164 uses MAX_NUM_LEN.

* Increased the size of MAX_NUM_LEN to 33 to support the maximum number length of 32, which is what we support here on our ISUP links.

Bug: The buffer overflow bug can be triggered by calling enum_pv_query with a number that is to long eg. +1234567890123456789