### PR TITLE
usrloc: really do the ignore location record if it's a non-local socket

### DIFF
--- a/modules/usrloc/doc/usrloc_admin.xml
+++ b/modules/usrloc/doc/usrloc_admin.xml
@@ -1064,6 +1064,28 @@ modparam("usrloc", "db_insert_null", 1)
 		</example>
 	</section>
 
+	<section id="usrloc.p.skip_remote_socket">
+		<title><varname>skip_remote_socket</varname> (int)</title>
+		<para>
+			If set to 1, Kamailio will skip location record when loading from
+			database, if socket value of the record does not in kamailio
+			listening socket list.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>skip_remote_socket</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("usrloc", "skip_remote_socket", 1)
+...
+</programlisting>
+		</example>
+	</section>
+
 	</section>
 
 	<section>

--- a/modules/usrloc/udomain.c
+++ b/modules/usrloc/udomain.c
@@ -477,7 +477,7 @@ int preload_udomain(db1_con_t* _c, udomain_t* _d)
 
 			ci = dbrow2info(ROW_VALUES(row)+1, &contact, 0);
 			if (ci==0) {
-				LM_ERR("sipping record for %.*s in table %s\n",
+				LM_ERR("skipping record for %.*s in table %s\n",
 						user.len, user.s, _d->name->s);
 				continue;
 			}

--- a/modules/usrloc/udomain.c
+++ b/modules/usrloc/udomain.c
@@ -311,6 +311,9 @@ static inline ucontact_info_t* dbrow2info(db_val_t *vals, str *contact, int rcon
 		ci.sock = grep_sock_info( &host, (unsigned short)port, proto);
 		if (ci.sock==0) {
 			LM_DBG("non-local socket <%s>...ignoring\n", p);
+			if (skip_remote_socket) {
+				return 0;
+			}
 		}
 	}
 

--- a/modules/usrloc/ul_mod.c
+++ b/modules/usrloc/ul_mod.c
@@ -161,6 +161,7 @@ int use_domain      = 0;				/*!< Whether usrloc should use domain part of aor */
 int desc_time_order = 0;				/*!< By default do not enable timestamp ordering */
 int handle_lost_tcp = 0;				/*!< By default do not remove contacts before expiration time */
 int close_expired_tcp = 0;				/*!< By default do not close TCP connections for expired contacts */
+int skip_remote_socket = 0;				/*!< By default do not skip remote socket */
 
 int ul_fetch_rows = 2000;				/*!< number of rows to fetch from result */
 int ul_hash_size = 10;
@@ -221,6 +222,7 @@ static param_export_t params[] = {
 	{"nat_bflag",           INT_PARAM, &nat_bflag       },
 	{"handle_lost_tcp",     INT_PARAM, &handle_lost_tcp },
 	{"close_expired_tcp",   INT_PARAM, &close_expired_tcp },
+	{"skip_remote_socket",  INT_PARAM, &skip_remote_socket },
 	{"preload",             PARAM_STRING|USE_FUNC_PARAM, (void*)ul_preload_param},
 	{"db_update_as_insert", INT_PARAM, &ul_db_update_as_insert},
 	{"timer_procs",         INT_PARAM, &ul_timer_procs},

--- a/modules/usrloc/ul_mod.h
+++ b/modules/usrloc/ul_mod.h
@@ -86,6 +86,7 @@ extern int ul_db_check_update;
 extern int ul_keepalive_timeout;
 extern int handle_lost_tcp;
 extern int close_expired_tcp;
+extern int skip_remote_socket;
 
 
 /*! nat branch flag */


### PR DESCRIPTION

* When usrloc loading location records from database, and if the socket of the record is not matched in kamailio's listening socket list, It only throws LM_ERR ignoring message only but still store into memory.
should `return 0` as well.

* And the message typo sometimes confused people to distinguish that kamailio is "sipping" the record (redirct) or "skipping" the record.