### PR TITLE
modules/htable: improves error message when loading from database

### DIFF
--- a/modules/htable/ht_db.c
+++ b/modules/htable/ht_db.c
@@ -197,11 +197,17 @@ int ht_db_load_table(ht_t *ht, str *dbtable, int mode)
 	do {
 		for(i=0; i<RES_ROW_N(db_res); i++)
 		{
-			if(RES_ROWS(db_res)[i].values[0].type!=DB1_STRING
-					|| VAL_NULL(&RES_ROWS(db_res)[i].values[0])) {
-				LM_ERR("key type must be string and its value not null\n");
+			if(VAL_NULL(&RES_ROWS(db_res)[i].values[0])) {
+				LM_ERR("key value must not be null\n");
 				goto error;
 			}
+
+			if(RES_ROWS(db_res)[i].values[0].type!=DB1_STRING) {
+				LM_ERR("key type must be string (type=%d)\n",
+						RES_ROWS(db_res)[i].values[0].type);
+				goto error;
+			}
+
 			kname.s = (char*)(RES_ROWS(db_res)[i].values[0].val.string_val);
 			if(kname.s==NULL) {
 				LM_ERR("null key in row %d\n", i);


### PR DESCRIPTION
I had trouble finding correct syntax with db_text backend, this patch helped me