### PR TITLE
tls: install-cfg: do not generate tls-cert by default

### DIFF
--- a/modules/tls/Makefile
+++ b/modules/tls/Makefile
@@ -40,7 +40,10 @@ include ../../Makefile.modules
 install-tls-cert: $(cfg_prefix)/$(cfg_dir)
 	MAIN_NAME=$(MAIN_NAME) ./$(SCR_NAME)_cert.sh -d $(cfg_prefix)/$(cfg_dir)
 
-install-cfg:  install-tls-cert
+install-cfg:
+	@if ! [ -d $(cfg_prefix)/$(cfg_dir) ]; then \
+		mkdir -p "$(cfg_prefix)/$(cfg_dir)" ; \
+	fi
 	@$(call try_err, $(INSTALL_TOUCH) \
 			"$(cfg_prefix)/$(cfg_dir)tls.cfg.sample" )
 	@sed -e "s#\/usr/local/etc/kamailio/#$(cfg_target)#g" \

--- a/modules/tls/doc/history.xml
+++ b/modules/tls/doc/history.xml
@@ -29,5 +29,10 @@
 			The code is currently maintained by Andrei Pelinescu-Onciul
 			<email>andrei@iptel.org</email>.
 		</para>
+		<para>
+			Install does not generate self-signed certificates by default
+			anymore. In order to generate them now you should do
+			"make install-tls-cert"
+		</para>
 	</section>
 </section>


### PR DESCRIPTION
In order to be able to generate reproducible builds we should not include an auto-generated cert in the default install-cfg rule at tls