### PR TITLE
kex: per module memory debugging

### DIFF
--- a/events.c
+++ b/events.c
@@ -165,6 +165,15 @@ int sr_event_register_cb(int type, sr_event_cb_f f)
 					_sr_events_list.rcv_nosip = f;
 				else return -1;
 			break;
+		case SREV_MODULE_PKG_STATS:
+				if(_sr_events_list.mod_update_pkg_stats==0)
+					_sr_events_list.mod_update_pkg_stats = f;
+				else return -1;
+		case SREV_MODULE_SHM_STATS:
+				if(_sr_events_list.mod_update_shm_stats==0)
+					_sr_events_list.mod_update_shm_stats = f;
+				else return -1;
+			break;
 		default:
 			return -1;
 	}
@@ -284,6 +293,18 @@ int sr_event_exec(int type, void *data)
 					ret = _sr_events_list.rcv_nosip(data);
 					return ret;
 				} else return 1;
+		case SREV_MODULE_PKG_STATS:
+				if(unlikely(_sr_events_list.mod_update_pkg_stats!=0))
+				{
+					ret = _sr_events_list.mod_update_pkg_stats(data);
+					return ret;
+				} else return 1;
+		case SREV_MODULE_SHM_STATS:
+				if(unlikely(_sr_events_list.mod_update_shm_stats!=0))
+				{
+					ret = _sr_events_list.mod_update_shm_stats(data);
+					return ret;
+				} else return 1;
 		default:
 			return -1;
 	}
@@ -319,6 +340,10 @@ int sr_event_enabled(int type)
 				return (_sr_events_list.stun_in!=0)?1:0;
 		case SREV_RCV_NOSIP:
 				return (_sr_events_list.rcv_nosip!=0)?1:0;
+		case SREV_MODULE_PKG_STATS:
+				return (_sr_events_list.mod_update_pkg_stats!=0)?1:0;
+		case SREV_MODULE_SHM_STATS:
+				return (_sr_events_list.mod_update_shm_stats!=0)?1:0;
 	}
 	return 0;
 }

--- a/events.h
+++ b/events.h
@@ -34,6 +34,8 @@
 #define SREV_TCP_WS_FRAME_IN		10
 #define SREV_TCP_WS_FRAME_OUT		11
 #define SREV_STUN_IN			12
+#define SREV_MODULE_PKG_STATS   13
+#define SREV_MODULE_SHM_STATS   14
 
 #define SREV_CB_LIST_SIZE	3
 
@@ -52,6 +54,8 @@ typedef struct sr_event_cb {
 	sr_event_cb_f tcp_ws_frame_out;
 	sr_event_cb_f stun_in;
 	sr_event_cb_f rcv_nosip;
+	sr_event_cb_f mod_update_pkg_stats;
+	sr_event_cb_f mod_update_shm_stats;
 } sr_event_cb_t;
 
 void sr_event_cb_init(void);

--- a/mem/f_malloc.h
+++ b/mem/f_malloc.h
@@ -86,6 +86,7 @@ struct fm_frag{
 #ifdef DBG_F_MALLOC
 	const char* file;
 	const char* func;
+	const char* mname;
 	unsigned long line;
 #endif
 	unsigned int check;
@@ -134,7 +135,8 @@ struct fm_block* fm_malloc_init(char* address, unsigned long size, int type);
  */
 #ifdef DBG_F_MALLOC
 void* fm_malloc(void* qmp, unsigned long size,
-					const char* file, const char* func, unsigned int line);
+					const char* file, const char* func, unsigned int line,
+					const char* mname);
 #else
 void* fm_malloc(void* qmp, unsigned long size);
 #endif
@@ -148,8 +150,8 @@ void* fm_malloc(void* qmp, unsigned long size);
  * \param p freed memory
  */
 #ifdef DBG_F_MALLOC
-void  fm_free(void* qmp, void* p, const char* file, const char* func, 
-				unsigned int line);
+void fm_free(void* qmp, void* p, const char* file, const char* func,
+				unsigned int line, const char* mname);
 #else
 void  fm_free(void* qmp, void* p);
 #endif
