### PR TITLE
websocket: Fix stats "connectons" typo's.

### DIFF
--- a/modules/websocket/ws_mod.c
+++ b/modules/websocket/ws_mod.c
@@ -108,9 +108,9 @@ static stat_export_t stats[] =
 	{ "ws_current_connections",            0, &ws_current_connections },
 	{ "ws_max_concurrent_connections",     0, &ws_max_concurrent_connections },
 	{ "ws_sip_current_connections",        0, &ws_sip_current_connections },
-        { "ws_sip_max_concurrent_connectons",  0, &ws_sip_max_concurrent_connections },
-        { "ws_msrp_current_connections",       0, &ws_msrp_current_connections },
-        { "ws_msrp_max_concurrent_connectons", 0, &ws_msrp_max_concurrent_connections },
+	{ "ws_sip_max_concurrent_connections", 0, &ws_sip_max_concurrent_connections },
+	{ "ws_msrp_current_connections",       0, &ws_msrp_current_connections },
+	{ "ws_msrp_max_concurrent_connections", 0, &ws_msrp_max_concurrent_connections },
 
 	/* ws_frame.c */
 	{ "ws_failed_connections",             0, &ws_failed_connections },
@@ -134,6 +134,10 @@ static stat_export_t stats[] =
 	{ "ws_successful_handshakes",          0, &ws_successful_handshakes },
 	{ "ws_sip_successful_handshakes",      0, &ws_sip_successful_handshakes },
 	{ "ws_msrp_successful_handshakes",     0, &ws_msrp_successful_handshakes },
+
+	/* legacy typo's, fixed in 4.4 */
+	{ "ws_sip_max_concurrent_connectons",  0, &ws_sip_max_concurrent_connections },
+	{ "ws_msrp_max_concurrent_connectons", 0, &ws_msrp_max_concurrent_connections },
 
 	{ 0, 0, 0 }
 };


### PR DESCRIPTION
The stats now list:

    ws_sip_max_concurrent_connections
    ws_msrp_max_concurrent_connections

Instead of:

    ws_sip_max_concurrent_connectons
    ws_msrp_max_concurrent_connectons

Note that the latter still exist as aliases to the corrected values for
a while.