### PR TITLE
kex: adding total_frags to kamcmd pkg.stats

### DIFF
--- a/events.c
+++ b/events.c
@@ -127,6 +127,11 @@ int sr_event_register_cb(int type, sr_event_cb_f f)
 					_sr_events_list.pkg_set_real_used = f;
 				else return -1;
 			break;
+		case SREV_PKG_SET_FRAGS:
+			if(_sr_events_list.pkg_set_frags==0)
+					_sr_events_list.pkg_set_frags = f;
+				else return -1;
+			break;
 		case SREV_NET_DGRAM_IN:
 				if(_sr_events_list.net_dgram_in==0)
 					_sr_events_list.net_dgram_in = f;
@@ -230,6 +235,12 @@ int sr_event_exec(int type, void *data)
 					ret = _sr_events_list.pkg_set_real_used(data);
 					return ret;
 				} else return 1;
+		case SREV_PKG_SET_FRAGS:
+				if(unlikely(_sr_events_list.pkg_set_real_used!=0))
+				{
+					ret = _sr_events_list.pkg_set_frags(data);
+					return ret;
+				} else return 1;
 		case SREV_NET_DGRAM_IN:
 				if(unlikely(_sr_events_list.net_dgram_in!=0))
 				{
@@ -289,6 +300,8 @@ int sr_event_enabled(int type)
 				return (_sr_events_list.pkg_set_used!=0)?1:0;
 		case SREV_PKG_SET_REAL_USED:
 				return (_sr_events_list.pkg_set_real_used!=0)?1:0;
+		case SREV_PKG_SET_FRAGS:
+				return (_sr_events_list.pkg_set_frags!=0)?1:0;
 		case SREV_NET_DGRAM_IN:
 				return (_sr_events_list.net_dgram_in!=0)?1:0;
 		case SREV_TCP_HTTP_100C:

--- a/events.h
+++ b/events.h
@@ -35,6 +35,7 @@
 #define SREV_TCP_WS_FRAME_IN		10
 #define SREV_TCP_WS_FRAME_OUT		11
 #define SREV_STUN_IN			12
+#define SREV_PKG_SET_FRAGS		13
 
 
 typedef int (*sr_event_cb_f)(void *data);
@@ -46,6 +47,7 @@ typedef struct sr_event_cb {
 	sr_event_cb_f run_action;
 	sr_event_cb_f pkg_set_used;
 	sr_event_cb_f pkg_set_real_used;
+	sr_event_cb_f pkg_set_frags;
 	sr_event_cb_f net_dgram_in;
 	sr_event_cb_f tcp_http_100c;
 	sr_event_cb_f tcp_msrp_frame;

--- a/mem/f_malloc.h
+++ b/mem/f_malloc.h
@@ -119,6 +119,7 @@ struct fm_block{
 	unsigned long used; /** allocated size*/
 	unsigned long real_used; /** used + malloc overhead */
 	unsigned long max_real_used;
+	unsigned long ffrags;
 #endif
 	
 	struct fm_frag* first_frag;

--- a/mem/q_malloc.h
+++ b/mem/q_malloc.h
@@ -116,6 +116,7 @@ struct qm_block{
 	unsigned long used; /* alloc'ed size*/
 	unsigned long real_used; /* used+malloc overhead*/
 	unsigned long max_real_used;
+	unsigned long ffrags;
 	
 	struct qm_frag* first_frag;
 	struct qm_frag_end* last_frag_end;


### PR DESCRIPTION
Created a patch for 4.1 which allows to display also the total number of pkg fragments upon calling kamcmd pkg.stats. This combines part of the master logic with existing 4.1 logic (for example this version does not combine the SREV_PKG_SET_USED, SREV_PKG_SET_REAL_USED, SREV_PKG_SET_FRAGS  into one callback.)

Does this look ok?  Feel free to close this if not needed.