@@ -165,8 +167,8 @@ void  fm_free(void* qmp, void* p);
  * \return reallocated memory block
  */
 #ifdef DBG_F_MALLOC
-void*  fm_realloc(void* qmp, void* p, unsigned long size, 
-					const char* file, const char* func, unsigned int line);
+void* fm_realloc(void* qmp, void* p, unsigned long size,
+					const char* file, const char* func, unsigned int line, const char *mname);
 #else
 void*  fm_realloc(void* qmp, void* p, unsigned long size);
 #endif
@@ -204,6 +206,20 @@ unsigned long fm_available(void* qmp);
  * \param qm memory block
  */
 void fm_sums(void* qmp);
+void fm_mod_get_stats(void* qm, void **fm_root);
+void fm_mod_free_stats(void *root);
+
+typedef struct _mem_counter{
+	const char *file;
+	const char *func;
+	const char *mname;
+	unsigned long line;
+
+	unsigned long size;
+	int count;
+
+	struct _mem_counter *next;
+} mem_counter;
 
 #endif
 #endif

--- a/mem/memapi.h
+++ b/mem/memapi.h
@@ -27,13 +27,13 @@
 #ifdef DBG_SR_MEMORY
 
 typedef void* (*sr_malloc_f)(void* mbp, unsigned long size,
-					const char* file, const char* func, unsigned int line);
-typedef void  (*sr_free_f)(void* mbp, void* p, const char* file, const char* func, 
-					unsigned int line);
+					const char* file, const char* func, unsigned int line, const char* mname);
+typedef void  (*sr_free_f)(void* mbp, void* p, const char* file, const char* func,
+					unsigned int line, const char* mname);
 typedef void* (*sr_realloc_f)(void* mbp, void* p, unsigned long size,
-					const char* file, const char* func, unsigned int line);
+					const char* file, const char* func, unsigned int line, const char* mname);
 typedef void* (*sr_resize_f)(void* mbp, void* p, unsigned long size,
-					const char* file, const char* func, unsigned int line);
+					const char* file, const char* func, unsigned int line, const char* mname);
 
 #else /*DBG_SR_MEMORY*/
 
@@ -50,6 +50,9 @@ typedef unsigned long (*sr_mem_available_f)(void* mbp);
 typedef void  (*sr_mem_sums_f)(void* mbp);
 
 typedef void  (*sr_mem_destroy_f)(void);
+
+typedef void (*sr_mem_mod_get_stats_f)(void* mbp, void **p);
+typedef void (*sr_mem_mod_free_stats_f)(void* mbp);
 
 /*private memory api*/
 typedef struct sr_pkg_api {
@@ -75,6 +78,10 @@ typedef struct sr_pkg_api {
 	sr_mem_sums_f      xsums;
 	/*memory destroy manager*/
 	sr_mem_destroy_f   xdestroy;
+	/*memory stats per module*/
+	sr_mem_mod_get_stats_f  xstats;
+	/*memory stats free per module*/
+	sr_mem_mod_free_stats_f xfstats;
 } sr_pkg_api_t;
 
 /*shared memory api*/
@@ -107,6 +114,10 @@ typedef struct sr_shm_api {
 	sr_mem_sums_f      xsums;
 	/*memory destroy manager*/
 	sr_mem_destroy_f   xdestroy;
+	/*memory stats per module*/
+	sr_mem_mod_get_stats_f  xstats;
+	/*memory stats free per module*/
+	sr_mem_mod_free_stats_f xfstats;
 } sr_shm_api_t;
 
 #endif

--- a/mem/pkg.c
+++ b/mem/pkg.c
@@ -46,6 +46,8 @@ int pkg_init_api(sr_pkg_api_t *ap)
 	_pkg_root.xavailable = ap->xavailable;
 	_pkg_root.xsums      = ap->xsums;
 	_pkg_root.xdestroy   = ap->xdestroy;
+	_pkg_root.xstats     = ap->xstats;
+	_pkg_root.xfstats    = ap->xfstats;
 	return 0;
 }
 

--- a/mem/pkg.h
+++ b/mem/pkg.h
@@ -28,11 +28,11 @@ extern sr_pkg_api_t _pkg_root;
 
 #ifdef DBG_SR_MEMORY
 #	define pkg_malloc(s)      _pkg_root.xmalloc(_pkg_root.mem_block, (s), _SRC_LOC_, \
