### PR TITLE
textops: prevent null dereference on tr_txt_eval_re error

### DIFF
--- a/modules/textops/txt_var.c
+++ b/modules/textops/txt_var.c
@@ -124,7 +124,7 @@ int tr_txt_eval_re(struct sip_msg *msg, tr_param_t *tp, int subtype,
 	return 0;
 
 error:
-	if (tp->type == TR_PARAM_SPEC) {
+	if (tp->type == TR_PARAM_SPEC && se!=NULL) {
 		subst_expr_free(se);
 	}
 	return -1;


### PR DESCRIPTION
- Check for NULL pointer before calling subst_expr_free
  to prevent NULL pointer dereference when there is an
  unknown subtype error.