### PR TITLE
permissions: time period in rules and trailing space removing

### DIFF
--- a/modules/permissions/Makefile
+++ b/modules/permissions/Makefile
@@ -1,6 +1,6 @@
 #
 # PERMISSIONS module makefile
-# 
+#
 # WARNING: do not run this directly, it should be run by the master Makefile
 
 include ../../Makefile.defs
@@ -14,4 +14,5 @@ SERLIBPATH=../../lib
 SER_LIBS+=$(SERLIBPATH)/kmi/kmi
 SER_LIBS+=$(SERLIBPATH)/srdb1/srdb1
 SER_LIBS+=$(SERLIBPATH)/kcore/kcore
+SER_LIBS+=$(SERLIBPATH)/srutils/srutils
 include ../../Makefile.modules

--- a/modules/permissions/README
+++ b/modules/permissions/README
@@ -18,9 +18,13 @@ Edited by
 
 Emmanuel Schmidbauer
 
-   Copyright © 2003 Miklos Tirpak
+Edited by
 
-   Copyright © 2006-2008 Juha Heinanen
+Guillaume Dhainaut
+
+   Copyright ï¿½ 2003 Miklos Tirpak
+
+   Copyright ï¿½ 2006-2008 Juha Heinanen
      __________________________________________________________________
 
    Table of Contents
@@ -77,6 +81,7 @@ Emmanuel Schmidbauer
               4.9. allow_source_address_group()
               4.10. allow_address_group(addr, port)
               4.11. allow_trusted([src_ip_pvar, proto_pvar])
+              4.42. log_attempt(log_file)
 
         5. MI Commands
 
@@ -130,6 +135,7 @@ Emmanuel Schmidbauer
    1.30. allow_source_address_group() usage
    1.31. allow_source_address_group() usage
    1.32. allow_trusted() usage
+   1.33. log_attempt() usage
 
 Chapter 1. Admin Guide
 
@@ -185,6 +191,7 @@ Chapter 1. Admin Guide
         4.9. allow_source_address_group()
         4.10. allow_address_group(addr, port)
         4.11. allow_trusted([src_ip_pvar, proto_pvar])
+        4.12. log_attempt(log_file)
 
    5. MI Commands
 
@@ -228,7 +235,8 @@ Chapter 1. Admin Guide
    The module can be used to determine if a call has appropriate
    permission to be established. Permission rules are stored in plaintext
    configuration files similar to hosts.allow and hosts.deny files used by
-   tcpd.
+   tcpd. A time period can be specified at the end of each rule to add time
+   restriction. The time period is in the RFC 2445 format.
 
    When allow_routing function is called it tries to find a rule that
    matches selected fields of the message.
@@ -242,9 +250,9 @@ Chapter 1. Admin Guide
      * Create a set of pairs of form (From, R-URI of branch 1), (From,
        R-URI of branch 2), etc.
      * Routing will be allowed when all pairs match an entry in the allow
-       file.
+       file at a correct time.
      * Otherwise routing will be denied when one of pairs matches an entry
-       in the deny file.
+       in the deny file at a correct time.
      * Otherwise, routing will be allowed.
 
    A non-existing permission control file is treated as if it were an
@@ -696,6 +704,7 @@ modparam("permissions", "peer_tag_mode", 1)
    4.9. allow_source_address_group()
    4.10. allow_address_group(addr, port)
    4.11. allow_trusted([src_ip_pvar, proto_pvar])
+   4.12. log_attempt(log_file)
 
 4.1. allow_routing()
 
