### PR TITLE
modules/call_control: change type to fix clang compiler warning

### DIFF
--- a/modules/call_control/call_control.c
+++ b/modules/call_control/call_control.c
@@ -490,7 +490,7 @@ static CallInfo*
 get_call_info(struct sip_msg *msg, CallControlAction action)
 {
     static CallInfo call_info;
-    int headers;
+    hdr_flags_t headers;
 
     memset(&call_info, 0, sizeof(struct CallInfo));
 


### PR DESCRIPTION
call_control.c:503:19: warning: implicit conversion from 'hdr_flags_t' (aka 'unsigned long long') to 'int' changes value from 18446744073709551615 to -1 [-Wconstant-conversion]