### PR TITLE
registrar: reg_xavp_cfg should not be reset when sock_flag is not set

### DIFF
--- a/modules/registrar/reg_mod.c
+++ b/modules/registrar/reg_mod.c
@@ -365,7 +365,6 @@ static int mod_init(void)
 	} else if (reg_xavp_cfg.s) {
 		if (reg_xavp_cfg.len == 0 || sock_flag == -1) {
 			LM_WARN("empty reg_xavp_cfg or sock_flag no set -> resetting\n");
-			reg_xavp_cfg.len = 0;
 			sock_flag = -1;
 		}
 	} else if (sock_flag!=-1) {


### PR DESCRIPTION
- since there are functions like `registered()` would use it
- reported by Jayesh Nambiar (@jayesh1017) in the comment of GH#470