### PR TITLE
rtpengine: hash table to keep the selected nodes

### DIFF
--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -73,6 +73,38 @@
 		If the set was selected using setid_avp, the avp needs to be
 		set only once before rtpengine_offer() or rtpengine_manage() call.
 	</para>
+	<para>
+		From the current implementation point of view, the sets of rtpproxy nodes
+		are shared memory(shm), so all processes can see a common list of nodes.
+		There is no locking when setting the nodes enabled/disabled (to keep the
+		memory access as fast as possible). Thus, problems related to node state
+		might appear for concurent processes that might set the nodes
+		enabled/disabled(e.g. by fifo command). This robustness problems are overcomed as follows.
+	</para>
+
+	<para>
+		If the current process sees the selected node as disabled, the node is
+		<emphasis>force tested</emphasis> before the current process actually
+		takes the disabled decision. If the test succeeds, the process will set
+		the node as enabled (but other concurrent process might still see it as disabled).
+.
+	</para>
+
+	<para>
+		If the current process sees the selected node as enabled, it does no additional checks
+		and sends the command which will fail in case the machine is actually broken.
+		The process will set the node as disabled (but other concurrent process might still see it as enabled).
+	</para>
+
+	<para>
+		The 'kamctl fifo' commands (including rtpengin ones) are executed by an exclusive
+		process which operate on the same shared memory node list.
+	</para>
+
+	<para>
+		All the nodes are pinged in the beginning by all the processes,
+		even if the node list is shared memory.
+	</para>
 	</section>
 
 	<section>

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -356,6 +356,32 @@ modparam("rtpproxy", "rtp_inst_pvar", "$avp(RTP_INSTANCE)")
 		</example>
 	</section>
 
+	<section id="rtpengine.p.hash_entry_tout">
+		<title><varname>hash_entry_tout</varname> (string)</title>
+		<para>
+			Number of seconds after an rtpengine hash table entry is marked for deletion.
+			By default, this parameter is set to 120 (seconds).
+		</para>
+		<para>
+			To maintain information about a selected rtp machine node, for a given call, entries are added in a hashtable of (callid, node) pairs.
+			When "offer" comes, insert new entry in the hastable.
+			When subsequent commands come, lookup callid and return chosen node.
+			When "delete" comes, remove old entry from hashtable.
+		</para>
+		<para>
+			NOTE: In the current implementation, the actual deletion happens <emphasis>on the fly</emphasis>,
+			while insert/remove/lookup the hastable, <emphasis>only</emphasis> for the entries in the insert/remove/lookup path.
+		</para>
+		<example>
+		<title>Set <varname>hash_entry_tout</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpproxy", "hash_entry_tout", "300")
+...
+</programlisting>
+		</example>
+	</section>
+
 	</section>
 
 	<section>

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -388,8 +388,26 @@ modparam("rtpproxy", "rtp_inst_pvar", "$avp(RTP_INSTANCE)")
 		</example>
 	</section>
 
-	<section id="rtpengine.p.hash_entry_tout">
-		<title><varname>hash_entry_tout</varname> (string)</title>
+	<section id="rtpengine.p.hash_table_size">
+		<title><varname>hash_table_size</varname> (integer)</title>
+		<para>
+			Size of the hash table. Default value is 256.
+		</para>
+		<para>
+			NOTE: If configured size is <emphasis>less than</emphasis> 1, the size will be defaulted to 1.
+		</para>
+		<example>
+		<title>Set <varname>hash_table_size</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpproxy", "hash_table_size", "123")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="rtpengine.p.hash_table_tout">
+		<title><varname>hash_table_tout</varname> (integer)</title>
 		<para>
 			Number of seconds after an rtpengine hash table entry is marked for deletion.
 			By default, this parameter is set to 120 (seconds).
@@ -405,14 +423,15 @@ modparam("rtpproxy", "rtp_inst_pvar", "$avp(RTP_INSTANCE)")
 			while insert/remove/lookup the hastable, <emphasis>only</emphasis> for the entries in the insert/remove/lookup path.
 		</para>
 		<example>
-		<title>Set <varname>hash_entry_tout</varname> parameter</title>
+		<title>Set <varname>hash_table_tout</varname> parameter</title>
 <programlisting format="linespecific">
 ...
-modparam("rtpproxy", "hash_entry_tout", "300")
+modparam("rtpproxy", "hash_table_tout", "300")
 ...
 </programlisting>
 		</example>
 	</section>
+
 
 	</section>
 

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -210,6 +210,30 @@ modparam("rtpengine", "rtpengine_tout_ms", 2000)
 </programlisting>
 		</example>
 	</section>
+	<section id="rtpengine.p.rtpengine_allow_op">
+		<title><varname>rtpengine_allow_op</varname> (integer)</title>
+		<para>
+		Enable this to allow finishing the current sessions while denying new sessions for the
+		<emphasis>manually deactivated nodes </emphasis> via kamctl command i.e. "disabled(permanent)" nodes.
+		Probably the manually deactivated machine is still running(did not crash).
+		</para>
+		<para>
+		This is <emphasis>useful</emphasis> when deactivating a node for maintanance and reject new sessions but allow current ones to finish.
+		</para>
+		<para>
+		<emphasis>
+		Default value is <quote>0</quote> to keep the current behaviour.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>rtpengine_allow_op</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("rtpengine", "rtpengine_allow_op", 1)
+...
+</programlisting>
+		</example>
+	</section>
 	<section id="rtpengine.p.queried_nodes_limit">
 		<title><varname>queried_nodes_limit</varname> (integer)</title>
 		<para>

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -1041,6 +1041,23 @@ $ &ctltool; fifo nh_ping_rtpp all
 			</programlisting>
 			</example>
 		</section>
+
+	    <section id="rtpengine.m.nh_show_hash_total">
+			<title><function moreinfo="none">nh_show_hash_total</function></title>
+			<para>
+				Print the total number of hash entries in the hash table at a given moment.
+			</para>
+			<example>
+			<title>
+				<function moreinfo="none">nh_show_hash_total</function> usage</title>
+			<programlisting format="linespecific">
+...
+$ &ctltool; fifo nh_show_hash_total
+...
+			</programlisting>
+			</example>
+		</section>
+
 	</section>
 
 </chapter>

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -361,7 +361,7 @@ modparam("rtpengine", "read_sdp_pv", "$var(sdp)")
 route {
 	...
 	$var(sdp) = $rb + "a=foo:bar\r\n";
-	rtpproxy_manage();
+	rtpengine_manage();
 }
 </programlisting>
 		</example>
