### PR TITLE
Return CSCF_RETURN_FALSE if AAR is not generated

### DIFF
--- a/modules/ims_qos/mod.c
+++ b/modules/ims_qos/mod.c
@@ -622,6 +622,7 @@ static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *c_id, int
     //We don't ever do AAR on request for calling scenario...
     if (msg->first_line.type != SIP_REPLY) {
         LM_DBG("Can't do AAR for call session in request\n");
+		result = CSCF_RETURN_FALSE;
         return result;
     }
 
@@ -634,17 +635,19 @@ static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *c_id, int
     }
 
     //we dont apply QoS if its not a reply to an INVITE! or UPDATE or PRACK!
-    if ((t->method.len == 5 && memcmp(t->method.s, "PRACK", 5) == 0)
-            || (t->method.len == 6 && (memcmp(t->method.s, "INVITE", 6) == 0
-            || memcmp(t->method.s, "UPDATE", 6) == 0))) {
-        if (cscf_get_content_length(msg) == 0
-                || cscf_get_content_length(t->uas.request) == 0) {
-            LM_DBG("No SDP offer answer -> therefore we can not do Rx AAR");
-            //goto aarna; //AAR na if we dont have offer/answer pair
-            return result;
-        }
+    if ((t->method.len == 5 && memcmp(t->method.s, "PRACK", 5) == 0) 
+		|| (t->method.len == 6 && (memcmp(t->method.s, "INVITE", 6) == 0 
+		|| memcmp(t->method.s, "UPDATE", 6) == 0))) {
+			if (cscf_get_content_length(msg) == 0 
+				|| cscf_get_content_length(t->uas.request) == 0) {
+				LM_DBG("No SDP offer answer -> therefore we can not do Rx AAR");
+				//goto aarna; //AAR na if we dont have offer/answer pair
+				result = CSCF_RETURN_FALSE;
+				return result;
+			}
     } else {
         LM_DBG("Message is not response to INVITE, PRACK or UPDATE -> therefore we do not Rx AAR");
+		result = CSCF_RETURN_FALSE;
         return result;
     }
 


### PR DESCRIPTION
Differentiate the cases where AAR is not sent because
of an error and the cases where AAR is not sent because it is logically wrong to sent them at that point of the transaction. In this way, in the routing script it is possible to distinguish between an error and (for example) send back an error to the UE and when AAR is not generated because (for example) the answer does not contain an SDP or you are not in a SIP reply. In this case, you should not send back an error but go ahead with your transaction.
I noticed that CSCF_RETURN_FALSE (-1) is never used in the function, so it can be suitable to be returned in the cases just explained