-				_SRC_FUNCTION_, _SRC_LINE_)
+				_SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 #	define pkg_free(p)        _pkg_root.xfree(_pkg_root.mem_block, (p), _SRC_LOC_, \
-				_SRC_FUNCTION_, _SRC_LINE_)
+				_SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 #	define pkg_realloc(p, s)  _pkg_root.xrealloc(_pkg_root.mem_block, (p), (s), \
-				_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_)
+				_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 #else
 #	define pkg_malloc(s)      _pkg_root.xmalloc(_pkg_root.mem_block, (s))
 #	define pkg_realloc(p, s)  _pkg_root.xrealloc(_pkg_root.mem_block, (p), (s))
@@ -43,6 +43,8 @@ extern sr_pkg_api_t _pkg_root;
 #	define pkg_info(mi)    _pkg_root.xinfo(_pkg_root.mem_block, mi)
 #	define pkg_available() _pkg_root.xavailable(_pkg_root.mem_block)
 #	define pkg_sums()      _pkg_root.xsums(_pkg_root.mem_block)
+#	define pkg_mod_get_stats(x)     _pkg_root.xstats(_pkg_root.mem_block, x)
+#	define pkg_mod_free_stats(x)    _pkg_root.xfstats(x)
 
 int pkg_init_api(sr_pkg_api_t *ap);
 int pkg_init_manager(char *name);

--- a/mem/q_malloc.h
+++ b/mem/q_malloc.h
@@ -77,6 +77,7 @@ struct qm_frag{
 #ifdef DBG_QM_MALLOC
 	const char* file;
 	const char* func;
+	const char* mname;
 	unsigned long line;
 	unsigned long check;
 #endif
@@ -128,20 +129,20 @@ struct qm_block* qm_malloc_init(char* address, unsigned long size, int type);
 
 #ifdef DBG_QM_MALLOC
 void* qm_malloc(void*, unsigned long size, const char* file,
-					const char* func, unsigned int line);
+					const char* func, unsigned int line, const char* mname);
 #else
 void* qm_malloc(void*, unsigned long size);
 #endif
 
 #ifdef DBG_QM_MALLOC
-void  qm_free(void*, void* p, const char* file, const char* func, 
-				unsigned int line);
+void  qm_free(void*, void* p, const char* file, const char* func,
+				unsigned int line, const char* mname);
 #else
 void  qm_free(void*, void* p);
 #endif
 #ifdef DBG_QM_MALLOC
 void* qm_realloc(void*, void* p, unsigned long size,
-					const char* file, const char* func, unsigned int line);
+					const char* file, const char* func, unsigned int line, const char *mname);
 #else
 void* qm_realloc(void*, void* p, unsigned long size);
 #endif
@@ -154,6 +155,20 @@ void  qm_info(void*, struct mem_info*);
 unsigned long qm_available(void* qm);
 
 void qm_sums(void* qm);
+void qm_mod_get_stats(void *qm, void **qm_root);
+void qm_mod_free_stats(void *root);
+
+typedef struct _mem_counter{
+	const char *file;
+	const char *func;
+	const char *mname;
+	unsigned long line;
+
+	unsigned long size;
+	int count;
+
+	struct _mem_counter *next;
+} mem_counter;
 
 #endif
 #endif

--- a/mem/shm.c
+++ b/mem/shm.c
@@ -221,6 +221,8 @@ int shm_init_api(sr_shm_api_t *ap)
 	_shm_root.xavailable     = ap->xavailable;
 	_shm_root.xsums          = ap->xsums;
 	_shm_root.xdestroy       = ap->xdestroy;
+	_shm_root.xstats         = ap->xstats;
+	_shm_root.xfstats        = ap->xfstats;
 	return 0;
 
 }

--- a/mem/shm.h
+++ b/mem/shm.h
@@ -49,17 +49,17 @@ extern sr_shm_api_t _shm_root;
 #ifdef DBG_SR_MEMORY
 
 #	define shm_malloc(s)         _shm_root.xmalloc(_shm_root.mem_block, (s), _SRC_LOC_, \
