### PR TITLE
tmx: safety check for bad callid header in t_precheck_tran()

### DIFF
--- a/modules/tmx/tmx_pretran.c
+++ b/modules/tmx/tmx_pretran.c
@@ -227,6 +227,10 @@ int tmx_check_pretran(sip_msg_t *msg)
 		LM_ERR("failed to get From header\n");
 		return -1;
 	}
+	if (msg->callid==NULL || msg->callid->body.s==NULL) {
+		LM_ERR("failed to parse callid headers\n");
+		return -1;
+	}
 
 	vbr = msg->via1->branch;
 


### PR DESCRIPTION
- reported by GH#331