### PR TITLE
siptrace: Use the trace_local_ip setting in sip_trace()

### DIFF
--- a/modules/siptrace/siptrace.c
+++ b/modules/siptrace/siptrace.c
@@ -1022,29 +1022,41 @@ static int sip_trace(struct sip_msg *msg, struct dest_info * dst, char *dir)
 		sto.body.s = msg->buf;
 		sto.body.len = msg->len;
 
-		siptrace_copy_proto(msg->rcv.proto, sto.fromip_buff);
-		strcat(sto.fromip_buff, ip_addr2a(&msg->rcv.src_ip));
-		strcat(sto.fromip_buff,":");
-		strcat(sto.fromip_buff, int2str(msg->rcv.src_port, NULL));
-		sto.fromip.s = sto.fromip_buff;
-		sto.fromip.len = strlen(sto.fromip_buff);
-
-		siptrace_copy_proto(msg->rcv.proto, sto.toip_buff);
-		strcat(sto.toip_buff, ip_addr2a(&msg->rcv.dst_ip));
-		strcat(sto.toip_buff,":");
-		strcat(sto.toip_buff, int2str(msg->rcv.dst_port, NULL));
-		sto.toip.s = sto.toip_buff;
-		sto.toip.len = strlen(sto.toip_buff);
-
 		sto.dir = (dir)?dir:"in";
+
+		if (trace_local_ip.s && trace_local_ip.len > 0 && strncmp(sto.dir, "out", 3) == 0) {
+			sto.fromip = trace_local_ip;
+		} else {
+			siptrace_copy_proto(msg->rcv.proto, sto.fromip_buff);
+			strcat(sto.fromip_buff, ip_addr2a(&msg->rcv.src_ip));
+			strcat(sto.fromip_buff,":");
+			strcat(sto.fromip_buff, int2str(msg->rcv.src_port, NULL));
+			sto.fromip.s = sto.fromip_buff;
+			sto.fromip.len = strlen(sto.fromip_buff);
+		}
+
+		if (trace_local_ip.s && trace_local_ip.len > 0 && strncmp(sto.dir, "in", 2) == 0) {
+			sto.toip = trace_local_ip;
+		} else {
+			siptrace_copy_proto(msg->rcv.proto, sto.toip_buff);
+			strcat(sto.toip_buff, ip_addr2a(&msg->rcv.dst_ip));
+			strcat(sto.toip_buff,":");
+			strcat(sto.toip_buff, int2str(msg->rcv.dst_port, NULL));
+			sto.toip.s = sto.toip_buff;
+			sto.toip.len = strlen(sto.toip_buff);
+		}
 	} else {
 		sto.body.s   = snd_inf->buf;
 		sto.body.len = snd_inf->len;
 
-		strncpy(sto.fromip_buff, snd_inf->send_sock->sock_str.s,
-				snd_inf->send_sock->sock_str.len);
-		sto.fromip.s = sto.fromip_buff;
-		sto.fromip.len = strlen(sto.fromip_buff);
+		if (trace_local_ip.s && trace_local_ip.len > 0) {
+			sto.fromip = trace_local_ip;
+		} else {
+			strncpy(sto.fromip_buff, snd_inf->send_sock->sock_str.s,
+					snd_inf->send_sock->sock_str.len);
+			sto.fromip.s = sto.fromip_buff;
+			sto.fromip.len = strlen(sto.fromip_buff);
+		}
 
 		siptrace_copy_proto(snd_inf->send_sock->proto, sto.toip_buff);
 		strcat(sto.toip_buff, suip2a(snd_inf->to, sizeof(*snd_inf->to)));


### PR DESCRIPTION
In some cases the trace_local_ip wasn't being updated when sending out sip trace messages.  This updates the cases I could find to use the trace_local_ip setting when needed.