### PR TITLE
Add RR parameter on sequential requests

### DIFF
--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -1400,7 +1400,7 @@ void dlg_onroute(struct sip_msg* req, str *route_params, void *param)
 			run_dlg_callbacks( DLGCB_REQ_WITHIN, dlg, req, NULL, dir, 0);
 			if (add_dlg_rr_param( req, dlg->h_entry, dlg->h_id)<0 ) {
 				LM_ERR("failed to add RR param\n");
-				goto error;
+				goto done;
 			}
 
 			if ( (event!=DLG_EVENT_REQACK) &&

--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -1398,6 +1398,10 @@ void dlg_onroute(struct sip_msg* req, str *route_params, void *param)
 
 			/* within dialog request */
 			run_dlg_callbacks( DLGCB_REQ_WITHIN, dlg, req, NULL, dir, 0);
+			if (add_dlg_rr_param( req, dlg->h_entry, dlg->h_id)<0 ) {
+				LM_ERR("failed to add RR param\n");
+				goto error;
+			}
 
 			if ( (event!=DLG_EVENT_REQACK) &&
 					(dlg->cbs.types)&DLGCB_RESPONSE_WITHIN ) {


### PR DESCRIPTION
The 2 commits restores vsf=, vst= and did= RR parameters on in-dialog requests