### PR TITLE
pv: create command to copy script vars to xavp

### DIFF
--- a/modules/pv/README
+++ b/modules/pv/README
@@ -11,11 +11,11 @@ Daniel-Constantin Mierla
 
    <daniel@asipto.com>
 
-   Copyright © 2008-2011 Daniel-Constantin Mierla (asipto.com)
+   Copyright (c) 2008-2011 Daniel-Constantin Mierla (asipto.com)
 
-   Copyright © 2011 Juha Heinanen
+   Copyright (c) 2011 Juha Heinanen
 
-   Copyright © 2013 Olle E. Johansson, Edvina AB
+   Copyright (c) 2013 Olle E. Johansson, Edvina AB
      __________________________________________________________________
 
    Table of Contents
@@ -46,6 +46,7 @@ Daniel-Constantin Mierla
               4.8. sbranch_append()
               4.9. sbranch_reset()
               4.10. pv_xavp_print()
+              4.11. pv_var_to_xavp(varname, xname)
 
         5. MI Commands
 
@@ -72,8 +73,9 @@ Daniel-Constantin Mierla
    1.11. sbranch_append() usage
    1.12. sbranch_append() usage
    1.13. pv_xavp_print() usage
-   1.14. shv_set usage
-   1.15. shv_get usage
+   1.14. pv_var_to_xavp() usage
+   1.15. shv_set usage
+   1.16. shv_get usage
 
 Chapter 1. Admin Guide
 
@@ -103,6 +105,7 @@ Chapter 1. Admin Guide
         4.8. sbranch_append()
         4.9. sbranch_reset()
         4.10. pv_xavp_print()
+        4.11. pv_var_to_xavp(varname, xname)
 
    5. MI Commands
 
@@ -207,6 +210,7 @@ modparam("pv","avp_aliases","email=s:email_addr;tmp=i:100")
    4.8. sbranch_append()
    4.9. sbranch_reset()
    4.10. pv_xavp_print()
+   4.11. pv_var_to_xavp(varname, xname)
 
 4.1. pv_isset(pvar)
 
@@ -239,7 +243,7 @@ if(pv_isset("$avp(s:x)"))
 pv_unset("$avp(s:x)");
 ...
 
-4.3. is_int(pvar)
+4.3.  is_int(pvar)
 
    Function checks if pvar argument contains integer value and returns 1
    if it does and -1 otherwise.
@@ -253,7 +257,7 @@ if (is_int("$var(foo)")) {
 }
 ...
 
-4.4. typeof(pvar, vtype)
+4.4.  typeof(pvar, vtype)
 
    Returns true if the type of pseudo-variable matches the second
    parameter. The second parameter can be: 'int' - type is integer; 'str'
@@ -268,7 +272,7 @@ if (typeof("$var(foo)", "str")) {
 }
 ...
 
-4.5. not_empty(pvar)
+4.5.  not_empty(pvar)
 
    Returns true if the pseudo-variables has the type string and is not
    empty value.
@@ -282,7 +286,7 @@ if (not_empty("$var(foo)")) {
 }
 ...
 
-4.6. xavp_params_explode(sparams, xname)
+4.6.  xavp_params_explode(sparams, xname)
 
    Convert a parameters string in xavp atributes.
 
@@ -303,7 +307,7 @@ xavp_params_explode("a=b;c=d;e=d", "x");
 #    $xavp(x=>e) = "f";
 ...
 
-4.7. sbranch_set_ruri()
+4.7.  sbranch_set_ruri()
 
    Use the attributes from static branch ($sbranch(key) variable) to set
    request URI and the other fields of the branch associated with request
@@ -324,7 +328,7 @@ $sbranch(send_socket) =  "udp:127.0.0.1:5060";
 sbranch_set_ruri();
 ...
 
-4.8. sbranch_append()
+4.8.  sbranch_append()
 
    Use the attributes from static branch ($sbranch(key) variable) to
    append a new branch to destination set. It is an alternative to
@@ -345,7 +349,7 @@ $sbranch(send_socket) =  "udp:127.0.0.1:5060";
 sbranch_append();
 ...
 
