### PR TITLE
core/futex: fix bug in futex_try

### DIFF
--- a/futexlock.h
+++ b/futexlock.h
@@ -142,7 +142,7 @@ static inline int futex_try(futex_lock_t* lock)
 {
 	int c;
 	c=atomic_cmpxchg(lock, 0, 1);
-	if (likely(c))
+	if (likely(c==0))
 		membar_enter_lock();
 	return c;
 }


### PR DESCRIPTION
atomic_cmpxchg returns the previous value.  If the previous value was 0 then it was previously unlocked and we now have acquired the lock.

Thus, it should  be c==0 that is considered as the case we enter the lock, not c!=0

As far as I can tell, lock_try (and lock_set_try) are currently no used anywhere in the code, so this fix shoudn't have any impact