### PR TITLE
Fix dialog module still loading DB when db_fetch_rows == 0

### DIFF
--- a/modules/dialog/README
+++ b/modules/dialog/README
@@ -706,8 +706,8 @@ modparam("dialog", "db_update_period", 120)
    the dialog records at startup from the database. This value can be used
    to tune the load time at startup. For 1MB of private memory (default),
    it should be below 400. The database driver must support the
-   fetch_result() capability. A value of 0 means the functionality is
-   disabled.
+   fetch_result() capability. A value of 0 means the db fetch is not
+   limited.
 
    Default value is "200".
 

--- a/modules/dialog/README
+++ b/modules/dialog/README
@@ -706,8 +706,8 @@ modparam("dialog", "db_update_period", 120)
    the dialog records at startup from the database. This value can be used
    to tune the load time at startup. For 1MB of private memory (default),
    it should be below 400. The database driver must support the
-   fetch_result() capability. A value of 0 means the db fetch is not
-   limited.
+   fetch_result() capability. A value of 0 means the functionality is
+   disabled.
 
    Default value is "200".
 

--- a/modules/dialog/dialog.c
+++ b/modules/dialog/dialog.c
@@ -99,6 +99,7 @@ static char* profiles_wv_s = NULL;
 static char* profiles_nv_s = NULL;
 str dlg_extra_hdrs = {NULL,0};
 static int db_fetch_rows = 200;
+static int db_skip_load = 0;
 int initial_cbs_inscript = 1;
 int dlg_wait_ack = 1;
 static int dlg_timer_procs = 0;
@@ -291,6 +292,7 @@ static param_export_t mod_params[]={
 	{ "timer_procs",           PARAM_INT, &dlg_timer_procs          },
 	{ "track_cseq_updates",    PARAM_INT, &_dlg_track_cseq_updates  },
 	{ "lreq_callee_headers",   PARAM_STR, &dlg_lreq_callee_headers  },
+	{ "db_skip_load",          INT_PARAM, &db_skip_load            },
 	{ 0,0,0 }
 };
 
@@ -687,9 +689,11 @@ static int mod_init(void)
 			LM_ERR("db_url not configured for db_mode %d\n", dlg_db_mode);
 			return -1;
 		}
-		if (init_dlg_db(&db_url, dlg_hash_size, db_update_period,db_fetch_rows)!=0) {
-			LM_ERR("failed to initialize the DB support\n");
-			return -1;
+		if (db_skip_load==0) {
+			if (init_dlg_db(&db_url, dlg_hash_size, db_update_period,db_fetch_rows)!=0) {
+				LM_ERR("failed to initialize the DB support\n");
+				return -1;
+			}
 		}
 		run_load_callbacks();
 	}

--- a/modules/dialog/dialog.c
+++ b/modules/dialog/dialog.c
@@ -687,13 +687,9 @@ static int mod_init(void)
 			LM_ERR("db_url not configured for db_mode %d\n", dlg_db_mode);
 			return -1;
 		}
-		// if db_fetch_rows=0 then no rows should be loaded form the db on startup.
-		// http://kamailio.org/docs/modules/3.3.x/modules_k/dialog.html#idp148408
-		if (db_fetch_rows>0) {
-			if (init_dlg_db(&db_url, dlg_hash_size, db_update_period,db_fetch_rows)!=0) {
-				LM_ERR("failed to initialize the DB support\n");
-				return -1;
-			}
+		if (init_dlg_db(&db_url, dlg_hash_size, db_update_period,db_fetch_rows)!=0) {
+			LM_ERR("failed to initialize the DB support\n");
+			return -1;
 		}
 		run_load_callbacks();
 	}

--- a/modules/dialog/dialog.c
+++ b/modules/dialog/dialog.c
@@ -687,9 +687,13 @@ static int mod_init(void)
 			LM_ERR("db_url not configured for db_mode %d\n", dlg_db_mode);
 			return -1;
 		}
-		if (init_dlg_db(&db_url, dlg_hash_size, db_update_period,db_fetch_rows)!=0) {
-			LM_ERR("failed to initialize the DB support\n");
-			return -1;
+		// if db_fetch_rows=0 then no rows should be loaded form the db on startup.
+		// http://kamailio.org/docs/modules/3.3.x/modules_k/dialog.html#idp148408
+		if (db_fetch_rows>0) {
+			if (init_dlg_db(&db_url, dlg_hash_size, db_update_period,db_fetch_rows)!=0) {
+				LM_ERR("failed to initialize the DB support\n");
+				return -1;
+			}
 		}
 		run_load_callbacks();
 	}

--- a/modules/dialog/doc/dialog_admin.xml
+++ b/modules/dialog/doc/dialog_admin.xml
@@ -472,7 +472,7 @@ modparam("dialog", "db_update_period", 120)
 		<para>
 			The number of the rows to be fetched at once from database when loading the dialog records at startup from the database.
 			This value can be used to tune the load time at startup. For 1MB of private memory (default), it should be below 400.
-			The database driver must support the fetch_result() capability. A value of 0 means the functionality is disabled.
+			The database driver must support the fetch_result() capability. A value of 0 means the database fetch is not limited.
 		</para>
 		<para>
 		<emphasis>
@@ -488,6 +488,28 @@ modparam("dialog", "db_fetch_rows", 500)
 </programlisting>
 		</example>
 	</section>
+
+<section>
+		<title><varname>db_skip_load</varname> (integer)</title>
+		<para>
+			Set db_skip_load to 1, to skip the loading of dialogs from the database alltogether.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote> ( not skipped ).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>db_skip_load</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dialog", "db_skip_load", 1)
+...
+</programlisting>
+		</example>
+	</section>
+
+
 
 	<section>
 		<title><varname>table_name</varname> (string)</title>


### PR DESCRIPTION
as per http://kamailio.org/docs/modules/3.3.x/modules_k/dialog.html#idp148408 a db_fetch_row of 0 should not load data from the DB At all.

I think doing this in mod_init makes the most sense, rather than further down in select_entire_dialog_table or similar.  The docs say setting to 0 will only restrict the initial load on startup, not any subsequent loads.