### PR TITLE
siputils: tel2sip(): fix 'off by one' when allocating memory

### DIFF
--- a/modules/siputils/checks.c
+++ b/modules/siputils/checks.c
@@ -374,7 +374,7 @@ int tel2sip(struct sip_msg* _msg, char* _uri, char* _hostpart, char* _res)
 
 	/* reserve memory for resulting sip uri */
 	sip_uri.len = 4 + tel_uri.len - 4 + 1 + hostpart.len + 1 + 10;
-	sip_uri.s = pkg_malloc(sip_uri.len);
+	sip_uri.s = pkg_malloc(sip_uri.len+1);
 	if (sip_uri.s == 0) {
 		LM_ERR("no more pkg memory\n");
 		pkg_free(tel_uri.s);


### PR DESCRIPTION
While building the sip uri in tel2sip() we have:
```
sip_uri.s = pkg_malloc(sip_uri.len) 
```
But later in pv_set_ruri():
```
val->rs.s[val->rs.len] = '\0';
```
It's overwriting the q_malloc control structures (a classic type of bug already).

Kamailio will log a line like this before crashing:
```
Mar  3 13:31:15 XXXXXXXX /opt/ims/sbin/kamailio[15030]: : <core> [mem/q_malloc.c:140]: qm_debug_frag(): BUG: qm_*: prev. fragm. tail overwritten(c0c0c000, abcdefed)[0x7feaf22bd558:0x7feaf22bd588]!
```
I get this crash with long "tel:" ruris, the ones that have a ";phone-context=" param . 
This patch fixes it.