-4.9. sbranch_reset()
+4.9.  sbranch_reset()
 
    Reset the content of static branch ($sbranch(key) variable.
 
@@ -356,7 +360,7 @@ sbranch_append();
 sbranch_reset();
 ...
 
-4.10. pv_xavp_print()
+4.10.  pv_xavp_print()
 
    Print all XAVPs to the syslog using INFO log level.
 
@@ -365,6 +369,30 @@ sbranch_reset();
    Example 1.13. pv_xavp_print() usage
 ...
 pv_xavp_print();
+...
+
+4.11.  pv_var_to_xavp(varname, xname)
+
+   Copy script variables values to a xavp.
+
+   First parameter can be '*' in order to copy all script variables.
+   Second parameter is the name of the destination xavp. If xavp already
+   exists it will be reset first.
+
+   Function can be used from ANY_ROUTE.
+
+   Example 1.14. pv_var_to_xavp() usage
+...
+$var("temp") = 3;
+$var("foo") = "foo indeed";
+pv_var_to_xavp("temp", "ok");
+...
+$xavp("ok[0]=>temp") now is 3
+...
+pv_var_to_xavp("*", "ok");
+...
+$xavp("ok[0]=>temp") now is 3
+$xavp("ok[0]=>foo") now is "foo indeed"
 ...
 
 5. MI Commands
@@ -390,7 +418,7 @@ pv_xavp_print();
                 _value_
                 _empty_line_
 
-   Example 1.14. shv_set usage
+   Example 1.15. shv_set usage
 ...
 $ kamctl fifo shv_set debug int 0
 ...
@@ -408,7 +436,7 @@ $ kamctl fifo shv_set debug int 0
                 _name_
                 _empty_line_
 
-   Example 1.15. shv_get usage
+   Example 1.16. shv_get usage
 ...
 $ kamctl fifo shv_get debug
 $ kamctl fifo shv_get

--- a/modules/pv/doc/pv_admin.xml
+++ b/modules/pv/doc/pv_admin.xml
@@ -395,6 +395,37 @@ pv_xavp_print();
 				</programlisting>
 			</example>
 		</section>
+		<section id="pv.f.pv_var_to_xavp">
+			<title>
+				<function moreinfo="none">pv_var_to_xavp(varname, xname)</function>
+			</title>
+			<para>
+				Copy script variables values to a xavp.
+			</para>
+			<para>
+				First parameter can be '*' in order to copy all script variables. Second parameter is the name of the destination xavp. If xavp already exists it will be reset first.
+			</para>
+			<para>
+			Function can be used from ANY_ROUTE.
+			</para>
+			<example>
+				<title><function>pv_var_to_xavp()</function> usage</title>
+				<programlisting format="linespecific">
+...
+$var("temp") = 3;
+$var("foo") = "foo indeed";
+pv_var_to_xavp("temp", "ok");
+...
+$xavp("ok[0]=>temp") now is 3
+...
+pv_var_to_xavp("*", "ok");
+...
+$xavp("ok[0]=>temp") now is 3
+$xavp("ok[0]=>foo") now is "foo indeed"
+...
+				</programlisting>
+			</example>
+		</section>
 	</section>
 
 	<section>

--- a/modules/pv/pv.c
+++ b/modules/pv/pv.c
@@ -494,6 +494,7 @@ static int w_xavp_params_explode(sip_msg_t *msg, char *pparams, char *pxname);
 static int w_sbranch_set_ruri(sip_msg_t *msg, char p1, char *p2);
 static int w_sbranch_append(sip_msg_t *msg, char p1, char *p2);
 static int w_sbranch_reset(sip_msg_t *msg, char p1, char *p2);
+static int w_var_to_xavp(sip_msg_t *msg, char *p1, char *p2);
 
 static int pv_init_rpc(void);
 
@@ -504,6 +505,8 @@ static cmd_export_t cmds[]={
 		ANY_ROUTE },
 #ifdef WITH_XAVP
 	{"pv_xavp_print",  (cmd_function)pv_xavp_print,  0, 0, 0, 
+		ANY_ROUTE },
+	{"pv_var_to_xavp",  (cmd_function)w_var_to_xavp, 2, 0, 0,
 		ANY_ROUTE },
 #endif
 	{"is_int", (cmd_function)is_int, 1, fixup_pvar_null, fixup_free_pvar_null,
@@ -691,6 +694,20 @@ static int is_int(struct sip_msg* msg, char* pvar, char* s2)
 	}
 
 	return -1;
+}
+
+static int w_var_to_xavp(sip_msg_t *msg, char *s1, char *s2)
+{
+	str xname, varname;
+
+	if(s1 == NULL || s2 == NULL) {
+		LM_ERR("wrong parameters\n");
+		return -1;
+	}
+
+	varname.len = strlen(s1); varname.s = s1;
+	xname.s = s2; xname.len = strlen(s2);
+	return pv_var_to_xavp(&varname, &xname);
 }
 
 /**

--- a/modules/pv/pv_svar.c
+++ b/modules/pv/pv_svar.c
@@ -186,6 +186,10 @@ script_var_t* get_varnull_by_name(str *name)
 	return 0;
 }
 
+script_var_t* get_var_all(void) {
+	return script_vars;
+}
+
 void reset_vars(void)
 {
 	script_var_t *it;

--- a/modules/pv/pv_svar.h
+++ b/modules/pv/pv_svar.h
@@ -51,6 +51,7 @@ script_var_t* add_var(str *name, int vtype);
 script_var_t* set_var_value(script_var_t *var, int_str *value, int flags);
 script_var_t* get_var_by_name(str *name);
 script_var_t* get_varnull_by_name(str *name);
+script_var_t* get_var_all(void);
 
 void reset_vars(void);
 void destroy_vars(void);

--- a/modules/pv/pv_xavp.h
+++ b/modules/pv/pv_xavp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Daniel-Constantin Mierla (asipto.com) 
+ * Copyright (C) 2009 Daniel-Constantin Mierla (asipto.com)
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -20,6 +20,7 @@
 #ifdef WITH_XAVP
 
 #include "../../pvar.h"
+#include "pv_svar.h"
 
 int pv_get_xavp(struct sip_msg *msg, pv_param_t *param,
 		pv_value_t *res);
@@ -30,6 +31,8 @@ int pv_parse_xavp_name(pv_spec_p sp, str *in);
 int pv_xavp_print(struct sip_msg* msg, char* s1, char *s2);
 
 int xavp_params_explode(str *params, str *xname);
+
+int pv_var_to_xavp(str *varname, str *xname);
 
 #endif
 #endif


### PR DESCRIPTION
pv_scriptvar2xavp(varname, xname)

Copy script variables values to a xavp.

First parameter can be '*' in order to copy all script variables.
Second parameter is the name of the destination xavp. If xavp already
exists it will be reset first.

Function can be used from ANY_ROUTE.