### PR TITLE
sqlops: Don't pkg_free memory that wasn't pkg_malloc'd

### DIFF
--- a/modules/sqlops/sql_var.c
+++ b/modules/sqlops/sql_var.c
@@ -104,7 +104,6 @@ int sql_parse_index(str *in, gparam_t *gp)
 		if (gp->v.pvs == NULL)
 		{
 			LM_ERR("no pkg memory left for pv_spec_t\n");
-		    pkg_free(gp);
 		    return -1;
 		}
 
@@ -112,7 +111,6 @@ int sql_parse_index(str *in, gparam_t *gp)
 		{
 			LM_ERR("invalid PV identifier\n");
 		    pkg_free(gp->v.pvs);
-		    pkg_free(gp);
 			return -1;
 		}
 	} else {


### PR DESCRIPTION
- Don't pkg_free the gparam_t parameter of sql_parse_index.
  When called within pv_parse_dbr_name that parameter is
  an internal field in the sql_pv_t structure and wasn't
  allocated with pkg_malloc.