### PR TITLE
test/travis: migrate to docker environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
+sudo: required
 language: c
 compiler:
   - gcc
   - clang
+services:
+  - docker
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y gdebi-core
-  - sudo test/travis/build_deps.sh precise $TRAVIS_BUILD_DIR
-script: ./test/travis/build_travis.sh
+  - docker pull linuxmaniac/pkg-kamailio-docker:stretch
+script: docker run -v $TRAVIS_BUILD_DIR:/code:rw linuxmaniac/pkg-kamailio-docker:stretch /bin/bash -c "export CC=$CC; cd /code; ./test/travis/build_travis.sh"
 branches:
   only:
     - 'master'

--- a/test/travis/build_travis.sh
+++ b/test/travis/build_travis.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 #
 # build script for travis CI
-# environment based on Ubuntu 12.04 LTS (precise)
+# environment based on Debian Stretch
 #
 
 set -e
 
+# choose freeradius
+export FREERADIUS=1
+
 export JAVA_HOME="/usr/lib/jvm/java-gcj"
 EXCLUDED_MODULES=""
-EXTRA_EXCLUDED_MODULES="bdb dbtext oracle pa iptrtpproxy mi_xmlrpc dnssec kazoo cnxcc"
+EXTRA_EXCLUDED_MODULES="bdb dbtext oracle pa iptrtpproxy mi_xmlrpc"
 PACKAGE_GROUPS="mysql postgres berkeley unixodbc radius presence ldap xml perl utils lua memcached \
 	snmpstats carrierroute xmpp cpl redis python geoip\
 	sqlite json mono ims sctp java \
-	purple tls outbound websocket autheph"
-export TESTS_EXCLUDE="3 12 17 19 20 23 25 26 30 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 50"
+	purple tls outbound websocket autheph \
+	dnssec kazoo cnxcc erlang"
 
 function build {
 	echo "make distclean"
@@ -30,6 +33,15 @@ function build {
 	done
 }
 
+if [[ "$CC" =~ clang ]] ; then
+	CLANG=$(find /usr/bin -type l -name 'clang-[0-9]*' | sort -r | head -1)
+	echo "setting clang to ${CLANG}"
+	update-alternatives --install /usr/bin/clang clang $CLANG 1
+fi
+
+echo "CC=$CC"
+echo "$($CC --version)"
+
 # build flags
 export MEMDBG=0
 echo "build with MEMDBG=0"
@@ -39,8 +51,6 @@ export MEMDBG=1
 echo "build with MEMDBG=1"
 build
 
-#echo "unit tests"
-#make -C test/unit
 if [[ "$CC" =~ gcc ]] ; then
 	echo "make install"
 	sudo make install


### PR DESCRIPTION
- using https://hub.docker.com/r/linuxmaniac/pkg-kamailio-docker
- update list of supported modules
- dynamic clang version
- show CC version
- stable build environment. No external dependences except hub.docker.com
- easy to reproduce