### PR TITLE
Small typo fix in config.

### DIFF
--- a/etc/kamailio.cfg
+++ b/etc/kamailio.cfg
@@ -884,7 +884,7 @@ route[TOVOICEMAIL] {
 
 	# check if VoiceMail server IP is defined
 	if (strempty($sel(cfg_get.voicemail.srv_ip))) {
-		xlog("SCRIPT: VoiceMail rotuing enabled but IP not defined\n");
+		xlog("SCRIPT: VoiceMail routing enabled but IP not defined\n");
 		return;
 	}
 	if(is_method("INVITE")) {


### PR DESCRIPTION
There is a small typo in kamailio.cfg where "Rotuing" has been written instead of "Routing".