### PR TITLE
janssonrpc-c: Fix use after free

### DIFF
--- a/modules/janssonrpc-c/janssonrpc_server.c
+++ b/modules/janssonrpc-c/janssonrpc_server.c
@@ -591,8 +591,10 @@ void free_server_list(server_list_t* list)
 		return;
 
 	server_list_t* node = NULL;
-	for(node=list; node!=NULL; node=node->next)
+	server_list_t* next = NULL;
+	for(node=list; node!=NULL; node=next)
 	{
+		next = node->next;
 		pkg_free(node);
 	}
 }


### PR DESCRIPTION
- Fix use after free due to pointer aliasing of 'arg' and 'a'
  in server_backoff_cb.
- Fix use after free in force_disconnect
- Fix use after free in free_server_list