### PR TITLE
Makefile.defs: fixes indentation

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -892,11 +892,8 @@ else		# CC_NAME, gcc
 ifeq		($(CC_NAME), clang)
 $(call                          set_if_empty,CPU,athlon64)
 					C_DEFS+=-DCC_GCC_LIKE_ASM
-                                        CFLAGS+=-g -m32
-                                                $(CC_OPT) \
-                                                          \
-                                                -mtune=$(CPU)
-                                        LDFLAGS+=-m32
+					CFLAGS+=-g -m32 $(CC_OPT) -mtune=$(CPU)
+					LDFLAGS+=-m32
 else			# CC_NAME, clang
 ifeq		($(CC_NAME), icc)
 			C_DEFS+=-DCC_GCC_LIKE_ASM


### PR DESCRIPTION
Makefile.defs:896: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.