### PR TITLE
modules/dialog: make dialog context available in event route tm:local…

### DIFF
--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -1402,8 +1402,12 @@ void dlg_ontimeout(struct dlg_tl *tl)
 
 		if(dlg->iflags&DLG_IFLAG_TIMEOUTBYE)
 		{
+			/* set the dialog context so that it's available in
+			 * tm:local-request event route */
+			dlg_set_ctx_iuid(dlg);
 			if(dlg_bye_all(dlg, NULL)<0)
 				dlg_unref(dlg, 1);
+			dlg_reset_ctx_iuid();	
 
 			dlg_unref(dlg, 1);
 			if_update_stat(dlg_enable_stats, expired_dlgs, 1);


### PR DESCRIPTION
…-request

Set the dialog context before calling dlg_bye_all. In this way the dialog context is the correct one in the event route tm:local-request; otherwise it could happen that, in the timer process, the context is invalid due to some previous timed-out transaction which set (and not reset) the dialog context in the dlg_onreply function (locally generated replies).