### PR TITLE
cdp: Fix cdp routing for Rx interface

### DIFF
--- a/modules/cdp/routing.c
+++ b/modules/cdp/routing.c
@@ -193,16 +193,14 @@ peer* get_routing_peer(cdp_session_t* cdp_session, AAAMessage *m) {
 
     avp_vendor = AAAFindMatchingAVP(m, 0, AVP_Vendor_Id, 0, AAA_FORWARD_SEARCH);
     avp = AAAFindMatchingAVP(m, 0, AVP_Auth_Application_Id, 0, AAA_FORWARD_SEARCH);
-    if (avp) {
-        if (avp_vendor) vendor_id = get_4bytes(avp_vendor->data.s);
-        else vendor_id = 0;
+    if (avp && avp_vendor) {
+	vendor_id = get_4bytes(avp_vendor->data.s);
         app_id = get_4bytes(avp->data.s);
     }
 
     avp = AAAFindMatchingAVP(m, 0, AVP_Acct_Application_Id, 0, AAA_FORWARD_SEARCH);
-    if (avp) {
-        if (avp_vendor) vendor_id = get_4bytes(avp_vendor->data.s);
-        else vendor_id = 0;
+    if (avp && avp_vendor) {
+	vendor_id = get_4bytes(avp_vendor->data.s);
         app_id = get_4bytes(avp->data.s);
     }
 


### PR DESCRIPTION
Avoid to force vendor_id variable to zero if AVP AVP_Auth_Application_Id or AVP_Acct_Application_Id does not exist on AAR message. 
In this case, if  Vendor_id AVP exists but AVP_Auth_Application_Id or AVP_Acct_Application_Id does not exist vendor_id is forced to zero, thus cdp is not able to route the requests correctly anymore.
vendor_id and app_id variables are updated only if both AVPs (vendor_id and Acct or vendor_id and Auth exist).