### PR TITLE
core: skip address family AF_PACKET on -l iface_name

### DIFF
--- a/socket_info.c
+++ b/socket_info.c
@@ -1205,6 +1205,9 @@ int add_interfaces(char* if_name, int family, unsigned short port,
 
 	for (ifa = ifap; ifa; ifa = ifa->ifa_next)
 	{
+		/* skip AF_PACKET addr family since it is of no use later on */
+		if (ifa->ifa_addr->sa_family == AF_PACKET)
+			continue;
 		if (if_name && strcmp(if_name, ifa->ifa_name))
 			continue;
 		if (family && family != ifa->ifa_addr->sa_family)


### PR DESCRIPTION
- socket_info.c: getifaddrs() returns AF_PACKET, AF_INET and AF_INET6 addressed of an interface.
  AF_PACKET are of no use and breaks startup with an -l eth0:5060 cmd line param