### PR TITLE
htable: Fix buffer overrun in htable_rpc_list

### DIFF
--- a/modules/htable/htable.c
+++ b/modules/htable/htable.c
@@ -1044,7 +1044,7 @@ static void  htable_rpc_list(rpc_t* rpc, void* c)
 		if (ht->dbtable.len > 0) {
 			len = ht->dbtable.len > 127 ? 127 : ht->dbtable.len;
 			memcpy(dbname, ht->dbtable.s, len);
-			dbname[ht->dbtable.len] = '\0';
+			dbname[len] = '\0';
 		} else {
 			dbname[0] = '\0';
 		}


### PR DESCRIPTION
- Fix for using wrong len variable in htable_rpc_list if
  ht->dbtable.len is greater than 127, causing an out of
  bounds write.