### PR TITLE
pua_dialoginfo: fixed crash when loading dialogs from database on restart

### DIFF
--- a/modules/pua_dialoginfo/doc/pua_dialoginfo.xml
+++ b/modules/pua_dialoginfo/doc/pua_dialoginfo.xml
@@ -34,9 +34,14 @@
 		<affiliation><orgname>IPCom (Module implementation was partly sponsored by Silver Server (www.sil.at))</orgname></affiliation>
 	    </author>
 	    <editor>
-		<firstname>Klaus </firstname>
-		<surname>Darilion</surname>
-		<affiliation><orgname>IPCom</orgname></affiliation>
+		<firstname>Phil</firstname>
+		<surname>Lavin</surname>
+		<affiliation><orgname>Synety</orgname></affiliation>
+	    </editor>
+	    <editor>
+		<firstname>Muhammad</firstname>
+		<surname>Zaka</surname>
+		<affiliation><orgname>Synety</orgname></affiliation>
 	    </editor>
 	</authorgroup>
 	<copyright>

--- a/modules/pua_dialoginfo/doc/pua_dialoginfo.xml
+++ b/modules/pua_dialoginfo/doc/pua_dialoginfo.xml
@@ -34,6 +34,11 @@
 		<affiliation><orgname>IPCom (Module implementation was partly sponsored by Silver Server (www.sil.at))</orgname></affiliation>
 	    </author>
 	    <editor>
+		<firstname>Klaus</firstname>
+		<surname>Darilion</surname>
+		<affiliation><orgname>IPCom</orgname></affiliation>
+	    </editor>
+	    <editor>
 		<firstname>Phil</firstname>
 		<surname>Lavin</surname>
 		<affiliation><orgname>Synety</orgname></affiliation>

--- a/modules/pua_dialoginfo/pua_dialoginfo.c
+++ b/modules/pua_dialoginfo/pua_dialoginfo.c
@@ -609,7 +609,6 @@ __dialog_loaded(struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
 	LM_DBG("INVITE dialog loaded: from=%.*s\n", dlg->from_uri.len, dlg->from_uri.s);
 
 	dlginfo=get_dialog_data(dlg, type);
-	if(dlginfo!=NULL) free_dlginfo_cell(dlginfo);
 }
 
 


### PR DESCRIPTION
 - SHM pointer is freed when it is required later by dialog callbacks. Remove the free_dlginfo_cell() call.

This is causing crashing after the BYE, when a call is ongoing during a Kamailio restart

The free is actually done by the callback function `dlg_api.register_dlgcb()` when it is registered in `pua_dialoginfo.c`