-									_SRC_FUNCTION_, _SRC_LINE_)
+									_SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 #	define shm_malloc_unsafe(s)  _shm_root.xmalloc_unsafe(_shm_root.mem_block, (s), _SRC_LOC_, \
-									_SRC_FUNCTION_, _SRC_LINE_)
+									_SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 #	define shm_realloc(p, s)     _shm_root.xrealloc(_shm_root.mem_block, (p), (s), \
-									_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_)
+									_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 #	define shm_resize(p, s)      _shm_root.xresize(_shm_root.mem_block, (p), (s), \
-									_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_)
+									_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 #	define shm_free(p)           _shm_root.xfree(_shm_root.mem_block, (p), _SRC_LOC_, \
-									_SRC_FUNCTION_, _SRC_LINE_)
+									_SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 #	define shm_free_unsafe(p)    _shm_root.xfree_unsafe(_shm_root.mem_block, (p), _SRC_LOC_, \
-									_SRC_FUNCTION_, _SRC_LINE_)
+									_SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 #else
 #	define shm_malloc(s)         _shm_root.xmalloc(_shm_root.mem_block, (s))
 #	define shm_malloc_unsafe(s)  _shm_root.xmalloc_unsafe(_shm_root.mem_block, (s))
@@ -73,6 +73,9 @@ extern sr_shm_api_t _shm_root;
 #	define shm_info(mi)    _shm_root.xinfo(_shm_root.mem_block, mi)
 #	define shm_available() _shm_root.xavailable(_shm_root.mem_block)
 #	define shm_sums()      _shm_root.xsums(_shm_root.mem_block)
+#	define shm_mod_get_stats(x)     _shm_root.xstats(_shm_root.mem_block, x)
+#	define shm_mod_free_stats(x)    _shm_root.xfstats(x)
+
 
 void* shm_core_get_pool(void);
 int shm_init_api(sr_shm_api_t *ap);

--- a/mem/shm_mem.c
+++ b/mem/shm_mem.c
@@ -94,7 +94,7 @@ inline static void* sh_realloc(void* p, unsigned int size)
 
 #ifdef DBG_QM_MALLOC
 void* _shm_resize( void* p, unsigned int s, const char* file, const char* func,
-							int line)
+							int line, const char *mname)
 #else
 void* _shm_resize( void* p , unsigned int s)
 #endif

--- a/mem/shm_mem.h
+++ b/mem/shm_mem.h
@@ -211,41 +211,41 @@ void shm_mem_destroy(void);
 #include "src_loc.h"
 
 #define shm_malloc_unsafe(_size ) \
-	MY_MALLOC(shm_block, (_size), _SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_ )
+	MY_MALLOC(shm_block, (_size), _SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 
 
 inline static void* _shm_malloc(unsigned int size, 
-	const char *file, const char *function, int line )
+	const char *file, const char *function, int line, const char *mname)
 {
 	void *p;
 	
 	shm_lock();
-	p=MY_MALLOC(shm_block, size, file, function, line );
+	p=MY_MALLOC(shm_block, size, file, function, line, mname);
 	shm_unlock();
 	return p; 
 }
 
 
 inline static void* _shm_realloc(void *ptr, unsigned int size, 
-		const char* file, const char* function, int line )
+		const char* file, const char* function, int line, const char *mname)
 {
 	void *p;
 	shm_lock();
-	p=MY_REALLOC(shm_block, ptr, size, file, function, line);
+	p=MY_REALLOC(shm_block, ptr, size, file, function, line, mname);
 	shm_unlock();
 	return p;
 }
 
 #define shm_malloc( _size ) _shm_malloc((_size), \
-	_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_ )
+	_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_ , _SRC_MODULE_)
 
 #define shm_realloc( _ptr, _size ) _shm_realloc( (_ptr), (_size), \
-	_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_ )
+	_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 
 
 
 #define shm_free_unsafe( _p  ) \
