### PR TITLE
modules/[rls|presence_xml]: fixes warning [-Wtautological-compare]

### DIFF
--- a/modules/presence_xml/presence_xml.c
+++ b/modules/presence_xml/presence_xml.c
@@ -382,7 +382,7 @@ static int pxml_add_xcap_server( modparam_t type, void* val)
 			LM_ERR("while converting string to int\n");
 			goto error;
 		}
-		if(port< 0 || port> 65535)
+		if(port< 1 || port> 65535)
 		{
 			LM_ERR("wrong port number\n");
 			goto error;

--- a/modules/rls/rls.c
+++ b/modules/rls/rls.c
@@ -338,7 +338,7 @@ static int mod_init(void)
 					port_str.len, port_str.s);
 				return -1;
 			}
-			if(xcap_port< 0 || xcap_port> 65535)
+			if(xcap_port< 1 || xcap_port> 65535)
 			{
 				LM_ERR("wrong xcap server port\n");
 				return -1;


### PR DESCRIPTION
warning: comparison of unsigned expression < 0 is always false