### PR TITLE
tcp:closed event enhancements

### DIFF
--- a/modules/tcpops/README
+++ b/modules/tcpops/README
@@ -8,9 +8,9 @@ Olle E. Johansson
 
    Edvina AB
 
-   Copyright © 2015 Orange
+   Copyright Â© 2015 Orange
 
-   Copyright © 2015 Edvina AB, Sollentuna, Sweden
+   Copyright Â© 2015 Edvina AB, Sollentuna, Sweden
      __________________________________________________________________
 
    Table of Contents
@@ -19,6 +19,9 @@ Olle E. Johansson
 
         1. Overview
         2. Parameters
+
+              2.1. closed_event (int)
+
         3. Functions
 
               3.1. tcp_conid_alive(conid)
@@ -26,14 +29,17 @@ Olle E. Johansson
               3.3. tcp_keepalive_enable([conid], idle, count, interval)
               3.4. tcp_keepalive_disable([conid])
               3.5. tcp_set_connection_lifetime([conid], lifetime)
+              3.6. tcp_enable_closed_event([conid])
 
    List of Examples
 
-   1.1. tcp_conid_alive usage
-   1.2. tcp_conid_state usage
-   1.3. tcp_keepalive_enable usage
-   1.4. tcp_keepalive_disable usage
-   1.5. tcp_set_connection_lifetime usage
+   1.1. Set closed_event parameter
+   1.2. tcp_conid_alive usage
+   1.3. tcp_conid_state usage
+   1.4. tcp_keepalive_enable usage
+   1.5. tcp_keepalive_disable usage
+   1.6. tcp_set_connection_lifetime usage
+   1.7. tcp_set_closed_event usage
 
 Chapter 1. Admin Guide
 
@@ -41,6 +47,9 @@ Chapter 1. Admin Guide
 
    1. Overview
    2. Parameters
+
+        2.1. closed_event (int)
+
    3. Functions
 
         3.1. tcp_conid_alive(conid)
@@ -48,6 +57,7 @@ Chapter 1. Admin Guide
         3.3. tcp_keepalive_enable([conid], idle, count, interval)
         3.4. tcp_keepalive_disable([conid])
         3.5. tcp_set_connection_lifetime([conid], lifetime)
+        3.6. tcp_enable_closed_event([conid])
 
 1. Overview
 
@@ -61,6 +71,27 @@ Chapter 1. Admin Guide
 
 2. Parameters
 
+   2.1. closed_event (int)
+
+2.1. closed_event (int)
+
+   If set to 0 (gloabbly disabled), the "tcp:closed" event route will
+   never be called on TCP disconnections.
+
+   If set to 1 (globally enabled), the "tcp:closed" event route will
+   always be called on TCP disconnections.
+
+   If set to 2 ("manual" mode), the "tcp:closed" event route will only be
+   called on TCP connections for which tcp_enable_closed_event() has been
+   applied, when a disconnection occurs.
+
+   Default value is 1 (globally enabled).
+
+   Example 1.1. Set closed_event parameter
+...
+modparam("tcpops", "closed_event", 0)
+...
+
 3. Functions
 
    3.1. tcp_conid_alive(conid)
@@ -68,8 +99,9 @@ Chapter 1. Admin Guide
    3.3. tcp_keepalive_enable([conid], idle, count, interval)
    3.4. tcp_keepalive_disable([conid])
    3.5. tcp_set_connection_lifetime([conid], lifetime)
+   3.6. tcp_enable_closed_event([conid])
 
-3.1. tcp_conid_alive(conid)
+3.1.  tcp_conid_alive(conid)
 
    Check the state of a TCP or WS connection ID
 
@@ -83,7 +115,7 @@ Chapter 1. Admin Guide
 
    -1: Connection has errors, does not exist or is about to be closed)
 
-   Example 1.1. tcp_conid_alive usage
+   Example 1.2. tcp_conid_alive usage
 ...
         $var(conid) = $conid;
         if(!tcp_conid_alive("$var(conid)")) {
@@ -91,7 +123,7 @@ Chapter 1. Admin Guide
         }
 ...
 
-3.2. tcp_conid_state(conid)
+3.2.  tcp_conid_state(conid)
 
    Check the state of a TCP or WS connection ID
 
@@ -115,14 +147,14 @@ Chapter 1. Admin Guide
 
    -4: Socket is in unknow bad state. Connection will likely close.
 
-   Example 1.2. tcp_conid_state usage
+   Example 1.3. tcp_conid_state usage
 ...
         if(!tcp_conid_state("$var(conid)")) {
                 xlog("L_ERR", "Connection $conid is closed or malfunctional\n");
         }
 ...
 
-3.3. tcp_keepalive_enable([conid], idle, count, interval)
+3.3.  tcp_keepalive_enable([conid], idle, count, interval)
 
    Enables keepalive on a TCP connection.
 
@@ -138,7 +170,7 @@ Chapter 1. Admin Guide
 
    Retuns 1 on success, -1 on failure.
 
