### PR TITLE
acc_radius : adding radius time mode

### DIFF
--- a/modules/acc_radius/acc_radius_mod.c
+++ b/modules/acc_radius/acc_radius_mod.c
@@ -74,6 +74,7 @@ static char *radius_config = 0;
 int radius_flag = -1;
 int radius_missed_flag = -1;
 static int service_type = -1;
+int rad_time_mode=0;
 void *rh;
 /* rad extra variables */
 static char *rad_extra_str = 0;
@@ -91,11 +92,12 @@ static cmd_export_t cmds[] = {
 
 
 static param_export_t params[] = {
-	{"radius_config",        PARAM_STRING, &radius_config        },
+	{"radius_config",        PARAM_STRING, &radius_config     },
 	{"radius_flag",          INT_PARAM, &radius_flag          },
 	{"radius_missed_flag",   INT_PARAM, &radius_missed_flag   },
 	{"service_type",         INT_PARAM, &service_type         },
-	{"radius_extra",         PARAM_STRING, &rad_extra_str        },
+	{"radius_extra",         PARAM_STRING, &rad_extra_str     },
+	{"rad_time_mode",          INT_PARAM, &rad_time_mode      },
 	{0,0,0}
 };
 
@@ -347,9 +349,20 @@ int acc_radius_send_request(struct sip_msg *req, acc_info_t *inf)
 	av_type = req->REQ_METHOD; /* method */
 	ADD_RAD_AVPAIR( RA_SIP_METHOD, &av_type, -1);
 
-	/* unix time */
-	av_type = (uint32_t)inf->env->ts;
-	ADD_RAD_AVPAIR( RA_TIME_STAMP, &av_type, -1);
+	// Event Time Stamp with Microseconds
+        if(rad_time_mode==1){
+                gettimeofday(&inf->env->tv, NULL);
+                double tsecmicro;
+                tsecmicro=inf->env->tv.tv_sec+((double)inf->env->tv.tv_usec/1000000.0);
+                char smicrosec[18];
+                //radius client doesn t support double
+                sprintf(smicrosec,"%f",tsecmicro);
+                ADD_RAD_AVPAIR(RA_TIME_STAMP, &smicrosec, -1);
+        }else{
+                av_type = (uint32_t)inf->env->ts;
+                ADD_RAD_AVPAIR(RA_TIME_STAMP, &av_type, -1);
+        }
+
 
 	/* add extra also */
 	o = accb.get_extra_attrs(rad_extra, req, inf->varr+attr_cnt,

--- a/modules/acc_radius/acc_radius_mod.c
+++ b/modules/acc_radius/acc_radius_mod.c
@@ -330,6 +330,8 @@ int acc_radius_send_request(struct sip_msg *req, acc_info_t *inf)
 	int m=0;
 	int o=0;
 	int rc_result=-1;
+	double tsecmicro;
+	char smicrosec[18];
 	
 	send=NULL;
 
@@ -352,9 +354,7 @@ int acc_radius_send_request(struct sip_msg *req, acc_info_t *inf)
 	// Event Time Stamp with Microseconds
         if(rad_time_mode==1){
                 gettimeofday(&inf->env->tv, NULL);
-                double tsecmicro;
                 tsecmicro=inf->env->tv.tv_sec+((double)inf->env->tv.tv_usec/1000000.0);
-                char smicrosec[18];
                 //radius client doesn t support double
                 sprintf(smicrosec,"%f",tsecmicro);
                 ADD_RAD_AVPAIR(RA_TIME_STAMP, &smicrosec, -1);


### PR DESCRIPTION
Hello;
with adding microseconds to Event-Time-Stamp , it will be more specific time. radiusclient library doesnt support double so i had to convert from double to char variable. in addition , after changing radius time mode to 1 , Event-Time-Stamp attribute needs to be switched integer/date to string in dictionary.kamailio and also radius server dictionary.
if you accept this request , i will add more information to radius docs.
Thanks.