### PR TITLE
test/travis: support different debian distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kamailio - The Open Source SIP Server
+# Kamailio - The Open Source SIP Server [![Build Status](https://travis-ci.org/kamailio/kamailio.svg?branch=master)](https://travis-ci.org/kamailio/kamailio)
 
 Project Website:
 
@@ -107,5 +107,10 @@ An open IRC discussion channel is managed by the community:
 News:
 
   * http://www.kamailio.org/w/category/news/
+
+## Travis-ci/Testing build environment
+
+ * [travis-ci](https://travis-ci.org/kamailio/kamailio/builds/)
+ * [docker build](/test/travis/README.md)
 
 **Thank you for flying Kamailio!**

--- a/test/travis/README.md
+++ b/test/travis/README.md
@@ -1,0 +1,62 @@
+Travis-ci build
+===============
+
+The build environment is based on docker containers, so it can be easily
+reproducible by any developer of the project.
+
+The container we use is build at [docker hub](https://hub.docker.com/r/linuxmaniac/pkg-kamailio-docker/)
+It's Debian Stretch based image build [DockerFile](https://github.com/linuxmaniac/pkg-kamailio-docker/blob/master/stretch/Dockerfile)
+
+Build locally
+-------------
+
+Same steps defined at [.travis.yml](https://github.com/kamailio/kamailio/blob/master/.travis.yml):
+
+- Choose the compiler you want to use setting `CC` to `gcc` or `clang`
+
+```
+$ docker pull linuxmaniac/pkg-kamailio-docker:stretch
+$ docker run \
+    -v $(pwd):/code:rw linuxmaniac/pkg-kamailio-docker:stretch \
+    /bin/bash -c "export CC=gcc; cd /code; ./test/travis/build_travis.sh"
+```
+
+You can always [login](./README.md#login-inside-the-build-environment) inside the container
+and build it [manually](http://www.kamailio.org/wiki/install/devel/git#compile_kamailio)
+
+Clean sources
+-------------
+
+```
+$ docker run \
+    -v $(pwd):/code:rw linuxmaniac/pkg-kamailio-docker:stretch \
+    /bin/bash -c "cd /code; make -f debian/rules clean; rm -rf debian"
+```
+
+Login inside the build environment
+----------------------------------
+
+```
+$ docker run -i -t \
+    -v $(pwd):/code:rw linuxmaniac/pkg-kamailio-docker:stretch /bin/bash
+```
+
+Test other Debian distributions
+-------------------------------
+
+There are several container [images available](https://hub.docker.com/r/linuxmaniac/pkg-kamailio-docker/tags/) already.
+You just need to use any of the them selecting the proper tag
+
+```
+$ export $DIST=sid
+$ docker pull linuxmaniac/pkg-kamailio-docker:$DIST
+$ docker run \
+    -v $(pwd):/code:rw linuxmaniac/pkg-kamailio-docker:$DIST \
+    /bin/bash -c "export CC=$CC; cd /code; DIST=$DIST ./test/travis/build_travis.sh"
+```
+
+
+TODO
+----
+
+- tests inside the docker container

--- a/test/travis/build_travis.sh
+++ b/test/travis/build_travis.sh
@@ -1,46 +1,37 @@
 #!/bin/bash
 #
 # build script for travis CI
-# environment based on Debian Stretch
+# environment based docker container at
+# https://hub.docker.com/r/linuxmaniac/pkg-kamailio-docker/
 #
 
 set -e
 
-# choose freeradius
-export FREERADIUS=1
+DIST=${DIST:-stretch}
+CC=${CC:-gcc}
 
-export JAVA_HOME="/usr/lib/jvm/java-gcj"
-EXCLUDED_MODULES=""
-EXTRA_EXCLUDED_MODULES="bdb dbtext oracle pa iptrtpproxy mi_xmlrpc"
-PACKAGE_GROUPS="mysql postgres berkeley unixodbc radius presence ldap xml perl utils lua memcached \
-	snmpstats carrierroute xmpp cpl redis python geoip\
-	sqlite json mono ims sctp java \
-	purple tls outbound websocket autheph \
-	dnssec kazoo cnxcc erlang"
-
+if ! [ -d /code/pkg/kamailio/deb/"${DIST}" ] ; then
+	echo "${DIST} not supported"
+	exit 1
+else
+	rm -rf /code/debian
+	ln -s /code/pkg/kamailio/deb/"${DIST}" /code/debian
+fi
 function build {
-	echo "make distclean"
-	make distclean
-	echo "make cfg"
-	make FLAVOUR=kamailio cfg \
-		skip_modules="${EXCLUDED_MODULES} ${EXTRA_EXCLUDED_MODULES}" \
-		group_include="kstandard"
-	echo "make all"
-	make all
-	echo "make groups"
-	for grp in ${PACKAGE_GROUPS}; do
-		make every-module group_include="k${grp}"
-	done
+	echo "make clean"
+	make -f debian/rules clean
+	echo "make build"
+	make -f debian/rules build
 }
 
-if [[ "$CC" =~ clang ]] ; then
+if [[ "${CC}" =~ clang ]] ; then
 	CLANG=$(find /usr/bin -type l -name 'clang-[0-9]*' | sort -r | head -1)
 	echo "setting clang to ${CLANG}"
-	update-alternatives --install /usr/bin/clang clang $CLANG 1
+	update-alternatives --install /usr/bin/clang clang "${CLANG}" 1
 fi
 
-echo "CC=$CC"
-echo "$($CC --version)"
+echo "environment DIST=$DIST CC=$CC"
+${CC} --version
 
 # build flags
 export MEMDBG=0
@@ -53,7 +44,7 @@ build
 
 if [[ "$CC" =~ gcc ]] ; then
 	echo "make install"
-	sudo make install
+	make install
 else
 	echo "skip make install step"
 fi


### PR DESCRIPTION
- add some documentation
- add link to travis doc at /README.md
- add travis build status at /README.md
- use ${DIST}/rules to control the build
  this simplifies the supported modules list by ${DIST}
  it is already defined there. K.I.S.S
- install is done at debian/kamailio dir