### PR TITLE
kamailio sending update ccr request instead of terminate request for initial ccr response having final_unit_action flag.

### DIFF
--- a/modules/ims_charging/ims_ro.c
+++ b/modules/ims_charging/ims_ro.c
@@ -1255,6 +1255,9 @@ static void resume_on_initial_ccr(int is_timeout, void *param, AAAMessage *cca, 
     ssd->ro_session->event_type = pending;
     ssd->ro_session->reserved_secs = ro_cca_data->mscc->granted_service_unit->cc_time;
     ssd->ro_session->valid_for = ro_cca_data->mscc->validity_time;
+    ssd->ro_session->is_final_allocation = 0;
+    if (ro_cca_data->mscc->final_unit_action && (ro_cca_data->mscc->final_unit_action->action == 0))
+        ssd->ro_session->is_final_allocation = 1;
 
     Ro_free_CCA(ro_cca_data);
 

--- a/modules/ims_charging/ro_session_hash.h
+++ b/modules/ims_charging/ro_session_hash.h
@@ -71,6 +71,7 @@ struct ro_session {
     str mac;
     int rating_group;
     int service_identifier;
+    unsigned int is_final_allocation;
 };
 
 /*! entries in the main ro_session table */

--- a/modules/ims_charging/ro_timer.c
+++ b/modules/ims_charging/ro_timer.c
@@ -400,6 +400,18 @@ void ro_session_ontimeout(struct ro_tl *tl) {
     //		return;
     //	}
 
+    if(ro_session->is_final_allocation) {
+        now = get_current_time_micro();
+        used_secs = now - ro_session->last_event_timestamp;
+        if((ro_session->reserved_secs - used_secs) > 0) {
+            update_ro_timer(&ro_session->ro_tl, (ro_session->reserved_secs - used_secs));
+            return;
+        }
+        else {
+            ro_session->event_type = no_more_credit;
+        }
+    }
+
     switch (ro_session->event_type) {
         case answered:
             now = get_current_time_micro();


### PR DESCRIPTION
If final_unit_action flag is set in initial ccr response, kamailio need to send terminate request after time out but it is sending update request.but it is fine for intermediate requests.