### PR TITLE
cnxcc: define inline functions in cnxcc.h

### DIFF
--- a/modules/cnxcc/cnxcc.c
+++ b/modules/cnxcc/cnxcc.c
@@ -28,30 +28,6 @@
 
 #include "cnxcc.h"
 
-inline void get_datetime(str *dest)
-{
-	timestamp2isodt(dest, get_current_timestamp());
-}
-
-inline unsigned int get_current_timestamp()
-{
-	return time(NULL);
-}
-
-inline int timestamp2isodt(str *dest, unsigned int timestamp)
-{
-	time_t  		tim;
-	struct tm 		*tmPtr;
-
-	tim 		= timestamp;
-	tmPtr 		= localtime(&tim);
-
-	strftime( dest->s, DATETIME_SIZE, "%Y-%m-%d %H:%M:%S", tmPtr);
-	dest->len	= DATETIME_LENGTH;
-
-	return 0;
-}
-
 double str2double(str *string)
 {
 	char buffer[string->len + 1];

--- a/modules/cnxcc/cnxcc.h
+++ b/modules/cnxcc/cnxcc.h
@@ -31,9 +31,30 @@
 #define DATETIME_LENGTH		DATETIME_SIZE - 1
 
 
-inline void get_datetime(str *dest);
-inline unsigned int get_current_timestamp();
-inline int timestamp2isodt(str *dest, unsigned int timestamp);
+static inline unsigned int get_current_timestamp()
+{
+	return time(NULL);
+}
+
+static inline int timestamp2isodt(str *dest, unsigned int timestamp)
+{
+	time_t  		tim;
+	struct tm 		*tmPtr;
+
+	tim 		= timestamp;
+	tmPtr 		= localtime(&tim);
+
+	strftime( dest->s, DATETIME_SIZE, "%Y-%m-%d %H:%M:%S", tmPtr);
+	dest->len	= DATETIME_LENGTH;
+
+	return 0;
+}
+
+static inline void get_datetime(str *dest)
+{
+	timestamp2isodt(dest, get_current_timestamp());
+}
+
 double str2double(str *string);
 
 #endif /* _CNXCC_H */


### PR DESCRIPTION
On some systems compiling cnxcc we get:

cnxcc.h:36:12: warning: inline function �timestamp2isodt� declared but never defined
 inline int timestamp2isodt(str *dest, unsigned int timestamp);
            ^
cnxcc.h:35:21: warning: inline function �get_current_timestamp� declared but never defined
 inline unsigned int get_current_timestamp();
                     ^
cnxcc.h:34:13: warning: inline function �get_datetime� declared but never defined
 inline void get_datetime(str *dest);
     
and then at runtime:

ERROR: <core> [sr_module.c:576]: load_module(): could not open module </usr/lib64/kamailio/modules/cnxcc.so>: /usr/lib64/kamailio/modules/cnxcc.so: undefined symbol: get_current_timestamp

The present patch moves the definition of the inline functions into the .h file.