### PR TITLE
acc_radius doc: information about freeradius-client

### DIFF
--- a/modules/acc_radius/doc/acc_radius_admin.xml
+++ b/modules/acc_radius/doc/acc_radius_admin.xml
@@ -50,10 +50,18 @@
 			</para>
 			<itemizedlist>
 				<listitem>
-				<para><emphasis>radiusclient-ng</emphasis> 0.5.0 or higher.
+				<para><emphasis>radiusclient-ng</emphasis> 0.5.0 or freeradius-client 
+				or higher.
 				See <ulink 
-				url='http://developer.berlios.de/projects/radiusclient-ng/'>
-				http://developer.berlios.de/projects/radiusclient-ng/</ulink>.
+				url='https://github.com/FreeRADIUS/freeradius-client/'>
+				https://github.com/FreeRADIUS/freeradius-client/</ulink>.
+				</para>
+				</listitem>
+				<listitem>
+				<para>
+				<emphasis>freeradius-client</emphasis> library can be used after 
+				setting FREERADIUS variable in source code with 
+				<emphasis>'export FREERADIUS=1'</emphasis> before compile.
 				</para>
 				</listitem>
 			</itemizedlist>


### PR DESCRIPTION
Added some information for freeradius-client to acc documents. radiusclient-ng website isn't avaible so is removed.