### PR TITLE
parser: Fix read buffer overflow in parse_hname2

### DIFF
--- a/parser/case_reas.h
+++ b/parser/case_reas.h
@@ -49,7 +49,7 @@
 
 #define reas_CASE		\
 	p += 4;				\
-	val = READ(p);		\
+	val = SAFE_READ(p, end - p);	\
 	ON_CASE;			\
 	goto other;
 

--- a/parser/parse_hname2.c
+++ b/parser/parse_hname2.c
@@ -95,11 +95,26 @@ static inline char* skip_ws(char* p, unsigned int size)
 
 /*@} */
 
+#define SAFE_READ(val, len) \
+((len) == 1 ? READ1(val) : ((len) == 2 ? READ2(val) : ((len) == 3 ? READ3(val) : ((len) > 3 ? READ4(val) : READ0(val)))))
+
 #define READ(val) \
-(*(val + 0) + (*(val + 1) << 8) + (*(val + 2) << 16) + (*(val + 3) << 24))
+READ4(val)
+
+#define READ4(val) \
+(*((val) + 0) + (*((val) + 1) << 8) + (*((val) + 2) << 16) + (*((val) + 3) << 24))
 
 #define READ3(val) \
-(*(val + 0) + (*(val + 1) << 8) + (*(val + 2) << 16))
+(*((val) + 0) + (*((val) + 1) << 8) + (*((val) + 2) << 16))
+
+#define READ2(val) \
+(*((val) + 0) + (*((val) + 1) << 8))
+
+#define READ1(val) \
+(*((val) + 0))
+
+#define READ0(val) \
+(0)
 
 #define FIRST_QUATERNIONS       \
         case _via1_: via1_CASE; \


### PR DESCRIPTION
Fix buffer overflow in READ call by making a SAFE_READ that checks
the actual length of the buffer.

In the buffer overflow case parse_hname2 is called with 'begin' set to
the string "Reason:". This string was originally allocated in in
rval_get_str as length 6, contents "Reason\0'. The actual pkg_malloc
is size of 7 to account for the null terminator.

In the caller to parse_hname2 (modules/textops/textops.c line 2229)
the null terminator is replaced with a ':' character.

parse_hname2 hits the FIRST_QUARTERNIONS macro which expands to a
bunch of case statements. The one for the Reason string looks like
(macro expanded):

       case _reas_:
        p += 4;
        val = READ(p);
        switch(LOWER_DWORD(val)) {
                case _on1_:
                        hdr->type = HDR_REASON_T;
                        hdr->name.len = 6;
                        return (p + 3);

The overflow occurs in the READ call. READ is:

    (*(val + 0) + (*(val + 1) << 8) + (*(val + 2) << 16) + (*(val + 3) << 24))

With 'p' pointing to "Reason:", then p+4 is "on:". That's only three
characters of allocated memory left(the : was originally the null
character as explained above and the total pkg_malloc allocated length
was 7). READ accesses 4 bytes so we go one past the end of the
allocated area.

The error is noticeable in a DBG_SYS_MALLOC build but not a PKG_MALLOC
build - I assume the latter has a large arena allocated making the
buffer overflow still valid memory.

There are likely other buffer overflows in the READ usage in other cases in this function. I've [posted to the mailing list](http://lists.sip-router.org/pipermail/sr-dev/2015-August/030529.html) about the issue and whether a more general fix is possible:

