### PR TITLE
core: fixed passed buffer size in suip2a()

### DIFF
--- a/ip_addr.h
+++ b/ip_addr.h
@@ -741,14 +741,14 @@ static inline char* suip2a(union sockaddr_union* su, int su_len)
 			return "<addr. error>";
 		buf[0]='[';
 		offs=1+ip6tosbuf((unsigned char*)su->sin6.sin6_addr.s6_addr, &buf[1],
-							sizeof(buf)-4);
+							IP6_MAX_STR_SIZE);
 		buf[offs]=']';
 		offs++;
 	}else
 	if (unlikely(su_len<sizeof(su->sin)))
 		return "<addr. error>";
 	else
-		offs=ip4tosbuf((unsigned char*)&su->sin.sin_addr, buf, sizeof(buf)-2);
+		offs=ip4tosbuf((unsigned char*)&su->sin.sin_addr, buf, IP4_MAX_STR_SIZE);
 	buf[offs]=0;
 	return buf;
 }


### PR DESCRIPTION
- fix regarding issue #379
- it makes sense to backport this fix to 4.2 and 4.3
- Function suip2a() has never worked properly for IPv6 addresses before.
  The passed buffer size 'sizeof(buf)-4' to ip6tosbuf() was 1 byte to small.
  So ip6tosbuf() has never written any IPv6 ASCII string to the buffer and
  therefor suip2a() always returned an empty IPv6 reference string ("[]").
  Fixed this by changing passed buffer size to IP6_MAX_STR_SIZE.
  For similarity also changed uncritical passed buffer size in call to
  ip4tosbuf() to IP4_MAX_STR_SIZE.
  The function suip2a() is only used by siptrace module when sip_trace()
  script function is explicitly called on sending side e.g. in onsend_route
  block.