### PR TITLE
cnxcc: change some log levels from INFO to DBG

### DIFF
--- a/modules/cnxcc/cnxcc_check.c
+++ b/modules/cnxcc/cnxcc_check.c
@@ -90,7 +90,7 @@ void check_calls_by_money(unsigned int ticks, void *param) {
 				}
 
 				if (_data.redis) {
-					LM_INFO("ec=%f, ca=%f, ca2=%f", credit_data->ended_calls_consumed_amount, total_consumed_money, credit_data->consumed_amount);
+					LM_DBG("ec=%f, ca=%f, ca2=%f", credit_data->ended_calls_consumed_amount, total_consumed_money, credit_data->consumed_amount);
 
 					consumption_diff = credit_data->ended_calls_consumed_amount + total_consumed_money - credit_data->consumed_amount;
 					if (consumption_diff > 0)

--- a/modules/cnxcc/cnxcc_redis.c
+++ b/modules/cnxcc/cnxcc_redis.c
@@ -65,11 +65,11 @@ int redis_get_or_create_credit_data(credit_data_t *credit_data) {
 		goto error;
 
 	if (!exists) {  // doesn't exist
-		LM_INFO("credit_data with ID=[%s] DOES NOT exist in the cluster, creating it...\n", credit_data->str_id);
+		LM_DBG("credit_data with ID=[%s] DOES NOT exist in the cluster, creating it...\n", credit_data->str_id);
 		return redis_insert_credit_data(credit_data);
 	}
 
-	LM_INFO("credit_data with ID=[%s] DOES exist in the cluster, retrieving it...\n", credit_data->str_id);
+	LM_DBG("credit_data with ID=[%s] DOES exist in the cluster, retrieving it...\n", credit_data->str_id);
 
 	if (redis_get_double(credit_data, "HGET", "consumed_amount", &credit_data->consumed_amount) < 0)
 		goto error;
@@ -332,7 +332,7 @@ int redis_get_str(credit_data_t *credit_data, const char *instruction, const cha
 	}
 
 	if (rpl->type == REDIS_REPLY_NIL) {
-		LM_INFO("Value of %s is (nil)\n", key);
+		LM_DBG("Value of %s is (nil)\n", key);
 		goto done;
 	}
 
@@ -348,7 +348,7 @@ int redis_get_str(credit_data_t *credit_data, const char *instruction, const cha
 done:
 	freeReplyObject(rpl);
 
-	LM_INFO("Got STRING value: %s=[%.*s]\n", key, value->len, value->s);
+	LM_DBG("Got STRING value: %s=[%.*s]\n", key, value->len, value->s);
 	return 1;
 }
 

--- a/modules/cnxcc/cnxcc_rpc.c
+++ b/modules/cnxcc/cnxcc_rpc.c
@@ -90,7 +90,7 @@ void rpc_check_client_stats(rpc_t* rpc, void* ctx) {
 
 	if (credit_data->number_of_calls <= 0) {
 		cnxcc_unlock(credit_data->lock);
-		LM_INFO("No calls for current client\n");
+		LM_DBG("No calls for current client\n");
 		return;
 	}
 


### PR DESCRIPTION
When using redis as cnxcc backend, too much log is printed, specially all the logs related to the periodic user's wallet check.