### PR TITLE
dnssec: link openssl

### DIFF
--- a/modules/dnssec/Makefile
+++ b/modules/dnssec/Makefile
@@ -7,7 +7,7 @@
 include ../../Makefile.defs
 auto_gen=
 NAME=dnssec.so
-LIBS= -lval-threads -lcrypto -lsres -lpthread
+LIBS= -lval-threads -lcrypto -lsres -lpthread -lssl
 
 DEFS+=-DKAMAILIO_MOD_INTERFACE
 


### PR DESCRIPTION
Fixes: #253
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=790291