### PR TITLE
lib/srdb1: use 6 digits for db_double2str

### DIFF
--- a/lib/srdb1/db_ut.c
+++ b/lib/srdb1/db_ut.c
@@ -193,7 +193,7 @@ inline int db_double2str(double _v, char* _s, int* _l)
 		return -1;
 	}
 
-	ret = snprintf(_s, *_l, "%-10.2f", _v);
+	ret = snprintf(_s, *_l, "%-10.6f", _v);
 	if (ret < 0 || ret >= *_l) {
 		LM_ERR("Error in snprintf\n");
 		return -1;


### PR DESCRIPTION
acc module was getting values rounded by this
```
Jun  8 14:41:26 spce proxy[28942]: DEBUG: acc [acc.c:456]: acc_db_request(): sec:1433767286 usec:272474
Jun  8 14:41:26 spce proxy[28942]: DEBUG: acc [acc.c:458]: acc_db_request(): val:1433767286.272000
```
```
528 Query	insert into acc (method,from_tag,to_tag,callid,sip_code,sip_reason,time,time_hires,src_user,src_domain,dst_ouser,dst_user,dst_domain,src_leg,dst_leg ) values ('INVITE','xXqybHIcxywNXlUjz-EnGrocmpZcBxVV','2CA0A9C5-55758D6F000A60E4-8F6F6700','-QEOe-t3EPk-k3Tly1yxOvc2Wh2JKNj0','200','OK','2015-06-08 14:41:26',1433767286.27,'43991003','10.15.20.177','43991002','83569074','10.15.20.121','42c40737-afaa-4377-aa95-da852abd2a17|43991003|10.15.20.177|43991003|||76|||0|call|10.15.20.121|1433767279.678516|||||||||||','0|||75|43991002|1c08361b-b712-4dbe-abe0-f39d9e7fc60e|43991002|10.15.20.177|43991002|10.15.20.177|0|||||||||||')
```
1433767286.272000 -> 1433767286.27 