-	MY_FREE( shm_block, (_p), _SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_ )
+	MY_FREE( shm_block, (_p), _SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 
 #define shm_free(_p) \
 do { \
@@ -257,9 +257,9 @@ do { \
 
 
 void* _shm_resize(void* ptr, unsigned int size, const char* f, const char* fn,
-					int line);
+					int line, const char *mname);
 #define shm_resize(_p, _s ) _shm_resize((_p), (_s), \
-		_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_ )
+		_SRC_LOC_, _SRC_FUNCTION_, _SRC_LINE_, _SRC_MODULE_)
 /*#define shm_resize(_p, _s ) shm_realloc( (_p), (_s))*/
 
 

--- a/mem/src_loc.h
+++ b/mem/src_loc.h
@@ -68,7 +68,7 @@
 #	ifdef MOD_NAME
 #		define _SRC_MODULE_ MOD_NAME
 #	else
-#		define _SRC_MODULE_ "<core>"
+#		define _SRC_MODULE_ "core"
 #	endif /* MOD_NAME */
 #endif /* _SRC_MODULE_ */
 

--- a/mem/tlsf_malloc.h
+++ b/mem/tlsf_malloc.h
@@ -47,11 +47,11 @@ void tlsf_remove_pool(tlsf_t tlsf, pool_t pool);
 /* malloc/memalign/realloc/free replacements. */
 #ifdef DBG_TLSF_MALLOC
 void* tlsf_malloc(tlsf_t tlsf, size_t size,
-		const char *file, const char *function, unsigned int line);
+		const char *file, const char *function, unsigned int line, const char *mname);
 void* tlsf_realloc(tlsf_t tlsf, void* ptr, size_t size,
-		const char *file, const char *function, unsigned int line);
+		const char *file, const char *function, unsigned int line, const char *mname);
 void tlsf_free(tlsf_t tlsf, void* ptr,
-		const char *file, const char *function, unsigned int line);
+		const char *file, const char *function, unsigned int line, const char *mname);
 #else
 void* tlsf_malloc(tlsf_t tlsf, size_t bytes);
 void* tlsf_realloc(tlsf_t tlsf, void* ptr, size_t size);
@@ -80,6 +80,20 @@ void tlsf_meminfo(tlsf_t pool, struct mem_info *info);
 void tlsf_status(tlsf_t pool);
 void tlsf_sums(tlsf_t pool);
 size_t tlsf_available(tlsf_t pool);
+void tlsf_mod_get_stats(tlsf_t pool, void **root);
+void tlsf_mod_free_stats(void *root);
+
+typedef struct _mem_counter{
+	const char *file;
+	const char *func;
+	const char *mname;
+	unsigned long line;
+
+	unsigned long size;
+	int count;
+
+	struct _mem_counter *next;
+} mem_counter;
 
 #if defined(__cplusplus)
 };

--- a/modules/ctl/binrpc_run.c
+++ b/modules/ctl/binrpc_run.c
@@ -36,8 +36,18 @@
    rpc->scan (default: not set) */
 int autoconvert=0;
 
+#ifdef DBG_SR_MEMORY
+/**
+ * note that if you get some error(overflow) when "kamcmd mod.stats all all" you might
+ * need to increase these values
+ **/
+int binrpc_max_body_size = 8; /* multiplied by 1024 in mod init */
+int binrpc_struct_max_body_size = 4; /* multiplied by 1024 in mod init */
+#else
 int binrpc_max_body_size = 4; /* multiplied by 1024 in mod init */
-int  binrpc_struct_max_body_size = 1; /* multiplied by 1024 in mod init */
+int binrpc_struct_max_body_size = 1; /* multiplied by 1024 in mod init */
+#endif
+
 #define BINRPC_MAX_BODY	binrpc_max_body_size  /* maximum body for send */
 #define STRUCT_MAX_BODY	binrpc_struct_max_body_size
 #define MAX_MSG_CHUNKS	96

--- a/modules/kex/doc/kex_admin.xml
+++ b/modules/kex/doc/kex_admin.xml
@@ -712,6 +712,82 @@ resetdebug();
 		&sercmd; stats.reset_statistics shmem: fwd_requests fwd_replies
 		</programlisting>
     </section>
