### PR TITLE
modules/call_control: fixes clang compile warning

### DIFF
--- a/modules/call_control/call_control.c
+++ b/modules/call_control/call_control.c
@@ -985,7 +985,7 @@ __dialog_ended(struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
         if( !msg || msg == FAKED_REPLY)
             msg = _params->req;
         call_control_stop(msg, dlg->callid);
-        *_params->param = CCInactive;
+        *_params->param = (void*)CCInactive;
     }
 }
 


### PR DESCRIPTION
- warning: expression which evaluates to zero treated as a null pointer constant of type 'void *' [-Wnon-literal-null-conversion]