### PR TITLE
auth_radius: support for not appending realm to the username passed to RADIUS

### DIFF
--- a/modules/auth_radius/authrad_mod.c
+++ b/modules/auth_radius/authrad_mod.c
@@ -66,6 +66,7 @@ static int service_type = -1;
 
 int use_ruri_flag = -1;
 int ar_radius_avps_mode = 0;
+int append_realm_to_username = 1;
 
 static char *auth_extra_str = 0;
 struct extra_attr *auth_extra = 0;
@@ -95,6 +96,7 @@ static param_export_t params[] = {
 	{"use_ruri_flag",    INT_PARAM, &use_ruri_flag	},
 	{"auth_extra",       PARAM_STRING, &auth_extra_str	},
 	{"radius_avps_mode",	 INT_PARAM, &ar_radius_avps_mode	},
+	{"append_realm_to_username", INT_PARAM, &append_realm_to_username       },
 	{0, 0, 0}
 };
 

--- a/modules/auth_radius/authrad_mod.h
+++ b/modules/auth_radius/authrad_mod.h
@@ -41,6 +41,7 @@ extern struct extra_attr *auth_extra;
 
 extern int use_ruri_flag;
 extern int ar_radius_avps_mode;
+extern int append_realm_to_username;
 
 extern auth_api_s_t auth_api;
 

--- a/modules/auth_radius/doc/auth_radius.xml
+++ b/modules/auth_radius/doc/auth_radius.xml
@@ -38,6 +38,11 @@
 		<surname>Janak</surname>
 		<email>jan@iptel.org</email>
 		</editor>
+		<editor>
+		<firstname>Phil</firstname>
+		<surname>Lavin</surname>
+		<email>phil.lavin@synety.com</email>
+		</editor>
 	</authorgroup>
 	<copyright>
 		<year>2002</year>

--- a/modules/auth_radius/doc/auth_radius_admin.xml
+++ b/modules/auth_radius/doc/auth_radius_admin.xml
@@ -206,6 +206,23 @@ modparam("auth_radius", "radius_avps_mode", 1)
 		</programlisting>
 		</example>
 	</section>
+	<section id="auth_radius.p.append_realm_to_username">
+		<title><varname>append_realm_to_username</varname> (integer)</title>
+		<para>
+			If set to 1, the username passed to the RADIUS server will have the
+			digest realm appended to it, if no domain is provided in the digest
+			username.
+		</para>
+		<para>
+			Default value is 1.
+		</para>
+		<example>
+		<title><varname>append_realm_to_username</varname> parameter usage</title>
+		<programlisting format="linespecific">
+modparam("auth_radius", "append_realm_to_username", 0)
+		</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>

--- a/modules/auth_radius/sterman.c
+++ b/modules/auth_radius/sterman.c
@@ -243,7 +243,7 @@ int radius_authorize_sterman(struct sip_msg* _msg, dig_cred_t* _cred, str* _meth
 	 * Add all the user digest parameters according to the qop defined.
 	 * Most devices tested only offer support for the simplest digest.
 	 */
-	if (_cred->username.domain.len) {
+	if (_cred->username.domain.len || !append_realm_to_username) {
 		if (!rc_avpair_add(rh, &send, attrs[A_USER_NAME].v, _cred->username.whole.s, _cred->username.whole.len, 0)) {
 			LM_ERR("unable to add User-Name attribute\n");
 			goto err;


### PR DESCRIPTION
- Implement append_realm_to_username parameter in auth_radius which allows
  the unmolested digest username to be passed to RADIUS in the User-Name
  attribute. This is required for some RADIUS implementations.

This is the same PR as #456 except based on master