### PR TITLE
dialog module : new rpc function for terminate

### DIFF
--- a/modules/dialog/dialog.c
+++ b/modules/dialog/dialog.c
@@ -1759,10 +1759,10 @@ static void rpc_dlg_terminate_dlg(rpc_t *rpc,void *c){
 
         if(ret>=0){
                 LM_WARN("Dialog is terminated callid: '%.*s' \n",callid.len, callid.s);
+                dlg_release(dlg);
                 rpc->add(c, "d", 200);
                 rpc->add(c, "s", "OK");
                 rpc->send(c);
-                dlg_release(dlg);
         }
 }
 

--- a/modules/dialog/dialog.c
+++ b/modules/dialog/dialog.c
@@ -1698,6 +1698,9 @@ static const char *rpc_print_dlg_ctx_doc[2] = {
 static const char *rpc_end_dlg_entry_id_doc[2] = {
 	"End a given dialog based on [h_entry] [h_id]", 0
 };
+static const char *rpc_dlg_terminate_dlg_doc[2] = {
+        "End a given dialog based on callid", 0
+};
 static const char *rpc_profile_get_size_doc[2] = {
 	"Returns the number of dialogs belonging to a profile", 0
 };
@@ -1722,6 +1725,46 @@ static void rpc_print_dlg(rpc_t *rpc, void *c) {
 static void rpc_print_dlg_ctx(rpc_t *rpc, void *c) {
 	internal_rpc_print_single_dlg(rpc, c, 1);
 }
+static void rpc_dlg_terminate_dlg(rpc_t *rpc,void *c){
+        str callid = {NULL,0};
+        str ftag = {NULL,0};
+        str ttag = {NULL,0};
+
+        dlg_cell_t * dlg = NULL;
+        unsigned int dir;
+        int ret=0;
+        dir = 0;
+
+
+        if(rpc->scan(c, ".S.S.S", &callid,&ftag,&ttag)<3)
+        {
+                LM_ERR("Unable to read the parameters dlg_terminate_dlg \n" );
+                rpc->fault(c, 400, "Need a Callid ,from tag ,to tag");
+                return;
+        }
+
+        dlg=get_dlg(&callid,&ftag,&ttag,&dir);
+
+        if(dlg==NULL){
+                LM_ERR("Couldnt find callid in dialog '%.*s' \n",callid.len, callid.s);
+                rpc->fault(c, 500, "Couldnt find callid in dialog");
+                return;
+        }
+
+        LM_DBG("Dialog is found with callid  for terminate rpc '%.*s' \n",callid.len, callid.s);
+
+        ret=dlg_bye_all(dlg,NULL);
+
+        LM_DBG("Dialog bye return code %d \n",ret);
+
+        if(ret>=0){
+                LM_WARN("Dialog is terminated callid: '%.*s' \n",callid.len, callid.s);
+                rpc->fault(c, 200, "Dialog terminated");
+                dlg_release(dlg);
+        }
+}
+
+
 static void rpc_end_dlg_entry_id(rpc_t *rpc, void *c) {
 	unsigned int h_entry, h_id;
 	dlg_cell_t * dlg = NULL;
@@ -1812,5 +1855,6 @@ static rpc_export_t rpc_methods[] = {
 	{"dlg.profile_get_size", rpc_profile_get_size, rpc_profile_get_size_doc, 0},
 	{"dlg.profile_list", rpc_profile_print_dlgs, rpc_profile_print_dlgs_doc, RET_ARRAY},
 	{"dlg.bridge_dlg", rpc_dlg_bridge, rpc_dlg_bridge_doc, 0},
+	{"dlg.dlg_terminate_dlg", rpc_dlg_terminate_dlg, rpc_dlg_terminate_dlg_doc, 0},
 	{0, 0, 0, 0}
 };

--- a/modules/dialog/dialog.c
+++ b/modules/dialog/dialog.c
@@ -1759,7 +1759,9 @@ static void rpc_dlg_terminate_dlg(rpc_t *rpc,void *c){
 
         if(ret>=0){
                 LM_WARN("Dialog is terminated callid: '%.*s' \n",callid.len, callid.s);
-                rpc->fault(c, 200, "Dialog terminated");
+                rpc->add(c, "d", 200);
+                rpc->add(c, "s", "OK");
+                rpc->send(c);
                 dlg_release(dlg);
         }
 }

--- a/modules/dialog/doc/dialog_admin.xml
+++ b/modules/dialog/doc/dialog_admin.xml
@@ -2304,7 +2304,7 @@ dlg_remote_profile("add", "caller", "test", "$sruid", "$var(exp)");
 		<para>Name: <emphasis>dlg.list</emphasis></para>
 		<para>RPC Command Format:</para>
 		<programlisting  format="linespecific">
-		serctl dlg_list
+		kamcmd dlg_list
 		</programlisting>
 		</section>
 
@@ -2318,7 +2318,7 @@ dlg_remote_profile("add", "caller", "test", "$sruid", "$var(exp)");
 		<para>Name: <emphasis>dlg.list_ctx</emphasis></para>
 		<para>RPC Command Format:</para>
 		<programlisting  format="linespecific">
-		serctl dlg.list_ctx
+		kamcmd dlg.list_ctx
 		</programlisting>
 		</section>
 
@@ -2341,10 +2341,9 @@ dlg_remote_profile("add", "caller", "test", "$sruid", "$var(exp)");
 		</itemizedlist>
 		<para>RPC Command Format:</para>
 		<programlisting  format="linespecific">
-		serctl dlg.list abcdrssfrs122444@192.168.1.1 AAdfeEFF33
+		kamcmd dlg.list abcdrssfrs122444@192.168.1.1 AAdfeEFF33
 		</programlisting>
 		</section>
-
 		<section>
 		<title><varname>dlg.dlg_list_ctx</varname></title>
 		<para>
@@ -2357,10 +2356,36 @@ dlg_remote_profile("add", "caller", "test", "$sruid", "$var(exp)");
 		</para>
 		<para>RPC Command Format:</para>
 		<programlisting  format="linespecific">
-		serctl dlg.list_ctx abcdrssfrs122444@192.168.1.1 AAdfeEFF33
+		kamcmd dlg.list_ctx abcdrssfrs122444@192.168.1.1 AAdfeEFF33
 		</programlisting>
 		</section>
-
+		<section>
+			<title><varname>dlg.dlg_terminate_dlg</varname></title>
+			<para>
+			Terminates an ongoing dialog by sending BYE in both directions.
+			</para>
+		<para>Name: <emphasis>dlg.dlg_terminate_dlg</emphasis></para>
+		<para>Parameters:</para>
+		<itemizedlist>
+			<listitem><para>
+				<emphasis>callid</emphasis> - callid of dialog to be terminated
+			</para></listitem>
+			<listitem><para>
+				<emphasis>from_tag</emphasis> -  from tag of the dialog to terminated
+			</para></listitem>
+			<listitem><para>
+				<emphasis>totag</emphasis> -  to tag of the dialog to terminated
+			</para></listitem>
+		</itemizedlist>
+		<para>
+		Works only for confirmed dialogs
+		RPC command.
+		</para>
+		<para>RPC Command Format:</para>
+		<programlisting  format="linespecific">
+		kamcmd dlg.dlg_terminate_dlg callid12345callid asfromtag123 astotag123
+		</programlisting>
+		</section>
 		<section>
 			<title><varname>dlg.end_dlg</varname></title>
 			<para>
@@ -2388,10 +2413,9 @@ dlg_remote_profile("add", "caller", "test", "$sruid", "$var(exp)");
 		</para>
 		<para>RPC Command Format:</para>
 		<programlisting  format="linespecific">
-		serctl dlg.end_dlg 342 56
+		kamcmd dlg.end_dlg 342 56
 		</programlisting>
 		</section>
-
 		<section>
 		<title><varname>dlg.profile_get_size</varname></title>
 		<para>
@@ -2416,7 +2440,7 @@ dlg_remote_profile("add", "caller", "test", "$sruid", "$var(exp)");
 		</itemizedlist>
 		<para>RPC Command Format:</para>
 		<programlisting  format="linespecific">
-		serctl dlg.dlg.profile_get_size inbound_calls
+		kamcmd dlg.dlg.profile_get_size inbound_calls
 		</programlisting>
 		</section>
 
@@ -2444,7 +2468,7 @@ dlg_remote_profile("add", "caller", "test", "$sruid", "$var(exp)");
 		</itemizedlist>
 		<para>RPC Command Format:</para>
 		<programlisting  format="linespecific">
-		serctl dlg.profile_list inbound_calls
+		kamcmd dlg.profile_list inbound_calls
 		</programlisting>
 		</section>
 
@@ -2469,7 +2493,7 @@ dlg_remote_profile("add", "caller", "test", "$sruid", "$var(exp)");
 		</itemizedlist>
 		<para>RPC Command Format:</para>
 		<programlisting  format="linespecific">
-		serctl dlg.list from to op
+		kamcmd dlg.list from to op
 		</programlisting>
 		</section>
 	</section>

--- a/modules/domain/domain_mod.c
+++ b/modules/domain/domain_mod.c
@@ -288,7 +288,10 @@ static void domain_rpc_reload(rpc_t* rpc, void* ctx)
 	rpc->fault(ctx, 400, "Reload of domain tables failed");
     }
     lock_release(reload_lock);
-    rpc->fault(ctx, 200, "domain table is reloaded");
+    rpc->add(c, "d", 200);
+    rpc->add(c, "s", "OK");
+    rpc->send(c);
+
 }
 
 

--- a/modules/domain/domain_mod.c
+++ b/modules/domain/domain_mod.c
@@ -288,9 +288,9 @@ static void domain_rpc_reload(rpc_t* rpc, void* ctx)
 	rpc->fault(ctx, 400, "Reload of domain tables failed");
     }
     lock_release(reload_lock);
-    rpc->add(c, "d", 200);
-    rpc->add(c, "s", "OK");
-    rpc->send(c);
+    rpc->add(ctx, "d", 200);
+    rpc->add(ctx, "s", "OK");
+    rpc->send(ctx);
 
 }
 

--- a/modules/domain/domain_mod.c
+++ b/modules/domain/domain_mod.c
@@ -288,6 +288,7 @@ static void domain_rpc_reload(rpc_t* rpc, void* ctx)
 	rpc->fault(ctx, 400, "Reload of domain tables failed");
     }
     lock_release(reload_lock);
+    rpc->fault(ctx, 200, "domain table is reloaded");
 }
 
 


### PR DESCRIPTION
- added new rpc command for terminate a dialog with callid, fromtag and totag.
- added new rpc command to doc and serctl is removed 
- added rpc return code  to dlg_terminate_dlg function
- added rpc return code to rpc domain reload function