### PR TITLE
rr: add enable_double_rr_always option

### DIFF
--- a/modules/rr/doc/rr_admin.xml
+++ b/modules/rr/doc/rr_admin.xml
@@ -175,6 +175,25 @@ modparam("rr", "enable_double_rr", 0)
 ...
 </programlisting>
       </example>
+      <para>Some useragents (e. g. Linphone) incorrectly use UDP transport for
+      subsequent requests in dialog, despite being configured to use another
+      SIP transport protocol. This can be worked around by setting Record-Route
+      header with explicit transport attribute. But enable_double_rr enabled in
+      default mode omits transport attribute from being added to header if it
+      detects that both sender and receiver use same protocol (e. g. TCP or
+      TLS), and this results in UDP being used by such broken clients. Set
+      enable_double_rr to value 2 to always have two RR headers with transport
+      attributes expicitly set.</para>
+
+      <example>
+        <title>Set <varname>enable_double_rr</varname> to 2 to always have two explicit RR headers</title>
+
+        <programlisting format="linespecific">
+...
+modparam("rr", "enable_double_rr", 2)
+...
+</programlisting>
+      </example>
     </section>
 
     <section>

--- a/modules/rr/record.c
+++ b/modules/rr/record.c
@@ -283,7 +283,7 @@ static inline int build_rr(struct lump* _l, struct lump* _l2, str* user,
 	if (_l ==0 )
 		goto lump_err;
 	if (enable_double_rr) {
-		if (!(_l = insert_cond_lump_after(_l, COND_IF_DIFF_REALMS, 0)))
+		if (!(_l = insert_cond_lump_after(_l, enable_double_rr == 2 ? COND_TRUE : COND_IF_DIFF_REALMS, 0)))
 			goto lump_err;
 		if (!(_l = insert_new_lump_after(_l, r2, RR_R2_LEN, 0)))
 			goto lump_err;
@@ -429,8 +429,8 @@ int record_route(struct sip_msg* _m, str *params)
 			ret = -5;
 			goto error;
 		}
-		l = insert_cond_lump_after(l, COND_IF_DIFF_REALMS, 0);
-		l2 = insert_cond_lump_before(l2, COND_IF_DIFF_REALMS, 0);
+		l = insert_cond_lump_after(l, enable_double_rr == 2 ? COND_TRUE : COND_IF_DIFF_REALMS, 0);
+		l2 = insert_cond_lump_before(l2, enable_double_rr == 2 ? COND_TRUE : COND_IF_DIFF_REALMS, 0);
 		if (!l || !l2) {
 			LM_ERR("failed to insert conditional lump\n");
 			ret = -6;
@@ -706,14 +706,14 @@ static inline int build_advertised_rr(struct lump* _l, struct lump* _l2, str *_d
 		goto lump_err;
 	}
 	hdr = NULL;
-	if (!(_l = insert_cond_lump_after(_l, COND_IF_DIFF_PROTO, 0)))
+	if (!(_l = insert_cond_lump_after(_l, enable_double_rr == 2 ? COND_TRUE : COND_IF_DIFF_PROTO, 0)))
 		goto lump_err;
 	if (!(_l = insert_new_lump_after(_l, trans, RR_TRANS_LEN, 0)))
 		goto lump_err;
 	if (!(_l = insert_subst_lump_after(_l, _inbound?SUBST_RCV_PROTO:SUBST_SND_PROTO, 0)))
 		goto lump_err;
 	if (enable_double_rr) {
-		if (!(_l = insert_cond_lump_after(_l, COND_IF_DIFF_REALMS, 0)))
+		if (!(_l = insert_cond_lump_after(_l, enable_double_rr == 2 ? COND_TRUE : COND_IF_DIFF_REALMS, 0)))
 			goto lump_err;
 		if (!(_l = insert_new_lump_after(_l, r2, RR_R2_LEN, 0)))
 			goto lump_err;
@@ -790,8 +790,8 @@ int record_route_advertised_address(struct sip_msg* _m, str* _data)
 			ret = -3;
 			goto error;
 		}
-		l = insert_cond_lump_after(l, COND_IF_DIFF_PROTO, 0);
-		l2 = insert_cond_lump_before(l2, COND_IF_DIFF_PROTO, 0);
+		l = insert_cond_lump_after(l, enable_double_rr == 2 ? COND_TRUE : COND_IF_DIFF_PROTO, 0);
+		l2 = insert_cond_lump_before(l2, enable_double_rr == 2 ? COND_TRUE : COND_IF_DIFF_PROTO, 0);
 		if (!l || !l2) {
 			LM_ERR("failed to insert conditional lump\n");
 			ret = -4;

--- a/tcp_read.c
+++ b/tcp_read.c
@@ -1663,6 +1663,7 @@ read_error:
 	return ret;
 con_error:
 	con->state=S_CONN_BAD;
+	LM_WARN("%s:%d %s releasing\n", __FILE__, __LINE__, __PRETTY_FUNCTION__);
 	release_tcpconn(con, CONN_ERROR, tcpmain_sock);
 	return ret;
 error:


### PR DESCRIPTION
This patch helps us to handle inadequatness of Linphone mobile apps (both iOS and Android flavours are affected) without reinventing a lot of logics to handle each transport (we use TCP, TLS, WS, WSS).
E.g. if we have two TLS-based Linphone clients, even with enable_double_rr for gentle cross-forwarding we would get single RR header without transport= attribute, resulting in Linphone sending ACK and BYE via UDP.
This new option, being enabled, results in two RR headers being always inserted, with transport attribute being always added. I believe this cannot harm the installation with enable_double_rr, just makes instructions more explicit.
The Linphone's behaviour looks like a set of different bugs, but it would get us much more efforts to fix.
I don't know if any other useragent needs such workaround. So I would perfectly understand if this commit wouldn't be accepted upstream.

Also this commit currently lacks README doc rebuild, because I don't know how to do that. Only XML doc is updated.