### PR TITLE
kazoo : add json keys function and escape character

### DIFF
--- a/modules/kazoo/kazoo.c
+++ b/modules/kazoo/kazoo.c
@@ -73,6 +73,8 @@ struct timeval kz_ack_tv = (struct timeval){0,100000};
 struct timeval kz_timer_tv = (struct timeval){0,200000};
 int kz_timer_ms = 200;
 
+str kz_json_escape_str = str_init("%");
+char kz_json_escape_char = '%';
 
 str dbk_consumer_event_key = str_init("Event-Category");
 str dbk_consumer_event_subkey = str_init("Event-Name");
@@ -139,6 +141,7 @@ static cmd_export_t cmds[] = {
 
 
     {"kazoo_json", (cmd_function) kz_json_get_field, 3, fixup_kz_json, fixup_kz_json_free, ANY_ROUTE},
+    {"kazoo_json_keys", (cmd_function) kz_json_get_keys, 3, fixup_kz_json, fixup_kz_json_free, ANY_ROUTE},
     {"kazoo_encode", (cmd_function) kz_amqp_encode, 2, fixup_kz_amqp_encode, fixup_kz_amqp_encode_free, ANY_ROUTE},
     {0, 0, 0, 0, 0, 0}
 };
@@ -172,6 +175,7 @@ static param_export_t params[] = {
     {"single_consumer_on_reconnect", INT_PARAM, &dbk_single_consumer_on_reconnect},
     {"consume_messages_on_reconnect", INT_PARAM, &dbk_consume_messages_on_reconnect},
     {"amqp_query_timeout_avp", STR_PARAM, &kz_query_timeout_avp.s},
+    {"json_escape_char", STR_PARAM, &kz_json_escape_str.s},
     {0, 0, 0}
 };
 
@@ -218,7 +222,7 @@ static int kz_init_avp(void) {
 static int mod_init(void) {
 	int i;
     startup_time = (int) time(NULL);
-
+    kz_json_escape_char = kz_json_escape_str.s[0];
 
     if (dbk_node_hostname.s == NULL) {
 	LM_ERR("You must set the node_hostname parameter\n");

--- a/modules/kazoo/kz_json.h
+++ b/modules/kazoo/kz_json.h
@@ -14,6 +14,7 @@
 
 int kz_json_get_field(struct sip_msg* msg, char* json, char* field, char* dst);
 int kz_json_get_field_ex(str* json, str* field, pv_value_p dst_val);
+int kz_json_get_keys(struct sip_msg* msg, char* json, char* field, char* dst);
 
 struct json_object* kz_json_parse(const char *str);
 struct json_object* kz_json_get_object(struct json_object* jso, const char *key);


### PR DESCRIPTION
json in the form of

{ "Nodes" :  {
       "mynode@my.tld.com" : { ... },
       "myothernode@my.tld.com" : { ...}
       }
}

doesn't have an easy to fetch the keys (it works already if it is an array)
kazoo_json_keys retrieves the keys to an avp

when querying inner fields in the form xx.yy.zzz
if one of xx / yy / zzz contains a dot (.) we cannot determine the field correctly.
use "json_escape_char" param value to encode the value before querying json and kazoo_json will decode using the same character