@@ -386,7 +386,7 @@ modparam("rtpengine", "write_sdp_pv", "$avp(sdp)")
 ...
 route {
 	...
-	rtpproxy_manage();
+	rtpengine_manage();
 	set_body("$avp(sdp)a=baz123\r\n", "application/sdp");
 }
 </programlisting>
@@ -406,7 +406,7 @@ route {
 		<title>Set <varname>rtp_inst_pvar</varname> parameter</title>
 <programlisting format="linespecific">
 ...
-modparam("rtpproxy", "rtp_inst_pvar", "$avp(RTP_INSTANCE)")
+modparam("rtpengine", "rtp_inst_pvar", "$avp(RTP_INSTANCE)")
 ...
 </programlisting>
 		</example>
@@ -424,7 +424,7 @@ modparam("rtpproxy", "rtp_inst_pvar", "$avp(RTP_INSTANCE)")
 		<title>Set <varname>hash_table_size</varname> parameter</title>
 <programlisting format="linespecific">
 ...
-modparam("rtpproxy", "hash_table_size", "123")
+modparam("rtpengine", "hash_table_size", "123")
 ...
 </programlisting>
 		</example>
@@ -434,23 +434,24 @@ modparam("rtpproxy", "hash_table_size", "123")
 		<title><varname>hash_table_tout</varname> (integer)</title>
 		<para>
 			Number of seconds after an rtpengine hash table entry is marked for deletion.
-			By default, this parameter is set to 120 (seconds).
+			By default, this parameter is set to 3600 (seconds).
 		</para>
 		<para>
 			To maintain information about a selected rtp machine node, for a given call, entries are added in a hashtable of (callid, node) pairs.
-			When "offer" comes, insert new entry in the hastable.
-			When subsequent commands come, lookup callid and return chosen node.
-			When "delete" comes, remove old entry from hashtable.
+			When command comes, lookup callid. If found, return chosen node. If not found, choose a new node, insert it in the hastable and return the chosen node.
 		</para>
 		<para>
 			NOTE: In the current implementation, the actual deletion happens <emphasis>on the fly</emphasis>,
 			while insert/remove/lookup the hastable, <emphasis>only</emphasis> for the entries in the insert/remove/lookup path.
 		</para>
+		<para>
+			NOTE: When configuring this parameter, one should consider maximum call time VS share memory for unfinished calls.
+		</para>
 		<example>
 		<title>Set <varname>hash_table_tout</varname> parameter</title>
 <programlisting format="linespecific">
 ...
-modparam("rtpproxy", "hash_table_tout", "300")
+modparam("rtpengine", "hash_table_tout", "300")
 ...
 </programlisting>
 		</example>

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -231,7 +231,8 @@ static pid_t mypid;
 static unsigned int myseqn = 0;
 static str extra_id_pv_param = {NULL, 0};
 static char *setid_avp_param = NULL;
-static int hash_entry_tout = 120;
+static int hash_table_tout = 120;
+static int hash_table_size = 256;
 
 static char ** rtpp_strings=0;
 static int rtpp_sets=0; /*used in rtpengine_set_store()*/
@@ -340,7 +341,8 @@ static param_export_t params[] = {
 	{"rtp_inst_pvar",         PARAM_STR, &rtp_inst_pv_param },
 	{"write_sdp_pv",          PARAM_STR, &write_sdp_pvar_str          },
 	{"read_sdp_pv",           PARAM_STR, &read_sdp_pvar_str          },
-	{"hash_entry_tout",       INT_PARAM, &hash_entry_tout        },
+	{"hash_table_tout",       INT_PARAM, &hash_table_tout        },
+	{"hash_table_size",       INT_PARAM, &hash_table_size        },
 	{0, 0, 0}
 };
 
@@ -1446,11 +1448,11 @@ mod_init(void)
 	}
 
 	/* init the hastable which keeps the call-id <-> selected_node relation */
-	if (!rtpengine_hash_table_init()) {
-		LM_ERR("rtpengine_hash_table_init() failed!\n");
+	if (!rtpengine_hash_table_init(hash_table_size)) {
+		LM_ERR("rtpengine_hash_table_init(%d) failed!\n", hash_table_size);
 		return -1;
 	} else {
-		LM_DBG("rtpengine_hash_table_init() success!\n");
+		LM_DBG("rtpengine_hash_table_init(%d) success!\n", hash_table_size);
 	}
 
 	return 0;
@@ -2307,7 +2309,7 @@ found:
 	}
 	entry->node = node;
 	entry->next = NULL;
-	entry->tout = get_ticks() + hash_entry_tout;
+	entry->tout = get_ticks() + hash_table_tout;
 
 	/* Insert the key<->entry from the hashtable */
 	if (!rtpengine_hash_table_insert(&callid, entry)) {

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -2452,18 +2452,16 @@ select_rtpp_node(str callid, str viabranch, int do_test)
 		return node;
 	}
 
