### PR TITLE
Makefile.groups was not updated when usrloc_dmq was renamed to dmq_usrloc

### DIFF
--- a/Makefile.groups
+++ b/Makefile.groups
@@ -20,7 +20,7 @@ mod_list_basic=async auth benchmark blst cfg_rpc cfgutils corex counters \
 # - extra used modules, with no extra dependency
 mod_list_extra=avp auth_diameter call_control dmq domainpolicy msrp pdb \
 			     qos sca seas sms sst timer tmrec uac_redirect xhttp \
-				 xhttp_rpc xprint jsonrpc-s nosip usrloc_dmq statsd rtjson
+				 xhttp_rpc xprint jsonrpc-s nosip dmq_usrloc statsd rtjson
 
 # - common modules depending on database
 mod_list_db=acc alias_db auth_db avpops cfg_db db_text db_flatstore \


### PR DESCRIPTION
Hi,

Makefile.groups was not updated when usrloc_dmq was renamed to
dmq_usrloc. So dmq_usrloc won't get build by default. This patch fixes that.

thanks,
Paul