### PR TITLE
modules/p_usrloc: fixes get_all_ucontacts() function signature

### DIFF
--- a/modules/p_usrloc/dlist.c
+++ b/modules/p_usrloc/dlist.c
@@ -153,7 +153,7 @@ unsigned long get_number_of_users(void)
 
 
 int get_all_ucontacts(void *buf, int len, unsigned int flags,
-                         unsigned int part_idx, unsigned int part_max)
+                         unsigned int part_idx, unsigned int part_max, int options)
 {
 	LM_INFO("not available with partitioned interface");
 	return -1;

--- a/modules/p_usrloc/dlist.h
+++ b/modules/p_usrloc/dlist.h
@@ -107,7 +107,7 @@ int register_udomain(const char* _n, udomain_t** _d);
  * \return 0 on success, positive if buffer size was not sufficient, negative on failure
  */
 int get_all_ucontacts(void *, int, unsigned int,
-           unsigned int part_idx, unsigned int part_max);
+           unsigned int part_idx, unsigned int part_max, int options);
 
 /*!
  * \brief Find a particular domain, small wrapper around find_dlist


### PR DESCRIPTION
I am not user of p_usrloc, but accidentally compiled this and bumped into mentioned warning.
Clang 3.0 and GCC 4.7 do not complain.
Clang 3.5 and GCC 4.8 do complain.