-	// if node _manually_ disabled(e.g kamctl) and proper configuration, return it
-	if (node->rn_recheck_ticks == MI_MAX_RECHECK_TICKS) {
-		if (rtpengine_allow_op) {
+	// if proper configuration and node manually or timeout disabled, return it
+	if (rtpengine_allow_op) {
+		if (node->rn_recheck_ticks == MI_MAX_RECHECK_TICKS) {
 			LM_DBG("node=%.*s for calllen=%d callid=%.*s is disabled(permanent) (probably still UP)! Return it\n",
 				node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
-			return node;
+		} else {
+			LM_DBG("node=%.*s for calllen=%d callid=%.*s is disabled, either broke or timeout disabled! Return it\n",
+				node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
 		}
-		LM_DBG("node=%.*s for calllen=%d callid=%.*s is disabled(permanent) (probably still UP)! Return NULL\n",
-			node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
-	} else {
-		LM_DBG("node=%.*s for calllen=%d callid=%.*s is disabled (probably BROKE)! Return NULL\n",
-			node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
+		return node;
 	}
 
 	return NULL;

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -193,9 +193,9 @@ static int rtpengine_offer_answer(struct sip_msg *msg, const char *flags, int op
 static int fixup_set_id(void ** param, int param_no);
 static int set_rtpengine_set_f(struct sip_msg * msg, char * str1, char * str2);
 static struct rtpp_set * select_rtpp_set(int id_set);
-static struct rtpp_node *select_rtpp_node_new(str, int, int);
-static struct rtpp_node *select_rtpp_node_old(str, int, int);
-static struct rtpp_node *select_rtpp_node(str, int, int);
+static struct rtpp_node *select_rtpp_node_new(str, str, int);
+static struct rtpp_node *select_rtpp_node_old(str, str, int);
+static struct rtpp_node *select_rtpp_node(str, str, int);
 static char *send_rtpp_command(struct rtpp_node *, bencode_item_t *, int *);
 static int get_extra_id(struct sip_msg* msg, str *id_str);
 
@@ -1859,7 +1859,8 @@ static bencode_item_t *rtpp_function_call(bencode_buffer_t *bencbuf, struct sip_
 {
 	struct ng_flags_parse ng_flags;
 	bencode_item_t *item, *resp;
-	str callid, from_tag, to_tag, body, viabranch, error;
+	str callid = STR_NULL, from_tag = STR_NULL, to_tag = STR_NULL, viabranch = STR_NULL;
+	str body = STR_NULL, error = STR_NULL;
 	int ret, queried_nodes;
 	struct rtpp_node *node;
 	char *cp;
@@ -1992,7 +1993,7 @@ select_node:
 			LM_ERR("queried nodes limit reached\n");
 			goto error;
 		}
-		node = select_rtpp_node(callid, 1, op);
+		node = select_rtpp_node(callid, viabranch, 1);
 		if (!node) {
 			LM_ERR("no available proxies\n");
 			goto error;
@@ -2036,12 +2037,12 @@ select_node:
 
 	if (op == OP_DELETE) {
 		/* Delete the key<->value from the hashtable */
-		if (!rtpengine_hash_table_remove(&callid)) {
-			LM_ERR("rtpengine hash table failed to remove entry for callen=%d callid=%.*s\n",
-				callid.len, callid.len, callid.s);
+		if (!rtpengine_hash_table_remove(callid, viabranch)) {
+			LM_ERR("rtpengine hash table failed to remove entry for callen=%d callid=%.*s viabranch=%.*s\n",
+				callid.len, callid.len, callid.s, viabranch.len, viabranch.s);
 		} else {
-			LM_DBG("rtpengine hash table remove entry for callen=%d callid=%.*s\n",
-				callid.len, callid.len, callid.s);
+			LM_DBG("rtpengine hash table remove entry for callen=%d callid=%.*s viabranch=%.*s\n",
+				callid.len, callid.len, callid.s, viabranch.len, viabranch.s);
 		}
 	}
 
@@ -2278,7 +2279,7 @@ static struct rtpp_set * select_rtpp_set(int id_set ){
  * run the selection algorithm and return the new selected node
  */
 static struct rtpp_node *
-select_rtpp_node_new(str callid, int do_test, int op)
+select_rtpp_node_new(str callid, str viabranch, int do_test)
 {
 	struct rtpp_node* node;
 	unsigned i, sum, sumcut, weight_sum;
@@ -2350,18 +2351,25 @@ found:
 	}
 
 	/* build the entry */
-	struct rtpengine_hash_entry *entry = shm_malloc(sizeof(struct rtpp_node));
+	struct rtpengine_hash_entry *entry = shm_malloc(sizeof(struct rtpengine_hash_entry));
 	if (!entry) {
-		LM_ERR("rtpengine hash table fail to create entry for calllen=%d callid=%.*s\n",
-			callid.len, callid.len, callid.s);
+		LM_ERR("rtpengine hash table fail to create entry for calllen=%d callid=%.*s viabranch=%.*s\n",
+			callid.len, callid.len, callid.s, viabranch.len, viabranch.s);
 		return node;
 	}
+        memset(entry, 0, sizeof(struct rtpengine_hash_entry));
 
 	/* fill the entry */
 	if (shm_str_dup(&entry->callid, &callid) < 0) {
 		LM_ERR("rtpengine hash table fail to duplicate calllen=%d callid=%.*s\n",
 			callid.len, callid.len, callid.s);
-		shm_free(entry);
+		rtpengine_hash_table_free_entry(entry);
+		return node;
+	}
+	if (shm_str_dup(&entry->viabranch, &viabranch) < 0) {
+		LM_ERR("rtpengine hash table fail to duplicate calllen=%d viabranch=%.*s\n",
+			callid.len, viabranch.len, viabranch.s);
+		rtpengine_hash_table_free_entry(entry);
 		return node;
 	}
 	entry->node = node;
@@ -2369,15 +2377,14 @@ found:
 	entry->tout = get_ticks() + hash_table_tout;
 
 	/* insert the key<->entry from the hashtable */
-	if (!rtpengine_hash_table_insert(&callid, entry)) {
-		LM_ERR("rtpengine hash table fail to insert node=%.*s for calllen=%d callid=%.*s\n",
-			node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
-		shm_free(entry->callid.s);
-		shm_free(entry);
+	if (!rtpengine_hash_table_insert(callid, viabranch, entry)) {
+		LM_ERR("rtpengine hash table fail to insert node=%.*s for calllen=%d callid=%.*s viabranch=%.*s\n",
+			node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s, viabranch.len, viabranch.s);
+		rtpengine_hash_table_free_entry(entry);
 		return node;
 	} else {
-		LM_DBG("rtpengine hash table insert node=%.*s for calllen=%d callid=%.*s\n",
-			node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
+		LM_DBG("rtpengine hash table insert node=%.*s for calllen=%d callid=%.*s viabranch=%.*s\n",
+			node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s, viabranch.len, viabranch.s);
 	}
 
 	/* return selected node */
@@ -2388,19 +2395,19 @@ found:
  * lookup the hastable (key=callid value=node) and get the old node (e.g. for answer/delete)
  */
 static struct rtpp_node *
-select_rtpp_node_old(str callid, int do_test, int op)
+select_rtpp_node_old(str callid, str viabranch, int do_test)
 {
 	struct rtpp_node *node = NULL;
 
-	node = rtpengine_hash_table_lookup(&callid);
+	node = rtpengine_hash_table_lookup(callid, viabranch);
 
 	if (!node) {
-		LM_NOTICE("rtpengine hash table lookup failed to find node for calllen=%d callid=%.*s\n",
-			callid.len, callid.len, callid.s);
+		LM_NOTICE("rtpengine hash table lookup failed to find node for calllen=%d callid=%.*s viabranch=%.*s\n",
+			callid.len, callid.len, callid.s, viabranch.len, viabranch.s);
 		return NULL;
 	} else {
-		LM_DBG("rtpengine hash table lookup find node=%.*s for calllen=%d callid=%.*s\n",
-			node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
+		LM_DBG("rtpengine hash table lookup find node=%.*s for calllen=%d callid=%.*s viabranch=%.*s\n",
+			node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s, viabranch.len, viabranch.s);
 	}
 
 	return node;
@@ -2411,7 +2418,7 @@ select_rtpp_node_old(str callid, int do_test, int op)
  * the call if some proxies were disabled or enabled (e.g. kamctl command)
  */
 static struct rtpp_node *
-select_rtpp_node(str callid, int do_test, int op)
+select_rtpp_node(str callid, str viabranch, int do_test)
 {
 	struct rtpp_node *node = NULL;
 
@@ -2421,12 +2428,12 @@ select_rtpp_node(str callid, int do_test, int op)
 	}
 
 	// lookup node
-	node = select_rtpp_node_old(callid, do_test, op);
+	node = select_rtpp_node_old(callid, viabranch, do_test);
 
 	// check node
 	if (!node) {
 		// run the selection algorithm
-		node = select_rtpp_node_new(callid, do_test, op);
+		node = select_rtpp_node_new(callid, viabranch, do_test);
 
 		// check node
 		if (!node) {

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -109,6 +109,7 @@ MODULE_VERSION
 #define MI_ENABLE_RTP_PROXY			"nh_enable_rtpp"
 #define MI_SHOW_RTP_PROXIES			"nh_show_rtpp"
 #define MI_PING_RTP_PROXY           "nh_ping_rtpp"
+#define MI_SHOW_HASH_TOTAL          "nh_show_hash_total"
 
 #define MI_RTP_PROXY_NOT_FOUND		"RTP proxy not found"
 #define MI_RTP_PROXY_NOT_FOUND_LEN	(sizeof(MI_RTP_PROXY_NOT_FOUND)-1)
@@ -143,6 +144,10 @@ MODULE_VERSION
 #define MI_SUCCESS_LEN         		(sizeof(MI_SUCCESS)-1)
 #define MI_FAIL                     "fail"
 #define MI_FAIL_LEN         		(sizeof(MI_FAIL)-1)
+#define MI_HASH_ENTRIES				"entries"
+#define MI_HASH_ENTRIES_LEN			(sizeof(MI_HASH_ENTRIES)-1)
+#define MI_HASH_ENTRIES_FAIL		"Fail to get entry details"
+#define MI_HASH_ENTRIES_FAIL_LEN	(sizeof(MI_HASH_ENTRIES_FAIL)-1)
 
 #define MI_FOUND_ALL                   2
 #define MI_FOUND_ONE                   1
@@ -215,12 +220,10 @@ static int rtpp_test_ping(struct rtpp_node *node);
 static int pv_get_rtpstat_f(struct sip_msg *, pv_param_t *, pv_value_t *);
 
 /*mi commands*/
-static struct mi_root* mi_enable_rtp_proxy(struct mi_root* cmd_tree,
-		void* param );
-static struct mi_root* mi_show_rtp_proxy(struct mi_root* cmd_tree,
-		void* param);
-static struct mi_root* mi_ping_rtp_proxy(struct mi_root* cmd_tree,
-        void* param);
+static struct mi_root* mi_enable_rtp_proxy(struct mi_root* cmd_tree, void* param);
+static struct mi_root* mi_show_rtp_proxy(struct mi_root* cmd_tree, void* param);
+static struct mi_root* mi_ping_rtp_proxy(struct mi_root* cmd_tree, void* param);
+static struct mi_root* mi_show_hash_total(struct mi_root* cmd_tree, void* param);
 
 
 static int rtpengine_disable_tout = 60;
@@ -350,6 +353,7 @@ static mi_export_t mi_cmds[] = {
 	{MI_ENABLE_RTP_PROXY,     mi_enable_rtp_proxy,  0,  0,  0},
 	{MI_SHOW_RTP_PROXIES,     mi_show_rtp_proxy,    0,  0,  0},
 	{MI_PING_RTP_PROXY,       mi_ping_rtp_proxy,    0,  0,  0},
+	{MI_SHOW_HASH_TOTAL,      mi_show_hash_total,    0,  0,  0},
 	{ 0, 0, 0, 0, 0}
 };
 
@@ -1106,8 +1110,7 @@ error:
 	return -1;
 }
 
-static struct mi_root* mi_show_rtp_proxy(struct mi_root* cmd_tree,
-												void* param)
+static struct mi_root* mi_show_rtp_proxy(struct mi_root* cmd_tree, void* param)
 {
 	struct mi_node *node;
 	struct mi_root *root = NULL;
@@ -1196,8 +1199,7 @@ error:
 	return init_mi_tree(404, MI_ERROR, MI_ERROR_LEN);
 }
 
-static struct mi_root* mi_ping_rtp_proxy(struct mi_root* cmd_tree,
-												void* param)
+static struct mi_root* mi_ping_rtp_proxy(struct mi_root* cmd_tree, void* param)
 {
 	struct mi_node *node, *crt_node;
 	struct mi_attr *attr;
@@ -1321,6 +1323,48 @@ error:
 	return init_mi_tree(404, MI_ERROR, MI_ERROR_LEN);
 }
 
+
+static struct mi_root* mi_show_hash_total(struct mi_root* cmd_tree, void* param)
+{
+	struct mi_node *node, *crt_node;
+	struct mi_attr *attr;
+	struct mi_root *root = NULL;
+	unsigned int total;
+	str total_str;
+
+	// Init print tree
+	root = init_mi_tree(200, MI_OK_S, MI_OK_LEN);
+	if (!root) {
+		LM_ERR("the MI tree cannot be initialized!\n");
+		return 0;
+	}
+	node = &root->node;
+
+	// Create new node and add it to the roots's kids
+	if(!(crt_node = add_mi_node_child(node, MI_DUP_NAME, "total", strlen("total"), 0, 0))) {
+		LM_ERR("cannot add the child node to the tree\n");
+		goto error;
+	}
+
+	// Get total number of entries
+	total = rtpengine_hash_table_total();
+	total_str.s = int2str(total, &total_str.len);
+
+	// Add node attributes
+	if ((attr = add_mi_attr(crt_node, MI_DUP_VALUE, MI_HASH_ENTRIES, MI_HASH_ENTRIES_LEN, total_str.s, total_str.len)) == 0) {
+		LM_ERR("cannot add attributes to the node\n");
+		goto error;
+	}
+
+	return root;
+
+error:
+	if (root) {
+	    free_mi_tree(root);
+	}
+
+	return init_mi_tree(404, MI_HASH_ENTRIES_FAIL, MI_HASH_ENTRIES_FAIL_LEN);
+}
 
 
 static int

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -227,6 +227,7 @@ static struct mi_root* mi_show_hash_total(struct mi_root* cmd_tree, void* param)
 
 
 static int rtpengine_disable_tout = 60;
+static int rtpengine_allow_op = 0;
 static int rtpengine_retr = 5;
 static int rtpengine_tout_ms = 1000;
 static int queried_nodes_limit = MAX_RTPP_TRIED_NODES;
@@ -334,6 +335,7 @@ static param_export_t params[] = {
 	{"rtpengine_disable_tout",INT_PARAM, &rtpengine_disable_tout },
 	{"rtpengine_retr",        INT_PARAM, &rtpengine_retr         },
 	{"rtpengine_tout_ms",     INT_PARAM, &rtpengine_tout_ms      },
+	{"rtpengine_allow_op",    INT_PARAM, &rtpengine_allow_op     },
 	{"queried_nodes_limit",   INT_PARAM, &queried_nodes_limit    },
 	{"db_url",                PARAM_STR, &rtpp_db_url },
 	{"table_name",            PARAM_STR, &rtpp_table_name },
@@ -2369,7 +2371,7 @@ found:
 }
 
 /*
- * lookup the hastable (key=callid value=node) and get the old node
+ * lookup the hastable (key=callid value=node) and get the old node (e.g. for answer/delete)
  */
 static struct rtpp_node *
 select_rtpp_node_old(str callid, int do_test, int op)
@@ -2396,11 +2398,22 @@ select_rtpp_node_old(str callid, int do_test, int op)
 			node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
 	}
 
-	// if node broke, don't send any message
+	// if node enabled, return it
 	if (!node->rn_disabled) {
 		return node;
+	}
+
+	// if node _manually_ disabled(e.g kamctl) and proper configuration, return it
+	if (node->rn_recheck_ticks == MI_MAX_RECHECK_TICKS) {
+		if (rtpengine_allow_op) {
+			LM_DBG("node=%.*s for calllen=%d callid=%.*s is disabled(permanent) (probably still UP)! Return it\n",
+				node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
+			return node;
+		}
+		LM_DBG("node=%.*s for calllen=%d callid=%.*s is disabled(permanent) (probably still UP)! Return NULL\n",
+			node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
 	} else {
-		LM_DBG("rtpengine hash table lookup find node=%.*s for calllen=%d callid=%.*s, which is disabled!\n",
+		LM_DBG("node=%.*s for calllen=%d callid=%.*s is disabled (probably BROKE)! Return NULL\n",
 			node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
 	}
 

--- a/modules/rtpengine/rtpengine.c
+++ b/modules/rtpengine/rtpengine.c
@@ -2360,17 +2360,21 @@ found:
         memset(entry, 0, sizeof(struct rtpengine_hash_entry));
 
 	/* fill the entry */
-	if (shm_str_dup(&entry->callid, &callid) < 0) {
-		LM_ERR("rtpengine hash table fail to duplicate calllen=%d callid=%.*s\n",
-			callid.len, callid.len, callid.s);
-		rtpengine_hash_table_free_entry(entry);
-		return node;
+        if (callid.s && callid.len > 0) {
+		if (shm_str_dup(&entry->callid, &callid) < 0) {
+			LM_ERR("rtpengine hash table fail to duplicate calllen=%d callid=%.*s\n",
+				callid.len, callid.len, callid.s);
+			rtpengine_hash_table_free_entry(entry);
+			return node;
+		}
 	}
-	if (shm_str_dup(&entry->viabranch, &viabranch) < 0) {
-		LM_ERR("rtpengine hash table fail to duplicate calllen=%d viabranch=%.*s\n",
-			callid.len, viabranch.len, viabranch.s);
-		rtpengine_hash_table_free_entry(entry);
-		return node;
+        if (viabranch.s && viabranch.len > 0) {
+		if (shm_str_dup(&entry->viabranch, &viabranch) < 0) {
+			LM_ERR("rtpengine hash table fail to duplicate calllen=%d viabranch=%.*s\n",
+				callid.len, viabranch.len, viabranch.s);
+			rtpengine_hash_table_free_entry(entry);
+			return node;
+		}
 	}
 	entry->node = node;
 	entry->next = NULL;

--- a/modules/rtpengine/rtpengine.h
+++ b/modules/rtpengine/rtpengine.h
@@ -61,7 +61,6 @@ struct rtpp_set_head{
 struct rtpp_set *get_rtpp_set(int set_id);
 int add_rtpengine_socks(struct rtpp_set * rtpp_list, char * rtpproxy);
 
-int set_rtp_inst_pvar(struct sip_msg *msg, const str * const uri);
 
 int init_rtpproxy_db(void);
 

--- a/modules/rtpengine/rtpengine_hash.c
+++ b/modules/rtpengine/rtpengine_hash.c
@@ -1,0 +1,314 @@
+#include "rtpengine_hash.h"
+
+#include "../../str.h"
+#include "../../dprint.h"
+#include "../../mem/shm_mem.h"
+#include "../../locking.h"
+#include "../../timer.h"
+
+static gen_lock_t *rtpengine_hash_lock;
+static struct rtpengine_hash_table *rtpengine_hash_table;
+
+/* from sipwise rtpengine */
+static int str_cmp_str(const str *a, const str *b) {
+	if (a->len < b->len)
+		return -1;
+	if (a->len > b->len)
+		return 1;
+	if (a->len == 0 && b->len == 0)
+		return 0;
+	return memcmp(a->s, b->s, a->len);
+}
+
+/* from sipwise rtpengine */
+static int str_equal(void *a, void *b) {
+	return (str_cmp_str((str *) a, (str *) b) == 0);
+}
+
+/* from sipwise rtpengine */
+static unsigned int str_hash(void *ss) {
+	const str *s = (str*) ss;
+	unsigned int ret = 5381;
+	str it = *s;
+
+	while (it.len > 0) {
+		ret = (ret << 5) + ret + *it.s;
+		it.s++;
+		it.len--;
+	}
+
+	return ret % RTPENGINE_HASH_TABLE_SIZE;
+}
+
+/* rtpengine glib hash API */
+int rtpengine_hash_table_init() {
+	int i;
+
+	// init hashtable
+	rtpengine_hash_table = shm_malloc(sizeof(struct rtpengine_hash_table));
+	if (!rtpengine_hash_table) {
+		LM_ERR("no shm left to create rtpengine_hash_table\n");
+		return 0;
+	}
+
+	// init hashtable entry_list heads (never filled)
+	for (i = 0; i < RTPENGINE_HASH_TABLE_SIZE; i++) {
+		rtpengine_hash_table->entry_list[i] = shm_malloc(sizeof(struct rtpengine_hash_entry));
+		if (!rtpengine_hash_table->entry_list[i]) {
+			LM_ERR("no shm left to create rtpengine_hash_table->entry_list[%d]\n", i);
+			return 0;
+		}
+
+		/* never expire the head of the hashtable index lists */
+		rtpengine_hash_table->entry_list[i]->tout = -1;
+		rtpengine_hash_table->entry_list[i]->next = NULL;
+	}
+
+	// init lock
+	rtpengine_hash_lock = lock_alloc();
+	if (!rtpengine_hash_lock) {
+		LM_ERR("no shm left to init rtpengine_hash_table lock");
+		return 0;
+	}
+
+	return 1;
+}
+
+int rtpengine_hash_table_destroy() {
+	int i;
+	struct rtpengine_hash_entry *entry, *last_entry;
+
+	// check rtpengine hashtable
+	if (!rtpengine_hash_table) {
+		LM_ERR("NULL rtpengine_hash_table");
+		return 0;
+	}
+
+	// destroy hashtable entry_list content
+	lock_get(rtpengine_hash_lock);
+	for (i = 0; i < RTPENGINE_HASH_TABLE_SIZE; i++) {
+		entry = rtpengine_hash_table->entry_list[i];
+		while (entry) {
+			last_entry = entry;
+			entry = entry->next;
+			shm_free(last_entry->callid.s);
+			shm_free(last_entry);
+		}
+	}
+
+	// destroy hashtable
+	shm_free(rtpengine_hash_table);
+	rtpengine_hash_table = NULL;
+	lock_release(rtpengine_hash_lock);
+
+	// destroy lock
+	if (!rtpengine_hash_lock) {
+		LM_ERR("NULL rtpengine_hash_lock");
+	} else {
+		lock_dealloc(rtpengine_hash_lock);
+		rtpengine_hash_lock = NULL;
+	}
+
+	return 1;
+}
+
+int rtpengine_hash_table_insert(void *key, void *value) {
+	struct rtpengine_hash_entry *entry, *last_entry;
+	struct rtpengine_hash_entry *new_entry = (struct rtpengine_hash_entry *) value;
+	unsigned int hash_index;
+
+	// check rtpengine hashtable
+	if (!rtpengine_hash_table) {
+		LM_ERR("NULL rtpengine_hash_table");
+		return 0;
+	}
+
+	// get entry list
+	hash_index = str_hash(key);
+	entry = rtpengine_hash_table->entry_list[hash_index];
+	last_entry = entry;
+
+	// lock
+	lock_get(rtpengine_hash_lock);
+	while (entry) {
+		// if key found, don't add new entry
+		if (str_equal(&entry->callid, &new_entry->callid)) {
+			// unlock
+			lock_release(rtpengine_hash_lock);
+			LM_ERR("Call id %.*s already in hashtable, ignore new value", entry->callid.len, entry->callid.s);
+			return 0;
+		}
+
+		// if expired entry discovered, delete it
+		if (entry->tout < get_ticks()) {
+			// set pointers; exclude entry
+			last_entry->next = entry->next;
+
+			// free current entry; entry points to unknown
+			shm_free(entry->callid.s);
+			shm_free(entry);
+
+			// set pointers
+			entry = last_entry;
+		}
+
+		// next entry in the list
+		last_entry = entry;
+		entry = entry->next;
+	}
+
+	last_entry->next = new_entry;
+
+	// unlock
+	lock_release(rtpengine_hash_lock);
+
+	return 1;
+}
+
+int rtpengine_hash_table_remove(void *key) {
+	struct rtpengine_hash_entry *entry, *last_entry;
+	unsigned int hash_index;
+
+	// check rtpengine hashtable
+	if (!rtpengine_hash_table) {
+		LM_ERR("NULL rtpengine_hash_table");
+		return 0;
+	}
+
+	// get first entry from entry list; jump over unused list head
+	hash_index = str_hash(key);
+	entry = rtpengine_hash_table->entry_list[hash_index];
+	last_entry = entry;
+
+	// lock
+	lock_get(rtpengine_hash_lock);
+	while (entry) {
+		// if key found, delete entry
+		if (str_equal(&entry->callid, (str *)key)) {
+			// free entry
+			last_entry->next = entry->next;
+			shm_free(entry->callid.s);
+			shm_free(entry);
+
+			// unlock
+			lock_release(rtpengine_hash_lock);
+
+			return 1;
+		}
+
+		// if expired entry discovered, delete it
+		if (entry->tout < get_ticks()) {
+			// set pointers; exclude entry
+			last_entry->next = entry->next;
+
+			// free current entry; entry points to unknown
+			shm_free(entry->callid.s);
+			shm_free(entry);
+
+			// set pointers
+			entry = last_entry;
+		}
+
+		last_entry = entry;
+		entry = entry->next;
+	}
+
+	// unlock
+	lock_release(rtpengine_hash_lock);
+
+	return 0;
+}
+
+void* rtpengine_hash_table_lookup(void *key) {
+	struct rtpengine_hash_entry *entry, *last_entry;
+	unsigned int hash_index;
+
+	// check rtpengine hashtable
+	if (!rtpengine_hash_table) {
+		LM_ERR("NULL rtpengine_hash_table");
+		return 0;
+	}
+
+	// get first entry from entry list; jump over unused list head
+	hash_index = str_hash(key);
+	entry = rtpengine_hash_table->entry_list[hash_index];
+	last_entry = entry;
+
+	// lock
+	lock_get(rtpengine_hash_lock);
+	while (entry) {
+		// if key found, return entry
+		if (str_equal(&entry->callid, (str *)key)) {
+			// unlock
+			lock_release(rtpengine_hash_lock);
+
+			return entry;
+		}
+
+		// if expired entry discovered, delete it
+		if (entry->tout < get_ticks()) {
+			// set pointers; exclude entry
+			last_entry->next = entry->next;
+
+			// free current entry; entry points to unknown
+			shm_free(entry->callid.s);
+			shm_free(entry);
+
+			// set pointers
+			entry = last_entry;
+		}
+
+		last_entry = entry;
+		entry = entry->next;
+	}
+
+	// unlock
+	lock_release(rtpengine_hash_lock);
+
+	return NULL;
+}
+
+// print hash table entries while deleting expired entries
+void rtpengine_hash_table_print() {
+	int i;
+	struct rtpengine_hash_entry *entry, *last_entry;
+
+	// check rtpengine hashtable
+	if (!rtpengine_hash_table) {
+		LM_ERR("NULL rtpengine_hash_table");
+		return ;
+	}
+
+	// lock
+	lock_get(rtpengine_hash_lock);
+
+	// print hashtable
+	for (i = 0; i < RTPENGINE_HASH_TABLE_SIZE; i++) {
+		entry = rtpengine_hash_table->entry_list[i];
+		last_entry = entry;
+
+		while (entry) {
+			// if expired entry discovered, delete it
+			if (entry->tout < get_ticks()) {
+				// set pointers; exclude entry
+				last_entry->next = entry->next;
+
+				// free current entry; entry points to unknown
+				shm_free(entry->callid.s);
+				shm_free(entry);
+
+				// set pointers
+				entry = last_entry;
+			} else {
+				LM_DBG("hash_index=%d callid=%.*s tout=%u\n",
+					i, entry->callid.len, entry->callid.s, entry->tout - get_ticks());
+			}
+
+			last_entry = entry;
+			entry = entry->next;
+		}
+	}
+
+	// unlock
+	lock_release(rtpengine_hash_lock);
+}

--- a/modules/rtpengine/rtpengine_hash.c
+++ b/modules/rtpengine/rtpengine_hash.c
@@ -74,6 +74,7 @@ int rtpengine_hash_table_init(int size) {
 		// never expire the head of the hashtable index lists
 		rtpengine_hash_table->entry_list[i]->tout = -1;
 		rtpengine_hash_table->entry_list[i]->next = NULL;
+		rtpengine_hash_table->total = 0;
 	}
 
 	// init lock
@@ -165,6 +166,9 @@ int rtpengine_hash_table_insert(void *key, void *value) {
 
 			// set pointers
 			entry = last_entry;
+
+			// update total
+			rtpengine_hash_table->total--;
 		}
 
 		// next entry in the list
@@ -173,6 +177,9 @@ int rtpengine_hash_table_insert(void *key, void *value) {
 	}
 
 	last_entry->next = new_entry;
+
+	// update total
+	rtpengine_hash_table->total++;
 
 	// unlock
 	lock_release(rtpengine_hash_lock);
@@ -205,6 +212,9 @@ int rtpengine_hash_table_remove(void *key) {
 			shm_free(entry->callid.s);
 			shm_free(entry);
 
+			// update total
+			rtpengine_hash_table->total--;
+
 			// unlock
 			lock_release(rtpengine_hash_lock);
 
@@ -222,6 +232,9 @@ int rtpengine_hash_table_remove(void *key) {
 
 			// set pointers
 			entry = last_entry;
+
+			// update total
+			rtpengine_hash_table->total--;
 		}
 
 		last_entry = entry;
@@ -271,6 +284,9 @@ void* rtpengine_hash_table_lookup(void *key) {
 
 			// set pointers
 			entry = last_entry;
+
+			// update total
+			rtpengine_hash_table->total--;
 		}
 
 		last_entry = entry;
@@ -314,6 +330,9 @@ void rtpengine_hash_table_print() {
 
 				// set pointers
 				entry = last_entry;
+
+				// update total
+				rtpengine_hash_table->total--;
 			} else {
 				LM_DBG("hash_index=%d callid=%.*s tout=%u\n",
 					i, entry->callid.len, entry->callid.s, entry->tout - get_ticks());
@@ -326,4 +345,15 @@ void rtpengine_hash_table_print() {
 
 	// unlock
 	lock_release(rtpengine_hash_lock);
+}
+
+unsigned int rtpengine_hash_table_total() {
+
+	// check rtpengine hashtable
+	if (!rtpengine_hash_table) {
+		LM_ERR("NULL rtpengine_hash_table");
+		return 0;
+	}
+
+	return rtpengine_hash_table->total;
 }

--- a/modules/rtpengine/rtpengine_hash.h
+++ b/modules/rtpengine/rtpengine_hash.h
@@ -2,6 +2,7 @@
 #define _RTPENGINE_HASH_H
 
 #include "../../str.h"
+#include "../../locking.h"
 
 
 /* table entry */
@@ -17,6 +18,7 @@ struct rtpengine_hash_entry {
 /* table */
 struct rtpengine_hash_table {
 	struct rtpengine_hash_entry **entry_list;	// hastable
+	gen_lock_t **row_locks;				// hastable row locks
 	unsigned int total;				// total number of entries in the hashtable
 };
 
@@ -31,5 +33,7 @@ unsigned int rtpengine_hash_table_total();
 
 void rtpengine_hash_table_free_entry(struct rtpengine_hash_entry *entry);
 void rtpengine_hash_table_free_entry_list(struct rtpengine_hash_entry *entry_list);
+
+void rtpengine_hash_table_free_row_lock(gen_lock_t *lock);
 
 #endif

--- a/modules/rtpengine/rtpengine_hash.h
+++ b/modules/rtpengine/rtpengine_hash.h
@@ -17,9 +17,10 @@ struct rtpengine_hash_entry {
 
 /* table */
 struct rtpengine_hash_table {
-	struct rtpengine_hash_entry **entry_list;	// hashtable
-	gen_lock_t **row_locks;				// vector of pointers to locks
-	unsigned int *row_totals;			// vector of numbers of entries in the hashtable rows
+	struct rtpengine_hash_entry **row_entry_list;	// vector of size pointers to entry
+	gen_lock_t **row_locks;				// vector of size pointers to locks
+	unsigned int *row_totals;			// vector of size numbers of entries in the hashtable rows
+	unsigned int size;				// hash table size
 };
 
 
@@ -32,7 +33,7 @@ void rtpengine_hash_table_print();
 unsigned int rtpengine_hash_table_total();
 
 void rtpengine_hash_table_free_entry(struct rtpengine_hash_entry *entry);
-void rtpengine_hash_table_free_entry_list(struct rtpengine_hash_entry *entry_list);
+void rtpengine_hash_table_free_row_entry_list(struct rtpengine_hash_entry *row_entry_list);
 
 void rtpengine_hash_table_free_row_lock(gen_lock_t *lock);
 int rtpengine_hash_table_sanity_checks();

--- a/modules/rtpengine/rtpengine_hash.h
+++ b/modules/rtpengine/rtpengine_hash.h
@@ -6,10 +6,11 @@
 
 /* table entry */
 struct rtpengine_hash_entry {
-	unsigned int tout;			// call timeout
 	str callid;				// call callid
+	str viabranch;				// call viabranch
 	struct rtpp_node *node;			// call selected node
 
+	unsigned int tout;			// call timeout
 	struct rtpengine_hash_entry *next;	// call next
 };
 
@@ -22,10 +23,13 @@ struct rtpengine_hash_table {
 
 int rtpengine_hash_table_init(int size);
 int rtpengine_hash_table_destroy();
-int rtpengine_hash_table_insert(str *key, struct rtpengine_hash_entry *value);
-int rtpengine_hash_table_remove(str *key);
-struct rtpp_node *rtpengine_hash_table_lookup(str *key);
+int rtpengine_hash_table_insert(str callid, str viabranch, struct rtpengine_hash_entry *value);
+int rtpengine_hash_table_remove(str callid, str viabranch);
+struct rtpp_node *rtpengine_hash_table_lookup(str callid, str viabranch);
 void rtpengine_hash_table_print();
 unsigned int rtpengine_hash_table_total();
+
+void rtpengine_hash_table_free_entry(struct rtpengine_hash_entry *entry);
+void rtpengine_hash_table_free_entry_list(struct rtpengine_hash_entry *entry_list);
 
 #endif

--- a/modules/rtpengine/rtpengine_hash.h
+++ b/modules/rtpengine/rtpengine_hash.h
@@ -22,9 +22,9 @@ struct rtpengine_hash_table {
 
 int rtpengine_hash_table_init(int size);
 int rtpengine_hash_table_destroy();
-int rtpengine_hash_table_insert(void *key, void *value);
-int rtpengine_hash_table_remove(void *key);
-void* rtpengine_hash_table_lookup(void *key);
+int rtpengine_hash_table_insert(str *key, struct rtpengine_hash_entry *value);
+int rtpengine_hash_table_remove(str *key);
+struct rtpp_node *rtpengine_hash_table_lookup(str *key);
 void rtpengine_hash_table_print();
 unsigned int rtpengine_hash_table_total();
 

--- a/modules/rtpengine/rtpengine_hash.h
+++ b/modules/rtpengine/rtpengine_hash.h
@@ -35,7 +35,6 @@ unsigned int rtpengine_hash_table_total();
 void rtpengine_hash_table_free_entry(struct rtpengine_hash_entry *entry);
 void rtpengine_hash_table_free_row_entry_list(struct rtpengine_hash_entry *row_entry_list);
 
-void rtpengine_hash_table_free_row_lock(gen_lock_t *lock);
 int rtpengine_hash_table_sanity_checks();
 
 #endif

--- a/modules/rtpengine/rtpengine_hash.h
+++ b/modules/rtpengine/rtpengine_hash.h
@@ -3,7 +3,6 @@
 
 #include "../../str.h"
 
-#define RTPENGINE_HASH_TABLE_SIZE       512
 
 /* table entry */
 struct rtpengine_hash_entry {
@@ -11,16 +10,16 @@ struct rtpengine_hash_entry {
 	str callid;				// call callid
 	struct rtpp_node *node;			// call selected node
 
-	struct rtpengine_hash_entry *next;	// next 
+	struct rtpengine_hash_entry *next;	// call next
 };
 
 /* table */
 struct rtpengine_hash_table {
-	struct rtpengine_hash_entry *entry_list[RTPENGINE_HASH_TABLE_SIZE];
+	struct rtpengine_hash_entry **entry_list;
 };
 
 
-int rtpengine_hash_table_init();
+int rtpengine_hash_table_init(int size);
 int rtpengine_hash_table_destroy();
 int rtpengine_hash_table_insert(void *key, void *value);
 int rtpengine_hash_table_remove(void *key);

--- a/modules/rtpengine/rtpengine_hash.h
+++ b/modules/rtpengine/rtpengine_hash.h
@@ -15,7 +15,8 @@ struct rtpengine_hash_entry {
 
 /* table */
 struct rtpengine_hash_table {
-	struct rtpengine_hash_entry **entry_list;
+	struct rtpengine_hash_entry **entry_list;	// hastable
+	unsigned int total;				// total number of entries in the hashtable
 };
 
 
@@ -24,6 +25,7 @@ int rtpengine_hash_table_destroy();
 int rtpengine_hash_table_insert(void *key, void *value);
 int rtpengine_hash_table_remove(void *key);
 void* rtpengine_hash_table_lookup(void *key);
-void rtpengine_hash_table_print() ;
+void rtpengine_hash_table_print();
+unsigned int rtpengine_hash_table_total();
 
 #endif

--- a/modules/rtpengine/rtpengine_hash.h
+++ b/modules/rtpengine/rtpengine_hash.h
@@ -1,0 +1,30 @@
+#ifndef _RTPENGINE_HASH_H
+#define _RTPENGINE_HASH_H
+
+#include "../../str.h"
+
+#define RTPENGINE_HASH_TABLE_SIZE       512
+
+/* table entry */
+struct rtpengine_hash_entry {
+	unsigned int tout;			// call timeout
+	str callid;				// call callid
+	struct rtpp_node *node;			// call selected node
+
+	struct rtpengine_hash_entry *next;	// next 
+};
+
+/* table */
+struct rtpengine_hash_table {
+	struct rtpengine_hash_entry *entry_list[RTPENGINE_HASH_TABLE_SIZE];
+};
+
+
+int rtpengine_hash_table_init();
+int rtpengine_hash_table_destroy();
+int rtpengine_hash_table_insert(void *key, void *value);
+int rtpengine_hash_table_remove(void *key);
+void* rtpengine_hash_table_lookup(void *key);
+void rtpengine_hash_table_print() ;
+
+#endif

--- a/modules/rtpengine/rtpengine_hash.h
+++ b/modules/rtpengine/rtpengine_hash.h
@@ -17,9 +17,9 @@ struct rtpengine_hash_entry {
 
 /* table */
 struct rtpengine_hash_table {
-	struct rtpengine_hash_entry **entry_list;	// hastable
-	gen_lock_t **row_locks;				// hastable row locks
-	unsigned int total;				// total number of entries in the hashtable
+	struct rtpengine_hash_entry **entry_list;	// hashtable
+	gen_lock_t **row_locks;				// vector of pointers to locks
+	unsigned int *row_totals;			// vector of numbers of entries in the hashtable rows
 };
 
 
@@ -35,5 +35,6 @@ void rtpengine_hash_table_free_entry(struct rtpengine_hash_entry *entry);
 void rtpengine_hash_table_free_entry_list(struct rtpengine_hash_entry *entry_list);
 
 void rtpengine_hash_table_free_row_lock(gen_lock_t *lock);
+int rtpengine_hash_table_sanity_checks();
 
 #endif


### PR DESCRIPTION
Shared memory hash table with global hashtable lock.
Add state maintaining the selected rtp node, for a given callid.
Hashtable entry expiration time configurable using hash_entry_tout modparam.
The actual deletion happens on the fly while insert/remove/lookup are called.
Updated doku.