@@ -953,6 +962,21 @@ if (allow_trusted()) {
 if (allow_trusted("$si", "$proto")) {
         t_relay();
 };
+...
+
+4.12. log_attempt(log_file)
+
+    Log the call attempts in the file log_file. Can be used to keep a trace
+    in case of call blocking with the allow_routing() function. The line is
+    like: from_uri, to_uri, date, method.
+
+    Example 1.33. log_attempt() usage
+...
+if(!allow_routing())
+{
+    log_attempt("forbidden_calls");
+    ...
+}
 ...
 
 5. MI Commands

--- a/modules/permissions/address.c
+++ b/modules/permissions/address.c
@@ -16,8 +16,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * History:
@@ -502,7 +502,7 @@ int allow_address(struct sip_msg* _msg, char* _addr_group, char* _addr_sp,
  * allow_source_address("group") equals to allow_address("group", "$si", "$sp")
  * but is faster.
  */
-int allow_source_address(struct sip_msg* _msg, char* _addr_group, char* _str2) 
+int allow_source_address(struct sip_msg* _msg, char* _addr_group, char* _str2)
 {
 	int addr_group = 1;
 
@@ -534,7 +534,7 @@ int allow_source_address(struct sip_msg* _msg, char* _addr_group, char* _str2)
  * subnet table in any group. If yes, returns that group. If not returns -1.
  * Port value 0 in cached address and group table matches any port.
  */
-int allow_source_address_group(struct sip_msg* _msg, char* _str1, char* _str2) 
+int allow_source_address_group(struct sip_msg* _msg, char* _str1, char* _str2)
 {
 	int group = -1;
 

--- a/modules/permissions/address.h
+++ b/modules/permissions/address.h
@@ -15,23 +15,23 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #ifndef ADDRESS_H
 #define ADDRESS_H
-		
+
 #include "../../parser/msg_parser.h"
 
 
 /* Pointer to current address hash table pointer */
-extern struct addr_list ***addr_hash_table; 
+extern struct addr_list ***addr_hash_table;
 
 
 /* Pointer to current subnet table */
-extern struct subnet **subnet_table; 
+extern struct subnet **subnet_table;
 
 
 /* Pointer to current domain name table */

--- a/modules/permissions/config/permissions.allow
+++ b/modules/permissions/config/permissions.allow
@@ -1,15 +1,19 @@
 # SIP Express Router permissions module config file
 #
-# Syntax: 
-#	from_list [EXCEPT from_list] : req_uri_list [EXCEPT req_uri_list]
+# Syntax:
+#   if you want to have time restriction:
+#       from_list [EXCEPT from_list] : req_uri_list [EXCEPT req_uri_list] : time_recurrence
+#   if you want the rule valid at any time
+#       from_list [EXCEPT from_list] : req_uri_list [EXCEPT req_uri_list]
 #
-# 	from_list and req_uri_list are comma separated expressions
+#   from_list and req_uri_list are comma separated expressions
 # 	Expressions are treated as case insensitive POSIX Extended Regular Expressions.
-# 	Keyword ALL matches any expression.	
+#   Keyword ALL matches any expression.
+#   The time recurrence rule is a list of attributes defined by RFC2445 as in the TMREC module.
 #
 # Examples:
 #	ALL : "^sip:361[0-9]*@abc\.com$" EXCEPT "^sip:361[0-9]*3@abc\.com$", "^sip:361[0-9]*4@abc\.com$"
 #
-#	"^sip:3677[0-9]*@abc\.com$" :  "^sip:361[0-9]*@abc\.com$"
+#	"^sip:3677[0-9]*@abc\.com$" :  "^sip:361[0-9]*@abc\.com$" : "20120101T000000|PT24H|weekly|||SA,SU"
 #
-#	ALL : ALL
+#	All : ALL : "20120101T083000|PT10H|weekly|||MO,TU,WE,TH,FR"

--- a/modules/permissions/config/permissions.deny
+++ b/modules/permissions/config/permissions.deny
@@ -1,15 +1,19 @@
 # SIP Express Router permissions module config file
 #
-# Syntax: 
-#	from_list [EXCEPT from_list] : req_uri_list [EXCEPT req_uri_list]
+# Syntax:
+#   if you want to have time restriction:
+#       from_list [EXCEPT from_list] : req_uri_list [EXCEPT req_uri_list] : time_recurrence
+#   if you want the rule valid at any time
+#       from_list [EXCEPT from_list] : req_uri_list [EXCEPT req_uri_list]
 #
-# 	from_list and req_uri_list are comma separated expressions
+#   from_list and req_uri_list are comma separated expressions
 # 	Expressions are treated as case insensitive POSIX Extended Regular Expressions.
-# 	Keyword ALL matches any expression.
+#   Keyword ALL matches any expression.
+#   The time recurrence rule is a list of attributes defined by RFC2445 as in the TMREC module.
 #
 # Examples:
 #	ALL : "^sip:361[0-9]*@abc\.com$" EXCEPT "^sip:361[0-9]*3@abc\.com$", "^sip:361[0-9]*4@abc\.com$"
 #
-#	"^sip:3677[0-9]*@abc\.com$" :  "^sip:361[0-9]*@abc\.com$"
+#	"^sip:3677[0-9]*@abc\.com$" :  "^sip:361[0-9]*@abc\.com$" : "20120101T000000|PT24H|weekly|||SA,SU"
 #
-#	All : ALL
+#	All : ALL : "20120101T083000|PT10H|weekly|||MO,TU,WE,TH,FR"

--- a/modules/permissions/doc/permissions.xml
+++ b/modules/permissions/doc/permissions.xml
@@ -66,8 +66,8 @@
 	</copyright>
 	</bookinfo>
 	<toc></toc>
-	
+
 	<xi:include href="permissions_admin.xml"/>
-	
-	
+
+
 </book>

--- a/modules/permissions/doc/permissions.xml
+++ b/modules/permissions/doc/permissions.xml
@@ -48,6 +48,13 @@
 			<email>eschmidbauer@voipxswitch.com</email>
 		</address>
 		</editor>
+                <editor>
+                <firstname>Guillaume</firstname>
+                <surname>Dhainaut</surname>
+                <address>
+                        <email>tetram100@hotmail.fr</email>
+                </address>
+                </editor>
 	</authorgroup>
 	<copyright>
 		<year>2003</year>

--- a/modules/permissions/doc/permissions_admin.xml
+++ b/modules/permissions/doc/permissions_admin.xml
@@ -10,9 +10,9 @@
 <!-- Module User's Guide -->
 
 <chapter>
-	
+
 	<title>&adminguide;</title>
-	
+
 	<section>
 	<title>Overview</title>
 	<para>
@@ -41,8 +41,8 @@
 	<section id="sec-call-routing">
 		<title>Call Routing</title>
 		<para>
-		The module can be used to determine if a call has appropriate 
-		permission to be established. Permission rules are stored in 
+		The module can be used to determine if a call has appropriate
+		permission to be established. Permission rules are stored in
 		plaintext configuration files similar to
 		<filename moreinfo="none">hosts.allow</filename> and <filename
 		moreinfo="none">hosts.deny</filename> files used by tcpd. A time
@@ -50,14 +50,14 @@
 	    	restriction. The time period is in the RFC 2445 format.
 		</para>
 		<para>
-		When <function moreinfo="none">allow_routing</function> function is 
-		called it tries to find a rule that matches selected fields of the 
+		When <function moreinfo="none">allow_routing</function> function is
+		called it tries to find a rule that matches selected fields of the
 		message.
 		</para>
 		<para>
-		&kamailio; is a forking proxy and therefore a single message can be sent 
-		to different destinations simultaneously. When checking permissions 
-		all the destinations must be checked and if one of them fails, the 
+		&kamailio; is a forking proxy and therefore a single message can be sent
+		to different destinations simultaneously. When checking permissions
+		all the destinations must be checked and if one of them fails, the
 		forwarding will fail.
 		</para>
 		<para>
@@ -66,19 +66,19 @@
 		<itemizedlist>
 		<listitem>
 			<para>
-			Create a set of pairs of form (From, R-URI of branch 1), 
+			Create a set of pairs of form (From, R-URI of branch 1),
 			(From, R-URI of branch 2), etc.
 			</para>
 		</listitem>
 		<listitem>
 			<para>
-			Routing will be allowed when all pairs match an entry in the 
+			Routing will be allowed when all pairs match an entry in the
 			allow file at a correct time.
 			</para>
 		</listitem>
 		<listitem>
 			<para>
-			Otherwise routing will be denied when one of pairs matches an 
+			Otherwise routing will be denied when one of pairs matches an
 			entry in the deny file at a correct time.
 			</para>
 		</listitem>
@@ -89,53 +89,53 @@
 		</listitem>
 		</itemizedlist>
 		<para>
-		A non-existing permission control file is treated as if it were an 
-		empty file. Thus, permission control can be turned off by providing 
+		A non-existing permission control file is treated as if it were an
+		empty file. Thus, permission control can be turned off by providing
 		no permission control files.
 		</para>
 		<para>
-		From header field and Request-URIs are always compared with regular 
-		expressions! For the syntax see the sample file: 
+		From header field and Request-URIs are always compared with regular
+		expressions! For the syntax see the sample file:
 		<filename moreinfo="none">config/permissions.allow</filename>.
 		</para>
 	</section>
 	<section id="sec-registration-permissions">
 		<title>Registration Permissions</title>
 		<para>
-		In addition to call routing it is also possible to check REGISTER 
-		messages and decide--based on the configuration files--whether the 
+		In addition to call routing it is also possible to check REGISTER
+		messages and decide--based on the configuration files--whether the
 		message should be allowed and the registration accepted or not.
 		</para>
 		<para>
-		Main purpose of the function is to prevent registration of "prohibited" 
-		IP addresses. One example, when a malicious user registers a contact 
-		containing IP address of a PSTN gateway, he might be able to bypass 
-		authorization checks performed by the SIP proxy. That is undesirable 
-		and therefore attempts to register IP address of a PSTN gateway should 
+		Main purpose of the function is to prevent registration of "prohibited"
+		IP addresses. One example, when a malicious user registers a contact
+		containing IP address of a PSTN gateway, he might be able to bypass
+		authorization checks performed by the SIP proxy. That is undesirable
+		and therefore attempts to register IP address of a PSTN gateway should
 		be rejected. Files <filename
 		moreinfo="none">config/register.allow</filename> and <filename
-		moreinfo="none">config/register.deny</filename> contain an example 
+		moreinfo="none">config/register.deny</filename> contain an example
 		configuration.
 		</para>
 		<para>
 		The function for registration checking is called <function
-		moreinfo="none">allow_register</function> and the algorithm is very 
-		similar to the algorithm described in 
-		<xref linkend="sec-call-routing"/>. The only difference is in the way 
+		moreinfo="none">allow_register</function> and the algorithm is very
+		similar to the algorithm described in
+		<xref linkend="sec-call-routing"/>. The only difference is in the way
 		how pairs are created.
 		</para>
 		<para>
-		Instead of the From header field the function uses the To header field because 
-		th To header field in REGISTER messages contains the URI of the person 
-		being registered. Instead of the Request-URI of branches the function 
+		Instead of the From header field the function uses the To header field because
+		th To header field in REGISTER messages contains the URI of the person
+		being registered. Instead of the Request-URI of branches the function
 		uses the Contact header field.
 		</para>
 		<para>
-		Thus, the pairs used in matching will look like this: (To, Contact 1), 
+		Thus, the pairs used in matching will look like this: (To, Contact 1),
 		(To, Contact 2), (To, Contact 3), and so on..
 		</para>
 		<para>
-		The algorithm of matching is the same as described in 
+		The algorithm of matching is the same as described in
 		<xref linkend="sec-call-routing"/>.
 		</para>
 	</section>
@@ -179,13 +179,13 @@
 		</listitem>
 		</itemizedlist>
 		<para>
-		A non-existing permission control file is treated as if it were an 
-		empty file. Thus, permission control can be turned off by providing 
+		A non-existing permission control file is treated as if it were an
+		empty file. Thus, permission control can be turned off by providing
 		no permission control files.
 		</para>
 		<para>
-		The From URI and the URI stored in pvar are always compared with regular 
-		expressions! For the syntax see the sample file: 
+		The From URI and the URI stored in pvar are always compared with regular
+		expressions! For the syntax see the sample file:
 		<filename moreinfo="none">config/permissions.allow</filename>.
 		</para>
 	</section>
@@ -207,18 +207,18 @@
 		identifier (positive integer value, i.e., equal or greater than 1).
 		The group identifier is given as an argument to the allow_address() and
 		allow_source_address() functions.
-		One group can contain all of the three types of addresses: exact 
+		One group can contain all of the three types of addresses: exact
 		IP address, subnet IP address or DNS domain name.
 		</para>
 		<para>
-		When the argument is an IP addess, it is tried to be matched with the 
-		records from that group that are of type exact IP or subnet. If the 
+		When the argument is an IP addess, it is tried to be matched with the
+		records from that group that are of type exact IP or subnet. If the
 		argument is not an IP it is tried to be matched
 		with the records that are DNS domain names. No DNS lookup is performed,
 		only strict matching.
 		</para>
 		<para>
-		As a side effect of matching the address, non-NULL tag 
+		As a side effect of matching the address, non-NULL tag
 		(see tag_col module parameter) is added as value to
 		peer_tag AVP if peer_tag_avp module parameter has been defined.
 		</para>
@@ -237,7 +237,7 @@
 		expression&gt;.
 		</para>
 		<para>
-		A requests is accepted if there exists a rule, where 
+		A requests is accepted if there exists a rule, where
 		</para>
 		<itemizedlist>
 		<listitem>
@@ -315,8 +315,8 @@
 	<section id ="permissions.p.default_allow_file">
 		<title><varname>default_allow_file</varname> (string)</title>
 		<para>
-		Default allow file used by the functions with no parameters. If you 
-		don't specify a full pathname then the directory in which is the main 
+		Default allow file used by the functions with no parameters. If you
+		don't specify a full pathname then the directory in which is the main
 		config file is located will be used.
 		</para>
 		<para>
@@ -337,7 +337,7 @@ modparam("permissions", "default_allow_file", "/etc/permissions.allow")
 		<title><varname>default_deny_file</varname> (string)</title>
 		<para>
 		Default file containing deny rules. The file is used by functions
-		with no parameters. If you don't specify a full pathname then the 
+		with no parameters. If you don't specify a full pathname then the
 		directory in which the main config file is located will be used.
 		</para>
 		<para>
@@ -357,13 +357,13 @@ modparam("permissions", "default_deny_file", "/etc/permissions.deny")
 	<section id ="permissions.p.check_all_branches">
 		<title><varname>check_all_branches</varname> (integer)</title>
 		<para>
-		If set then allow_routing functions will check Request-URI of all 
-		branches (default). If disabled then only Request-URI of the first 
+		If set then allow_routing functions will check Request-URI of all
+		branches (default). If disabled then only Request-URI of the first
 		branch will be checked.
 		</para>
 		<warning>
 		<para>
-		Do not disable this parameter unless you really know what you 
+		Do not disable this parameter unless you really know what you
 		are doing.
 		</para>
 		</warning>
@@ -384,8 +384,8 @@ modparam("permissions", "check_all_branches", 0)
 	<section id ="permissions.p.allow_suffix">
 		<title><varname>allow_suffix</varname> (string)</title>
 		<para>
-		Suffix to be appended to basename to create filename of the allow 
-		file when version with one parameter of either 
+		Suffix to be appended to basename to create filename of the allow
+		file when version with one parameter of either
 		<function moreinfo="none">allow_routing</function> or
 		<function moreinfo="none">allow_register</function> is used.
 		</para>
@@ -411,8 +411,8 @@ modparam("permissions", "allow_suffix", ".allow")
 	<section id ="permissions.p.deny_suffix">
 		<title><varname>deny_suffix</varname> (string)</title>
 		<para>
-		Suffix to be appended to basename to create filename of the deny file 
-		when version with one parameter of either 
+		Suffix to be appended to basename to create filename of the deny file
+		when version with one parameter of either
 		<function moreinfo="none">allow_routing</function> or
 		<function moreinfo="none">allow_register</function> is used.
 		</para>
@@ -438,7 +438,7 @@ modparam("permissions", "deny_suffix", ".deny")
 	<section id ="permissions.p.db_url">
 		<title><varname>db_url</varname> (string)</title>
 		<para>
-		This is URL of the database to be used to store rules used by 
+		This is URL of the database to be used to store rules used by
 		<function moreinfo="none">allow_trusted</function> function.
 		</para>
 		<para>
@@ -627,7 +627,7 @@ modparam("permissions", "source_col", "source_ip_address")
 		the received request.  Possible values that can be stored in
 		proto_col are <quote>any</quote>, <quote>udp</quote>,
 		<quote>tcp</quote>, <quote>tls</quote>,
-		<quote>sctp</quote>, <quote>ws</quote>, <quote>wss</quote>, 
+		<quote>sctp</quote>, <quote>ws</quote>, <quote>wss</quote>,
 		and <quote>none</quote>.  Value
 		<quote>any</quote> matches always and value
 		<quote>none</quote> never.
@@ -689,7 +689,7 @@ modparam("permissions", "ruri_col", "regexp")
 	<section id ="permissions.p.tag_col">
 		<title><varname>tag_col</varname> (string)</title>
 		<para>
-		Name of the column in the <quote>address</quote> or 
+		Name of the column in the <quote>address</quote> or
 		<quote>trusted</quote> table containing a string
 		that is added as value to peer_tag AVP if peer_tag AVP
         	has been defined and if the address or peer matches.
@@ -755,7 +755,7 @@ modparam("permissions", "peer_tag_avp", "$avp(i:707)")
 		<title><varname>peer_tag_mode</varname> (integer)</title>
 		<para>
 		Tag mode for <function moreinfo="none">allow_trusted</function>.
-		<quote>0</quote> sets only the tag of the first match. 
+		<quote>0</quote> sets only the tag of the first match.
 		<quote>1</quote> adds the tags of all matches to the avp. In addition
 		the return value of <function moreinfo="none">allow_trusted</function>
 		is the number of matches. This parameter is not used for address table matching functions.
@@ -784,8 +784,8 @@ modparam("permissions", "peer_tag_mode", 1)
 		</title>
 		<para>
 		Returns true if all pairs constructed as described in <xref
-			linkend="sec-call-routing"/> have appropriate permissions according to 
-		the configuration files. This function uses default configuration 
+			linkend="sec-call-routing"/> have appropriate permissions according to
+		the configuration files. This function uses default configuration
 		files specified in <varname>default_allow_file</varname> and
 		<varname>default_deny_file</varname>.
 		</para>
@@ -809,20 +809,20 @@ if (allow_routing()) {
 		</title>
 		<para>
 		Returns true if all pairs constructed as described in <xref
-			linkend="sec-call-routing"/> have appropriate permissions according 
+			linkend="sec-call-routing"/> have appropriate permissions according
 		to the configuration files given as parameters.
 		</para>
 		<para>Meaning of the parameters is as follows:</para>
 		<itemizedlist>
 		<listitem>
-			<para><emphasis>basename</emphasis> - Basename from which allow 
+			<para><emphasis>basename</emphasis> - Basename from which allow
 			and deny filenames will be created by appending contents of
 			<varname>allow_suffix</varname> and <varname>deny_suffix</varname>
 			parameters.
 			</para>
 			<para>
-			If the parameter doesn't contain full pathname then the function 
-			expects the file to be located in the same directory as the main 
+			If the parameter doesn't contain full pathname then the function
+			expects the file to be located in the same directory as the main
 			configuration file of the server.
 			</para>
 		</listitem>
@@ -846,8 +846,8 @@ if (allow_routing("basename")) {
 		<function moreinfo="none">allow_routing(allow_file,deny_file)</function>
 		</title>
 		<para>
-		Returns true if all pairs constructed as described in 
-		<xref linkend="sec-call-routing"/> have appropriate permissions 
+		Returns true if all pairs constructed as described in
+		<xref linkend="sec-call-routing"/> have appropriate permissions
 		according to the configuration files given as parameters.
 		</para>
 		<para>Meaning of the parameters is as follows:</para>
@@ -856,8 +856,8 @@ if (allow_routing("basename")) {
 			<para><emphasis>allow_file</emphasis> - File containing allow rules.
 			</para>
 			<para>
-			If the parameter doesn't contain full pathname then the function 
-			expects the file to be located in the same directory as the main 
+			If the parameter doesn't contain full pathname then the function
+			expects the file to be located in the same directory as the main
 			configuration file of the server.
 			</para>
 		</listitem>
@@ -865,8 +865,8 @@ if (allow_routing("basename")) {
 			<para><emphasis>deny_file</emphasis> - File containing deny rules.
 			</para>
 			<para>
-			If the parameter doesn't contain full pathname then the function 
-			expects the file to be located in the same directory as the main 
+			If the parameter doesn't contain full pathname then the function
+			expects the file to be located in the same directory as the main
 			configuration file of the server.
 			</para>
 		</listitem>
@@ -891,20 +891,20 @@ if (allow_routing("rules.allow", "rules.deny")) {
 		</title>
 		<para>
 		The function returns true if all pairs constructed as described in <xref
-			linkend="sec-registration-permissions"/> have appropriate permissions 
+			linkend="sec-registration-permissions"/> have appropriate permissions
 		according to the configuration files given as parameters.
 		</para>
 		<para>Meaning of the parameters is as follows:</para>
 		<itemizedlist>
 		<listitem>
-			<para><emphasis>basename</emphasis> - Basename from which allow 
+			<para><emphasis>basename</emphasis> - Basename from which allow
 			and deny filenames will be created by appending contents of
 			<varname>allow_suffix</varname> and <varname>deny_suffix</varname>
 			parameters.
 			</para>
 			<para>
-			If the parameter doesn't contain full pathname then the function 
-			expects the file to be located in the same directory as the main 
+			If the parameter doesn't contain full pathname then the function
+			expects the file to be located in the same directory as the main
 			configuration file of the server.
 			</para>
 		</listitem>
@@ -933,8 +933,8 @@ if (method=="REGISTER") {
 		<function moreinfo="none">allow_register(allow_file, deny_file)</function>
 		</title>
 		<para>
-		The function returns true if all pairs constructed as described in 
-		<xref linkend="sec-registration-permissions"/> have appropriate 
+		The function returns true if all pairs constructed as described in
+		<xref linkend="sec-registration-permissions"/> have appropriate
 		permissions according to the configuration files given as parameters.
 		</para>
 		<para>Meaning of the parameters is as follows:</para>
@@ -943,8 +943,8 @@ if (method=="REGISTER") {
 			<para><emphasis>allow_file</emphasis> - File containing allow rules.
 			</para>
 			<para>
-			If the parameter doesn't contain full pathname then the function 
-			expects the file to be located in the same directory as the main 
+			If the parameter doesn't contain full pathname then the function
+			expects the file to be located in the same directory as the main
 			configuration file of the server.
 			</para>
 		</listitem>
@@ -952,8 +952,8 @@ if (method=="REGISTER") {
 			<para><emphasis>deny_file</emphasis> - File containing deny rules.
 			</para>
 			<para>
-			If the parameter doesn't contain full pathname then the function 
-			expects the file to be located in the same directory as the main 
+			If the parameter doesn't contain full pathname then the function
+			expects the file to be located in the same directory as the main
 			configuration file of the server.
 			</para>
 		</listitem>
@@ -983,20 +983,20 @@ if (method=="REGISTER") {
 		</title>
 		<para>
 		Returns true if the pair constructed as described in <xref
-			linkend="sec-uri-permissions"/> have appropriate permissions 
+			linkend="sec-uri-permissions"/> have appropriate permissions
 		according to the configuration files specified by the parameter.
 		</para>
 		<para>Meaning of the parameter is as follows:</para>
 		<itemizedlist>
 		<listitem>
-			<para><emphasis>basename</emphasis> - Basename from which allow 
+			<para><emphasis>basename</emphasis> - Basename from which allow
 			and deny filenames will be created by appending contents of
 			<varname>allow_suffix</varname> and <varname>deny_suffix</varname>
 			parameters.
 			</para>
 			<para>
-			If the parameter doesn't contain full pathname then the function 
-			expects the file to be located in the same directory as the main 
+			If the parameter doesn't contain full pathname then the function
+			expects the file to be located in the same directory as the main
 			configuration file of the server.
 			</para>
 		</listitem>
@@ -1034,14 +1034,14 @@ if (allow_uri("basename", "$avp(i:705)") {  // Check URI stored in $avp(i:705)
 		address table.
 		</para>
 		<para>
-		When matching is done if the argument is an IP address, it is 
+		When matching is done if the argument is an IP address, it is
 		matched with the records from that group that are of type exact
 		IP or subnet. If the argument is not an IP it is tried to be matched
 		with the records that are DNS domain names. No DNS lookup is performed,
 		only strict matching.
 		Cached address table entry containing port value <quote>0</quote>
 		matches any port. The <quote>group_id</quote> argument can be an integer
-		string or a pseudo variable. 
+		string or a pseudo variable.
 		</para>
 		<para>
 		This function can be used from REQUEST_ROUTE, FAILURE_ROUTE.
@@ -1182,7 +1182,7 @@ if (allow_trusted("$si", "$proto")) {
 		</example>
 	</section>
 	</section>
-	
+
 	<section>
 	<title>MI Commands</title>
 	<section id ="permissions.m.address_reload">
@@ -1191,7 +1191,7 @@ if (allow_trusted("$si", "$proto")) {
 		</title>
 		<para>
 			Causes the permissions module to re-read the contents of
-			address database table into cache memory. 
+			address database table into cache memory.
 			The in-cache memory entries are
 			for performance reasons stored in two
                         different tables:  address table and
@@ -1201,7 +1201,7 @@ if (allow_trusted("$si", "$proto")) {
 		</para>
 		<para>Parameters: <emphasis>none</emphasis></para>
 	</section>
-	
+
 	<section id ="permissions.m.address_dump">
 		<title>
 		<function moreinfo="none">address_dump</function>
@@ -1242,7 +1242,7 @@ if (allow_trusted("$si", "$proto")) {
 		<function moreinfo="none">trusted_dump</function>
 		</title>
 		<para>
-			Causes the permissions module to dump the 
+			Causes the permissions module to dump the
 			contents of trusted table from cache memory.
 		</para>
 		<para>Parameters: <emphasis>none</emphasis></para>
@@ -1295,7 +1295,7 @@ if (allow_trusted("$si", "$proto")) {
 		</para>
 		<para>Parameters: <emphasis>none</emphasis></para>
 	</section>
-	
+
 	<section id ="permissions.r.addressDump">
 		<title>
 		<function moreinfo="none">addressDump</function>

--- a/modules/permissions/doc/permissions_admin.xml
+++ b/modules/permissions/doc/permissions_admin.xml
@@ -45,7 +45,9 @@
 		permission to be established. Permission rules are stored in 
 		plaintext configuration files similar to
 		<filename moreinfo="none">hosts.allow</filename> and <filename
-		moreinfo="none">hosts.deny</filename> files used by tcpd.
+		moreinfo="none">hosts.deny</filename> files used by tcpd. A time
+		period can be specified at the end of each rule to add time
+	    	restriction. The time period is in the RFC 2445 format.
 		</para>
 		<para>
 		When <function moreinfo="none">allow_routing</function> function is 
@@ -71,13 +73,13 @@
 		<listitem>
 			<para>
 			Routing will be allowed when all pairs match an entry in the 
-			allow file.
+			allow file at a correct time.
 			</para>
 		</listitem>
 		<listitem>
 			<para>
 			Otherwise routing will be denied when one of pairs matches an 
-			entry in the deny file.
+			entry in the deny file at a correct time.
 			</para>
 		</listitem>
 		<listitem>

--- a/modules/permissions/hash.c
+++ b/modules/permissions/hash.c
@@ -15,8 +15,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
@@ -116,11 +116,11 @@ void free_hash_table(struct trusted_list** table)
 }
 
 
-/* 
+/*
  * Add <src_ip, proto, pattern, ruri_pattern, tag, priority> into hash table, where proto is integer
  * representation of string argument proto.
  */
-int hash_table_insert(struct trusted_list** table, char* src_ip, 
+int hash_table_insert(struct trusted_list** table, char* src_ip,
 		char* proto, char* pattern, char* ruri_pattern, char* tag, int priority)
 {
 	struct trusted_list *np;
@@ -240,7 +240,7 @@ int hash_table_insert(struct trusted_list** table, char* src_ip,
 }
 
 
-/* 
+/*
  * Check if an entry exists in hash table that has given src_ip and protocol
  * value and pattern that matches to From URI.  If an entry exists and tag_avp
  * has been defined, tag of the entry is added as a value to tag_avp.
@@ -281,7 +281,7 @@ int match_hash_table(struct trusted_list** table, struct sip_msg* msg,
 	}
 
 	for (np = table[perm_hash(src_ip)]; np != NULL; np = np->next) {
-	    if ((np->src_ip.len == src_ip.len) && 
+	    if ((np->src_ip.len == src_ip.len) &&
 		(strncmp(np->src_ip.s, src_ip.s, src_ip.len) == 0) &&
 		((np->proto == PROTO_NONE) || (proto == PROTO_NONE) ||
 		 (np->proto == proto))) {
@@ -326,13 +326,13 @@ int match_hash_table(struct trusted_list** table, struct sip_msg* msg,
 	}
 	if (!count)
 	    return -1;
-	else 
+	else
 	    return count;
 }
 
 
 /*! \brief
- * MI Interface :: Print trusted entries stored in hash table 
+ * MI Interface :: Print trusted entries stored in hash table
  */
 int hash_table_mi_print(struct trusted_list** table, struct mi_node* rpl)
 {
@@ -360,7 +360,7 @@ int hash_table_mi_print(struct trusted_list** table, struct mi_node* rpl)
 }
 
 /*! \brief
- * RPC interface :: Print trusted entries stored in hash table 
+ * RPC interface :: Print trusted entries stored in hash table
  */
 int hash_table_rpc_print(struct trusted_list** hash_table, rpc_t* rpc, void* c)
 {
@@ -378,7 +378,7 @@ int hash_table_rpc_print(struct trusted_list** hash_table, rpc_t* rpc, void* c)
 	for (i = 0; i < PERM_HASH_SIZE; i++) {
 		np = hash_table[i];
 		while (np) {
-			if(rpc->struct_add(th, "d{", 
+			if(rpc->struct_add(th, "d{",
 					"table", i,
 					"item", &ih) < 0)
                         {
@@ -406,7 +406,7 @@ int hash_table_rpc_print(struct trusted_list** hash_table, rpc_t* rpc, void* c)
 	return 0;
 }
 
-/* 
+/*
  * Free contents of hash table, it doesn't destroy the
  * hash table itself
  */
@@ -463,7 +463,7 @@ void free_addr_hash_table(struct addr_list** table)
 }
 
 
-/* 
+/*
  * Add <grp, ip_addr, port> into hash table
  */
 int addr_hash_table_insert(struct addr_list** table, unsigned int grp,
@@ -506,7 +506,7 @@ int addr_hash_table_insert(struct addr_list** table, unsigned int grp,
 }
 
 
-/* 
+/*
  * Check if an entry exists in hash table that has given group, ip_addr, and
  * port.  Port 0 in hash table matches any port.
  */
@@ -541,10 +541,10 @@ int match_addr_hash_table(struct addr_list** table, unsigned int group,
 }
 
 
-/* 
+/*
  * Check if an ip_addr/port entry exists in hash table in any group.
  * Returns first group in which ip_addr/port is found.
- * Port 0 in hash table matches any port. 
+ * Port 0 in hash table matches any port.
  */
 int find_group_in_addr_hash_table(struct addr_list** table,
 		ip_addr_t *addr, unsigned int port)
@@ -576,7 +576,7 @@ int find_group_in_addr_hash_table(struct addr_list** table,
 }
 
 /*! \brief
- * MI: Print addresses stored in hash table 
+ * MI: Print addresses stored in hash table
  */
 int addr_hash_table_mi_print(struct addr_list** table, struct mi_node* rpl)
 {
@@ -598,7 +598,7 @@ int addr_hash_table_mi_print(struct addr_list** table, struct mi_node* rpl)
 }
 
 /*! \brief
- * RPC: Print addresses stored in hash table 
+ * RPC: Print addresses stored in hash table
  */
 int addr_hash_table_rpc_print(struct addr_list** table, rpc_t* rpc, void* c)
 {
@@ -617,7 +617,7 @@ int addr_hash_table_rpc_print(struct addr_list** table, rpc_t* rpc, void* c)
 	for (i = 0; i < PERM_HASH_SIZE; i++) {
 		np = table[i];
 		while (np) {
-			if(rpc->struct_add(th, "dd{", 
+			if(rpc->struct_add(th, "dd{",
 					"table", i,
 					"group", np->grp,
 					"item", &ih) < 0)
@@ -644,7 +644,7 @@ int addr_hash_table_rpc_print(struct addr_list** table, rpc_t* rpc, void* c)
 }
 
 
-/* 
+/*
  * Free contents of hash table, it doesn't destroy the
  * hash table itself
  */
@@ -672,7 +672,7 @@ struct subnet* new_subnet_table(void)
 {
 	struct subnet* ptr;
 
-	/* subnet record [PERM_MAX_SUBNETS] contains in its grp field 
+	/* subnet record [PERM_MAX_SUBNETS] contains in its grp field
 	   the number of subnet records in the subnet table */
 	ptr = (struct subnet *)shm_malloc
 		(sizeof(struct subnet) * (PERM_MAX_SUBNETS + 1));
@@ -685,7 +685,7 @@ struct subnet* new_subnet_table(void)
 }
 
 
-/* 
+/*
  * Add <grp, subnet, mask, port, tag> into subnet table so that table is
  * kept in increasing ordered according to grp.
  */
@@ -738,7 +738,7 @@ int subnet_table_insert(struct subnet* table, unsigned int grp,
 }
 
 
-/* 
+/*
  * Check if an entry exists in subnet table that matches given group, ip_addr,
  * and port.  Port 0 in subnet table matches any port.
  */
@@ -776,7 +776,7 @@ int match_subnet_table(struct subnet* table, unsigned int grp,
 }
 
 
-/* 
+/*
  * Check if an entry exists in subnet table that matches given ip_addr,
  * and port.  Port 0 in subnet table matches any port.  Return group of
  * first match or -1 if no match is found.
@@ -810,8 +810,8 @@ int find_group_in_subnet_table(struct subnet* table,
 }
 
 
-/* 
- * Print subnets stored in subnet table 
+/*
+ * Print subnets stored in subnet table
  */
 int subnet_table_mi_print(struct subnet* table, struct mi_node* rpl)
 {
@@ -832,7 +832,7 @@ int subnet_table_mi_print(struct subnet* table, struct mi_node* rpl)
 }
 
 /*! \brief
- * RPC interface :: Print subnet entries stored in hash table 
+ * RPC interface :: Print subnet entries stored in hash table
  */
 int subnet_table_rpc_print(struct subnet* table, rpc_t* rpc, void* c)
 {
@@ -850,7 +850,7 @@ int subnet_table_rpc_print(struct subnet* table, rpc_t* rpc, void* c)
 	}
 
 	for (i = 0; i < count; i++) {
-		if(rpc->struct_add(th, "dd{", 
+		if(rpc->struct_add(th, "dd{",
 				"id", i,
 				"group", table[i].grp,
 				"item", &ih) < 0)
@@ -876,7 +876,7 @@ int subnet_table_rpc_print(struct subnet* table, rpc_t* rpc, void* c)
 }
 
 
-/* 
+/*
  * Empty contents of subnet table
  */
 void empty_subnet_table(struct subnet *table)
@@ -936,7 +936,7 @@ struct domain_name_list** new_domain_name_table(void)
 }
 
 
-/* 
+/*
  * Free contents of hash table, it doesn't destroy the
  * hash table itself
  */
@@ -969,7 +969,7 @@ void free_domain_name_table(struct domain_name_list** table)
 }
 
 
-/* 
+/*
  * Check if an entry exists in hash table that has given group, domain_name, and
  * port.  Port 0 in hash table matches any port.
  */
@@ -1001,10 +1001,10 @@ int match_domain_name_table(struct domain_name_list** table, unsigned int group,
 }
 
 
-/* 
+/*
  * Check if an domain_name/port entry exists in hash table in any group.
  * Returns first group in which ip_addr/port is found.
- * Port 0 in hash table matches any port. 
+ * Port 0 in hash table matches any port.
  */
 int find_group_in_domain_name_table(struct domain_name_list** table,
 		str *domain_name, unsigned int port)
@@ -1023,7 +1023,7 @@ int find_group_in_domain_name_table(struct domain_name_list** table,
 }
 
 
-/* 
+/*
  * Add <grp, domain_name, port> into hash table
  */
 int domain_name_table_insert(struct domain_name_list** table, unsigned int grp,
@@ -1067,7 +1067,7 @@ int domain_name_table_insert(struct domain_name_list** table, unsigned int grp,
 
 
 /*! \brief
- * RPC: Print addresses stored in hash table 
+ * RPC: Print addresses stored in hash table
  */
 int domain_name_table_rpc_print(struct domain_name_list** table, rpc_t* rpc, void* c)
 {
@@ -1086,7 +1086,7 @@ int domain_name_table_rpc_print(struct domain_name_list** table, rpc_t* rpc, voi
 	for (i = 0; i < PERM_HASH_SIZE; i++) {
 		np = table[i];
 		while (np) {
-			if(rpc->struct_add(th, "dd{", 
+			if(rpc->struct_add(th, "dd{",
 					"table", i,
 					"group", np->grp,
 					"item", &ih) < 0) {
@@ -1110,7 +1110,7 @@ int domain_name_table_rpc_print(struct domain_name_list** table, rpc_t* rpc, voi
 }
 
 /*! \brief
- * MI: Print domain name stored in hash table 
+ * MI: Print domain name stored in hash table
  */
 int domain_name_table_mi_print(struct domain_name_list** table, struct mi_node* rpl)
 {
@@ -1130,5 +1130,3 @@ int domain_name_table_mi_print(struct domain_name_list** table, struct mi_node* 
 	}
 	return 0;
 }
-
-

--- a/modules/permissions/hash.h
+++ b/modules/permissions/hash.h
@@ -17,8 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
@@ -78,7 +78,7 @@ void free_hash_table(struct trusted_list** table);
 void destroy_hash_table(struct trusted_list** table);
 
 
-/* 
+/*
  * Add <src_ip, proto, pattern, ruri_pattern, priority> into hash table, where proto is integer
  * representation of string argument proto.
  */
@@ -86,7 +86,7 @@ int hash_table_insert(struct trusted_list** hash_table, char* src_ip,
 		      char* proto, char* pattern, char* ruri_pattern, char* tag, int priority);
 
 
-/* 
+/*
  * Check if an entry exists in hash table that has given src_ip and protocol
  * value and pattern or ruri_pattern that matches to From URI.
  */
@@ -94,14 +94,14 @@ int match_hash_table(struct trusted_list** table, struct sip_msg* msg,
 		     char *scr_ip, int proto);
 
 
-/* 
- * Print entries stored in hash table 
+/*
+ * Print entries stored in hash table
  */
 void hash_table_print(struct trusted_list** hash_table, FILE* reply_file);
 int hash_table_mi_print(struct trusted_list **hash_table, struct mi_node* rpl);
 int hash_table_rpc_print(struct trusted_list **hash_table, rpc_t* rpc, void* c);
 
-/* 
+/*
  * Empty hash table
  */
 void empty_hash_table(struct trusted_list** hash_table);
@@ -137,14 +137,14 @@ void free_addr_hash_table(struct addr_list** table);
 void destroy_addr_hash_table(struct addr_list** table);
 
 
-/* 
+/*
  * Add <group, ip_addr, port> into hash table
  */
 int addr_hash_table_insert(struct addr_list** hash_table, unsigned int grp,
 			    ip_addr_t *addr, unsigned int port, char *tagv);
 
 
-/* 
+/*
  * Check if an entry exists in hash table that has given group, ip_addr, and
  * port.  Port 0 in hash table matches any port.
  */
@@ -152,7 +152,7 @@ int match_addr_hash_table(struct addr_list** table, unsigned int grp,
 			  ip_addr_t *addr, unsigned int port);
 
 
-/* 
+/*
  * Checks if an ip_addr/port entry exists in address hash table in any group.
  * Port 0 in hash table matches any port.   Returns group of the first match
  * or -1 if no match is found.
@@ -161,7 +161,7 @@ int find_group_in_addr_hash_table(struct addr_list** table,
 				  ip_addr_t *addr, unsigned int port);
 
 
-/* 
+/*
  * Print addresses stored in hash table
  */
 void addr_hash_table_print(struct addr_list** hash_table, FILE* reply_file);
@@ -170,13 +170,13 @@ int addr_hash_table_mi_print(struct addr_list** hash_table,
 int addr_hash_table_rpc_print(struct addr_list** table, rpc_t* rpc, void* c);
 
 
-/* 
+/*
  * Empty hash table
  */
 void empty_addr_hash_table(struct addr_list** hash_table);
 
 
-#define PERM_MAX_SUBNETS 128 
+#define PERM_MAX_SUBNETS 128
 
 
 /*
@@ -197,7 +197,7 @@ struct subnet {
 struct subnet* new_subnet_table(void);
 
 
-/* 
+/*
  * Check if an entry exists in subnet table that matches given group, ip_addr,
  * and port.  Port 0 in subnet table matches any port.
  */
@@ -205,7 +205,7 @@ int match_subnet_table(struct subnet* table, unsigned int group,
 		       ip_addr_t *addr, unsigned int port);
 
 
-/* 
+/*
  * Checks if an entry exists in subnet table that matches given ip_addr,
  * and port.  Port 0 in subnet table matches any port.  Returns group of
  * the first match or -1 if no match is found.
@@ -213,7 +213,7 @@ int match_subnet_table(struct subnet* table, unsigned int group,
 int find_group_in_subnet_table(struct subnet* table,
 			       ip_addr_t *addr, unsigned int port);
 
-/* 
+/*
  * Empty contents of subnet table
  */
 void empty_subnet_table(struct subnet *table);
@@ -225,7 +225,7 @@ void empty_subnet_table(struct subnet *table);
 void free_subnet_table(struct subnet* table);
 
 
-/* 
+/*
  * Add <grp, subnet, mask, port> into subnet table so that table is
  * kept ordered according to subnet, port, grp.
  */
@@ -234,7 +234,7 @@ int subnet_table_insert(struct subnet* table, unsigned int grp,
 			unsigned int port, char *tagv);
 
 
-/* 
+/*
  * Print subnets stored in subnet table
  */
 void subnet_table_print(struct subnet* table, FILE* reply_file);
@@ -263,34 +263,34 @@ struct domain_name_list** new_domain_name_table(void);
  */
 void free_domain_name_table(struct domain_name_list** table);
 
-/* 
+/*
  * Empty contents of domain_name hash table
  */
 void empty_domain_name_table(struct domain_name_list** table);
 
-/* 
+/*
  * Check if an entry exists in domain_name table that matches given group, domain_name,
  * and port.  Port 0 in  matches any port.
  */
 int match_domain_name_table(struct domain_name_list** table, unsigned int group,
 		str *domain_name, unsigned int port);
 
-/* 
+/*
  * Add <grp, domain_name, port> into hash table
  */
 int domain_name_table_insert(struct domain_name_list** table, unsigned int grp,
 		str *domain_name, unsigned int port, char *tagv);
 
-/* 
+/*
  * Check if an domain_name/port entry exists in hash table in any group.
  * Returns first group in which ip_addr/port is found.
- * Port 0 in hash table matches any port. 
+ * Port 0 in hash table matches any port.
  */
 int find_group_in_domain_name_table(struct domain_name_list** table,
 		str *domain_name, unsigned int port);
 
 /*! \brief
- * RPC: Print addresses stored in hash table 
+ * RPC: Print addresses stored in hash table
  */
 void domain_name_table_print(struct subnet* table, FILE* reply_file);
 int domain_name_table_rpc_print(struct domain_name_list** table, rpc_t* rpc, void* c);

--- a/modules/permissions/mi.c
+++ b/modules/permissions/mi.c
@@ -16,8 +16,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * History:
@@ -136,10 +136,10 @@ void rpc_address_reload(rpc_t* rpc, void* c) {
 struct mi_root* mi_address_dump(struct mi_root *cmd_tree, void *param)
 {
     struct mi_root* rpl_tree;
-    
+
     rpl_tree = init_mi_tree( 200, MI_SSTR(MI_OK));
     if (rpl_tree==NULL) return 0;
-    
+
     if(addr_hash_table_mi_print(*addr_hash_table, &rpl_tree->node) <  0) {
 	LM_ERR("failed to add a node\n");
 	free_mi_tree(rpl_tree);
@@ -172,10 +172,10 @@ void rpc_address_dump(rpc_t* rpc, void* c) {
 struct mi_root* mi_subnet_dump(struct mi_root *cmd_tree, void *param)
 {
     struct mi_root* rpl_tree;
-    
+
     rpl_tree = init_mi_tree( 200, MI_SSTR(MI_OK));
     if (rpl_tree==NULL) return 0;
-    
+
     if(subnet_table && subnet_table_mi_print(*subnet_table, &rpl_tree->node) <  0) {
 	LM_ERR("failed to add a node\n");
 	free_mi_tree(rpl_tree);
@@ -246,14 +246,14 @@ struct mi_root* mi_allow_uri(struct mi_root *cmd, void *param)
     struct mi_node *node;
     str *basenamep, *urip, *contactp;
     char basename[MAX_FILE_LEN + 1];
-    char uri[MAX_URI_SIZE + 1], contact[MAX_URI_SIZE + 1]; 
+    char uri[MAX_URI_SIZE + 1], contact[MAX_URI_SIZE + 1];
     unsigned int allow_suffix_len;
 
     node = cmd->node.kids;
     if (node == NULL || node->next == NULL || node->next->next == NULL ||
 	node->next->next->next != NULL)
 	return init_mi_tree(400, MI_SSTR(MI_MISSING_PARM));
-    
+
     /* look for base name */
     basenamep = &node->value;
     if (basenamep == NULL)
@@ -297,7 +297,7 @@ void rpc_test_uri(rpc_t* rpc, void* c)
 {
     	str basenamep, urip, contactp;
 	char basename[MAX_FILE_LEN + 1];
-	char uri[MAX_URI_SIZE + 1], contact[MAX_URI_SIZE + 1]; 
+	char uri[MAX_URI_SIZE + 1], contact[MAX_URI_SIZE + 1];
 	unsigned int allow_suffix_len;
 
 	if (rpc->scan(c, "S", &basenamep) != 1) {

--- a/modules/permissions/mi.h
+++ b/modules/permissions/mi.h
@@ -16,8 +16,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 

--- a/modules/permissions/parse_config.c
+++ b/modules/permissions/parse_config.c
@@ -17,8 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
@@ -37,12 +37,12 @@
  * return 0 on success, -1 on error
  * parsed expressions are returned in **e
  */
-static int parse_expression_list(char *str, expression **e) 
+static int parse_expression_list(char *str, expression **e)
 {
 	int start=0, i=-1, j=-1, apost=0;
 	char str2[EXPRESSION_LENGTH];
 	expression *e1=NULL, *e2;
-	
+
 	if (!str || !e) return -1;
 
 	*e = NULL;
@@ -67,12 +67,12 @@ static int parse_expression_list(char *str, expression **e)
 						}
 						strncpy(str2, str+start, j-start+1);
 						str2[j-start+1] = '\0';
-						
+
 						e2 = new_expression(str2);
 						if (!e2)
 							/* memory error */
 							goto error;
-						
+
 						if (e1) {
 							/* it is not the first */
 							e1->next = e2;
@@ -105,7 +105,7 @@ error:
  * return 0 on success, -1 on error
  * parsed expressions are returned in **e, and exceptions are returned in **e_exceptions
  */
-static int parse_expression(char *str, expression **e, expression **e_exceptions) 
+static int parse_expression(char *str, expression **e, expression **e_exceptions)
 {
 	char *except, str2[LINE_LENGTH+1];
 	int  i,j;
@@ -150,7 +150,7 @@ static int parse_expression(char *str, expression **e, expression **e_exceptions
  * parse one line of the config file
  * return the rule according to line
  */
-static rule *parse_config_line(char *line) 
+static rule *parse_config_line(char *line)
 {
 	rule	*rule1;
 	expression *left, *left_exceptions, *right, *right_exceptions;
@@ -184,24 +184,24 @@ static rule *parse_config_line(char *line)
 					}
 					eval = 1;
 					break;
-			
-			case '#':	if (apost) break;			
+
+			case '#':	if (apost) break;
 			case '\0':
 			case '\n':
 					exit = 1;
 					break;
 			case ' ':	break;
 			case '\t':	break;
-				
+
 			default:	eval = 1;
-			
+
 		}
 	}
 
 	if (eval) {
 		if ((0<colon1) && (colon1+1<i)) {
 			/* valid line */
-			
+
 			/* left expression */
 			strncpy(str1, line, colon1);
 			str1[colon1] = '\0';
@@ -210,7 +210,7 @@ static rule *parse_config_line(char *line)
 				LM_ERR("failed to parse line-left: %s\n", line);
 				goto error;
 			}
-			
+
 			/* right expression */
 			if (nbr==2){
 				strncpy(str2, line+colon1+1, colon2-colon1-1);
@@ -225,7 +225,7 @@ static rule *parse_config_line(char *line)
 				LM_ERR("failed to parse line-right: %s\n", line);
 				goto error;
 			}
-			
+
 			if (nbr==2){
 				/* Time period */
 				static char temp[LINE_LENGTH+1];
@@ -298,7 +298,7 @@ static rule *parse_config_line(char *line)
  * parse a config file
  * return a list of rules
  */
-rule *parse_config_file(char *filename) 
+rule *parse_config_file(char *filename)
 {
 	FILE	*file;
 	char	line[LINE_LENGTH+1];
@@ -308,7 +308,7 @@ rule *parse_config_file(char *filename)
 		LM_INFO("file not found: %s\n", filename);
 		return NULL;
 	}
-	
+
 	while (fgets(line, LINE_LENGTH, file)) {
 		rule2 = parse_config_line(line);
 		if (rule2) {
@@ -322,7 +322,7 @@ rule *parse_config_file(char *filename)
 			rule1 = rule2;
 		}
 	}
-	
+
 	fclose(file);
 	return start_rule;	/* returns the linked list */
 }

--- a/modules/permissions/parse_config.c
+++ b/modules/permissions/parse_config.c
@@ -3,7 +3,7 @@
  *
  * PERMISSIONS module
  *
- * Copyright (C) 2003 MiklÛs Tirp·k (mtirpak@sztaki.hu)
+ * Copyright (C) 2003 Mikl√≥s Tirp√°k (mtirpak@sztaki.hu)
  *
  * This file is part of Kamailio, a free SIP server.
  *
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "../../sr_module.h"
+#include "../../lib/srutils/tmrec.h"
 #include "rule.h"
 #include "parse_config.h"
 
@@ -153,12 +154,15 @@ static rule *parse_config_line(char *line)
 {
 	rule	*rule1;
 	expression *left, *left_exceptions, *right, *right_exceptions;
-	int	i=-1, exit=0, apost=0, colon=-1, eval=0;
-	static char	str1[LINE_LENGTH], str2[LINE_LENGTH+1];
+	tmrec_t *time_period;
+	int	i=-1, exit=0, apost=0, colon1=-1, colon2=-1, nbr=0, eval=0;
+	static char	str1[LINE_LENGTH], str2[LINE_LENGTH+1], str3[LINE_LENGTH+1];
+	char tmrec_separator = '|';
 
 	if (!line) return 0;
 
 	rule1 = 0;
+	time_period = malloc(sizeof(tmrec_t));
 	left = left_exceptions = right = right_exceptions = 0;
 
 	while (!exit) {
@@ -167,8 +171,17 @@ static rule *parse_config_line(char *line)
 			case '"':	apost = !apost;
 					eval = 1;
 					break;
-			
-			case ':':	if (!apost) colon = i;
+
+			case ':':
+					if (!apost) {
+						if (nbr==0){
+							colon1 = i;
+							nbr++;
+						} else {
+							colon2 = i;
+							nbr++;
+						}
+					}
 					eval = 1;
 					break;
 			
@@ -186,12 +199,12 @@ static rule *parse_config_line(char *line)
 	}
 
 	if (eval) {
-		if ((0<colon) && (colon+1<i)) {
+		if ((0<colon1) && (colon1+1<i)) {
 			/* valid line */
 			
 			/* left expression */
-			strncpy(str1, line, colon);
-			str1[colon] = '\0';
+			strncpy(str1, line, colon1);
+			str1[colon1] = '\0';
 			if (parse_expression(str1, &left, &left_exceptions)) {
 				/* error */
 				LM_ERR("failed to parse line-left: %s\n", line);
@@ -199,14 +212,54 @@ static rule *parse_config_line(char *line)
 			}
 			
 			/* right expression */
-			strncpy(str2, line+colon+1, i-colon-1);
-			str2[i-colon-1] = '\0';
+			if (nbr==2){
+				strncpy(str2, line+colon1+1, colon2-colon1-1);
+				str2[colon2-colon1-1] = '\0';
+			} else {
+				strncpy(str2, line+colon1+1, i-colon1-1);
+				str2[i-colon1-1] = '\0';
+			}
+
 			if (parse_expression(str2, &right, &right_exceptions)) {
 				/* error */
 				LM_ERR("failed to parse line-right: %s\n", line);
 				goto error;
 			}
 			
+			if (nbr==2){
+				/* Time period */
+				static char temp[LINE_LENGTH+1];
+				strncpy(temp, line+colon2+1, i-colon2-1);
+				temp[i-colon2-1] = '\0';
+
+				/* Remove space and quotes*/
+				/* Trim leading space and first quote*/
+				while(isspace(*temp)) memmove (temp, temp+1, strlen (temp+1) + 1);
+				/* Empty string */
+				if(*temp == 0) {
+					goto error;
+				}
+
+				/* Trim trailing space and last quote*/
+				char *end = temp + strlen(temp) - 1;
+				while(end > temp && isspace(*end)) end--;
+				*(end+1) = 0;
+
+				/* Remove the quote */
+				strncpy(str3, temp+1, strlen(temp)-2);
+				str3[strlen(temp)-2] = '\0';
+			} else {
+				strcpy(str3, "|||||");
+				str3[5] = '\0';
+			}
+
+			memset(time_period, 0, sizeof(*time_period));
+			/* parse time recurrence definition */
+			if (tr_parse_recurrence_string(time_period, str3, tmrec_separator)<0) {
+				LM_ERR("failed to parse line-period: %s\n", line);
+				goto error;
+			}
+
 			rule1 = new_rule();
 			if (!rule1) {
 				LM_ERR("can't create new rule\n");
@@ -217,6 +270,7 @@ static rule *parse_config_line(char *line)
 			rule1->left_exceptions = left_exceptions;
 			rule1->right = right;
 			rule1->right_exceptions = right_exceptions;
+			rule1->time_period = time_period;
 			return rule1;
 		} else {
 			/* error */
@@ -231,7 +285,11 @@ static rule *parse_config_line(char *line)
 
 	if (right) free_expression(right);
 	if (right_exceptions) free_expression(right_exceptions);
-	
+	if (time_period) {
+		free(time_period);
+		time_period = NULL;
+	}
+
 	return 0;
 }
 
@@ -245,7 +303,6 @@ rule *parse_config_file(char *filename)
 	FILE	*file;
 	char	line[LINE_LENGTH+1];
 	rule	*start_rule = NULL, *rule1 = NULL, *rule2 = NULL;
-
 	file = fopen(filename,"r");
 	if (!file) {
 		LM_INFO("file not found: %s\n", filename);

--- a/modules/permissions/parse_config.h
+++ b/modules/permissions/parse_config.h
@@ -17,8 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */

--- a/modules/permissions/parse_config.h
+++ b/modules/permissions/parse_config.h
@@ -3,7 +3,7 @@
  *
  * PERMISSIONS module
  *
- * Copyright (C) 2003 MiklÛs Tirp·k (mtirpak@sztaki.hu)
+ * Copyright (C) 2003 Mikl√≥s Tirp√°k (mtirpak@sztaki.hu)
  *
  * This file is part of Kamailio, a free SIP server.
  *

--- a/modules/permissions/permissions.c
+++ b/modules/permissions/permissions.c
@@ -88,7 +88,7 @@ str port_col = str_init("port");           /* Name of port column */
 static int check_all_branches = 1;
 
 
-/*  
+/* 
  * Convert the name of the files into table index
  */
 static int load_fixup(void** param, int param_no);
@@ -435,7 +435,7 @@ check_branches:
 }
 
 
-/*  
+/* 
  * Convert the name of the files into table index
  */
 static int load_fixup(void** param, int param_no)
@@ -666,7 +666,7 @@ static int mi_addr_child_init(void)
 }
 
 
-/* 
+/*
  * destroy function 
  */
 static void mod_exit(void) 

--- a/modules/permissions/permissions.c
+++ b/modules/permissions/permissions.c
@@ -19,8 +19,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
@@ -88,7 +88,7 @@ str port_col = str_init("port");           /* Name of port column */
 static int check_all_branches = 1;
 
 
-/* 
+/*
  * Convert the name of the files into table index
  */
 static int load_fixup(void** param, int param_no);
@@ -330,7 +330,7 @@ static char* get_plain_uri(const str* uri)
  * -1:	deny
  * 1:	allow
  */
-static int check_routing(struct sip_msg* msg, int idx) 
+static int check_routing(struct sip_msg* msg, int idx)
 {
 	struct hdr_field *from;
 	int len, q;
@@ -435,7 +435,7 @@ check_branches:
 }
 
 
-/* 
+/*
  * Convert the name of the files into table index
  */
 static int load_fixup(void** param, int param_no)
@@ -501,7 +501,7 @@ static int single_fixup(void** param, int param_no)
 
 	strcpy(buffer, (char*)*param);
 	strcat(buffer, allow_suffix);
-	tmp = buffer; 
+	tmp = buffer;
 	ret = load_fixup(&tmp, 1);
 
 	strcpy(buffer + param_len, deny_suffix);
@@ -543,7 +543,7 @@ static int double_fixup(void** param, int param_no)
 
 		strcpy(buffer, (char*)*param);
 		strcat(buffer, allow_suffix);
-		tmp = buffer; 
+		tmp = buffer;
 		ret = load_fixup(&tmp, 1);
 
 		strcpy(buffer + param_len, deny_suffix);
@@ -587,7 +587,7 @@ static int double_fixup(void** param, int param_no)
 
 
 /*
- * module initialization function 
+ * module initialization function
  */
 static int mod_init(void)
 {
@@ -667,9 +667,9 @@ static int mi_addr_child_init(void)
 
 
 /*
- * destroy function 
+ * destroy function
  */
-static void mod_exit(void) 
+static void mod_exit(void)
 {
 	int i;
 
@@ -715,7 +715,7 @@ int allow_routing_2(struct sip_msg* msg, char* allow_file, char* deny_file)
 /*
  * Test of REGISTER messages. Creates To-Contact pairs and compares them
  * against rules in allow and deny files passed as parameters. The function
- * iterates over all Contacts and creates a pair with To for each contact 
+ * iterates over all Contacts and creates a pair with To for each contact
  * found. That allows to restrict what IPs may be used in registrations, for
  * example
  */
@@ -831,7 +831,7 @@ int allow_register_2(struct sip_msg* msg, char* allow_file, char* deny_file)
  * -1:	deny
  * 1:	allow
  */
-static int allow_uri(struct sip_msg* msg, char* _idx, char* _sp) 
+static int allow_uri(struct sip_msg* msg, char* _idx, char* _sp)
 {
 	struct hdr_field *from;
 	int idx, len;

--- a/modules/permissions/permissions.h
+++ b/modules/permissions/permissions.h
@@ -18,15 +18,15 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * History:
  * --------
  *  2003-09-03  replaced /usr/local/et/ser/ with CFG_DIR (andrei)
  */
- 
+
 #ifndef PERMISSIONS_H
 #define PERMISSIONS_H 1
 

--- a/modules/permissions/rule.c
+++ b/modules/permissions/rule.c
@@ -17,12 +17,12 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
- 
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -34,10 +34,10 @@
 #include "rule.h"
 
 
-/* 
- * allocate memory for a new rule 
+/*
+ * allocate memory for a new rule
  */
-rule *new_rule(void) 
+rule *new_rule(void)
 {
 	rule	*r;
 
@@ -52,13 +52,13 @@ rule *new_rule(void)
 }
 
 
-/* 
- * free memory allocated by a rule 
+/*
+ * free memory allocated by a rule
  */
-void free_rule(rule *r) 
+void free_rule(rule *r)
 {
 	if (!r) return;
-		
+
 	if (r->left) free_expression(r->left);
 	if (r->left_exceptions) free_expression(r->left_exceptions);
 	if (r->right) free_expression(r->right);
@@ -73,13 +73,13 @@ void free_rule(rule *r)
 }
 
 
-/* 
- * list rules 
+/*
+ * list rules
  */
-void print_rule(rule *r) 
+void print_rule(rule *r)
 {
 	if (!r) return;
-		
+
 	printf("\nNEW RULE:\n");
 	printf("\n\tLEFT: ");
 	if (r->left) print_expression(r->left);  else printf("ALL");
@@ -98,10 +98,10 @@ void print_rule(rule *r)
 }
 
 
-/* 
+/*
  * look for a proper rule matching with left:right and correct time
  */
-int search_rule(rule *r, char *left, char *right) 
+int search_rule(rule *r, char *left, char *right)
 {
 	rule	*r1;
 
@@ -121,13 +121,13 @@ int search_rule(rule *r, char *left, char *right)
 
 
 /*
- * allocate memory for a new expression 
+ * allocate memory for a new expression
  * str is saved in vale, and compiled to POSIX regexp (reg_value)
  */
-expression *new_expression(char *str) 
+expression *new_expression(char *str)
 {
 	expression	*e;
-	
+
 	if (!str) return 0;
 
 	e = (expression *)pkg_malloc(sizeof(expression));
@@ -137,7 +137,7 @@ expression *new_expression(char *str)
 	}
 
 	strcpy(e->value, str);
-	
+
 	e->reg_value = (regex_t*)pkg_malloc(sizeof(regex_t));
 	if (!e->reg_value) {
 		LM_ERR("not enough pkg memory\n");
@@ -151,16 +151,16 @@ expression *new_expression(char *str)
 		pkg_free(e);
 		return NULL;
 	}
-	
+
 	e->next = 0;
 	return e;
 }
 
 
-/* 
- * free memory allocated by an expression 
+/*
+ * free memory allocated by an expression
  */
-void free_expression(expression *e) 
+void free_expression(expression *e)
 {
 	if (!e) return;
 
@@ -170,10 +170,10 @@ void free_expression(expression *e)
 }
 
 
-/* 
- * list expressions 
+/*
+ * list expressions
  */
-void print_expression(expression *e) 
+void print_expression(expression *e)
 {
 	if (!e) return;
 

--- a/modules/permissions/rule.h
+++ b/modules/permissions/rule.h
@@ -3,7 +3,7 @@
  *
  * PERMISSIONS module
  *
- * Copyright (C) 2003 MiklÛs Tirp·k (mtirpak@sztaki.hu)
+ * Copyright (C) 2003 Mikl√≥s Tirp√°k (mtirpak@sztaki.hu)
  *
  * This file is part of Kamailio, a free SIP server.
  *
@@ -27,6 +27,7 @@
 #define RULE_H 1
 
 #include <regex.h>
+#include "../../lib/srutils/tmrec.h"
 
 #define EXPRESSION_LENGTH 256	/* maximum length of an expression */
 #define LINE_LENGTH 500		/* maximum length of lines in the config file */
@@ -47,6 +48,7 @@ expression *new_expression(char *str);
 void free_expression(expression *e);
 void print_expression(expression *e);
 int search_expression(expression *e, char *value);
+int check_time(tmrec_t *time_period);
 
 /*
  * stores an expression
@@ -70,6 +72,7 @@ struct expression_struct  {
  */
 struct rule_struct {
 	expression *left, *left_exceptions, *right, *right_exceptions;
+    tmrec_t *time_period;
 	struct rule_struct	*next;
 };
 

--- a/modules/permissions/rule.h
+++ b/modules/permissions/rule.h
@@ -17,12 +17,12 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
- 
+
 #ifndef RULE_H
 #define RULE_H 1
 
@@ -38,7 +38,7 @@ typedef struct rule_struct rule;
 
 struct expression_struct;
 typedef struct expression_struct expression;
-	
+
 rule *new_rule(void);
 void free_rule(rule *r);
 void print_rule(rule *r);

--- a/modules/permissions/trusted.c
+++ b/modules/permissions/trusted.c
@@ -17,8 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * History:
@@ -108,11 +108,11 @@ int reload_trusted_table(void)
 	row = RES_ROWS(res);
 
 	LM_DBG("number of rows in trusted table: %d\n", RES_ROW_N(res));
-		
+
 	for (i = 0; i < RES_ROW_N(res); i++) {
 	    val = ROW_VALUES(row + i);
 	    if ((ROW_N(row + i) == 6) &&
-		((VAL_TYPE(val) == DB1_STRING) || (VAL_TYPE(val) == DB1_STR) ) && 
+		((VAL_TYPE(val) == DB1_STRING) || (VAL_TYPE(val) == DB1_STR) ) &&
 		!VAL_NULL(val) &&
 		((VAL_TYPE(val + 1) == DB1_STRING) || (VAL_TYPE(val + 1) == DB1_STR))
 		&& !VAL_NULL(val + 1) &&
@@ -170,7 +170,7 @@ int reload_trusted_table(void)
 	empty_hash_table(old_hash_table);
 
 	LM_DBG("trusted table reloaded successfully.\n");
-	
+
 	return 1;
 }
 
@@ -215,10 +215,10 @@ int init_trusted(void)
 
 		hash_table_1 = new_hash_table();
 		if (!hash_table_1) return -1;
-		
+
 		hash_table_2  = new_hash_table();
 		if (!hash_table_2) goto error;
-		
+
 		hash_table = (struct trusted_list ***)shm_malloc
 			(sizeof(struct trusted_list **));
 		if (!hash_table) goto error;
@@ -321,7 +321,7 @@ static inline int match_proto(const char *proto_string, int proto_int)
         if ((proto_int == PROTO_NONE) ||
 	                (strcasecmp(proto_string, "any") == 0))
 	        return 1;
-	
+
 	if (proto_int == PROTO_UDP) {
 		if (strcasecmp(proto_string, "udp") == 0) {
 			return 1;
@@ -329,7 +329,7 @@ static inline int match_proto(const char *proto_string, int proto_int)
 			return 0;
 		}
 	}
-	
+
 	if (proto_int == PROTO_TCP) {
 		if (strcasecmp(proto_string, "tcp") == 0) {
 			return 1;
@@ -337,7 +337,7 @@ static inline int match_proto(const char *proto_string, int proto_int)
 			return 0;
 		}
 	}
-	
+
 	if (proto_int == PROTO_TLS) {
 		if (strcasecmp(proto_string, "tls") == 0) {
 			return 1;
@@ -345,7 +345,7 @@ static inline int match_proto(const char *proto_string, int proto_int)
 			return 0;
 		}
 	}
-	
+
 	if (proto_int == PROTO_SCTP) {
 		if (strcasecmp(proto_string, "sctp") == 0) {
 			return 1;
@@ -361,7 +361,7 @@ static inline int match_proto(const char *proto_string, int proto_int)
 			return 0;
 		}
 	}
-	
+
 	if (proto_int == PROTO_WSS) {
 		if (strcasecmp(proto_string, "wss") == 0) {
 			return 1;
@@ -459,14 +459,14 @@ static int match_res(struct sip_msg* msg, int proto, db1_res_t* _r)
 					return -1;
 				}
 			}
-			if (!peer_tag_mode) 
+			if (!peer_tag_mode)
 				return 1;
 			count++;
 		}
 	}
 	if (!count)
 		return -1;
-	else 
+	else
 		return count;
 }
 
@@ -475,18 +475,18 @@ static int match_res(struct sip_msg* msg, int proto, db1_res_t* _r)
  * Checks based on given source IP address and protocol, and From URI
  * of request if request can be trusted without authentication.
  */
-int allow_trusted(struct sip_msg* msg, char *src_ip, int proto) 
+int allow_trusted(struct sip_msg* msg, char *src_ip, int proto)
 {
 	int result;
 	db1_res_t* res = NULL;
-	
+
 	db_key_t keys[1];
 	db_val_t vals[1];
 	db_key_t cols[4];
 
 	if (db_mode == DISABLE_CACHE) {
 		db_key_t order = &priority_col;
-	
+
 	        if (db_handle == 0) {
 		    LM_ERR("no connection to database\n");
 		    return -1;
@@ -502,7 +502,7 @@ int allow_trusted(struct sip_msg* msg, char *src_ip, int proto)
 			LM_ERR("failed to use trusted table\n");
 			return -1;
 		}
-		
+
 		VAL_TYPE(vals) = DB1_STRING;
 		VAL_NULL(vals) = 0;
 		VAL_STRING(vals) = src_ip;
@@ -517,7 +517,7 @@ int allow_trusted(struct sip_msg* msg, char *src_ip, int proto)
 			perm_dbf.free_result(db_handle, res);
 			return -1;
 		}
-		
+
 		result = match_res(msg, proto, res);
 		perm_dbf.free_result(db_handle, res);
 		return result;
@@ -531,7 +531,7 @@ int allow_trusted(struct sip_msg* msg, char *src_ip, int proto)
  * Checks based on request's source address, protocol, and From URI
  * if request can be trusted without authentication.
  */
-int allow_trusted_0(struct sip_msg* _msg, char* str1, char* str2) 
+int allow_trusted_0(struct sip_msg* _msg, char* str1, char* str2)
 {
     return allow_trusted(_msg, ip_addr2a(&(_msg->rcv.src_ip)),
 			 _msg->rcv.proto);
@@ -542,7 +542,7 @@ int allow_trusted_0(struct sip_msg* _msg, char* str1, char* str2)
  * Checks based on source address and protocol given in pvar arguments and
  * and requests's From URI, if request can be trusted without authentication.
  */
-int allow_trusted_2(struct sip_msg* _msg, char* _src_ip_sp, char* _proto_sp) 
+int allow_trusted_2(struct sip_msg* _msg, char* _src_ip_sp, char* _proto_sp)
 {
     str src_ip, proto;
     int proto_int;
@@ -552,7 +552,7 @@ int allow_trusted_2(struct sip_msg* _msg, char* _src_ip_sp, char* _proto_sp)
 	LM_ERR("src_ip param does not exist or has no value\n");
 	return -1;
     }
-    
+
     if (_proto_sp==NULL
 	|| (fixup_get_svalue(_msg, (gparam_p)_proto_sp, &proto) != 0)) {
 	LM_ERR("proto param does not exist or has no value\n");

--- a/modules/permissions/trusted.h
+++ b/modules/permissions/trusted.h
@@ -17,14 +17,14 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
 #ifndef TRUSTED_H
 #define TRUSTED_H
-		
+
 #include "../../parser/msg_parser.h"
 
 


### PR DESCRIPTION
Possibility to specify a time period following the RFC 2445 (explained in the TMREC module readme)
at the end of a rule in the allow and deny files. The rule will be valid only during this period.
Usefull for company or people that don't want calls during night or want to receive calls from someone
only during a specific period of time. It was already possible with the TMREC module in a routing
script but this was redundant with the permission module so it simplifies the conf.