### PR TITLE
usrloc|nathelper: add filtering by server_id support

### DIFF
--- a/modules/usrloc/dlist.h
+++ b/modules/usrloc/dlist.h
@@ -109,10 +109,11 @@ int synchronize_all_udomains(int istart, int istep);
  * \param flags contact flags
  * \param part_idx part index
  * \param part_max maximal part
+ * \param GAU options
  * \return 0 on success, positive if buffer size was not sufficient, negative on failure
  */
 int get_all_ucontacts(void *buf, int len, unsigned int flags,
-		unsigned int part_idx, unsigned int part_max);
+		unsigned int part_idx, unsigned int part_max, int options);
 
 
 /*!

--- a/modules/usrloc/udomain.c
+++ b/modules/usrloc/udomain.c
@@ -379,6 +379,9 @@ int preload_udomain(db1_con_t* _c, udomain_t* _d)
 	db_row_t *row;
 	db_key_t columns[21];
 	db1_res_t* res = NULL;
+	db_key_t keys[1]; /* where */
+	db_val_t vals[1];
+	db_op_t  ops[1];
 	str user, contact;
 	char* domain;
 	int i;
@@ -418,9 +421,21 @@ int preload_udomain(db1_con_t* _c, udomain_t* _d)
 	LM_NOTICE("load start time [%d]\n", (int)time(NULL));
 #endif
 
+	if (ul_db_srvid) {
+		LM_NOTICE("filtered by server_id[%d]\n", server_id);
+		keys[0] = &srv_id_col;
+		ops[0] = OP_EQ;
+		vals[0].type = DB1_INT;
+		vals[0].nul = 0;
+		vals[0].val.int_val = server_id;
+	}
+
 	if (DB_CAPABILITY(ul_dbf, DB_CAP_FETCH)) {
-		if (ul_dbf.query(_c, 0, 0, 0, columns, 0, (use_domain)?(21):(20), 0,
-		0) < 0) {
+		if (ul_dbf.query(_c, (ul_db_srvid)?(keys):(0),
+							(ul_db_srvid)?(ops):(0), (ul_db_srvid)?(vals):(0),
+							columns, (ul_db_srvid)?(1):(0),
+							(use_domain)?(21):(20), 0, 0) < 0)
+		{
 			LM_ERR("db_query (1) failed\n");
 			return -1;
 		}
@@ -429,8 +444,11 @@ int preload_udomain(db1_con_t* _c, udomain_t* _d)
 			return -1;
 		}
 	} else {
-		if (ul_dbf.query(_c, 0, 0, 0, columns, 0, (use_domain)?(21):(20), 0,
-		&res) < 0) {
+		if (ul_dbf.query(_c, (ul_db_srvid)?(keys):(0),
+							(ul_db_srvid)?(ops):(0), (ul_db_srvid)?(vals):(0),
+							columns, (ul_db_srvid)?(1):(0),
+							(use_domain)?(21):(20), 0, &res) < 0)
+		{
 			LM_ERR("db_query failed\n");
 			return -1;
 		}

--- a/modules/usrloc/ul_mod.c
+++ b/modules/usrloc/ul_mod.c
@@ -173,7 +173,8 @@ unsigned int init_flag = 0;
 db1_con_t* ul_dbh = 0; /* Database connection handle */
 db_func_t ul_dbf;
 
-
+/* filter on load by server id */
+unsigned int ul_db_srvid = 0;
 
 /*! \brief
  * Exported functions
@@ -229,6 +230,7 @@ static param_export_t params[] = {
 	{"expires_type",        PARAM_INT, &ul_expires_type},
 	{"db_raw_fetch_type",   PARAM_INT, &ul_db_raw_fetch_type},
 	{"db_insert_null",      PARAM_INT, &ul_db_insert_null},
+	{"server_id_filter",    PARAM_INT, &ul_db_srvid},
 	{0, 0, 0}
 };
 

--- a/modules/usrloc/ul_mod.h
+++ b/modules/usrloc/ul_mod.h
@@ -98,6 +98,8 @@ extern str ul_xavp_contact_name;
 extern db1_con_t* ul_dbh;   /* Database connection handle */
 extern db_func_t ul_dbf;
 
+/* filter on load by server id */
+extern unsigned int ul_db_srvid;
 
 /*
  * Matching algorithms

--- a/modules/usrloc/usrloc.h
+++ b/modules/usrloc/usrloc.h
@@ -40,6 +40,8 @@
 #define DB_ONLY       3
 #define DB_READONLY   4
 
+#define GAU_OPT_SERVER_ID  (1<<0)  /* filter query by server_id */
+
 /*forward declaration necessary for udomain*/
 
 struct udomain;
@@ -181,7 +183,7 @@ typedef void (*unlock_udomain_t)(struct udomain* _d, str *_aor);
 typedef int (*register_udomain_t)(const char* _n, struct udomain** _d);
 
 typedef int  (*get_all_ucontacts_t) (void* buf, int len, unsigned int flags,
-		unsigned int part_idx, unsigned int part_max);
+		unsigned int part_idx, unsigned int part_max, int options);
 
 typedef int (*get_udomain_t)(const char* _n, udomain_t** _d);
 


### PR DESCRIPTION
Use the new field server_id on usrloc module to be able to load/get contacts filtered by server_id