### PR TITLE
core: clean previous routename

### DIFF
--- a/cfg.y
+++ b/cfg.y
@@ -1778,8 +1778,8 @@ route_name:		NUMBER	{
 ;
 
 
-route_main:	ROUTE { ; }
-		  | ROUTE_REQUEST { ; }
+route_main:	ROUTE { routename=NULL; }
+		  | ROUTE_REQUEST { routename=NULL; }
 ;
 
 route_stm:
@@ -1845,8 +1845,8 @@ failure_route_stm:
 	;
 
 
-route_reply_main:	ROUTE_ONREPLY { ; }
-		  | ROUTE_REPLY { ; }
+route_reply_main:	ROUTE_ONREPLY { routename=NULL; }
+		  | ROUTE_REPLY { routename=NULL; }
 ;
 
 


### PR DESCRIPTION
fix c44685cbcefb8f6ecfa6f11369699906db832c39

routename is not been reset when no name is use like on main or reply route