+
+	<section id="kex.r.mod.stats">
+		<title>
+		<function moreinfo="none">mod.stats module_name/all pkg/shm/all</function>
+		</title>
+		<para>
+			Print private(pkg) or shared(shm) memory currently allocated a given module or by all modules.
+		</para>
+		<para>
+			NOTE: Processing is done only when the command is issued and involves iterating
+            throug the list of memory fragments and printing details about them.
+		</para>
+		<para>
+			NOTE: Only the module functions that <emphasis>directly</emphasis> calls shm_alloc or
+            pkg_alloc are taken into consideration.
+		</para>
+		<para>The firt parameter can be:</para>
+		<itemizedlist>
+		<listitem>
+			<para>
+				<emphasis>module_name</emphasis> - print statistics for specific module.
+			</para>
+		</listitem>
+		<listitem>
+			<para>
+				<emphasis>all</emphasis> - print statistics for all modules that uses memory.
+			</para>
+		</listitem>
+		</itemizedlist>
+
+		<para>The second parameter can be:</para>
+		<itemizedlist>
+		<listitem>
+			<para>
+				<emphasis>pkg</emphasis> - print private memory statistics.
+			</para>
+		</listitem>
+		<listitem>
+			<para>
+				<emphasis>shm</emphasis> - print shared memory statistics.
+			</para>
+		</listitem>
+		<listitem>
+			<para>
+				<emphasis>all</emphasis> - print both private and shared memory statistics.
+			</para>
+		</listitem>
+		</itemizedlist>
+		<para>
+		Examples:
+		</para>
+        <programlisting  format="linespecific">
+		&sercmd; mod.stats core all
+		&sercmd; mod.stats userblacklist shm
+		&sercmd; mod.stats kex pkg
+		&sercmd; mod.stats all all
+		</programlisting>
+		<para>
+		Output:
+		</para>
+        <programlisting  format="linespecific">
+Module: kex
+{
+    // this is the pkg zone of the module
+    // function_name(line_where_pkg_malloc_was_called): size_alloc'ed_by_pkg_malloc
+    init_mi_uptime(74): 56
+    Total: 56
+}
+{
+    // this is the shm zone of the module
+    // function_name(line_where_shm_malloc_was_called): size_alloc'ed_by_shm_malloc
+    pkg_proc_stats_init(79): 864
+    Total: 864
+}
+		</programlisting>
+    </section>
     </section>
 </chapter>
 

--- a/modules/kex/kex_mod.c
+++ b/modules/kex/kex_mod.c
@@ -40,6 +40,7 @@
 #include "mi_core.h"
 #include "core_stats.h"
 #include "pkg_stats.h"
+#include "mod_stats.h"
 
 
 MODULE_VERSION
@@ -145,6 +146,11 @@ static int mod_init(void)
 #endif
 	register_pkg_proc_stats();
 	pkg_proc_stats_init_rpc();
+
+	register_mod_stats();
+    mod_stats_init();
+	mod_stats_init_rpc();
+
 	return 0;
 }
 
@@ -168,6 +174,7 @@ static int child_init(int rank)
 static void destroy(void)
 {
 	pkg_proc_stats_destroy();
+	mod_stats_destroy();
 	return;
 }
 

