### PR TITLE
Change remove_ts_transaction so it updates head pointer of list

### DIFF
--- a/modules/tsilo/ts_hash.c
+++ b/modules/tsilo/ts_hash.c
@@ -396,8 +396,8 @@ void remove_ts_transaction(ts_transaction_t* ts_t)
 	if (ts_t->prev)
 		ts_t->prev->next = ts_t->next;
 
-	if ((ts_t->prev == NULL) && (ts_t->next == NULL))
-		ts_t->urecord->transactions = NULL;
+	if (ts_t->urecord->transactions == ts_t)
+		ts_t->urecord->transactions = ts_t->next;
 
 	free_ts_transaction((void*)ts_t);
 


### PR DESCRIPTION
If the transaction being removed is the first item in the list
of transactions then we need to update the pointer to the head
of the list so it does not have a stale reference.

This is an attempt to fix the tsilo crashes we've been seeing. The crashes occur in ts_onreply while iterating over the transactions to remove the transaction for the TMCB_DESTROY callback. One of the transaction pointers is not a valid shared memory address and the process crashes.

This crash results in the main kamailio process getting a SIGCHILD signal and it tries to shut down. This reaches code to free the transactions and it crashes in free_ts_urecord while trying to free the same transaction.

Inspecting code I can't tell how remove_ts_transaction resets urecord->transactions to be the head of the list of the first transaction to be removed is the first item in the list. This would leave a dangling pointer there and seems likely to be the cause of the crash.