-   Example 1.3. tcp_keepalive_enable usage
+   Example 1.4. tcp_keepalive_enable usage
 request_route {
         if (is_method("INVITE")) {
                 $avp(caller_conid) = $conid;
@@ -157,7 +189,7 @@ onreply_route[foo] {
         ...
 }
 
-3.4. tcp_keepalive_disable([conid])
+3.4.  tcp_keepalive_disable([conid])
 
    Disables keepalive on a TCP connection.
 
@@ -169,7 +201,7 @@ onreply_route[foo] {
 
    Retuns 1 on success, -1 on failure.
 
-   Example 1.4. tcp_keepalive_disable usage
+   Example 1.5. tcp_keepalive_disable usage
 request_route {
         ...
         if (is_method("BYE")) {
@@ -188,7 +220,7 @@ onreply_route[foo] {
         ...
 }
 
-3.5. tcp_set_connection_lifetime([conid], lifetime)
+3.5.  tcp_set_connection_lifetime([conid], lifetime)
 
    Sets the connection lifetime of a connection (TCP).
 
@@ -200,7 +232,7 @@ onreply_route[foo] {
 
    Retuns 1 on success, -1 on failure.
 
-   Example 1.5. tcp_set_connection_lifetime usage
+   Example 1.6. tcp_set_connection_lifetime usage
 ...
 # use 10s as default lifetime
 tcp_connection_lifetime=10
@@ -213,4 +245,35 @@ request_route {
                 tcp_set_connection_lifetime("3605");
         }
         ...
+}
+
+3.6.  tcp_enable_closed_event([conid])
+
+   Explicitly enables the "tcp:closed" event route on a TCP connection.
+
+   Meaning of the parameters is as follows:
+     * conid (optionnal): the kamailio internal connection id. If no
+       parameter is given, it will be enabled on the current message
+       source connection.
+
+   Retuns 1 on success, -1 on failure.
+
+   Example 1.7. tcp_set_closed_event usage
+...
+# "tcp:closed" event route is "manual" mode
+modparam("tcpops", "closed_event", 2)
+...
+
+request_route {
+        ...
+        if (is_method("REGISTER") && pv_www_authenticate("$td", "xxx", "0")) {
+                # it will be called for this specific connection
+                tcp_enable_closed_event();
+        }
+        ...
+
+}
+
+event_route[tcp:closed] {
+        xlog("connection $conid was closed");
 }

--- a/modules/tcpops/doc/functions.xml
+++ b/modules/tcpops/doc/functions.xml
@@ -234,14 +234,14 @@ request_route {
                         <title><function>tcp_set_closed_event</function> usage</title>
                         <programlisting><![CDATA[
 ...
-# "tcp:closed" event route is globally disabled
-modparam("tcpops", "closed_event", 0)
+# "tcp:closed" event route is "manual" mode
+modparam("tcpops", "closed_event", 2)
 ...
 
 request_route {
 	...
 	if (is_method("REGISTER") && pv_www_authenticate("$td", "xxx", "0")) {
-		# but it will be enabled on this specific connection
+		# it will be called for this specific connection
 		tcp_enable_closed_event();
 	}
 	...

--- a/modules/tcpops/doc/functions.xml
+++ b/modules/tcpops/doc/functions.xml
@@ -211,4 +211,47 @@ request_route {
                         ]]></programlisting>
                 </example>
         </section>
+
+        <section id="tcpops.f.tcp_enable_closed_event">
+                <title>
+                        <function>tcp_enable_closed_event([conid])</function>
+                </title>
+                <para>
+                                Explicitly enables the "tcp:closed" event route
+                                on a TCP connection.
+                </para>
+                <para>Meaning of the parameters is as follows:</para>
+                <itemizedlist>
+                        <listitem>
+                                <para><emphasis>conid</emphasis> (optionnal): the kamailio internal
+                                connection id. If no parameter
+                                is given, it will be enabled on the current message source connection.
+                                </para>
+                        </listitem>
+                </itemizedlist>
+                <para>Retuns 1 on success, -1 on failure.</para>
+                <example>
+                        <title><function>tcp_set_closed_event</function> usage</title>
+                        <programlisting><![CDATA[
+...
+# "tcp:closed" event route is globally disabled
+modparam("tcpops", "closed_event", 0)
+...
+
+request_route {
+	...
+	if (is_method("REGISTER") && pv_www_authenticate("$td", "xxx", "0")) {
+		# but it will be enabled on this specific connection
+		tcp_enable_closed_event();
+	}
+	...
+
+}
+
+event_route[tcp:closed] {
+	xlog("connection $conid was closed");
+}
+]]></programlisting>
+                </example>
+        </section>
 </section>

--- a/modules/tcpops/doc/params.xml
+++ b/modules/tcpops/doc/params.xml
@@ -10,13 +10,21 @@
 		<section>
 		<title><varname>closed_event</varname> (int)</title>
 		<para>
-			if set to 0, the "tcp:closed" event route will not be called on TCP
-			disconnections (unless the "tcp_enable_closed_event()" function enabled
-			it explicitly).
+			If set to 0 (gloabbly disabled), the "tcp:closed" event route will never be called on TCP
+			disconnections.
+		</para>
+		<para>
+			If set to 1 (globally enabled), the "tcp:closed" event route will always be called on TCP
+			disconnections.
+		</para>
+		<para>
+			If set to 2 ("manual" mode), the "tcp:closed" event route will only be called on TCP
+			connections for which <literal>tcp_enable_closed_event()</literal> has
+			been applied, when a disconnection occurs.
 		</para>
 		<para>
 		<emphasis>
-			Default value is 1 (enabled).
+			Default value is 1 (globally enabled).
 		</emphasis>
 		</para>
 		<example>

--- a/modules/tcpops/doc/params.xml
+++ b/modules/tcpops/doc/params.xml
@@ -7,6 +7,27 @@
     </sectioninfo>
 
     <title>Parameters</title>
+		<section>
+		<title><varname>closed_event</varname> (int)</title>
+		<para>
+			if set to 0, the "tcp:closed" event route will not be called on TCP
+			disconnections (unless the "tcp_enable_closed_event()" function enabled
+			it explicitly).
+		</para>
+		<para>
+		<emphasis>
+			Default value is 1 (enabled).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>closed_event</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("tcpops", "closed_event", 0)
+...
+</programlisting>
+		</example>
+	</section>
 
 
 

--- a/modules/tcpops/tcpops.c
+++ b/modules/tcpops/tcpops.c
@@ -35,6 +35,7 @@
 #include "../../sr_module.h"
 
 
+/* globally enabled by default */
 int tcp_closed_event = 1;
 
 /**
@@ -197,11 +198,6 @@ static void tcpops_tcp_closed_run_route(struct tcp_connection *con)
 	struct run_act_ctx ctx;
 	sip_msg_t *fmsg;
 
-	/* bypass event route if tcp_closed_event == 0 and the
-	 * F_CONN_CLOSE_EV flag is not explicitly set */
-	if (!(tcp_closed_event || (con->flags & F_CONN_CLOSE_EV)))
-		return;
-
 	LM_DBG("tcp_closed_run_route event_route[tcp:closed]\n");
 
 	rt = route_get(&event_rt, "tcp:closed");
@@ -235,7 +231,10 @@ int tcpops_handle_tcp_closed(void *data)
 		return -1;
 	}
 
-	tcpops_tcp_closed_run_route(tev->con);
+	/* run event route if tcp_closed_event == 1 or if the
+	 * F_CONN_CLOSE_EV flag is explicitly set */
+	if (tcp_closed_event == 1 || (tev->con->flags & F_CONN_CLOSE_EV))
+		tcpops_tcp_closed_run_route(tev->con);
 
 	return 0;
 }

--- a/modules/tcpops/tcpops.c
+++ b/modules/tcpops/tcpops.c
@@ -34,6 +34,9 @@
 #include "../../fmsg.h"
 #include "../../sr_module.h"
 
+
+int tcp_closed_event = 1;
+
 /**
  * gets the fd of the current message source connection
  *
@@ -193,6 +196,12 @@ static void tcpops_tcp_closed_run_route(struct tcp_connection *con)
 	int rt, backup_rt;
 	struct run_act_ctx ctx;
 	sip_msg_t *fmsg;
+
+	/* bypass event route if tcp_closed_event == 0 and the
+	 * F_CONN_CLOSE_EV flag is not explicitly set */
+	if (!(tcp_closed_event || (con->flags & F_CONN_CLOSE_EV)))
+		return;
+
 	LM_DBG("tcp_closed_run_route event_route[tcp:closed]\n");
 
 	rt = route_get(&event_rt, "tcp:closed");

--- a/modules/tcpops/tcpops.h
+++ b/modules/tcpops/tcpops.h
@@ -27,6 +27,8 @@
 #include "../../tcp_conn.h"
 #include "../../events.h"
 
+extern int tcp_closed_event;
+
 int tcpops_get_current_fd(int conid, int *fd);
 int tcpops_acquire_fd_from_tcpmain(int conid, int *fd);
 int tcpops_keepalive_enable(int fd, int idle, int count, int interval, int closefd);

--- a/tcp_conn.h
+++ b/tcp_conn.h
@@ -55,6 +55,7 @@
 #define F_CONN_WANTS_RD  4096  /* conn. should be watched for READ */
 #define F_CONN_WANTS_WR  8192  /* conn. should be watched for WRITE */
 #define F_CONN_PASSIVE  16384 /* conn. created via accept() and not connect()*/
+#define F_CONN_CLOSE_EV 32768 /* explicitely call tcpops ev route when closed */
 
 #ifndef NO_READ_HTTP11
 #define READ_HTTP11


### PR DESCRIPTION
these new commits on top of those proposed in issue #461 now define 3 modes for the `tcp:closed` event route:
- **0**: globally disabled
- **1**: globally enabled
- **2**: manual (enabled when `tcp_enable_closed_event()` was applied)
