### PR TITLE
htable: fixing htable.stats for max slot value

### DIFF
--- a/modules/htable/htable.c
+++ b/modules/htable/htable.c
@@ -1125,7 +1125,7 @@ static void  htable_rpc_stats(rpc_t* rpc, void* c)
 			ht_slot_unlock(ht, i);
 		}
 
-		if(rpc->struct_add(th, "Sddd",
+		if(rpc->struct_add(th, "Sdddd",
 						"name", &ht->name,	/* str */
 						"slots", (int)ht->htsize,	/* uint */
 						"all", (int)all,	/* uint */


### PR DESCRIPTION
add missed 'd' parameter to rpc->struct_add format string
before patch
```
[root@sw4 kamailio]# kamcmd htable.stats
{
	name: some_htable
	slots: 4096
	all: 285304
	min: 43
}
```
after patch
```
[root@sw4 kamailio]# kamcmd htable.stats
{
	name: some_htable
	slots: 4096
	all: 285304
	min: 43
	max: 103
}
```