### PR TITLE
modules/websocket: ensure linkage to libcrypto

### DIFF
--- a/modules/websocket/Makefile
+++ b/modules/websocket/Makefile
@@ -13,6 +13,12 @@ SSL_BUILDER=$(shell \
 	if pkg-config --exists libssl; then \
 		echo 'pkg-config libssl'; \
 	fi)
+ifneq($(SSL_BUILDER),)
+SSL_BUILDER+=$(shell \
+	if pkg-config --exists libcrypto; then \
+		echo 'libcrypto'; \
+	fi)
+endif
 endif
 
 ifneq ($(SSL_BUILDER),)


### PR DESCRIPTION
Fixes linkage for Ubuntu Wily (15.10).
The issue manifests itself as "undefined symbol: SHA1" error at module loading.

In Ubuntu 14 LTS (Trusty), ```pkg-config --libs libssl``` returns ```-lssl -lcrypto```, but in Ubuntu 15.10 (Wily) it returns only ```-lssl```. In the end, websocket.so gets SHA1 symbol (and some more) unresolved.

For unclear reason, this change is not needed for tls.so - it gets linked to libcrypto automatically, despite it is linked only with ```-lssl``` flag. Maybe it is something symbol-specific, or something I am completely unaware of.

SSL_BUILDER stuff in Makefile seems to become even more mostruous with the proposed change. Keep in mind that there is ~5 more modules with identical construction in their Makefiles. Rejection of this patch in favor of cleaner solution is appreciated.