### PR TITLE
Added modparam id_in_avp for carrierroute

### DIFF
--- a/modules/carrierroute/carrierroute.c
+++ b/modules/carrierroute/carrierroute.c
@@ -79,6 +79,7 @@ const str CR_EMPTY_PREFIX = str_init("null");
 int mode = 0;
 int cr_match_mode = 10;
 int cr_avoid_failed_dests = 1;
+int cr_id_in_avp = 0;
 
 /************* Declaration of Interface Functions **************************/
 static int mod_init(void);
@@ -120,6 +121,7 @@ static param_export_t params[]= {
 	{"fetch_rows",                INT_PARAM, &default_carrierroute_cfg.fetch_rows },
 	{"match_mode",                INT_PARAM, &cr_match_mode },
 	{"avoid_failed_destinations", INT_PARAM, &cr_avoid_failed_dests },
+	{"id_in_avp",				  INT_PARAM, &cr_id_in_avp},
 	{0,0,0}
 };
 
@@ -183,6 +185,11 @@ static int mod_init(void) {
 
 	if (cr_avoid_failed_dests != 0 && cr_avoid_failed_dests != 1) {
 		LM_ERR("avoid_failed_dests must be 0 or 1");
+		return -1;
+	}
+
+	if (cr_id_in_avp < 0 || cr_id_in_avp > 2) {
+		LM_ERR("id_in_avp must be between 0 and 2");
 		return -1;
 	}
 

--- a/modules/carrierroute/carrierroute.h
+++ b/modules/carrierroute/carrierroute.h
@@ -54,6 +54,7 @@ extern const str CR_EMPTY_PREFIX;
 extern int mode;
 extern int cr_match_mode;
 extern int cr_avoid_failed_dests;
+extern int cr_id_in_avp;
 
 extern int_str cr_uris_avp;
 


### PR DESCRIPTION
We have 2M lines in carrierroute, so we often need to get back the ID of the line from the DB from carrierroute.

This commit creates a new modparam "id_in_avp" for the module carrierroute which may be 0 - 2
 
0 - no ID, only the description is saved in the avp
1 - ID and descrptiotion is saved in the AVP
2 - Only ID is saved in the AVP.

