### PR TITLE
kex: Call pkg_proc_update_stats only when needed

### DIFF
--- a/events.c
+++ b/events.c
@@ -125,11 +125,6 @@ int sr_event_register_cb(int type, sr_event_cb_f f)
 					_sr_events_list.run_action = f;
 				else return -1;
 			break;
-		case SREV_PKG_UPDATE_STATS:
-				if(_sr_events_list.pkg_update_stats==0)
-					_sr_events_list.pkg_update_stats = f;
-				else return -1;
-			break;
 		case SREV_NET_DGRAM_IN:
 				if(_sr_events_list.net_dgram_in==0)
 					_sr_events_list.net_dgram_in = f;
@@ -251,12 +246,6 @@ int sr_event_exec(int type, void *data)
 					ret = _sr_events_list.run_action(data);
 					return ret;
 				} else return 1;
-		case SREV_PKG_UPDATE_STATS:
-				if(unlikely(_sr_events_list.pkg_update_stats!=0))
-				{
-					ret = _sr_events_list.pkg_update_stats(data);
-					return ret;
-				} else return 1;
 		case SREV_NET_DGRAM_IN:
 				if(unlikely(_sr_events_list.net_dgram_in!=0))
 				{
@@ -336,8 +325,6 @@ int sr_event_enabled(int type)
 				return (_sr_events_list.core_stats!=0)?1:0;
 		case SREV_CFG_RUN_ACTION:
 				return (_sr_events_list.run_action!=0)?1:0;
-		case SREV_PKG_UPDATE_STATS:
-				return (_sr_events_list.pkg_update_stats!=0)?1:0;
 		case SREV_NET_DGRAM_IN:
 				return (_sr_events_list.net_dgram_in!=0)?1:0;
 		case SREV_TCP_HTTP_100C:

--- a/events.h
+++ b/events.h
@@ -26,7 +26,6 @@
 #define SREV_NET_DATA_OUT		2
 #define SREV_CORE_STATS			3
 #define SREV_CFG_RUN_ACTION		4
-#define SREV_PKG_UPDATE_STATS	5
 #define SREV_RCV_NOSIP			6
 #define SREV_NET_DGRAM_IN		7
 #define SREV_TCP_HTTP_100C		8

--- a/mem/f_malloc.c
+++ b/mem/f_malloc.c
@@ -518,9 +518,6 @@ finish:
 	if (qm->max_real_used<qm->real_used)
 		qm->max_real_used=qm->real_used;
 	FRAG_MARK_USED(frag); /* mark it as used */
-	if(qm->type==MEM_TYPE_PKG) {
-		sr_event_exec(SREV_PKG_UPDATE_STATS, 0);
-	}
 	return (char*)frag+sizeof(struct fm_frag);
 }
 
@@ -597,9 +594,6 @@ void fm_free(void* qmp, void* p)
 		LM_INFO("freeing a free fragment (%p/%p) - ignore\n",
 				f, p);
 		return;
-	}
-	if(qm->type==MEM_TYPE_PKG) {
-		sr_event_exec(SREV_PKG_UPDATE_STATS, 0);
 	}
 #ifdef DBG_F_MALLOC
 	f->file=file;
@@ -733,9 +727,6 @@ void* fm_realloc(void* qmp, void* p, unsigned long size)
 #ifdef DBG_F_MALLOC
 	MDBG("fm_realloc: returning %p\n", p);
 #endif
-	if(qm->type==MEM_TYPE_PKG) {
-		sr_event_exec(SREV_PKG_UPDATE_STATS, 0);
-	}
 	return p;
 }
 

--- a/mem/q_malloc.c
+++ b/mem/q_malloc.c
@@ -33,9 +33,6 @@
 #include "../globals.h"
 #include "memdbg.h"
 #include "../cfg/cfg.h" /* memlog */
-#ifdef MALLOC_STATS
-#include "../events.h"
-#endif
 
 #include "pkg.h"
 
@@ -406,11 +403,6 @@ void* qm_malloc(void* qmp, unsigned long size)
 				" -th hit\n",
 			 qm, size, (char*)f+sizeof(struct qm_frag), f, f->size, list_cntr );
 #endif
-#ifdef MALLOC_STATS
-		if(qm->type==MEM_TYPE_PKG) {
-			sr_event_exec(SREV_PKG_UPDATE_STATS, 0);
-		}
-#endif
 		return (char*)f+sizeof(struct qm_frag);
 	}
 	return 0;
@@ -532,11 +524,6 @@ void qm_free(void* qmp, void* p)
 	f->line=line;
 #endif
 	qm_insert_free(qm, f);
-#ifdef MALLOC_STATS
-	if(qm->type==MEM_TYPE_PKG) {
-		sr_event_exec(SREV_PKG_UPDATE_STATS, 0);
-	}
-#endif
 }
 
 
@@ -670,11 +657,6 @@ void* qm_realloc(void* qmp, void* p, unsigned long size)
 	}
 #ifdef DBG_QM_MALLOC
 	MDBG("qm_realloc: returning %p\n", p);
-#endif
-#ifdef MALLOC_STATS
-	if(qm->type==MEM_TYPE_PKG) {
-		sr_event_exec(SREV_PKG_UPDATE_STATS, 0);
-	}
 #endif
 	return p;
 }

--- a/modules/kex/pkg_stats.c
+++ b/modules/kex/pkg_stats.c
@@ -145,7 +145,6 @@ static int pkg_proc_update_stats(void *data)
  */
 int register_pkg_proc_stats(void)
 {
-	sr_event_register_cb(SREV_PKG_UPDATE_STATS, pkg_proc_update_stats);
 	return 0;
 }
 
@@ -224,6 +223,8 @@ static void rpc_pkg_stats(rpc_t* rpc, void* ctx)
 			limit = i + 1;
 		}
 	}
+
+	pkg_proc_update_stats(NULL);
 
 	for(; i<limit; i++)
 	{


### PR DESCRIPTION
I created a patch for 4.1 which allows to display also the total number of pkg fragments upon calling `kamcmd pkg.stats`, inspiring myself from the latest upstream. This PR comes as a result to enabling MALLOC_STATS and noticing kamailio slowdown with my applied patch, for 4.1. The slowdown was happening because each time a memory function was called, iteration through all fragments happened upon `pkg_info`. The solution was to call the stats gathering only when kamcmd command is issued.

On master this slowdown is not happening anymore, because `qm->ffrags` variable counts the fragments "on the fly", while memory functions are called. Still, is it necessarily to call pkg_proc_update_stats() callback every time?!

Feel free to close this if not needed.