### PR TITLE
tmx: Fix relayed_replies counter

### DIFF
--- a/modules/tm/t_reply.c
+++ b/modules/tm/t_reply.c
@@ -555,6 +555,7 @@ static int _reply_light( struct cell *trans, char* buf, unsigned int len,
 	update_reply_stats( code );
 	trans->relayed_reply_branch=-2;
 	t_stats_replied_locally();
+	t_stats_replied_total();
 	if (lock) UNLOCK_REPLIES( trans );
 
 	/* do UAC cleanup procedures in case we generated
@@ -1866,6 +1867,7 @@ enum rps relay_reply( struct cell *t, struct sip_msg *p_msg, int branch,
 			}
 		}
 		update_reply_stats( relayed_code );
+		t_stats_replied_total();
 		if (!buf) {
 			LOG(L_ERR, "ERROR: relay_reply: "
 				"no mem for outbound reply buffer\n");
@@ -1890,7 +1892,7 @@ enum rps relay_reply( struct cell *t, struct sip_msg *p_msg, int branch,
 			update_local_tags(t, &bm, uas_rb->buffer, buf);
 			t_stats_replied_locally();
 		}
-		
+
 		/* update the status ... */
 		t->uas.status = relayed_code;
 		t->relayed_reply_branch = relay;
@@ -2047,6 +2049,7 @@ enum rps local_reply( struct cell *t, struct sip_msg *p_msg, int branch,
 		}
 		t->uas.status = winning_code;
 		update_reply_stats( winning_code );
+		t_stats_replied_total();
 		if (unlikely(is_invite(t) && winning_msg!=FAKED_REPLY &&
 					 winning_code>=200 && winning_code <300 &&
 					 has_tran_tmcbs(t, TMCB_LOCAL_COMPLETED) ))  {

--- a/modules/tm/t_stats.c
+++ b/modules/tm/t_stats.c
@@ -94,6 +94,7 @@ void free_tm_stats()
 		(res)->completed_6xx=(s1)->completed_6xx+(s2)->completed_6xx; \
 		(res)->completed_2xx=(s1)->completed_2xx+(s2)->completed_2xx; \
 		(res)->replied_locally=(s1)->replied_locally+(s2)->replied_locally; \
+		(res)->replied_total=(s1)->replied_total+(s2)->replied_total; \
 		(res)->deleted=(s1)->deleted+(s2)->deleted; \
 	}while(0)
 

--- a/modules/tm/t_stats.h
+++ b/modules/tm/t_stats.h
@@ -44,6 +44,7 @@ struct t_proc_stats {
 	stat_counter completed_3xx, completed_4xx, completed_5xx, 
 		completed_6xx, completed_2xx;
 	stat_counter replied_locally;
+	stat_counter replied_total;
 	stat_counter deleted;
 #ifdef TM_MORE_STATS
 	/* number of created transactions */
@@ -124,6 +125,11 @@ inline static void update_reply_stats( int code ) {
 inline void static t_stats_replied_locally(void)
 {
 	tm_stats[process_no].s.replied_locally++;
+}
+
+inline void static t_stats_replied_total(void)
+{
+	tm_stats[process_no].s.replied_total++;
 }
 
 

--- a/modules/tmx/tmx_mod.c
+++ b/modules/tmx/tmx_mod.c
@@ -820,12 +820,7 @@ unsigned long tmx_stats_rcv_rpls(void)
 unsigned long tmx_stats_rld_rpls(void)
 {
 	tmx_stats_update();
-	return _tmx_stats_all.completed_6xx
-		+ _tmx_stats_all.completed_5xx
-		+ _tmx_stats_all.completed_4xx
-		+ _tmx_stats_all.completed_3xx
-		+ _tmx_stats_all.completed_2xx
-		- _tmx_stats_all.replied_locally;
+	return _tmx_stats_all.replied_total - _tmx_stats_all.replied_locally;
 }
 
 unsigned long tmx_stats_loc_rpls(void)


### PR DESCRIPTION
Consider the simple timeout scenario:
```
                     Messages
INVITE ---------->      1             
407 <----------         1   
ACK ---------->         1              
INVITE ---------->      1           
100 <----------         1      
180 <----------         0    
183 <----------         0       
408 <----------         1
ACK ---------->         1
```   
In the current implementation, running _kamctl fifo get_statistics tmx:_ on a fresh kamailio prints:
```
...
tmx:local_replies = 2
tmx:received_replies = 1
tmx:relayed_replies = 18446744073709551615
```
After this patch:
```
...
tmx:local_replies = 2
tmx:received_replies = 1
tmx:relayed_replies = 0
```
Fix the above by counting the relayed_total and substracting the relayed_local.