### PR TITLE
Make tcpops module usable on BSD

### DIFF
--- a/modules/tcpops/doc/functions.xml
+++ b/modules/tcpops/doc/functions.xml
@@ -18,7 +18,7 @@
 		<para>Meaning of the parameters is as follows:</para>
 		<itemizedlist>
 			<listitem>
-				<para><emphasis>conid</emphasis> (optionnal): the Kamailio internal
+				<para><emphasis>conid</emphasis> (optional): the Kamailio internal
 				connection id (as in the <emphasis>$conid</emphasis> pseudovariable).
 				</para>
 			</listitem>
@@ -48,7 +48,7 @@
 		<para>Meaning of the parameters is as follows:</para>
 		<itemizedlist>
 			<listitem>
-				<para><emphasis>conid</emphasis> (optionnal): the Kamailio internal
+				<para><emphasis>conid</emphasis> (optional): the Kamailio internal
 				connection id (as in the <emphasis>$conid</emphasis> pseudovariable).
 				</para>
 			</listitem>
@@ -83,7 +83,7 @@
 		<para>Meaning of the parameters is as follows:</para>
 		<itemizedlist>
 			<listitem>
-				<para><emphasis>conid</emphasis> (optionnal): the kamailio internal
+				<para><emphasis>conid</emphasis> (optional): the kamailio internal
 				connection id on which TCP keepalive will be enabled. If no parameter
 				is given, the keepalive mechanism will be enabled on the current message
 				source connection.
@@ -140,7 +140,7 @@ onreply_route[foo] {
 		<para>Meaning of the parameters is as follows:</para>
 		<itemizedlist>
 			<listitem>
-				<para><emphasis>conid</emphasis> (optionnal): the kamailio internal
+				<para><emphasis>conid</emphasis> (optional): the kamailio internal
 				connection id on which TCP keepalive will be disabled. If no parameter
 				is given, the keepalive mechanism will be disabled on the current message
 				source connection.
@@ -181,7 +181,7 @@ onreply_route[foo] {
                 <para>Meaning of the parameters is as follows:</para>
                 <itemizedlist>
                         <listitem>
-                                <para><emphasis>conid</emphasis> (optionnal): the kamailio internal
+                                <para><emphasis>conid</emphasis> (optional): the kamailio internal
                                 connection id on which to set the new lifetime. If no parameter
                                 is given, it will be set on the current message source connection.
                                 </para>

--- a/modules/tcpops/doc/tcpops.xml
+++ b/modules/tcpops/doc/tcpops.xml
@@ -45,7 +45,7 @@
 	<para>
 	<emphasis>Note</emphasis>: the keepalive functions only work on systems with the
 	HAVE_TCP_KEEPIDLE, HAVE_TCP_KEEPCNT and HAVE_TCP_KEEPINTVL macros defined
-	(currently only Linux).
+	(Linux, FreeBSD, DragonFly BSD, NetBSD).
 	</para>
     </section>
     

--- a/tcp_options.h
+++ b/tcp_options.h
@@ -23,6 +23,7 @@
 
 #ifdef USE_TCP
 
+#include <netinet/tcp.h>
 #ifndef NO_TCP_ASYNC
 #define TCP_ASYNC /* enabled async mode */
 #endif

--- a/tcp_options.h
+++ b/tcp_options.h
@@ -74,24 +74,24 @@
 
 /* keepintvl */
 #ifndef NO_TCP_KEEPINTVL
-#ifdef __OS_linux
+#ifdef TCP_KEEPINTVL
 #define HAVE_TCP_KEEPINTVL
-#endif /* __OS_ */
-#endif /* NO_TCP_KEEPIDLE */
+#endif /* TCP_KEEPINTVL */
+#endif /* NO_TCP_KEEPINTVL */
 
 /* keepidle */
 #ifndef NO_TCP_KEEPIDLE
-#ifdef __OS_linux
+#ifdef TCP_KEEPIDLE
 #define HAVE_TCP_KEEPIDLE
-#endif /* __OS_*/
+#endif /* TCP_KEEPIDLE*/
 #endif /* NO_TCP_KEEPIDLE */
 
 
 /* keepcnt */
 #ifndef NO_TCP_KEEPCNT
-#ifdef __OS_linux
+#ifdef TCP_KEEPCNT
 #define HAVE_TCP_KEEPCNT
-#endif /* __OS_ */
+#endif /* TCP_KEEPCNT */
 #endif /* NO_TCP_KEEPCNT */
 
 


### PR DESCRIPTION
Tested with FreeBSD 10 and Linux 3.2 (Debian Wheezy 7.6).
List of other platforms gathered with [FreeBSD and Linux Kernel Cross-Reference](http://fxr.watson.org/fxr/trackident?i=TCP_KEEPIDLE)