### PR TITLE
Utils module: http_request modification

### DIFF
--- a/modules/utils/functions.c
+++ b/modules/utils/functions.c
@@ -86,6 +86,8 @@ int http_query(struct sip_msg* _m, char* _url, char* _dst, char* _post, char* _h
 	pv_value_t val;
 	double download_size;
 	struct curl_slist *chunk = NULL;
+	double size;
+    	char *head;
 
 	memset(&stream, 0, sizeof(http_res_stream_t));
 
@@ -200,18 +202,20 @@ int http_query(struct sip_msg* _m, char* _url, char* _dst, char* _post, char* _h
 		LM_DBG("http_query download size: %u\n", (unsigned int)download_size);
 
 		/* search for line feed and remove initial empty lines*/
-		at = memchr(stream.buf, (char)10, download_size);
-		while (at == stream.buf) {
-                	stream.buf += 1 ;
-                	download_size -= 1 ;
-                	at = memchr(stream.buf, (char)10, download_size);
+		head = stream.buf;
+		size = download_size;
+		at = memchr(head, (char)10, size);
+		while (at == head) {
+                	head += 1 ;
+                	size -= 1 ;
+                	at = memchr(head, (char)10, size);
         	}
 		if (at == NULL) {
 			/* not found: use whole stream */
-			at = stream.buf + (unsigned int)download_size;
+			at = head + (unsigned int)size;
 		}
-		val.rs.s = stream.buf;
-		val.rs.len = at - stream.buf;
+		val.rs.s = head;
+		val.rs.len = at - head;
 		LM_DBG("http_query result: %.*s\n", val.rs.len, val.rs.s);
 		val.flags = PV_VAL_STR;
 		dst = (pv_spec_t *)_dst;

--- a/modules/utils/functions.c
+++ b/modules/utils/functions.c
@@ -199,8 +199,13 @@ int http_query(struct sip_msg* _m, char* _url, char* _dst, char* _post, char* _h
 		curl_easy_getinfo(curl, CURLINFO_SIZE_DOWNLOAD, &download_size);
 		LM_DBG("http_query download size: %u\n", (unsigned int)download_size);
 
-		/* search for line feed */
+		/* search for line feed and remove initial empty lines*/
 		at = memchr(stream.buf, (char)10, download_size);
+		while (at == stream.buf) {
+                	stream.buf += 1 ;
+                	download_size -= 1 ;
+                	at = memchr(stream.buf, (char)10, download_size);
+        	}
 		if (at == NULL) {
 			/* not found: use whole stream */
 			at = stream.buf + (unsigned int)download_size;


### PR DESCRIPTION
Hi,
Here is a modification of the http_request function of the utils module.
The idea is to ignore empty lines at the beginning of the http response.
This way, the response returned to Kamailio is the first non empty line of the http response.
This is to solve an issue encountered with apache2 sometimes returning empty lines.
I am no c++ developper and no acquainted to Github (double check the patch).
Thanks,
Laurent.