### PR TITLE
etc/kamailio-oob.cfg: Updated module path

### DIFF
--- a/etc/kamailio-oob.cfg
+++ b/etc/kamailio-oob.cfg
@@ -223,9 +223,9 @@ voicemail.srv_port = "5060" desc "VoiceMail Port"
 
 # set paths to location of modules (to sources or installation folders)
 #!ifdef WITH_SRCPATH
-mpath="modules_k:modules"
+mpath="modules"
 #!else
-mpath="/usr/local/lib/kamailio/modules_k/:/usr/local/lib/kamailio/modules/"
+mpath="/usr/lib/x86_64-linux-gnu/kamailio/modules"
 #!endif
 
 #!ifdef WITH_MYSQL


### PR DESCRIPTION
- Removed "_k" on mpath as it's depreciated
- mpath full path updated to /usr/lib/x86_64-linux-gnu/ from /usr/local/lib/
- Now matches other examples