### PR TITLE
etc: simple typo fixes in kamailio.cfg

### DIFF
--- a/etc/kamailio.cfg
+++ b/etc/kamailio.cfg
@@ -546,7 +546,7 @@ route[RELAY] {
 # Per SIP request initial checks
 route[REQINIT] {
 #!ifdef WITH_ANTIFLOOD
-	# flood dection from same IP and traffic ban for a while
+	# flood detection from same IP and traffic ban for a while
 	# be sure you exclude checking trusted peers, such as pstn gateways
 	# - local host excluded (e.g., loop to self)
 	if(src_ip!=myself) {
@@ -721,7 +721,7 @@ route[PRESENCE] {
 	return;
 }
 
-# IP authorization and user uthentication
+# IP authorization and user authentication
 route[AUTH] {
 #!ifdef WITH_AUTH
 
@@ -771,7 +771,7 @@ route[NATDETECT] {
 	return;
 }
 
-# RTPProxy control and singaling updates for NAT traversal
+# RTPProxy control and signaling updates for NAT traversal
 route[NATMANAGE] {
 #!ifdef WITH_NAT
 	if (is_request()) {
@@ -827,7 +827,7 @@ route[PSTN] {
 #!ifdef WITH_PSTN
 	# check if PSTN GW IP is defined
 	if (strempty($sel(cfg_get.pstn.gw_ip))) {
-		xlog("SCRIPT: PSTN rotuing enabled but pstn.gw_ip not defined\n");
+		xlog("SCRIPT: PSTN routing enabled but pstn.gw_ip not defined\n");
 		return;
 	}
 


### PR DESCRIPTION
- fixed small typos within comments of default kamailio config