### PR TITLE
jsonrpc-c: support load module even if no server is online and max reconnect attempts

### DIFF
--- a/modules/jsonrpc-c/doc/jsonrpc-c_admin.xml
+++ b/modules/jsonrpc-c/doc/jsonrpc-c_admin.xml
@@ -91,6 +91,21 @@ modparam("jsonrpc", "servers", "localhost:9999,2 10.10.0.1:9999,2 backup.server:
 				</programlisting>
 			</example>
 		</section>
+		<section>
+			<title><varname>max_conn_attempts</varname> (int)</title>
+			<para>
+				Max number of connection attempts for a server. -1 will keep reconnecting
+				forever, 0 will skip any attempt to reconnect.
+			</para>
+			<example>
+				<title>Set <varname>max_conn_attempts</varname> parameter</title>
+				<programlisting format="linespecific">
+...
+modparam("jsonrpc", "max_conn_attempts", 10)
+...
+				</programlisting>
+			</example>
+		</section>
 	</section>
 	<section>
 		<title>Functions</title>

--- a/modules/jsonrpc-c/jsonrpc_io.c
+++ b/modules/jsonrpc-c/jsonrpc_io.c
@@ -85,8 +85,7 @@ int jsonrpc_io_child_process(int cmd_pipe, char* _servers)
 
 	if (!connect_servers(server_group))
 	{
-		LM_ERR("failed to connect to any servers\n");
-		return -1;
+		LM_WARN("failed to connect to any servers\n");
 	}
 
 	event_dispatch();

--- a/modules/jsonrpc-c/jsonrpc_io.c
+++ b/modules/jsonrpc-c/jsonrpc_io.c
@@ -44,7 +44,7 @@
 
 struct jsonrpc_server {
 	char *host;
-	int  port, socket, status;
+	int  port, socket, status, conn_attempts;
 	struct jsonrpc_server *next;
 	struct event *ev;
 	struct itimerspec *timer;
@@ -67,6 +67,9 @@ int  parse_servers(char *_servers, struct jsonrpc_server_group **group_ptr);
 int  connect_servers(struct jsonrpc_server_group *group);
 int  connect_server(struct jsonrpc_server *server);
 int  handle_server_failure(struct jsonrpc_server *server);
+
+/* module config from jsonrpc_mod.c */
+int _jsonrpcc_max_conn_retry = 0; /* max retries to connect. -1 forever 0 none */
 
 int jsonrpc_io_child_process(int cmd_pipe, char* _servers)
 {
@@ -346,6 +349,7 @@ int parse_servers(char *_servers, struct jsonrpc_server_group **group_ptr)
 		server->port = port;
 		server->status = JSONRPC_SERVER_DISCONNECTED;
 		server->socket = 0;
+		server->conn_attempts = _jsonrpcc_max_conn_retry;
 
 		int group_cnt = 0;
 
@@ -443,6 +447,7 @@ int connect_server(struct jsonrpc_server *server)
 
 	server->socket = sockfd;
 	server->status = JSONRPC_SERVER_CONNECTED;
+	server->conn_attempts = _jsonrpcc_max_conn_retry;
 
 	struct event *socket_ev = pkg_malloc(sizeof(struct event));
 	CHECK_MALLOC(socket_ev);
@@ -507,6 +512,12 @@ int handle_server_failure(struct jsonrpc_server *server)
 		server->ev = NULL;
 	}
 	server->status = JSONRPC_SERVER_FAILURE;
+	server->conn_attempts--;
+	if(_jsonrpcc_max_conn_retry!=-1 && server->conn_attempts<0) {
+		LM_ERR("max reconnect attempts. No further attempts will be made to reconnect this server.");
+		return -1;
+	}
+
 	int timerfd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
 	
 	if (timerfd == -1) {

--- a/modules/jsonrpc-c/jsonrpc_mod.c
+++ b/modules/jsonrpc-c/jsonrpc_mod.c
@@ -48,6 +48,8 @@ int        fixup_pvar_shm(void** param, int param_no);
 char *servers_param;
 int  pipe_fds[2] = {-1,-1};
 
+extern int _jsonrpcc_max_conn_retry; /* max retries to connect */
+
 struct tm_binds tmb;
 
 /*
@@ -65,6 +67,7 @@ static cmd_export_t cmds[]={
  */
 static param_export_t mod_params[]={
 	{"servers", PARAM_STRING, &servers_param},
+	{"max_conn_attempts", INT_PARAM, &_jsonrpcc_max_conn_retry},
 	{ 0,0,0 }
 };
 


### PR DESCRIPTION
Fixes: #269 