### PR TITLE
app_perl: Fix "use UNIVERSAL" is a fatal error since perl 5.22

### DIFF
--- a/modules/app_perl/lib/perl/Kamailio/LDAPUtils/LDAPConnection.pm
+++ b/modules/app_perl/lib/perl/Kamailio/LDAPUtils/LDAPConnection.pm
@@ -52,7 +52,6 @@ package Kamailio::LDAPUtils::LDAPConnection;
 use Kamailio::LDAPUtils::LDAPConf;
 use Net::LDAP;
 use Authen::SASL;
-use UNIVERSAL qw( isa );
 
 my $ldap_singleton = undef;
 
@@ -185,7 +184,7 @@ sub search {
 
     my $ldap = undef;
 
-    if( isa($conf ,"Kamailio::LDAPUtils::LDAPConnection") ) {
+    if( $conf->isa("Kamailio::LDAPUtils::LDAPConnection") ) {
       $ldap = $conf;
     } else {
       if( ! $ldap_singleton ) {

--- a/modules/app_perl/lib/perl/Kamailio/VDB.pm
+++ b/modules/app_perl/lib/perl/Kamailio/VDB.pm
@@ -45,7 +45,6 @@ use Kamailio::VDB::Result;
 use Kamailio::VDB::Value;
 use Kamailio::VDB::VTab;
 
-use UNIVERSAL qw ( can );
 
 our @ISA = qw ( Kamailio::Utils::Debug );
 
@@ -87,12 +86,12 @@ sub use_table {
 
 		Kamailio::log(L_DBG, "perlvdb:VDB: Setting VTab: v is $v (pkg is $pkg, func/method is $3)\n");
 
-		if (can($pkg, $3)) {
+		if ($pkg->can($3)) {
 			$self->{vtabs}->{$v} = new Kamailio::VDB::VTab( func => $pkg . "::" . $3);
-		} elsif (can($v, "init")) {
+		} elsif ($v->can("init")) {
 			$v->init();
 			$self->{vtabs}->{$v} = new Kamailio::VDB::VTab( obj => $v );
-		} elsif (can($v, "new")) {
+		} elsif ($v->can("new")) {
 			my $obj = $v->new();
 			$self->{vtabs}->{$v} = new Kamailio::VDB::VTab( obj => $obj );
 		} else {


### PR DESCRIPTION
* Author: Julián Moreno Patiño <julian@debian.org>
* Fix #516
* from: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=821039