### PR TITLE
acc: add acc_prepare_always parameter

### DIFF
--- a/modules/acc/acc_logic.c
+++ b/modules/acc/acc_logic.c
@@ -102,7 +102,7 @@ struct acc_enviroment acc_env;
 	(((_rq)->REQ_METHOD==METHOD_CANCEL) && report_cancels==0)
 
 #define is_acc_prepare_on(_rq) \
-	(is_acc_flag_set(_rq,acc_prepare_flag))
+	(acc_prepare_always || is_acc_flag_set(_rq,acc_prepare_flag))
 
 static void tmcb_func( struct cell* t, int type, struct tmcb_params *ps );
 

--- a/modules/acc/acc_mod.c
+++ b/modules/acc/acc_mod.c
@@ -108,6 +108,7 @@ static char *failed_filter_str = 0;  /* by default, do not filter logging of
 unsigned short failed_filter[MAX_FAILED_FILTER_COUNT + 1];
 static char* leg_info_str = 0;	/*!< multi call-leg support */
 struct acc_extra *leg_info = 0;
+int acc_prepare_always = 0; /* prepare the request always for later acc */
 int acc_prepare_flag = -1; /*!< should the request be prepared for later acc */
 char *acc_time_format = "%Y-%m-%d %H:%M:%S";
 int reason_from_hf = 0; /*!< assign reason from reason hf if present */
@@ -262,6 +263,7 @@ static param_export_t params[] = {
 	{"multi_leg_info",          PARAM_STRING, &leg_info_str            },
 	{"detect_direction",        INT_PARAM, &detect_direction        },
 	{"acc_prepare_flag",        INT_PARAM, &acc_prepare_flag        },
+	{"acc_prepare_always",      INT_PARAM, &acc_prepare_always      },
 	{"reason_from_hf",          INT_PARAM, &reason_from_hf          },
 	/* syslog specific */
 	{"log_flag",             INT_PARAM, &log_flag             },

--- a/modules/acc/acc_mod.h
+++ b/modules/acc/acc_mod.h
@@ -103,5 +103,6 @@ extern int acc_time_mode;
 extern str acc_time_attr;
 extern str acc_time_exten;
 
+extern int acc_prepare_always;
 
 #endif

--- a/modules/acc/doc/acc_admin.xml
+++ b/modules/acc/doc/acc_admin.xml
@@ -624,7 +624,7 @@ modparam("acc", "detect_direction", 1)
 		later, with flags set in TM module specific routes (e.g., like
 		failure_route). If this flag is not set and acc or missed_call flag
 		are not set either in request route block, there is no way to mark the
-		request for transaction later. If either acc or missed_call flags are
+		request for transaction later unless you set acc_prepare_always. If either acc or missed_call flags are
 		set in request route block, there is no need to set this flag.
 		</para>
 		<para>
@@ -635,6 +635,23 @@ modparam("acc", "detect_direction", 1)
 		<programlisting format="linespecific">
 ...
 modparam("acc", "acc_prepare_flag", 5)
+...
+</programlisting>
+		</example>
+	</section>
+	<section id="acc.p.acc_prepare_always">
+		<title><varname>acc_prepare_always</varname> (integer)</title>
+		<para>
+		Prepare all request even if acc_prepare_flag is not set to mark the request for transaction later.
+		</para>
+		<para>
+		Default value is not-set (previous behaviour).
+		</para>
+		<example>
+		<title>acc_prepare_flag example</title>
+		<programlisting format="linespecific">
+...
+modparam("acc", "acc_prepare_always", 1)
 ...
 </programlisting>
 		</example>


### PR DESCRIPTION
This will force the preparation of the request no matter if the acc_prepare_flag is set at the moment of the transaction creation.

Following @miconda idea at: http://lists.sip-router.org/pipermail/sr-users/2015-July/089191.html