### PR TITLE
tsilo: Fix pointer comparison in ts_set_tm_callbacks

### DIFF
--- a/modules/tsilo/ts_handlers.c
+++ b/modules/tsilo/ts_handlers.c
@@ -40,14 +40,11 @@ int ts_set_tm_callbacks(struct cell *t, sip_msg_t *req, ts_transaction_t *ts)
 	if(t==NULL)
 		return -1;
 
-	if ( (ts_clone=clone_ts_transaction(ts)) < 0 ) {
+	if ( (ts_clone=clone_ts_transaction(ts)) == NULL ) {
 		LM_ERR("failed to clone transaction\n");
 		return -1;
 	}
 
-	if (ts_clone == NULL) {
-		LM_ERR("transaction clone null\n");
-	}
 	if ( _tmb.register_tmcb( req, t,TMCB_DESTROY,
 			ts_onreply, (void*)ts_clone, free_ts_transaction)<0 ) {
 		LM_ERR("failed to register TMCB for transaction %d:%d\n", t->hash_index, t->label);


### PR DESCRIPTION
- Fix cloned ts_transaction pointer comparison to check for
  NULL rather than less than zero. The latter doesn't make
  sense for an allocated pointer.

The commit also ensure that the function returns with an error in the case of a NULL cloned pointer so that it's not later dereferenced.