### PR TITLE
rtpengine: Add timestamp column to rtpengine table

### DIFF
--- a/lib/srdb1/schema/rtpengine.xml
+++ b/lib/srdb1/schema/rtpengine.xml
@@ -50,6 +50,14 @@
         <natural/>
     </column>
 
+    <column id="stamp">
+        <name>stamp</name>
+        <type>datetime</type>
+        <description>RTPEngine instance add timestamp</description>
+        <default>1900-01-01 00:00:01</default>
+        <natural/>
+    </column>
+
     <index>
         <name>rtpengine_nodes</name>
         <colref linkend="setid"/>

--- a/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/modules/rtpengine/doc/rtpengine_admin.xml
@@ -511,22 +511,23 @@ modparam("rtpengine", "table_name", "rtpengine_table_name")
 		<title>Setup <varname>rtpengine</varname> table</title>
 <programlisting format="linespecific">
 mysql> describe rtpengine;
-+----------+------------------+------+-----+---------+-------+
-| Field    | Type             | Null | Key | Default | Extra |
-+----------+------------------+------+-----+---------+-------+
-| setid    | int(10) unsigned | NO   |     | NULL    |       |
-| url      | varchar(256)     | NO   |     | NULL    |       |
-| weight   | int(10) unsigned | NO   |     | NULL    |       |
-| disabled | int(11)          | NO   |     | NULL    |       |
-+----------+------------------+------+-----+---------+-------+
++----------+------------------+------+-----+---------------------+-------+
+| Field    | Type             | Null | Key | Default             | Extra |
++----------+------------------+------+-----+---------------------+-------+
+| setid    | int(10) unsigned | NO   | PRI | 0                   |       |
+| url      | varchar(64)      | NO   | PRI | NULL                |       |
+| weight   | int(10) unsigned | NO   |     | 1                   |       |
+| disabled | int(1)           | NO   |     | 0                   |       |
+| stamp    | datetime         | NO   |     | 1900-01-01 00:00:01 |       |
++----------+------------------+------+-----+---------------------+-------+
 
 mysql> select * from rtpengine;
-+-------+---------------------------+--------+----------+
-| setid | url                       | weight | disabled |
-+-------+---------------------------+--------+----------+
-|     0 | udp:rtpproxy1.domain:8800 |    100 |        0 |
-|     0 | udp:rtpproxy2.domain:8800 |    200 |        1 |
-+-------+---------------------------+--------+----------+
++-------+---------------------------+--------+----------+---------------------+
+| setid | url                       | weight | disabled | stamp               |
++-------+---------------------------+--------+----------+---------------------+
+|     0 | udp:rtpproxy1.domain:8800 |      1 |        0 | 2016-03-10 10:30:54 |
+|     0 | udp:rtpproxy2.domain:8800 |      1 |        1 | 2016-03-10 10:30:54 |
++-------+---------------------------+--------+----------+---------------------+
 
 mysql> select * from version;
 +---------------------------+---------------+

--- a/utils/kamctl/db_berkeley/kamailio/rtpengine
+++ b/utils/kamctl/db_berkeley/kamailio/rtpengine
@@ -1,10 +1,10 @@
 METADATA_COLUMNS
-setid(int) url(str) weight(int) disabled(int)
+setid(int) url(str) weight(int) disabled(int) stamp(datetime)
 METADATA_KEY
-0 2 3
+0 2 3 4
 METADATA_READONLY
 0
 METADATA_LOGFLAGS
 0
 METADATA_DEFAULTS
-0|NIL|1|0
+0|NIL|1|0|'1900-01-01 00:00:01'

--- a/utils/kamctl/db_sqlite/rtpengine-create.sql
+++ b/utils/kamctl/db_sqlite/rtpengine-create.sql
@@ -3,6 +3,7 @@ CREATE TABLE rtpengine (
     url VARCHAR(64) NOT NULL,
     weight INTEGER DEFAULT 1 NOT NULL,
     disabled INTEGER DEFAULT 0 NOT NULL,
+    stamp TIMESTAMP WITHOUT TIME ZONE DEFAULT '1900-01-01 00:00:01' NOT NULL,
     CONSTRAINT rtpengine_rtpengine_nodes PRIMARY KEY  (setid, url)
 );
 

