### PR TITLE
kex: support VERSION_NODATE and VERSION_DATE for reproducible builds

### DIFF
--- a/modules/kex/mi_core.c
+++ b/modules/kex/mi_core.c
@@ -51,7 +51,15 @@
 #include "../../cfg/cfg.h"
 #include "../../cfg/cfg_ctx.h"
 
+#ifdef VERSION_NODATE
+#define BUILD_STR __FILE__ " compiled with " COMPILER "\n"
+#else
+#ifdef VERSION_DATE
+#define BUILD_STR __FILE__ " compiled on " VERSION_DATE " with " COMPILER "\n"
+#else
 #define BUILD_STR __FILE__ " compiled on "__TIME__ " " __DATE__ " with " COMPILER "\n"
+#endif
+#endif
 #define BUILD_STR_LEN (sizeof(BUILD_STR)-1)
 
 #ifndef SVNREVISION


### PR DESCRIPTION
support added e03d1279f49709e0d320478fa1ff7c27161c30ed

Related: #60 

See https://reproducible.debian.net/dbd/unstable/amd64/kamailio_4.3.0-1.debbindiff.html for results using -DVERSION_NODATE