### PR TITLE
registrar: do make use of reg_xavp_cfg

### DIFF
--- a/modules/registrar/reg_mod.c
+++ b/modules/registrar/reg_mod.c
@@ -362,8 +362,14 @@ static int mod_init(void)
 			sock_hdr_name.len = 0;
 			sock_flag = -1;
 		}
+	} else if (reg_xavp_cfg.s) {
+		if (reg_xavp_cfg.len == 0 || sock_flag == -1) {
+			LM_WARN("empty reg_xavp_cfg or sock_flag no set -> resetting\n");
+			reg_xavp_cfg.len = 0;
+			sock_flag = -1;
+		}
 	} else if (sock_flag!=-1) {
-		LM_WARN("sock_flag defined but no sock_hdr_name -> reseting flag\n");
+		LM_WARN("sock_flag defined but no sock_hdr_name or no reg_xavp_cfg -> resetting flag\n");
 		sock_flag = -1;
 	}
 


### PR DESCRIPTION
- prevent from resetting sock_flag to -1 when reg_xavp_cfg is set