### PR TITLE
dialog: implement db_skip_load to skip loading dialogs on startup

### DIFF
--- a/modules/dialog/dialog.c
+++ b/modules/dialog/dialog.c
@@ -99,6 +99,7 @@ static char* profiles_wv_s = NULL;
 static char* profiles_nv_s = NULL;
 str dlg_extra_hdrs = {NULL,0};
 static int db_fetch_rows = 200;
+static int db_skip_load = 0;
 int initial_cbs_inscript = 1;
 int dlg_wait_ack = 1;
 static int dlg_timer_procs = 0;
@@ -291,6 +292,7 @@ static param_export_t mod_params[]={
 	{ "timer_procs",           PARAM_INT, &dlg_timer_procs          },
 	{ "track_cseq_updates",    PARAM_INT, &_dlg_track_cseq_updates  },
 	{ "lreq_callee_headers",   PARAM_STR, &dlg_lreq_callee_headers  },
+	{ "db_skip_load",          INT_PARAM, &db_skip_load             },
 	{ 0,0,0 }
 };
 
@@ -687,7 +689,7 @@ static int mod_init(void)
 			LM_ERR("db_url not configured for db_mode %d\n", dlg_db_mode);
 			return -1;
 		}
-		if (init_dlg_db(&db_url, dlg_hash_size, db_update_period,db_fetch_rows)!=0) {
+		if (init_dlg_db(&db_url, dlg_hash_size, db_update_period, db_fetch_rows, db_skip_load)!=0) {
 			LM_ERR("failed to initialize the DB support\n");
 			return -1;
 		}

--- a/modules/dialog/dlg_db_handler.c
+++ b/modules/dialog/dlg_db_handler.c
@@ -135,7 +135,7 @@ int dlg_connect_db(const str *db_url)
 }
 
 
-int init_dlg_db(const str *db_url, int dlg_hash_size , int db_update_period, int fetch_num_rows)
+int init_dlg_db(const str *db_url, int dlg_hash_size , int db_update_period, int fetch_num_rows, int db_skip_load)
 {
 	/* Find a database module */
 	if (db_bind_mod(db_url, &dialog_dbf) < 0){
@@ -164,15 +164,16 @@ int init_dlg_db(const str *db_url, int dlg_hash_size , int db_update_period, int
 		return -1;
 	}
 
-	if( (load_dialog_info_from_db(dlg_hash_size, fetch_num_rows) ) !=0 ){
-		LM_ERR("unable to load the dialog data\n");
-		return -1;
+	if ( db_skip_load == 0 ) {
+		if( (load_dialog_info_from_db(dlg_hash_size, fetch_num_rows) ) !=0 ){
+			LM_ERR("unable to load the dialog data\n");
+			return -1;
+		}
+		if( (load_dialog_vars_from_db(fetch_num_rows) ) !=0 ){
+			LM_ERR("unable to load the dialog data\n");
+			return -1;
+		}
 	}
-	if( (load_dialog_vars_from_db(fetch_num_rows) ) !=0 ){
-		LM_ERR("unable to load the dialog data\n");
-		return -1;
-	}
-
 	dialog_dbf.close(dialog_db_handle);
 	dialog_db_handle = 0;
 

--- a/modules/dialog/dlg_db_handler.h
+++ b/modules/dialog/dlg_db_handler.h
@@ -112,7 +112,7 @@ extern str vars_value_column;
 extern str dialog_vars_table_name;
 
 
-int init_dlg_db(const str *db_url, int dlg_hash_size, int db_update_period, int fetch_num_rows);
+int init_dlg_db(const str *db_url, int dlg_hash_size , int db_update_period, int fetch_num_rows, int db_skip_load);
 int dlg_connect_db(const str *db_url);
 void destroy_dlg_db(void);
 

--- a/modules/dialog/doc/dialog_admin.xml
+++ b/modules/dialog/doc/dialog_admin.xml
@@ -472,7 +472,7 @@ modparam("dialog", "db_update_period", 120)
 		<para>
 			The number of the rows to be fetched at once from database when loading the dialog records at startup from the database.
 			This value can be used to tune the load time at startup. For 1MB of private memory (default), it should be below 400.
-			The database driver must support the fetch_result() capability. A value of 0 means the functionality is disabled.
+			The database driver must support the fetch_result() capability. A value of 0 means the database fetch is not limited.
 		</para>
 		<para>
 		<emphasis>
@@ -488,6 +488,28 @@ modparam("dialog", "db_fetch_rows", 500)
 </programlisting>
 		</example>
 	</section>
+
+<section>
+		<title><varname>db_skip_load</varname> (integer)</title>
+		<para>
+			Set db_skip_load to 1, to skip the loading of dialogs from the database alltogether.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote> ( not skipped ).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>db_skip_load</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dialog", "db_skip_load", 1)
+...
+</programlisting>
+		</example>
+	</section>
+
+
 
 	<section>
 		<title><varname>table_name</varname> (string)</title>


### PR DESCRIPTION
re-implemented inside init_dlg_db as per your comments, sorry I missed this ! 
hopefully this commit message is correct !