### PR TITLE
[4.3 BACKPORT] pua_dialoginfo: don't free dlginfo structure in dlg loaded callback

### DIFF
--- a/modules/pua_dialoginfo/pua_dialoginfo.c
+++ b/modules/pua_dialoginfo/pua_dialoginfo.c
@@ -609,7 +609,11 @@ __dialog_loaded(struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
 	LM_DBG("INVITE dialog loaded: from=%.*s\n", dlg->from_uri.len, dlg->from_uri.s);
 
 	dlginfo=get_dialog_data(dlg, type);
-	if(dlginfo!=NULL) free_dlginfo_cell(dlginfo);
+	if(dlginfo!=NULL) {
+		LM_DBG("dialog info initialized (from=%.*s)\n",
+				dlg->from_uri.len, dlg->from_uri.s);
+		/* free_dlginfo_cell(dlginfo); */
+	}
 }
 
 


### PR DESCRIPTION
I figured it was worth backporting this crash fix, before the v4.3.5 release Daniel mentioned on the mailing list

- the structure will be destroyed in a later dlg callback, enabled by
  dlg_api.register_dlgcb(), via free_dlginfo_cell()
- based and includes partial patch from GH #492, by Phil Lavin