### PR TITLE
ims_dialog: fix double free (unref early dialog)

### DIFF
--- a/modules/ims_dialog/dlg_handlers.c
+++ b/modules/ims_dialog/dlg_handlers.c
@@ -1460,9 +1460,6 @@ void dlg_onreply(struct cell* t, int type, struct tmcb_params *param) {
         LM_DBG("dialog %p failed (negative reply)\n", dlg);
         /* dialog setup not completed (3456XX) */
         run_dlg_callbacks(DLGCB_FAILED, dlg, req, rpl, DLG_DIR_UPSTREAM, 0);
-        /* do unref */
-        if (unref)
-            unref_dlg(dlg, unref);
 
         if (old_state == DLG_STATE_EARLY)
             counter_add(dialog_ng_cnts_h.early, -1);


### PR DESCRIPTION
Attempt fix for when an INVITE goes out and there is no 100 Trying reply to it , and then ims_dialog destroys the dialog twice via unref_dlg_unsafe()  .