--- a/utils/kamctl/dbtext/kamailio/rtpengine
+++ b/utils/kamctl/dbtext/kamailio/rtpengine
@@ -1,1 +1,1 @@
-setid(int) url(string) weight(int) disabled(int) 
+setid(int) url(string) weight(int) disabled(int) stamp(int) 

--- a/utils/kamctl/mysql/rtpengine-create.sql
+++ b/utils/kamctl/mysql/rtpengine-create.sql
@@ -3,6 +3,7 @@ CREATE TABLE `rtpengine` (
     `url` VARCHAR(64) NOT NULL,
     `weight` INT(10) UNSIGNED DEFAULT 1 NOT NULL,
     `disabled` INT(1) DEFAULT 0 NOT NULL,
+    `stamp` DATETIME DEFAULT '1900-01-01 00:00:01' NOT NULL,
     CONSTRAINT rtpengine_nodes PRIMARY KEY  (`setid`, `url`)
 );
 

--- a/utils/kamctl/oracle/rtpengine-create.sql
+++ b/utils/kamctl/oracle/rtpengine-create.sql
@@ -3,6 +3,7 @@ CREATE TABLE rtpengine (
     url VARCHAR2(64),
     weight NUMBER(10) DEFAULT 1 NOT NULL,
     disabled NUMBER(10) DEFAULT 0 NOT NULL,
+    stamp DATE DEFAULT '1900-01-01 00:00:01',
     CONSTRAINT rtpengine_rtpengine_nodes  PRIMARY KEY  (setid, url)
 );
 

--- a/utils/kamctl/postgres/rtpengine-create.sql
+++ b/utils/kamctl/postgres/rtpengine-create.sql
@@ -3,6 +3,7 @@ CREATE TABLE rtpengine (
     url VARCHAR(64) NOT NULL,
     weight INTEGER DEFAULT 1 NOT NULL,
     disabled INTEGER DEFAULT 0 NOT NULL,
+    stamp TIMESTAMP WITHOUT TIME ZONE DEFAULT '1900-01-01 00:00:01' NOT NULL,
     CONSTRAINT rtpengine_rtpengine_nodes PRIMARY KEY  (setid, url)
 );
 

--- a/utils/kamctl/xhttp_pi/rtpengine-mod
+++ b/utils/kamctl/xhttp_pi/rtpengine-mod
@@ -8,6 +8,7 @@
 				<col><field>url</field></col>
 				<col><field>weight</field></col>
 				<col><field>disabled</field></col>
+				<col><field>stamp</field></col>
 			</query_cols>
 		</cmd>
 		<cmd><cmd_name>add</cmd_name>
@@ -18,6 +19,7 @@
 				<col><field>url</field></col>
 				<col><field>weight</field></col>
 				<col><field>disabled</field></col>
+				<col><field>stamp</field></col>
 			</query_cols>
 		</cmd>
 	</mod>

--- a/utils/kamctl/xhttp_pi/rtpengine-table
+++ b/utils/kamctl/xhttp_pi/rtpengine-table
@@ -6,4 +6,5 @@
 		<column><field>url</field><type>DB1_STR</type></column>
 		<column><field>weight</field><type>DB1_INT</type></column>
 		<column><field>disabled</field><type>DB1_INT</type></column>
+		<column><field>stamp</field><type>DB1_DATETIME</type></column>
 	</db_table>


### PR DESCRIPTION
The rtpengine module is not affected by this change as it currently ignores the new column.
Updated db scripts and documentations.

Is it possible for the http://kamailio.org/docs/db-tables/kamailio-db-devel.html to be regenerated after this commit?