### PR TITLE
db_mysql: change log level from WARN to INFO for ping checks

### DIFF
--- a/modules/db_mysql/km_dbase.c
+++ b/modules/db_mysql/km_dbase.c
@@ -82,7 +82,7 @@ static int db_mysql_submit_query(const db1_con_t* _h, const str* _s)
 		if ((t - CON_TIMESTAMP(_h)) > my_ping_interval) {
 			for (i=0; i < (db_mysql_auto_reconnect ? 3 : 1); i++) {
 				if (mysql_ping(CON_CONNECTION(_h))) {
-					LM_WARN("driver error on ping: %s\n", mysql_error(CON_CONNECTION(_h)));
+					LM_INFO("driver error on ping: %s\n", mysql_error(CON_CONNECTION(_h)));
 					counter_inc(mysql_cnts_h.driver_err);
 				} else {
 					break;


### PR DESCRIPTION
Customers are complaining because of this kind of messages:
 > proxy[XXX]: WARNING: db_mysql [km_dbase.c:85]: db_mysql_submit_query(): driver error on ping: Lost connection to MySQL server during query

Not really and error here, so lets put it on INFO level then