### PR TITLE
core: exit with failure code if a child dies

### DIFF
--- a/main.c
+++ b/main.c
@@ -755,7 +755,11 @@ void handle_sigs(void)
 			/* exit */
 			shutdown_children(SIGTERM, 1);
 			LM_DBG("terminating due to SIGCHLD\n");
-			exit(0);
+			if (WIFSIGNALED(chld_status)) {
+				exit(1);
+			} else {
+				exit(0);
+			}
 			break;
 
 		case SIGHUP: /* ignoring it*/


### PR DESCRIPTION
I made this patch to ensure kamailio exits with an unclean status if it stops due to a child exits. This allows systemd's unit `Restart=on-failure` parameter to actually automatically restart kamailio, in a segfault or any other signal-throwing situation.

The side effect is that it would trigger a kamailio restart if one of the children is stopped with a TERM signal, but I considered here that the only clean way to stop kamailio is to send a signal to the main attendant process, and not to a child.