### PR TITLE
jsonrpc-c: fix crash at reconnect_cb if server was never connected

### DIFF
--- a/modules/jsonrpc-c/jsonrpc_io.c
+++ b/modules/jsonrpc-c/jsonrpc_io.c
@@ -338,6 +338,7 @@ int parse_servers(char *_servers, struct jsonrpc_server_group **group_ptr)
 	
 		struct jsonrpc_server *server = pkg_malloc(sizeof(struct jsonrpc_server));
 		CHECK_MALLOC(server);
+		memset(server, 0, sizeof(struct jsonrpc_server));
 		char *h = pkg_malloc(strlen(host)+1);
 		CHECK_MALLOC(h);
 
@@ -365,6 +366,7 @@ int parse_servers(char *_servers, struct jsonrpc_server_group **group_ptr)
 			
 			selected_group = pkg_malloc(sizeof(struct jsonrpc_server_group));
 			CHECK_MALLOC(selected_group);
+			memset(selected_group, 0, sizeof(struct jsonrpc_server_group));
 			selected_group->priority = priority;
 			selected_group->next_server = server;
 			


### PR DESCRIPTION
```
void reconnect_cb(int fd, short event, void *arg)
...
	if (server->ev != NULL) { /* this was never initializated, so we crash!! */
		event_del(server->ev);
		pkg_free(server->ev);
		server->ev = NULL;
	}
```