--- a/modules/kex/mod_stats.c
+++ b/modules/kex/mod_stats.c
@@ -1,0 +1,282 @@
+/*
+ * Copyright (C) 2010 Daniel-Constantin Mierla (asipto.com)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/*!
+ * \file
+ * \brief KEX :: Kamailio private memory pool statistics
+ * \ingroup kex
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "../../dprint.h"
+#include "../../ut.h"
+#include "../../pt.h"
+#include "../../sr_module.h"
+#include "../../events.h"
+#include "../../mem/f_malloc.h"
+#include "../../rpc.h"
+#include "../../rpc_lookup.h"
+
+#include "mod_stats.h"
+
+
+#define DBG_MOD_PKG_FLAG		0
+#define DBG_MOD_SHM_FLAG		1
+#define DBG_MOD_ALL_FLAG		2
+
+/**
+ *
+ */
+int mod_stats_init(void)
+{
+	return 0;
+}
+
+/**
+ *
+ */
+int mod_stats_destroy(void)
+{
+	return 0;
+}
+
+
+/**
+ *
+ */
+static int mod_update_pkg_mod_stats_list(void *data)
+{
+	return 0;
+}
+
+
+/**
+ *
+ */
+static int mod_update_shm_mod_stats_list(void *data)
+{
+	return 0;
+}
+
+
+/**
+ *
+ */
+int register_mod_stats(void)
+{
+	sr_event_register_cb(SREV_MODULE_PKG_STATS, mod_update_pkg_mod_stats_list);
+	sr_event_register_cb(SREV_MODULE_SHM_STATS, mod_update_shm_mod_stats_list);
+	return 0;
+}
+
+/**
+ *
+ */
+static const char* rpc_mod_stats_doc[2] = {
+	"Per module memory statistics",
+	0
+};
+
+/* test if the current mod info was already printed */
+static int rpc_mod_is_printed_one(mem_counter *stats, mem_counter *current) {
+	mem_counter *iter = stats;
+
+	while (iter && iter != current) {
+		if (strcmp(iter->mname, current->mname) == 0) {
+			return 1;
+		}
+		iter = iter->next;
+	}
+
+	return 0;
+}
+
+/* print memory info for a specific module in a specific stats list */
+static int rpc_mod_print(rpc_t *rpc, void *ctx, const char *mname,
+	mem_counter *stats)
+{
+	char buff[128];
+	const char *total_str= "Total";
+	void *stats_th = NULL;
+	int total = 0;
+	mem_counter *iter = stats;
+
+	if (stats == NULL) {
+		return -1;
+	}
+
+	if (rpc->add(ctx, "{", &stats_th) < 0) {
+		rpc->fault(ctx, 500, "Internal error creating struct rpc");
+		return -1;
+	}
+
+	while (iter) {
+		if (strcmp(mname, iter->mname) == 0) {
+			sprintf(buff, "%s(%ld)", iter->func, iter->line);
+			if (rpc->struct_add(stats_th, "d", buff, iter->size) < 0) {
+				rpc->fault(ctx, 500, "Internal error adding to struct rpc");
+				return -1;
+			}
+			total += iter->size;
+		}
+		iter = iter->next;
+	}
+
+	if (rpc->struct_add(stats_th, "d", total_str, total) < 0) {
+		rpc->fault(ctx, 500, "Internal error adding total to struct rpc");
+		return -1;
+	}
+
+	return total;
+}
+
+/* print memory info for a specific module */
+static int rpc_mod_print_one(rpc_t *rpc, void *ctx, const char *mname,
+	mem_counter *pkg_stats, mem_counter *shm_stats, int flag)
+{
+	if (rpc->rpl_printf(ctx, "Module: %s", mname) < 0) {
+		rpc->fault(ctx, 500, "Internal error adding module name to ctx");
+		return -1;
+	}
+
+	switch (flag){
+		case DBG_MOD_PKG_FLAG:
+			rpc_mod_print(rpc, ctx, mname, pkg_stats);
+			break;
+		case DBG_MOD_SHM_FLAG:
+			rpc_mod_print(rpc, ctx, mname, shm_stats);
+			break;
+		case DBG_MOD_ALL_FLAG:
+			rpc_mod_print(rpc, ctx, mname, pkg_stats);
+			rpc_mod_print(rpc, ctx, mname, shm_stats);
+			break;
+		default:
+			rpc_mod_print(rpc, ctx, mname, pkg_stats);
+			rpc_mod_print(rpc, ctx, mname, shm_stats);
+			break;
+	}
+
+	if (rpc->rpl_printf(ctx, "") < 0) {
+		rpc->fault(ctx, 500, "Internal error adding module name to ctx");
+		return -1;
+	}
+
+	return 0;
+}
+
+/* print memory info for all modules */
+static int rpc_mod_print_all(rpc_t *rpc, void *ctx,
+	mem_counter *pkg_stats, mem_counter *shm_stats, int flag)
+{
+	mem_counter *pkg_iter = pkg_stats;
+	mem_counter *shm_iter = shm_stats;
+
+	/* print unique module info found in pkg_stats */
+	while (pkg_iter) {
+		if (!rpc_mod_is_printed_one(pkg_stats, pkg_iter)) {
+		   rpc_mod_print_one(rpc, ctx,
+				pkg_iter->mname, pkg_stats, shm_stats, flag);
+		}
+		pkg_iter = pkg_iter->next;
+	}
+
+	/* print unique module info found in shm_stats and not found in pkg_stats */
+	while (shm_iter) {
+		if (!rpc_mod_is_printed_one(shm_stats, shm_iter) &&
+			!rpc_mod_is_printed_one(pkg_stats, shm_iter)) {
+		   rpc_mod_print_one(rpc, ctx,
+				shm_iter->mname, pkg_stats, shm_stats, flag);
+		}
+		shm_iter = shm_iter->next;
+	}
+	return 0;
+}
+
+/**
+ *
+ */
+static void rpc_mod_stats(rpc_t *rpc, void *ctx)
+{
+	int flag = DBG_MOD_ALL_FLAG;
+	str mname = STR_NULL;
+	str mtype = STR_NULL;
+
+	mem_counter *pkg_mod_stats_list = NULL;
+	mem_counter *shm_mod_stats_list = NULL;
+
+	if (rpc->scan(ctx, "*S", &mname) != 1) {
+		rpc->fault(ctx, 500, "Module name or \"all\" needed");
+		return;
+	}
+
+	if (rpc->scan(ctx, "*S", &mtype) != 1) {
+		rpc->fault(ctx, 500, "\"pkg\" or \"shm\" or \"all\" needed");
+		return;
+	}
+
+	if (strcmp(mtype.s, "pkg") == 0) {
+		flag = DBG_MOD_PKG_FLAG;
+	} else if (strcmp(mtype.s, "shm") == 0) {
+		flag = DBG_MOD_SHM_FLAG;
+	} else if (strcmp(mtype.s, "all") == 0) {
+		flag = DBG_MOD_ALL_FLAG;
+	}
+
+	pkg_mod_get_stats((void **)&pkg_mod_stats_list);
+	shm_mod_get_stats((void **)&shm_mod_stats_list);
+
+	/* print info about all modules */
+	if (strcmp(mname.s, "all") == 0) {
+		rpc_mod_print_all(rpc, ctx, pkg_mod_stats_list, shm_mod_stats_list, flag);
+
+	/* print info about a particular module */
+	} else {
+		rpc_mod_print_one(rpc, ctx, mname.s, pkg_mod_stats_list, shm_mod_stats_list, flag);
+	}
+
+	pkg_mod_free_stats(pkg_mod_stats_list);
+	shm_mod_free_stats(shm_mod_stats_list);
+}
+
+/**
+ *
+ */
+rpc_export_t kex_mod_rpc[] = {
+	{"mod.stats", rpc_mod_stats,  rpc_mod_stats_doc,	   RET_ARRAY},
+	{0, 0, 0, 0}
+};
+
+/**
+ *
+ */
+int mod_stats_init_rpc(void)
+{
+	if (rpc_register_array(kex_mod_rpc)!=0)
+	{
+		LM_ERR("failed to register RPC commands\n");
+		return -1;
+	}
+	return 0;
+}

--- a/modules/kex/mod_stats.h
+++ b/modules/kex/mod_stats.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2010 Daniel-Constantin Mierla (asipto.com)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/*!
+ * \file
+ * \brief KEX :: Kamailio private memory pool statistics
+ * \ingroup kex
+ */
+
+
+#ifndef _MOD_STATS_H_
+#define _MOD_STATS_H_
+
+int mod_stats_init(void);
+int mod_stats_destroy(void);
+int register_mod_stats(void);
+int mod_stats_init_rpc(void);
+
+#endif /*_MOD_STATS_H_*/


### PR DESCRIPTION
Kex module updated to also give some details about memory used by each module.
Changed f_*, q_* and tlsf_* memory stubs to also include the module name.
Added 2 new memory API functions(for each of the memory algos) which will
iterate throughout the memory fragments and agregate the memory size used by
each function in order to print it.
Tested with MEMMNG=0,1,2 and MEMDBG=0,1. Use "**kamcmd mem.stat [mod_name]/[all] [pkg]/[shm]/[all]**" to test
Updated doku.