### PR TITLE
modules/*/doc: reorganize “Known limitations”

### DIFF
--- a/modules/db_mongodb/README
+++ b/modules/db_mongodb/README
@@ -10,7 +10,7 @@ Daniel-Constantin Mierla
 
    <miconda@gmail.com>
 
-   Copyright © 2014 asipto.com
+   Copyright Â© 2014 asipto.com
      __________________________________________________________________
 
    Table of Contents
@@ -18,15 +18,13 @@ Daniel-Constantin Mierla
    1. Admin Guide
 
         1. Overview
+        2. Limitations
+        3. Dependencies
 
-              1.1. Limitations
+              3.1. Kamailio Modules
+              3.2. External Libraries or Applications
 
-        2. Dependencies
-
-              2.1. Kamailio Modules
-              2.2. External Libraries or Applications
-
-        3. Usage
+        4. Usage
 
    List of Examples
 
@@ -37,19 +35,15 @@ Chapter 1. Admin Guide
    Table of Contents
 
    1. Overview
+   2. Limitations
+   3. Dependencies
 
-        1.1. Limitations
+        3.1. Kamailio Modules
+        3.2. External Libraries or Applications
 
-   2. Dependencies
-
-        2.1. Kamailio Modules
-        2.2. External Libraries or Applications
-
-   3. Usage
+   4. Usage
 
 1. Overview
-
-   1.1. Limitations
 
    This module provides DB APIv1 connector for MongoDB NoSQL server.
 
@@ -60,33 +54,33 @@ Chapter 1. Admin Guide
 
    You can read more about MongoDB at: http://www.mongodb.org.
 
-1.1. Limitations
+2. Limitations
 
-     * This module has implemented the equivalent operations for INSERT,
-       UPDATE, DELETE and SELECT. The match condition (WHERE clause) works
-       with the operators: equal, not equal, greater than, less than,
-       equal or greater than, equal or less than. Raw query is not
-       implemented inside this module, use ndb_mongodb for sending any
-       kind of command to a MongoDB server.
+   This module has implemented the equivalent operations for INSERT,
+   UPDATE, DELETE and SELECT. The match condition (WHERE clause) works
+   with the operators: equal, not equal, greater than, less than, equal or
+   greater than, equal or less than. Raw query is not implemented inside
+   this module, use ndb_mongodb for sending any kind of command to a
+   MongoDB server.
 
-2. Dependencies
+3. Dependencies
 
-   2.1. Kamailio Modules
-   2.2. External Libraries or Applications
+   3.1. Kamailio Modules
+   3.2. External Libraries or Applications
 
-2.1. Kamailio Modules
+3.1. Kamailio Modules
 
    The following modules must be loaded before this module:
      * none.
 
-2.2. External Libraries or Applications
+3.2. External Libraries or Applications
 
    The following libraries or applications must be installed before
    running Kamailio with this module loaded:
      * mongo-c-driver - available at
        https://github.com/mongodb/mongo-c-driver
 
-3. Usage
+4. Usage
 
    Load the module and set the the DB URL for specific modules to:
    mongodb://username:password@host:port/database. Username, password and

--- a/modules/db_mongodb/doc/db_mongodb_admin.xml
+++ b/modules/db_mongodb/doc/db_mongodb_admin.xml
@@ -28,11 +28,10 @@
 		You can read more about MongoDB at:
 		<ulink url="http://www.mongodb.org">http://www.mongodb.org</ulink>.
 	</para>
+	</section>
 
 	<section>
 	<title>Limitations</title>
-	<itemizedlist>
-	<listitem>
 	<para>
 		This module has implemented the equivalent operations for INSERT,
 		UPDATE, DELETE and SELECT. The match condition (WHERE clause)
@@ -41,9 +40,6 @@
 		implemented inside this module, use ndb_mongodb for sending any
 		kind of command to a MongoDB server.
 	</para>
-	</listitem>
-	</itemizedlist>
-	</section>
 	</section>
 
 	<section>

--- a/modules/db_text/README
+++ b/modules/db_text/README
@@ -10,13 +10,9 @@ Ovidiu Sas
 
    <osas@voipembedded.com>
 
-Edited by
-
 Daniel-Constantin Mierla
 
    <miconda@gmail.com>
-
-Edited by
 
 Olle E. Johansson
 
@@ -33,26 +29,26 @@ Olle E. Johansson
 
               1.1. Design of dbtext engine
               1.2. Internal format of a dbtext table
-              1.3. Existing limitations
 
-        2. Dependencies
+        2. Known limitations
+        3. Dependencies
 
-              2.1. Kamailio modules
-              2.2. External libraries or applications
+              3.1. Kamailio modules
+              3.2. External libraries or applications
 
-        3. Parameters
+        4. Parameters
 
-              3.1. db_mode (integer)
-              3.2. emptystring (integer)
-              3.3. file_buffer_size (integer)
+              4.1. db_mode (integer)
+              4.2. emptystring (integer)
+              4.3. file_buffer_size (integer)
 
-        4. Exported RPC Functions
+        5. Exported RPC Functions
 
-              4.1. db_text.dump
+              5.1. db_text.dump
 
-        5. Installation and Running
+        6. Installation and Running
 
-              5.1. Using db_text with a basic Kamailio configuration
+              6.1. Using db_text with a basic Kamailio configuration
 
    2. Developer Guide
 
@@ -78,32 +74,31 @@ Chapter 1. Admin Guide
 
         1.1. Design of dbtext engine
         1.2. Internal format of a dbtext table
-        1.3. Existing limitations
 
-   2. Dependencies
+   2. Known limitations
+   3. Dependencies
 
-        2.1. Kamailio modules
-        2.2. External libraries or applications
+        3.1. Kamailio modules
+        3.2. External libraries or applications
 
-   3. Parameters
+   4. Parameters
 
-        3.1. db_mode (integer)
-        3.2. emptystring (integer)
-        3.3. file_buffer_size (integer)
+        4.1. db_mode (integer)
+        4.2. emptystring (integer)
+        4.3. file_buffer_size (integer)
 
-   4. Exported RPC Functions
+   5. Exported RPC Functions
 
-        4.1. db_text.dump
+        5.1. db_text.dump
 
-   5. Installation and Running
+   6. Installation and Running
 
-        5.1. Using db_text with a basic Kamailio configuration
+        6.1. Using db_text with a basic Kamailio configuration
 
 1. Overview
 
    1.1. Design of dbtext engine
    1.2. Internal format of a dbtext table
-   1.3. Existing limitations
 
    The module implements a simplified database engine based on text files.
    It can be used by Kamailio DB interface instead of other database
@@ -187,36 +182,36 @@ username(str) password(str) ha1(str) domain(str) ha1b(str)
 suser:supasswd:xxx:alpha.org:xxx
 ...
 
-1.3. Existing limitations
+2. Known limitations
 
    This database interface does not support data insertion with default
    values. All such values specified in the database template are ignored.
    So its advisable to specify all data for a column at insertion
    operations.
 
-2. Dependencies
+3. Dependencies
 
-   2.1. Kamailio modules
-   2.2. External libraries or applications
+   3.1. Kamailio modules
+   3.2. External libraries or applications
 
-2.1. Kamailio modules
+3.1. Kamailio modules
 
    These modules must be loaded before this module:
      * none.
 
-2.2. External libraries or applications
+3.2. External libraries or applications
 
    These libraries or applications must be installed before running
    Kamailio with this module:
      * none.
 
-3. Parameters
+4. Parameters
 
-   3.1. db_mode (integer)
-   3.2. emptystring (integer)
-   3.3. file_buffer_size (integer)
+   4.1. db_mode (integer)
+   4.2. emptystring (integer)
+   4.3. file_buffer_size (integer)
 
-3.1. db_mode (integer)
+4.1. db_mode (integer)
 
    Set caching mode (0) or non-caching mode (1). In caching mode, data is
    loaded at startup. In non-caching mode, the module check every time a
@@ -230,7 +225,7 @@ suser:supasswd:xxx:alpha.org:xxx
 modparam("db_text", "db_mode", 1)
 ...
 
-3.2. emptystring (integer)
+4.2. emptystring (integer)
 
    db_text by default handles an empty string as a NULL value. Some
    modules, like the dialplan module, does not accept NULL strings. If you
@@ -244,7 +239,7 @@ modparam("db_text", "db_mode", 1)
 modparam("db_text", "emptystring", 1)
 ...
 
-3.3. file_buffer_size (integer)
+4.3. file_buffer_size (integer)
 
    size of the buffer used to read the text file. Some presence tables
    have columns with large content.
@@ -256,11 +251,11 @@ modparam("db_text", "emptystring", 1)
 modparam("db_text", "file_buffer_size", 8192)
 ...
 
-4. Exported RPC Functions
+5. Exported RPC Functions
 
-   4.1. db_text.dump
+   5.1. db_text.dump
 
-4.1.  db_text.dump
+5.1.  db_text.dump
 
    Write back to hard drive all modified tables.
 
@@ -271,9 +266,9 @@ modparam("db_text", "file_buffer_size", 8192)
    RPC Command Format:
         kamcmd db_text.dump
 
-5. Installation and Running
+6. Installation and Running
 
-   5.1. Using db_text with a basic Kamailio configuration
+   6.1. Using db_text with a basic Kamailio configuration
 
    Compile the module and load it instead of mysql or other DB modules.
 
@@ -291,7 +286,7 @@ loadmodule "/path/to/kamailio/modules_k/db_text.so"
 modparam("module_name", "db_url", "text:///path/to/dbtext/database")
 ...
 
-5.1. Using db_text with a basic Kamailio configuration
+6.1. Using db_text with a basic Kamailio configuration
 
    Here are definitions for the most important tables as well as a basic
    configuration file to use db_text with Kamailio. The table structures
@@ -305,17 +300,17 @@ modparam("module_name", "db_url", "text:///path/to/dbtext/database")
 
    Example 1.8. Definition of 'subscriber' table (one line)
 ...
-username(str) domain(str) password(str) first_name(str) last_name(str) phone(st
-r) email_address(str) datetime_created(int) datetime_modified(int) confirmation
-(str) flag(str) sendnotification(str) greeting(str) ha1(str) ha1b(str) perms(st
-r) allow_find(str) timezone(str,null) rpid(str,null)
+username(str) domain(str) password(str) first_name(str) last_name(str) phone(str
+) email_address(str) datetime_created(int) datetime_modified(int) confirmation(s
+tr) flag(str) sendnotification(str) greeting(str) ha1(str) ha1b(str) perms(str)
+allow_find(str) timezone(str,null) rpid(str,null)
 ...
 
    Example 1.9. Definition of 'location' and 'aliases' tables (one line)
 ...
-username(str) domain(str,null) contact(str,null) received(str) expires(int,null
-) q(double,null) callid(str,null) cseq(int,null) last_modified(str) flags(int)
-user_agent(str) socket(str)
+username(str) domain(str,null) contact(str,null) received(str) expires(int,null)
+ q(double,null) callid(str,null) cseq(int,null) last_modified(str) flags(int) us
+er_agent(str) socket(str)
 ...
 
    Example 1.10. Definition of 'version' table and sample records

--- a/modules/db_text/doc/db_text_admin.xml
+++ b/modules/db_text/doc/db_text_admin.xml
@@ -206,14 +206,14 @@ suser:supasswd:xxx:alpha.org:xxx
 </programlisting>
 		</example>
 		</section>
-		<section>
-		<title>Existing limitations</title>
+	</section>
+	<section>
+	<title>Known limitations</title>
 		<para>This database interface does not support data insertion with
 			default values. All such values specified in the database template
 			are ignored. So its advisable to specify all data for a column at
 			insertion operations.
 		</para>
-		</section>
 	</section>
 	<section>
 	<title>Dependencies</title>

--- a/modules/iptrtpproxy/README
+++ b/modules/iptrtpproxy/README
@@ -1,56 +1,56 @@
-
 The Iptrtpproxy module
 
 Tomas Mandys
 
    Iptel.org
 
-   Copyright © 2007 Tomas Mandys
-     _________________________________________________________________
+   Copyright Â© 2007 Tomas Mandys
+     __________________________________________________________________
 
    Table of Contents
 
    1. Admin Guide
 
         1. Overview
-        2. Dependencies
-        3. Parameters
+        2. Known limitations
+        3. Dependencies
+        4. Parameters
 
-              3.1. config (string)
-              3.2. switchboard (string)
-              3.3. rpc_heartbeat_timeout (int)
-              3.4. hostname (string)
-              3.5. declare_codec (string)
-              3.6. codec_set (string)
+              4.1. config (string)
+              4.2. switchboard (string)
+              4.3. rpc_heartbeat_timeout (int)
+              4.4. hostname (string)
+              4.5. declare_codec (string)
+              4.6. codec_set (string)
 
-        4. Functions
+        5. Functions
 
-              4.1. iptrtpproxy_alloc(gate_a_to_b [, existing_sess_ids]) 
-              4.2. iptrtpproxy_update(gate_a_to_b, session_ids) 
-              4.3. iptrtpproxy_adjust_timeout(gate_a_to_b, session_ids) 
-              4.4. iptrtpproxy_delete(session_ids) 
-              4.5. iptrtpproxy_authorize_media() 
-              4.6. iptrtpproxy_set_param(param, value) 
-              4.7.
-                      iptrtpproxy_set_param("(aggregation/switchboard)_by_sip
-                      _ip_(a/b)", sip_ip) 
+              5.1. iptrtpproxy_alloc(gate_a_to_b [, existing_sess_ids])
+              5.2. iptrtpproxy_update(gate_a_to_b, session_ids)
+              5.3. iptrtpproxy_adjust_timeout(gate_a_to_b, session_ids)
+              5.4. iptrtpproxy_delete(session_ids)
+              5.5. iptrtpproxy_authorize_media()
+              5.6. iptrtpproxy_set_param(param, value)
+              5.7.
+                      iptrtpproxy_set_param("(aggregation/switchboard)_by_sip_
+                      ip_(a/b)", sip_ip)
 
-              4.8. iptrtpproxy_set_param("protected_session_ids",
-                      sess_ids) 
+              5.8. iptrtpproxy_set_param("protected_session_ids",
+                      sess_ids)
 
-              4.9. iptrtpproxy_set_param("o_name", value) 
-              4.10. iptrtpproxy_set_param("o_addr", value) 
-              4.11. iptrtpproxy_set_param("codec_set", value) 
-              4.12. iptrtpproxy_set_param("remove_codec_mask", value) 
+              5.9. iptrtpproxy_set_param("o_name", value)
+              5.10. iptrtpproxy_set_param("o_addr", value)
+              5.11. iptrtpproxy_set_param("codec_set", value)
+              5.12. iptrtpproxy_set_param("remove_codec_mask", value)
 
-        5. Selects
+        6. Selects
 
-              5.1. @iptrtpproxy.session_ids 
-              5.2. @iptrtpproxy.sdp_ip 
-              5.3. @iptrtpproxy.o_name 
-              5.4. @iptrtpproxy.o_addr 
-              5.5. @iptrtpproxy.auth_rights 
-              5.6. @iptrtpproxy.active_media_num 
+              6.1. @iptrtpproxy.session_ids
+              6.2. @iptrtpproxy.sdp_ip
+              6.3. @iptrtpproxy.o_name
+              6.4. @iptrtpproxy.o_addr
+              6.5. @iptrtpproxy.auth_rights
+              6.6. @iptrtpproxy.active_media_num
 
    List of Examples
 
@@ -67,104 +67,106 @@ Chapter 1. Admin Guide
    Table of Contents
 
    1. Overview
-   2. Dependencies
-   3. Parameters
+   2. Known limitations
+   3. Dependencies
+   4. Parameters
 
-        3.1. config (string)
-        3.2. switchboard (string)
-        3.3. rpc_heartbeat_timeout (int)
-        3.4. hostname (string)
-        3.5. declare_codec (string)
-        3.6. codec_set (string)
+        4.1. config (string)
+        4.2. switchboard (string)
+        4.3. rpc_heartbeat_timeout (int)
+        4.4. hostname (string)
+        4.5. declare_codec (string)
+        4.6. codec_set (string)
 
-   4. Functions
+   5. Functions
 
-        4.1. iptrtpproxy_alloc(gate_a_to_b [, existing_sess_ids]) 
-        4.2. iptrtpproxy_update(gate_a_to_b, session_ids) 
-        4.3. iptrtpproxy_adjust_timeout(gate_a_to_b, session_ids) 
-        4.4. iptrtpproxy_delete(session_ids) 
-        4.5. iptrtpproxy_authorize_media() 
-        4.6. iptrtpproxy_set_param(param, value) 
-        4.7.
-                iptrtpproxy_set_param("(aggregation/switchboard)_by_sip_ip_(a
-                /b)", sip_ip) 
+        5.1. iptrtpproxy_alloc(gate_a_to_b [, existing_sess_ids])
+        5.2. iptrtpproxy_update(gate_a_to_b, session_ids)
+        5.3. iptrtpproxy_adjust_timeout(gate_a_to_b, session_ids)
+        5.4. iptrtpproxy_delete(session_ids)
+        5.5. iptrtpproxy_authorize_media()
+        5.6. iptrtpproxy_set_param(param, value)
+        5.7.
+                iptrtpproxy_set_param("(aggregation/switchboard)_by_sip_ip_(a/
+                b)", sip_ip)
 
-        4.8. iptrtpproxy_set_param("protected_session_ids", sess_ids) 
-        4.9. iptrtpproxy_set_param("o_name", value) 
-        4.10. iptrtpproxy_set_param("o_addr", value) 
-        4.11. iptrtpproxy_set_param("codec_set", value) 
-        4.12. iptrtpproxy_set_param("remove_codec_mask", value) 
+        5.8. iptrtpproxy_set_param("protected_session_ids", sess_ids)
+        5.9. iptrtpproxy_set_param("o_name", value)
+        5.10. iptrtpproxy_set_param("o_addr", value)
+        5.11. iptrtpproxy_set_param("codec_set", value)
+        5.12. iptrtpproxy_set_param("remove_codec_mask", value)
 
-   5. Selects
+   6. Selects
 
-        5.1. @iptrtpproxy.session_ids 
-        5.2. @iptrtpproxy.sdp_ip 
-        5.3. @iptrtpproxy.o_name 
-        5.4. @iptrtpproxy.o_addr 
-        5.5. @iptrtpproxy.auth_rights 
-        5.6. @iptrtpproxy.active_media_num 
+        6.1. @iptrtpproxy.session_ids
+        6.2. @iptrtpproxy.sdp_ip
+        6.3. @iptrtpproxy.o_name
+        6.4. @iptrtpproxy.o_addr
+        6.5. @iptrtpproxy.auth_rights
+        6.6. @iptrtpproxy.active_media_num
 
 1. Overview
 
-   This   module   provides   similar   functionality  as  nathelper  but
-   communicates  with  netfilter  kernel  xt_RTPPROXY  module  using  the
-   libipt_RTPPROXY  userspace  library.  All  RTP streams are manipulated
-   directly  in  kernel space, no data is copied from kernel to userspace
+   This module provides similar functionality as nathelper but
+   communicates with netfilter kernel xt_RTPPROXY module using the
+   libipt_RTPPROXY userspace library. All RTP streams are manipulated
+   directly in kernel space, no data is copied from kernel to userspace
    and back, it reduces load and delay. See
    http://www.2p.cz/en/netfilter_rtp_proxy for more details.
 
-   This  Kamailio module is written as a light-weight module, there is no
-   dialog  managment  as  in  Nathelper.  The  reason is that such an API
-   should  be  provided  by  core or a specialized dialog manager module.
-   Because  such  module is not in git, session information may be stored
-   in  extra attributes of the avp_db module and the session id itself in
+   This Kamailio module is written as a light-weight module, there is no
+   dialog management as in Nathelper. The reason is that such an API
+   should be provided by core or a specialized dialog manager module.
+   Because such module is not in git, session information may be stored in
+   extra attributes of the avp_db module and the session id itself in
    record route as cookie, see the rr module.
 
-   It  should  be able to support all cases as re-invites when SIP client
-   offers  media  change in SDP and when number of medias in offer/answer
+   It should be able to support all cases as re-invites when SIP client
+   offers media change in SDP and when number of medias in offer/answer
    are different.
 
    Nathelper may be still used for testing if client is behind the NAT.
 
-   There  is  also  support for media authorization. Number of codec sets
-   may  be  defined.  When a message containing SDP offer/answer is being
+   There is also support for media authorization. Number of codec sets may
+   be defined. When a message containing SDP offer/answer is being
    processed then current codecs and streams may be inspected, removed or
    signallized according a codec set.
 
-   Limitations:
+2. Known limitations
+
      * Only IPv4 addresses are supported.
      * More media streams per session supported
 
-2. Dependencies
+3. Dependencies
 
-   The  following  libraries  or  applications  must  be installed before
+   The following libraries or applications must be installed before
    running Kamailio with this module loaded:
-     * netfilter       xt_RTPPROXY       &      libipt_RTPPROXY,      see
+     * netfilter xt_RTPPROXY & libipt_RTPPROXY, see
        http://www.2p.cz/en/netfilter_rtp_proxy
 
 Note
 
-   The  modules Makefile must be edited and iptdir setup to the directory
+   The modules Makefile must be edited and iptdir setup to the directory
    with the iptable sources (if different from ~/iptables). Alternatively
    compile the module using:
                 make -C modules/iptrtpproxy iptdir=path_to_iptables_src
 
-3. Parameters
+4. Parameters
 
-   3.1. config (string)
-   3.2. switchboard (string)
-   3.3. rpc_heartbeat_timeout (int)
-   3.4. hostname (string)
-   3.5. declare_codec (string)
-   3.6. codec_set (string)
+   4.1. config (string)
+   4.2. switchboard (string)
+   4.3. rpc_heartbeat_timeout (int)
+   4.4. hostname (string)
+   4.5. declare_codec (string)
+   4.6. codec_set (string)
 
-3.1. config (string)
+4.1. config (string)
 
-   References  iptrtpproxy.cfg,  see iptrtpproxy_helper. Default value is
-   /etc/iptrtpproxy.cfg.  If  only codec authorization is to be used then
+   References iptrtpproxy.cfg, see iptrtpproxy_helper. Default value is
+   /etc/iptrtpproxy.cfg. If only codec authorization is to be used then
    /dev/null may be used.
 
-3.2. switchboard (string)
+4.2. switchboard (string)
 
    References xt_RTPPROXY switchboard for usage by ser module.
 
@@ -173,156 +175,153 @@ Note
 
   name =  "aggregation" | "sip-addr-"
 
-   The  name  is  the  switchboard name as declared in config and will be
-   used  by  script  functions and references switchboard. It's mandatory
+   The name is the switchboard name as declared in config and will be used
+   by script functions and references switchboard. It's mandatory
    parameter. The special name * set values for all switchboards.
 
-   The  sip-addr  is  address used by iptrtpproxy_ser_param(by_sip_ip) to
-   find  a  switchboard  for  particular  connection.  If  not explicitly
-   configured  then  RTP  switchboard  gate  address  are  used  for this
-   feature.
+   The sip-addr is address used by iptrtpproxy_ser_param(by_sip_ip) to
+   find a switchboard for particular connection. If not explicitly
+   configured then RTP switchboard gate address are used for this feature.
 
-   The  aggregation enables to aggregate more switchboards in cluster and
-   to  widden  bandwidth.  Aggregation  will take sip-addr from the first
+   The aggregation enables to aggregate more switchboards in cluster and
+   to widden bandwidth. Aggregation will take sip-addr from the first
    switchboard of its.
 
    Example 1.1. Declare switchboard
         ...
         modparam("iptrtpproxy", "config", "/etc/iptrtpproxy.cfg");
-        modparam("iptrtpproxy", "switchboard", "name=my1;sip-addr-a=1.2.3.4;sip
--addr-b=5.6.7.8");
-        modparam("iptrtpproxy", "switchboard", "name=my2;sip-addr-a=2.3.4.5;sip
--addr-b=3.4.5.6;aggregation=my23");
+        modparam("iptrtpproxy", "switchboard", "name=my1;sip-addr-a=1.2.3.4;sip-
+addr-b=5.6.7.8");
+        modparam("iptrtpproxy", "switchboard", "name=my2;sip-addr-a=2.3.4.5;sip-
+addr-b=3.4.5.6;aggregation=my23");
         modparam("iptrtpproxy", "switchboard", "name=my3;aggregation=my23");
         modparam("iptrtpproxy", "switchboard", "name=*;aggregation=my123");
         ...
 
-3.3. rpc_heartbeat_timeout (int)
+4.3. rpc_heartbeat_timeout (int)
 
    Timeout in seconds used for rerequest remote RTP proxy via RPC command
    after preceeding error. In other words if a RPC server is unresponsive
-   at  the  moment  then  next attempt will be forced after this timeout.
+   at the moment then next attempt will be forced after this timeout.
    Default value is 30.
 
-3.4. hostname (string)
+4.4. hostname (string)
 
-   The  hostname  used by RPC to identify machine where Ser is running to
-   communicate  which  RTP  proxy  via  local interface. Default value is
-   taken from system hostname.
+   The hostname used by RPC to identify machine where Ser is running to
+   communicate which RTP proxy via local interface. Default value is taken
+   from system hostname.
 
-3.5. declare_codec (string)
+4.5. declare_codec (string)
 
    There are basic implicit codecs compiled in module, more codecs may be
    added by this parameter (one codec per modparam).
 
-3.6. codec_set (string)
+4.6. codec_set (string)
 
-   Declares  new  codec  set.  Codecs  are  declared  for each media type
+   Declares new codec set. Codecs are declared for each media type
    independently.
 
    The format is:
   "name=" value * ( ";" name "=" value )
 
   name =  "media_type" | "rights" | "codecs" | "max_streams" | ( "rtp" | "rtcp"
- ) "_" ( "bytes" | "packets" )
+) "_" ( "bytes" | "packets" )
 
   media_types = "audio" | "video" | "application" | "text" | "message" | "data"
- | "control" | "?" | "*"
+| "control" | "?" | "*"
 
    The name is the codec set name to be defined.
 
-   The  media_type  belongs  to  type at m= SDP line. Question mark means
+   The media_type belongs to type at m= SDP line. Question mark means
    "unknown media" type and asterisk "all media types".
 
-   The  max_streams  defines  how  many streams (m= lines) is allowed per
+   The max_streams defines how many streams (m= lines) is allowed per
    media type.
 
-   The  rights defines if particular codec is allowed 0, disallowed, i.e.
-   will  be  removed  if  bit  AND  operation  with  remove_codec_mask is
-   non-zero     or     its    presence    will    be    signallized    by
-   @iptrtpproxy.auth_rights (any other value).
+   The rights defines if particular codec is allowed 0, disallowed, i.e.
+   will be removed if bit AND operation with remove_codec_mask is non-zero
+   or its presence will be signallized by @iptrtpproxy.auth_rights (any
+   other value).
 
-   The  codecs comma separated list of codecs. Previous media_type&rights
+   The codecs comma separated list of codecs. Previous media_type&rights
    will be applied.
 
-   The  rtp/rtcp_bytes/packets  limits  bandwidth  per  media_type  (0 is
-   unlimited).     It     will     override    bandwidth    limited    by
+   The rtp/rtcp_bytes/packets limits bandwidth per media_type (0 is
+   unlimited). It will override bandwidth limited by
    iptrtpproxy_set_param("throttle_*").
 
    Example 1.2. Declare codec_set
         ...
         # enable all codecs, default state when codec is declared
-        modparam("iptrtpproxy", "codec_set", "name=cs1;media_type=*;max_streams
-=9999;rights=0;codecs=*");
+        modparam("iptrtpproxy", "codec_set", "name=cs1;media_type=*;max_streams=
+9999;rights=0;codecs=*");
         # allow only 2 audio and 1 video stream
-        modparam("iptrtpproxy", "codec_set", "name=cs2;media_type=*;max_streams
-=0;media_type=audio;max_streams=2;media_type=video;max_streams=1");
-        # dtto, allow only a few audio and video codecs, GSM codec is allowed b
-ut signallized
-        modparam("iptrtpproxy", "codec_set", "name=cs3;media_type=*;max_streams
-=0;rights=1;codecs=*;media_type=audio;max_streams=2;rights=0;codecs=PCMU,G729,G
-728,parityfec,telephone-events;rights=2;codecs=GSM;media_type=video;max_streams
-=1;rights=0;codecs=jpeg,parityfec");
-        # limit max. bandwidth for video¨
-        modparam("iptrtpproxy", "codec_set", "name=cs4;media_type=video;rtp_byt
-es=10000;rtcp_bytes=1000");
+        modparam("iptrtpproxy", "codec_set", "name=cs2;media_type=*;max_streams=
+0;media_type=audio;max_streams=2;media_type=video;max_streams=1");
+        # dtto, allow only a few audio and video codecs, GSM codec is allowed bu
+t signallized
+        modparam("iptrtpproxy", "codec_set", "name=cs3;media_type=*;max_streams=
+0;rights=1;codecs=*;media_type=audio;max_streams=2;rights=0;codecs=PCMU,G729,G72
+8,parityfec,telephone-events;rights=2;codecs=GSM;media_type=video;max_streams=1;
+rights=0;codecs=jpeg,parityfec");
+        # limit max. bandwidth for videoÂ¨
+        modparam("iptrtpproxy", "codec_set", "name=cs4;media_type=video;rtp_byte
+s=10000;rtcp_bytes=1000");
         ...
 
-4. Functions
+5. Functions
 
-   4.1. iptrtpproxy_alloc(gate_a_to_b [, existing_sess_ids]) 
-   4.2. iptrtpproxy_update(gate_a_to_b, session_ids) 
-   4.3. iptrtpproxy_adjust_timeout(gate_a_to_b, session_ids) 
-   4.4. iptrtpproxy_delete(session_ids) 
-   4.5. iptrtpproxy_authorize_media() 
-   4.6. iptrtpproxy_set_param(param, value) 
-   4.7.
-          iptrtpproxy_set_param("(aggregation/switchboard)_by_sip_ip_(a/b)",
-          sip_ip) 
+   5.1. iptrtpproxy_alloc(gate_a_to_b [, existing_sess_ids])
+   5.2. iptrtpproxy_update(gate_a_to_b, session_ids)
+   5.3. iptrtpproxy_adjust_timeout(gate_a_to_b, session_ids)
+   5.4. iptrtpproxy_delete(session_ids)
+   5.5. iptrtpproxy_authorize_media()
+   5.6. iptrtpproxy_set_param(param, value)
+   5.7. iptrtpproxy_set_param("(aggregation/switchboard)_by_sip_ip_(a/b)",
+          sip_ip)
 
-   4.8. iptrtpproxy_set_param("protected_session_ids", sess_ids) 
-   4.9. iptrtpproxy_set_param("o_name", value) 
-   4.10. iptrtpproxy_set_param("o_addr", value) 
-   4.11. iptrtpproxy_set_param("codec_set", value) 
-   4.12. iptrtpproxy_set_param("remove_codec_mask", value) 
+   5.8. iptrtpproxy_set_param("protected_session_ids", sess_ids)
+   5.9. iptrtpproxy_set_param("o_name", value)
+   5.10. iptrtpproxy_set_param("o_addr", value)
+   5.11. iptrtpproxy_set_param("codec_set", value)
+   5.12. iptrtpproxy_set_param("remove_codec_mask", value)
 
-4.1.  iptrtpproxy_alloc(gate_a_to_b [, existing_sess_ids])
+5.1.  iptrtpproxy_alloc(gate_a_to_b [, existing_sess_ids])
 
-   Parses  SDP  content  and  allocates for each RTP media stream one RTP
-   proxy   session.   SDP  is  updates  to  reflect  allocated  sessions.
-   Switchboard/aggregation  is set using iptrtpproxy_set_param(by_sip_ip)
+   Parses SDP content and allocates for each RTP media stream one RTP
+   proxy session. SDP is updates to reflect allocated sessions.
+   Switchboard/aggregation is set using iptrtpproxy_set_param(by_sip_ip)
    or iptrtpproxy_set_param("switchboard/aggregation").
 
-   Aggregation  supports load balancing among more RTP proxies controlled
-   by  RPC.  The  module  try  to  allocate  at  machines/switchboards in
-   following  order  (priorities)  not  yet  asked (or being heartbeated)
-   machines,  responsive  machines,  switchboards having percentualy more
+   Aggregation supports load balancing among more RTP proxies controlled
+   by RPC. The module try to allocate at machines/switchboards in
+   following order (priorities) not yet asked (or being heartbeated)
+   machines, responsive machines, switchboards having percentualy more
    free slots, non responsive machines.
 
-   Proxy   may   hide   caller   identity   provided  at  o=  line  using
-   @iptrtpproxy.o_name/addr     and    iptrtpproxy_set_param(o_name/addr)
-   functions.  But  the  script is responsible for rewritting to original
-   values  in  a  response  or  a  callee  initiated re-INVITE. Therefore
+   Proxy may hide caller identity provided at o= line using
+   @iptrtpproxy.o_name/addr and iptrtpproxy_set_param(o_name/addr)
+   functions. But the script is responsible for rewritting to original
+   values in a response or a callee initiated re-INVITE. Therefore
    original value need to be stored in-dialog.
-     * if  gate_a_to_b  bit 0 is set then SDP regards to gate-a to gate-b
+     * if gate_a_to_b bit 0 is set then SDP regards to gate-a to gate-b
        direction.
-     * protected_session_ids  list  of  existing sessions enables reusing
-       already  allocated  sessions  in  re-INVITE without allocating new
-       sessions  for each stream in SDP regardless a IP/port is required.
+     * protected_session_ids list of existing sessions enables reusing
+       already allocated sessions in re-INVITE without allocating new
+       sessions for each stream in SDP regardless a IP/port is required.
        It's mostly undesirable, typically "hold-on" is done via re-INVITE
        without any change. There is drawback because callee cannot change
-       IP:port  in 200OK which is legal case in RFC3264. But because some
-       non-RFC3264  compliant  phones dislike proactively changed IP:port
-       at RTP proxy it seems it's less evil.
-     * function  returns  true  is  a  session was created, identifier is
+       IP:port in 200OK which is legal case in RFC3264. But because some
+       non-RFC3264 compliant phones dislike proactively changed IP:port at
+       RTP proxy it seems it's less evil.
+     * function returns true is a session was created, identifier is
        available via select @iptrtpproxy.session_ids.
 
    Example 1.3. iptrtpproxy_alloc usage
         ...
-        if (!iptrtpproxy_set_param("aggregation_by_sip_ip_a", "@received.ip"))
-{
-                if (!iptrtpproxy_set_param("switchboard_by_sip_ip_a", "@receive
-d.ip")) {
+        if (!iptrtpproxy_set_param("aggregation_by_sip_ip_a", "@received.ip")) {
+                if (!iptrtpproxy_set_param("switchboard_by_sip_ip_a", "@received
+.ip")) {
                         t_reply("500", "RTP proxy error");
                         drop;
                 }
@@ -330,19 +329,19 @@ d.ip")) {
         eval_push("x:%@next_hop.src_ip");
         if (@eval.get[-1] == @received.ip) {
                 if (@iptrtpproxy.aggregation_a) {
-                        iptrtpproxy_set_param("aggregation_b", "@iptrtpproxy.ag
-gregation_a");
+                        iptrtpproxy_set_param("aggregation_b", "@iptrtpproxy.agg
+regation_a");
                 }
                 else {
-                        iptrtpproxy_set_param("switchboard_b", "@iptrtpproxy.sw
-itchboard_a");
+                        iptrtpproxy_set_param("switchboard_b", "@iptrtpproxy.swi
+tchboard_a");
                 }
         }
         else {
-                if (!iptrtpproxy_set_param("aggregation_by_sip_ip_b", "@eval.ge
-t[-1]")) {
-                        if (!iptrtpproxy_set_param("switchboard_by_sip_ip_b", "
-@eval.get[-1]")) {
+                if (!iptrtpproxy_set_param("aggregation_by_sip_ip_b", "@eval.get
+[-1]")) {
+                        if (!iptrtpproxy_set_param("switchboard_by_sip_ip_b", "@
+eval.get[-1]")) {
                                 t_reply("500", "RTP proxy error");
                                 drop;
                         }
@@ -357,22 +356,22 @@ t[-1]")) {
         $sess_ids = @iptrtpproxy.session_ids;
         ...
 
-4.2.  iptrtpproxy_update(gate_a_to_b, session_ids)
+5.2.  iptrtpproxy_update(gate_a_to_b, session_ids)
 
-   Parses  SDP  content  and updates sessions provided by session_ids and
-   updates  SDP.  If  succesfull then session_ids may be changed (in case
-   e.g.  media  stream has port zero particular session is released), the
-   result   of  @iptrtpproxy.session_ids  should  be  stored  for  future
+   Parses SDP content and updates sessions provided by session_ids and
+   updates SDP. If succesfull then session_ids may be changed (in case
+   e.g. media stream has port zero particular session is released), the
+   result of @iptrtpproxy.session_ids should be stored for future
    in-dialog usage.
 
    The SDP contect is also affected by iptrtpproxy_set_param(o_name/addr)
-   functions.  If  a  stream  is  deactivated in SDP then Sessions may be
+   functions. If a stream is deactivated in SDP then Sessions may be
    deleted unless mentioned in protected_session_ids.
-     * if  gate_a_to_b  bit 0 is set then SDP regards to gate-a to gate-b
+     * if gate_a_to_b bit 0 is set then SDP regards to gate-a to gate-b
        direction.
-       if  gate_a_to_b  bit  1  is  set  then SDP is updated only, no RTP
-       session  are affected. Should be used when handling retransmission
-       in  onreply  route,  retransmission  replies  are  not eaten be tm
+       if gate_a_to_b bit 1 is set then SDP is updated only, no RTP
+       session are affected. Should be used when handling retransmission
+       in onreply route, retransmission replies are not eaten be tm
        module!
 
    Example 1.4. iptrtpproxy_update usage
@@ -384,11 +383,11 @@ t[-1]")) {
         }
         ...
 
-4.3.  iptrtpproxy_adjust_timeout(gate_a_to_b, session_ids)
+5.3.  iptrtpproxy_adjust_timeout(gate_a_to_b, session_ids)
 
-   Adjust  timeout  for particular gate. It's useful in "200 OK" decrease
+   Adjust timeout for particular gate. It's useful in "200 OK" decrease
    timeout to learning timeout if INVITE has set (long) ringing timeout.
-     * if  gate_a_to_b  bit  0 is set then it regards to gate-a to gate-b
+     * if gate_a_to_b bit 0 is set then it regards to gate-a to gate-b
        direction.
 
    Example 1.5. iptrtpproxy_adjust_timeout usage
@@ -404,11 +403,11 @@ t[-1]")) {
         }
         ...
 
-4.4.  iptrtpproxy_delete(session_ids)
+5.4.  iptrtpproxy_delete(session_ids)
 
-   Delete  sessions identified by session_ids. May be used when dialog is
-   being  destroyed  (BYE)  or  when  INVITE  failed in failure route. If
-   protected_session_ids  list is provided then this set is excluded from
+   Delete sessions identified by session_ids. May be used when dialog is
+   being destroyed (BYE) or when INVITE failed in failure route. If
+   protected_session_ids list is provided then this set is excluded from
    sessions to be deleted.
 
    Example 1.6. iptrtpproxy_delete usage
@@ -417,16 +416,16 @@ t[-1]")) {
         iptrtpproxy_delete($sess_ids);
         ...
 
-4.5.  iptrtpproxy_authorize_media()
+5.5.  iptrtpproxy_authorize_media()
 
    Authorizes SDP media according currect codec_set. If bit AND operation
-   between  rights  in  codec  set and remove_codec_mask is non zero then
-   such  a  codec  are  to  be  removed.  The result may be obtained from
-   @iptrtpproxy.auth_rights  which  returns  max.  right  which  has been
+   between rights in codec set and remove_codec_mask is non zero then such
+   a codec are to be removed. The result may be obtained from
+   @iptrtpproxy.auth_rights which returns max. right which has been
    applied when processing all codecs of enabled streams.
 
-   The  function  MUST  NOT be called after iptrtpproxy_alloc/update! But
-   the function may be called several times to authorize using more codec
+   The function MUST NOT be called after iptrtpproxy_alloc/update! But the
+   function may be called several times to authorize using more codec
    sets.
 
    Example 1.7. iptrtpproxy_authorize_media usage
@@ -455,91 +454,90 @@ t[-1]")) {
         }
         ...
 
-4.6.  iptrtpproxy_set_param(param, value)
+5.6.  iptrtpproxy_set_param(param, value)
 
    Set particular parameter needed mainly by
-   iptrtpproxy_alloc/update/adjust_timeout.   The   paramter   value   is
-   availble via @iptrtpproxy.<param>.
-     * Supported  parameters:  expiration_timeout, ttl, learning_timeout,
-       always_learn,    aggregation_a,    aggregation_b,   switchboard_a,
-       switchboard_b,        throttle_mark,       throttle_rtp_max_bytes,
-       throttle_rtp_max_packets,                 throttle_rtcp_max_bytes,
+   iptrtpproxy_alloc/update/adjust_timeout. The paramter value is availble
+   via @iptrtpproxy.<param>.
+     * Supported parameters: expiration_timeout, ttl, learning_timeout,
+       always_learn, aggregation_a, aggregation_b, switchboard_a,
+       switchboard_b, throttle_mark, throttle_rtp_max_bytes,
+       throttle_rtp_max_packets, throttle_rtcp_max_bytes,
        throttle_rtcp_max_packets.
 
-4.7.  iptrtpproxy_set_param("(aggregation/switchboard)_by_sip_ip_(a/b)",
+5.7.  iptrtpproxy_set_param("(aggregation/switchboard)_by_sip_ip_(a/b)",
 sip_ip)
 
-   Find    corresponding    aggregation    or    switchboard    and   set
-   @iptrtpproxy.aggregation_a/b      or     @iptrtpproxy.switchboard_a/b.
-   Switchboards/aggregations  are  compared  against  sip-addr,  it allow
+   Find corresponding aggregation or switchboard and set
+   @iptrtpproxy.aggregation_a/b or @iptrtpproxy.switchboard_a/b.
+   Switchboards/aggregations are compared against sip-addr, it allow
    separate SIP and RTP traffic and RTP aggregation.
-     * sip_ip    IP   to   be   compared,   typically   @received.ip   or
+     * sip_ip IP to be compared, typically @received.ip or
        @next_hop.src_ip.
      * function returns true if switchboard/aggregation was found
 
-4.8.  iptrtpproxy_set_param("protected_session_ids", sess_ids)
+5.8.  iptrtpproxy_set_param("protected_session_ids", sess_ids)
 
    Used for reusing sessions in iptrtpproxy_alloc, iptrtpproxy_update and
    iptrtpproxy_delete.
 
-4.9.  iptrtpproxy_set_param("o_name", value)
+5.9.  iptrtpproxy_set_param("o_name", value)
 
-   Username  to  be  rewritten  at o= line by iptrtpproxy_alloc/update to
-   hide  caller  identity.  If  value  is  blank  then  username  is left
-   unchanged.
+   Username to be rewritten at o= line by iptrtpproxy_alloc/update to hide
+   caller identity. If value is blank then username is left unchanged.
 
-4.10.  iptrtpproxy_set_param("o_addr", value)
+5.10.  iptrtpproxy_set_param("o_addr", value)
 
    Address to be rewritten at o= line by iptrtpproxy_alloc/update to hide
    caller identity. If value is blank then address is left unchanged.
 
-4.11.  iptrtpproxy_set_param("codec_set", value)
+5.11.  iptrtpproxy_set_param("codec_set", value)
 
-   Codec  set  for  iptrtpproxy_authorize_media. Current codec set may be
+   Codec set for iptrtpproxy_authorize_media. Current codec set may be
    obtained by @iptrtpproxy.codec_set.
 
-4.12.  iptrtpproxy_set_param("remove_codec_mask", value)
+5.12.  iptrtpproxy_set_param("remove_codec_mask", value)
 
    Mask used in iptrtpproxy_authorize_media. Current mask may be obtained
    by @iptrtpproxy.remove_codec_mask.
 
-5. Selects
+6. Selects
 
-   5.1. @iptrtpproxy.session_ids 
-   5.2. @iptrtpproxy.sdp_ip 
-   5.3. @iptrtpproxy.o_name 
-   5.4. @iptrtpproxy.o_addr 
-   5.5. @iptrtpproxy.auth_rights 
-   5.6. @iptrtpproxy.active_media_num 
+   6.1. @iptrtpproxy.session_ids
+   6.2. @iptrtpproxy.sdp_ip
+   6.3. @iptrtpproxy.o_name
+   6.4. @iptrtpproxy.o_addr
+   6.5. @iptrtpproxy.auth_rights
+   6.6. @iptrtpproxy.active_media_num
 
-5.1.  @iptrtpproxy.session_ids
+6.1.  @iptrtpproxy.session_ids
 
    Returns sessions allocated/updated in iptrtpproxy_alloc/update.
 
    The format is:
-switchboard_name [ ":" [ session_id "/" created ] * ( "," session_id "/" create
-d ) ] ]
+switchboard_name [ ":" [ session_id "/" created ] * ( "," session_id "/" created
+ ) ] ]
 session_id = * ( [0-9] )   ; empty when no session allocated
 created = timestamp
 
-5.2.  @iptrtpproxy.sdp_ip
+6.2.  @iptrtpproxy.sdp_ip
 
    Return first rewritten IP provided at SDP c= line.
 
-5.3.  @iptrtpproxy.o_name
+6.3.  @iptrtpproxy.o_name
 
    Return username from original o= line.
 
-5.4.  @iptrtpproxy.o_addr
+6.4.  @iptrtpproxy.o_addr
 
    Return address from original o= line.
 
-5.5.  @iptrtpproxy.auth_rights
+6.5.  @iptrtpproxy.auth_rights
 
    Result of iptrtpproxy_authorize_media.
 
-5.6.  @iptrtpproxy.active_media_num
+6.6.  @iptrtpproxy.active_media_num
 
-   Returns     number     of     active    media    streams    in    SDP.
-   iptrtpproxy_authorize_media  may  disable  some streams, i.e. returned
+   Returns number of active media streams in SDP.
+   iptrtpproxy_authorize_media may disable some streams, i.e. returned
    value may change after authorization.

--- a/modules/iptrtpproxy/doc/iptrtpproxy_admin.xml
+++ b/modules/iptrtpproxy/doc/iptrtpproxy_admin.xml
@@ -48,10 +48,11 @@
 	When a message containing SDP offer/answer is being processed then current codecs
 	and streams may be inspected, removed or signallized according a codec set.
 	</para>
+    </section>
 
 
-	<para>
-	Limitations:
+    <section id="iptrtpproxy.known_limitations">
+	<title>Known limitations</title>
 	<itemizedlist>
 		<listitem>
 			<para>
@@ -64,7 +65,6 @@
 			</para>
 		</listitem>
 	</itemizedlist>
-	</para>
     </section>
 
 	<section id="iptrtpproxy.dep">

--- a/modules/jsonrpc-s/README
+++ b/modules/jsonrpc-s/README
@@ -10,7 +10,7 @@ Daniel-Constantin Mierla
 
    <miconda@gmail.com>
 
-   Copyright � 2014 asipto.com
+   Copyright © 2014 asipto.com
      __________________________________________________________________
 
    Table of Contents
@@ -18,33 +18,31 @@ Daniel-Constantin Mierla
    1. Admin Guide
 
         1. Overview
+        2. Limitations
+        3. Dependencies
 
-              1.1. Limitations
+              3.1. Kamailio Modules
+              3.2. External Libraries or Applications
 
-        2. Dependencies
+        4. Parameters
 
-              2.1. Kamailio Modules
-              2.2. External Libraries or Applications
+              4.1. pretty_format (int)
+              4.2. transport (int)
+              4.3. fifo_name (str)
+              4.4. fifo_mode (int)
+              4.5. fifo_group (int or str)
+              4.6. fifo_user (int or str)
+              4.7. fifo_reply_dir (str)
 
-        3. Parameters
+        5. Functions
 
-              3.1. pretty_format (int)
-              3.2. transport (int)
-              3.3. fifo_name (str)
-              3.4. fifo_mode (int)
-              3.5. fifo_group (int or str)
-              3.6. fifo_user (int or str)
-              3.7. fifo_reply_dir (str)
+              5.1. jsonrpc_dispatch()
+              5.2. jsonrpc_exec(cmd)
 
-        4. Functions
+        6. JSONRPC Transports
 
-              4.1. jsonrpc_dispatch()
-              4.2. jsonrpc_exec(cmd)
-
-        5. JSONRPC Transports
-
-              5.1. JSONRPC Over HTTP
-              5.2. JSONRPC Over FIFO
+              6.1. JSONRPC Over HTTP
+              6.2. JSONRPC Over FIFO
 
    List of Examples
 
@@ -65,37 +63,33 @@ Chapter 1. Admin Guide
    Table of Contents
 
    1. Overview
+   2. Limitations
+   3. Dependencies
 
-        1.1. Limitations
+        3.1. Kamailio Modules
+        3.2. External Libraries or Applications
 
-   2. Dependencies
+   4. Parameters
 
-        2.1. Kamailio Modules
-        2.2. External Libraries or Applications
+        4.1. pretty_format (int)
+        4.2. transport (int)
+        4.3. fifo_name (str)
+        4.4. fifo_mode (int)
+        4.5. fifo_group (int or str)
+        4.6. fifo_user (int or str)
+        4.7. fifo_reply_dir (str)
 
-   3. Parameters
+   5. Functions
 
-        3.1. pretty_format (int)
-        3.2. transport (int)
-        3.3. fifo_name (str)
-        3.4. fifo_mode (int)
-        3.5. fifo_group (int or str)
-        3.6. fifo_user (int or str)
-        3.7. fifo_reply_dir (str)
+        5.1. jsonrpc_dispatch()
+        5.2. jsonrpc_exec(cmd)
 
-   4. Functions
+   6. JSONRPC Transports
 
-        4.1. jsonrpc_dispatch()
-        4.2. jsonrpc_exec(cmd)
-
-   5. JSONRPC Transports
-
-        5.1. JSONRPC Over HTTP
-        5.2. JSONRPC Over FIFO
+        6.1. JSONRPC Over HTTP
+        6.2. JSONRPC Over FIFO
 
 1. Overview
-
-   1.1. Limitations
 
    This module provides a JSON-RPC v2 server over HTTP implementation,
    tailored for the needs of Kamailio. It implements the Kamailio RPC
@@ -107,7 +101,7 @@ Chapter 1. Admin Guide
    The JSONRPC-S module uses the xHTTP module to handle HTTP/S requests.
    Read the documentation of the xHTTP module for more details.
 
-1.1. Limitations
+2. Limitations
 
      * This module does not implement asynchronous RPC commands. It is
        unlikely that asynchronous RPC commands will be executed from an
@@ -116,33 +110,33 @@ Chapter 1. Admin Guide
        the RPC documentation for more info about how parameters can be
        passed to RPC).
 
-2. Dependencies
+3. Dependencies
 
-   2.1. Kamailio Modules
-   2.2. External Libraries or Applications
+   3.1. Kamailio Modules
+   3.2. External Libraries or Applications
 
-2.1. Kamailio Modules
+3.1. Kamailio Modules
 
    The following modules must be loaded before this module:
      * xhttp - xHTTP.
 
-2.2. External Libraries or Applications
+3.2. External Libraries or Applications
 
    The following libraries or applications must be installed before
    running Kamailio with this module loaded:
      * None
 
-3. Parameters
+4. Parameters
 
-   3.1. pretty_format (int)
-   3.2. transport (int)
-   3.3. fifo_name (str)
-   3.4. fifo_mode (int)
-   3.5. fifo_group (int or str)
-   3.6. fifo_user (int or str)
-   3.7. fifo_reply_dir (str)
+   4.1. pretty_format (int)
+   4.2. transport (int)
+   4.3. fifo_name (str)
+   4.4. fifo_mode (int)
+   4.5. fifo_group (int or str)
+   4.6. fifo_user (int or str)
+   4.7. fifo_reply_dir (str)
 
-3.1. pretty_format (int)
+4.1. pretty_format (int)
 
    Pretty format for JSON-RPC response document.
 
@@ -153,7 +147,7 @@ Chapter 1. Admin Guide
 modparam("jsonrpc-s", "pretty_format", 1)
 ...
 
-3.2. transport (int)
+4.2. transport (int)
 
    Control what transports are enabled. The value can be:
      * 0 - all transports that can be enabled. For http, the xhttp module
@@ -168,7 +162,7 @@ modparam("jsonrpc-s", "pretty_format", 1)
 modparam("jsonrpc-s", "transport", 1)
 ...
 
-3.3. fifo_name (str)
+4.3. fifo_name (str)
 
    The name of the FIFO file to be created for listening and reading
    external commands. If the given path is not absolute, the fifo file is
@@ -181,7 +175,7 @@ modparam("jsonrpc-s", "transport", 1)
 modparam("jsonrpc-s", "fifo_name", "/tmp/kamailio_jsonrpc_fifo")
 ...
 
-3.4. fifo_mode (int)
+4.4. fifo_mode (int)
 
    Permission to be used for creating the listening FIFO file. It follows
    the UNIX conventions.
@@ -193,7 +187,7 @@ modparam("jsonrpc-s", "fifo_name", "/tmp/kamailio_jsonrpc_fifo")
 modparam("jsonrpc-s", "fifo_mode", 0600)
 ...
 
-3.5. fifo_group (int or str)
+4.5. fifo_group (int or str)
 
    System Group to be used for creating the listening FIFO file.
 
@@ -205,7 +199,7 @@ modparam("jsonrpc-s", "fifo_group", 0)
 modparam("jsonrpc-s", "fifo_group", "root")
 ...
 
-3.6. fifo_user (int or str)
+4.6. fifo_user (int or str)
 
    System User to be used for creating the listening FIFO file.
 
@@ -217,23 +211,23 @@ modparam("jsonrpc-s", "fifo_user", 0)
 modparam("jsonrpc-s", "fifo_user", "root")
 ...
 
-3.7. fifo_reply_dir (str)
+4.7. fifo_reply_dir (str)
 
    Directory to be used for creating the reply FIFO files.
 
-   Default value is "/tmp/"
+   Default value is “/tmp/”
 
    Example 1.7. Set fifo_reply_dir parameter
 ...
 modparam("jsonrpc-s", "fifo_reply_dir", "/home/kamailio/tmp/")
 ...
 
-4. Functions
+5. Functions
 
-   4.1. jsonrpc_dispatch()
-   4.2. jsonrpc_exec(cmd)
+   5.1. jsonrpc_dispatch()
+   5.2. jsonrpc_exec(cmd)
 
-4.1. jsonrpc_dispatch()
+5.1.  jsonrpc_dispatch()
 
    Handle the JSONRPC request and generate a response.
 
@@ -280,7 +274,7 @@ event_route[xhttp:request] {
 }
 ...
 
-4.2. jsonrpc_exec(cmd)
+5.2.  jsonrpc_exec(cmd)
 
    Execute a JSON-RPC command given as a parameter.
 
@@ -293,17 +287,17 @@ event_route[xhttp:request] {
 jsonrpc_exec({"jsonrpc": "2.0", "method": "dispatcher.reload", "id": 1}');
 ...
 
-5. JSONRPC Transports
+6. JSONRPC Transports
 
-   5.1. JSONRPC Over HTTP
-   5.2. JSONRPC Over FIFO
+   6.1. JSONRPC Over HTTP
+   6.2. JSONRPC Over FIFO
 
    JSONRPC specifications do not enforce a specific transport to carry the
    JSON documents. Very common is JSONRPC over HTTP or HTTPS, and they are
    supported by Kamailio. In addition, Kamailio supports receiving JSON
    documents via a local FIFO file.
 
-5.1. JSONRPC Over HTTP
+6.1. JSONRPC Over HTTP
 
    It requires that XHTTP module is loaded. HTTPS can be used if you
    enable TLS for Kamailio. The JSONRPC requests have to be sent to the
@@ -313,7 +307,7 @@ jsonrpc_exec({"jsonrpc": "2.0", "method": "dispatcher.reload", "id": 1}');
 
    The format of the JSON document must follow the JSONRPC specifications.
 
-5.2. JSONRPC Over FIFO
+6.2. JSONRPC Over FIFO
 
    This module can retrive JSONRPC requests via a local FIFO file. To
    enable this feature, 'fifo_name' parameter must be set and 'transport'

--- a/modules/jsonrpc-s/doc/jsonrpc-s_admin.xml
+++ b/modules/jsonrpc-s/doc/jsonrpc-s_admin.xml
@@ -28,6 +28,7 @@
 		The JSONRPC-S module uses the xHTTP module to handle HTTP/S requests.
 		Read the documentation of the xHTTP module for more details.
 	</para>
+	</section>
 
 	<section>
 	<title>Limitations</title>
@@ -47,7 +48,6 @@
 	</para>
 	</listitem>
 	</itemizedlist>
-	</section>
 	</section>
 
 	<section>

--- a/modules/purple/README
+++ b/modules/purple/README
@@ -19,24 +19,25 @@ Eric Ptak
    1. Admin Guide
 
         1. Overview
-        2. Dependencies
+        2. Known limitations
+        3. Dependencies
 
-              2.1. Kamailio Modules
-              2.2. External Libraries or Applications
+              3.1. Kamailio Modules
+              3.2. External Libraries or Applications
 
-        3. Database
-        4. Parameters
+        4. Database
+        5. Parameters
 
-              4.1. db_url (str)
-              4.2. db_table (str)
-              4.3. httpProxy_host (str)
-              4.4. httpProxy_port (int)
+              5.1. db_url (str)
+              5.2. db_table (str)
+              5.3. httpProxy_host (str)
+              5.4. httpProxy_port (int)
 
-        5. Functions
+        6. Functions
 
-              5.1. purple_send_message()
-              5.2. purple_handle_publish()
-              5.3. purple_handle_subscribe()
+              6.1. purple_send_message()
+              6.2. purple_handle_publish()
+              6.3. purple_handle_subscribe()
 
    List of Examples
 
@@ -56,24 +57,25 @@ Chapter 1. Admin Guide
    Table of Contents
 
    1. Overview
-   2. Dependencies
+   2. Known limitations
+   3. Dependencies
 
-        2.1. Kamailio Modules
-        2.2. External Libraries or Applications
+        3.1. Kamailio Modules
+        3.2. External Libraries or Applications
 
-   3. Database
-   4. Parameters
+   4. Database
+   5. Parameters
 
-        4.1. db_url (str)
-        4.2. db_table (str)
-        4.3. httpProxy_host (str)
-        4.4. httpProxy_port (int)
+        5.1. db_url (str)
+        5.2. db_table (str)
+        5.3. httpProxy_host (str)
+        5.4. httpProxy_port (int)
 
-   5. Functions
+   6. Functions
 
-        5.1. purple_send_message()
-        5.2. purple_handle_publish()
-        5.3. purple_handle_subscribe()
+        6.1. purple_send_message()
+        6.2. purple_handle_publish()
+        6.3. purple_handle_subscribe()
 
 1. Overview
 
@@ -100,28 +102,29 @@ Chapter 1. Admin Guide
    Before starting Kamailio use (adapt the path to your environment):
                 export LD_PRELOAD=$LD_PRELOAD:/usr/local/lib/libpurple.so
 
-   Limitations: doesn't implement authorization requests from external
-   accounts to SIP.
+2. Known limitations
 
-2. Dependencies
+   Doesn't implement authorization requests from external accounts to SIP.
 
-   2.1. Kamailio Modules
-   2.2. External Libraries or Applications
+3. Dependencies
 
-2.1. Kamailio Modules
+   3.1. Kamailio Modules
+   3.2. External Libraries or Applications
+
+3.1. Kamailio Modules
 
    The following modules must be loaded before this module:
      * presence*.
      * pua.
      * database driver module (db_mysql, ...).
 
-2.2. External Libraries or Applications
+3.2. External Libraries or Applications
 
    The following libraries or applications must be installed before
    running Kamailio with this module loaded:
      * libpurple, e.g. from pidgin 2.5.2.
 
-3. Database
+4. Database
 
    The database is used to map SIP URIs with external accounts (eg. MSN).
 
@@ -167,25 +170,25 @@ CREATE TABLE purplemap (
 );
 ...
 
-4. Parameters
+5. Parameters
 
-   4.1. db_url (str)
-   4.2. db_table (str)
-   4.3. httpProxy_host (str)
-   4.4. httpProxy_port (int)
+   5.1. db_url (str)
+   5.2. db_table (str)
+   5.3. httpProxy_host (str)
+   5.4. httpProxy_port (int)
 
-4.1. db_url (str)
+5.1. db_url (str)
 
    The URL to connect to database.
 
-   Default value is “mysql://openserro:openserro@localhost/openser”.
+   Default value is “mysql://kamailioro:kamailioro@localhost/kamailio”.
 
    Example 1.4. Set db_url parameter
 ...
 modparam("purple", "db_url", "dbdriver://username:password@dbhost/dbname")
 ...
 
-4.2. db_table (str)
+5.2. db_table (str)
 
    Database table name.
 
@@ -196,7 +199,7 @@ modparam("purple", "db_url", "dbdriver://username:password@dbhost/dbname")
 modparam("purple", "db_table", "purplemap")
 ...
 
-4.3. httpProxy_host (str)
+5.3. httpProxy_host (str)
 
    Address of HTTP proxy.
 
@@ -207,7 +210,7 @@ modparam("purple", "db_table", "purplemap")
 modparam("purple", "httpProxy_host", "10.26.52.12")
 ...
 
-4.4. httpProxy_port (int)
+5.4. httpProxy_port (int)
 
    Port of HTTP proxy.
 
@@ -218,13 +221,13 @@ modparam("purple", "httpProxy_host", "10.26.52.12")
 modparam("purple", "httpProxy_port", 3128)
 ...
 
-5. Functions
+6. Functions
 
-   5.1. purple_send_message()
-   5.2. purple_handle_publish()
-   5.3. purple_handle_subscribe()
+   6.1. purple_send_message()
+   6.2. purple_handle_publish()
+   6.3. purple_handle_subscribe()
 
-5.1.  purple_send_message()
+6.1.  purple_send_message()
 
    Send message to a purple destination.
 
@@ -241,7 +244,7 @@ if (is_method("MESSAGE")) {
 }
 ...
 
-5.2.  purple_handle_publish()
+6.2.  purple_handle_publish()
 
    Handle PUBLISH to a purple destination.
 
@@ -256,7 +259,7 @@ if(is_method("PUBLISH")) {
 }
 ...
 
-5.3.  purple_handle_subscribe()
+6.3.  purple_handle_subscribe()
 
    Handle SUBSCRIBE to a purple destination.
 

--- a/modules/purple/doc/purple_admin.xml
+++ b/modules/purple/doc/purple_admin.xml
@@ -50,9 +50,11 @@
 	<programlisting>
 		export LD_PRELOAD=$LD_PRELOAD:/usr/local/lib/libpurple.so
 	</programlisting>
+	</section>
+	<section>
+	<title>Known limitations</title>
 	<para>
-		Limitations: doesn't implement authorization requests from external
-		accounts to SIP.
+		Doesn't implement authorization requests from external accounts to SIP.
 	</para>
 	</section>
 

--- a/modules/textops/README
+++ b/modules/textops/README
@@ -11,19 +11,15 @@ Andrei Pelinescu-Onciul
 
    <pelinescu-onciul@fokus.fraunhofer.de>
 
-Edited by
-
 Daniel-Constantin Mierla
 
    <miconda@gmail.com>
-
-Edited by
 
 Juha Heinanen
 
    <jh@tutpro.com>
 
-   Copyright � 2003 FhG FOKUS
+   Copyright © 2003 FhG FOKUS
      __________________________________________________________________
 
    Table of Contents
@@ -31,61 +27,57 @@ Juha Heinanen
    1. Admin Guide
 
         1. Overview
+        2. Known Limitations
+        3. Dependencies
 
-              1.1. Known Limitations
+              3.1. Kamailio Modules
+              3.2. External Libraries or Applications
 
-        2. Dependencies
+        4. Functions
 
-              2.1. Kamailio Modules
-              2.2. External Libraries or Applications
-
-        3. Functions
-
-              3.1. search(re)
-              3.2. search_body(re)
-              3.3. search_hf(hf, re, flags)
-              3.4. search_append(re, txt)
-              3.5. search_append_body(re, txt)
-              3.6. replace(re, txt)
-              3.7. replace_body(re, txt)
-              3.8. replace_all(re, txt)
-              3.9. replace_body_all(re, txt)
-              3.10. replace_body_atonce(re, txt)
-              3.11. subst('/re/repl/flags')
-              3.12. subst_uri('/re/repl/flags')
-              3.13. subst_user('/re/repl/flags')
-              3.14. subst_body('/re/repl/flags')
-              3.15. subst_hf(hf, subexp, flags)
-              3.16. set_body(txt,content_type)
-              3.17. set_reply_body(txt,content_type)
-              3.18. filter_body(content_type)
-              3.19. append_to_reply(txt)
-              3.20. append_hf(txt[, hdr])
-              3.21. insert_hf(txt[, hdr])
-              3.22. append_urihf(prefix, suffix)
-              3.23. is_present_hf(hf_name)
-              3.24. is_present_hf_re(hf_name_re)
-              3.25. append_time()
-              3.26. append_time_to_request()
-              3.27. is_method(name)
-              3.28. remove_hf(hname)
-              3.29. remove_hf_re(re)
-              3.30. has_body(), has_body(mime)
-              3.31. is_audio_on_hold()
-              3.32. is_privacy(privacy_type)
-              3.33. in_list(subject, list, separator)
-              3.34. cmp_str(str1, str2)
-              3.35. cmp_istr(str1, str2)
-              3.36. starts_with(str1, str2)
-              3.37. set_body_multipart([txt,content_type][,boundary])
-              3.38. append_body_part(txt,content_type[,
+              4.1. search(re)
+              4.2. search_body(re)
+              4.3. search_hf(hf, re, flags)
+              4.4. search_append(re, txt)
+              4.5. search_append_body(re, txt)
+              4.6. replace(re, txt)
+              4.7. replace_body(re, txt)
+              4.8. replace_all(re, txt)
+              4.9. replace_body_all(re, txt)
+              4.10. replace_body_atonce(re, txt)
+              4.11. subst('/re/repl/flags')
+              4.12. subst_uri('/re/repl/flags')
+              4.13. subst_user('/re/repl/flags')
+              4.14. subst_body('/re/repl/flags')
+              4.15. subst_hf(hf, subexp, flags)
+              4.16. set_body(txt,content_type)
+              4.17. set_reply_body(txt,content_type)
+              4.18. filter_body(content_type)
+              4.19. append_to_reply(txt)
+              4.20. append_hf(txt[, hdr])
+              4.21. insert_hf(txt[, hdr])
+              4.22. append_urihf(prefix, suffix)
+              4.23. is_present_hf(hf_name)
+              4.24. is_present_hf_re(hf_name_re)
+              4.25. append_time()
+              4.26. append_time_to_request()
+              4.27. is_method(name)
+              4.28. remove_hf(hname)
+              4.29. remove_hf_re(re)
+              4.30. has_body(), has_body(mime)
+              4.31. is_audio_on_hold()
+              4.32. is_privacy(privacy_type)
+              4.33. in_list(subject, list, separator)
+              4.34. cmp_str(str1, str2)
+              4.35. cmp_istr(str1, str2)
+              4.36. starts_with(str1, str2)
+              4.37. set_body_multipart([txt,content_type][,boundary])
+              4.38. append_body_part(txt,content_type[,
                       content_disposition])
 
-              3.39. get_body_part(content_type, opv)
-              3.40. get_body_part_raw(content_type, opv)
-              3.41. remove_body_part(content_type)
-
-        4. Known Limitations
+              4.39. get_body_part(content_type, opv)
+              4.40. get_body_part_raw(content_type, opv)
+              4.41. remove_body_part(content_type)
 
    2. Developer Guide
 
@@ -142,63 +134,57 @@ Chapter 1. Admin Guide
    Table of Contents
 
    1. Overview
+   2. Known Limitations
+   3. Dependencies
 
-        1.1. Known Limitations
+        3.1. Kamailio Modules
+        3.2. External Libraries or Applications
 
-   2. Dependencies
+   4. Functions
 
-        2.1. Kamailio Modules
-        2.2. External Libraries or Applications
-
-   3. Functions
-
-        3.1. search(re)
-        3.2. search_body(re)
-        3.3. search_hf(hf, re, flags)
-        3.4. search_append(re, txt)
-        3.5. search_append_body(re, txt)
-        3.6. replace(re, txt)
-        3.7. replace_body(re, txt)
-        3.8. replace_all(re, txt)
-        3.9. replace_body_all(re, txt)
-        3.10. replace_body_atonce(re, txt)
-        3.11. subst('/re/repl/flags')
-        3.12. subst_uri('/re/repl/flags')
-        3.13. subst_user('/re/repl/flags')
-        3.14. subst_body('/re/repl/flags')
-        3.15. subst_hf(hf, subexp, flags)
-        3.16. set_body(txt,content_type)
-        3.17. set_reply_body(txt,content_type)
-        3.18. filter_body(content_type)
-        3.19. append_to_reply(txt)
-        3.20. append_hf(txt[, hdr])
-        3.21. insert_hf(txt[, hdr])
-        3.22. append_urihf(prefix, suffix)
-        3.23. is_present_hf(hf_name)
-        3.24. is_present_hf_re(hf_name_re)
-        3.25. append_time()
-        3.26. append_time_to_request()
-        3.27. is_method(name)
-        3.28. remove_hf(hname)
-        3.29. remove_hf_re(re)
-        3.30. has_body(), has_body(mime)
-        3.31. is_audio_on_hold()
-        3.32. is_privacy(privacy_type)
-        3.33. in_list(subject, list, separator)
-        3.34. cmp_str(str1, str2)
-        3.35. cmp_istr(str1, str2)
-        3.36. starts_with(str1, str2)
-        3.37. set_body_multipart([txt,content_type][,boundary])
-        3.38. append_body_part(txt,content_type[, content_disposition])
-        3.39. get_body_part(content_type, opv)
-        3.40. get_body_part_raw(content_type, opv)
-        3.41. remove_body_part(content_type)
-
-   4. Known Limitations
+        4.1. search(re)
+        4.2. search_body(re)
+        4.3. search_hf(hf, re, flags)
+        4.4. search_append(re, txt)
+        4.5. search_append_body(re, txt)
+        4.6. replace(re, txt)
+        4.7. replace_body(re, txt)
+        4.8. replace_all(re, txt)
+        4.9. replace_body_all(re, txt)
+        4.10. replace_body_atonce(re, txt)
+        4.11. subst('/re/repl/flags')
+        4.12. subst_uri('/re/repl/flags')
+        4.13. subst_user('/re/repl/flags')
+        4.14. subst_body('/re/repl/flags')
+        4.15. subst_hf(hf, subexp, flags)
+        4.16. set_body(txt,content_type)
+        4.17. set_reply_body(txt,content_type)
+        4.18. filter_body(content_type)
+        4.19. append_to_reply(txt)
+        4.20. append_hf(txt[, hdr])
+        4.21. insert_hf(txt[, hdr])
+        4.22. append_urihf(prefix, suffix)
+        4.23. is_present_hf(hf_name)
+        4.24. is_present_hf_re(hf_name_re)
+        4.25. append_time()
+        4.26. append_time_to_request()
+        4.27. is_method(name)
+        4.28. remove_hf(hname)
+        4.29. remove_hf_re(re)
+        4.30. has_body(), has_body(mime)
+        4.31. is_audio_on_hold()
+        4.32. is_privacy(privacy_type)
+        4.33. in_list(subject, list, separator)
+        4.34. cmp_str(str1, str2)
+        4.35. cmp_istr(str1, str2)
+        4.36. starts_with(str1, str2)
+        4.37. set_body_multipart([txt,content_type][,boundary])
+        4.38. append_body_part(txt,content_type[, content_disposition])
+        4.39. get_body_part(content_type, opv)
+        4.40. get_body_part_raw(content_type, opv)
+        4.41. remove_body_part(content_type)
 
 1. Overview
-
-   1.1. Known Limitations
 
    The module implements text based operations over the SIP message
    processed by Kamailio. SIP is a text based protocol and the module
@@ -207,74 +193,77 @@ Chapter 1. Admin Guide
    substitutions, checks for method type, header presence, insert of new
    header and date, etc.
 
-1.1. Known Limitations
+2. Known Limitations
 
-   search ignores folded lines. For example, search("(From|f):.*@foo.bar")
+   Search functions are applied to the original request, i.e., they ignore
+   all changes resulting from message processing in Kamailio script.
+
+   Search ignores folded lines. For example, search(“(From|f):.*@foo.bar”)
    doesn't match the following From header field:
 From: medabeda
  <sip:medameda@foo.bar>;tag=1234
 
-2. Dependencies
+3. Dependencies
 
-   2.1. Kamailio Modules
-   2.2. External Libraries or Applications
+   3.1. Kamailio Modules
+   3.2. External Libraries or Applications
 
-2.1. Kamailio Modules
+3.1. Kamailio Modules
 
    The following modules must be loaded before this module:
      * No dependencies on other Kamailio modules.
 
-2.2. External Libraries or Applications
+3.2. External Libraries or Applications
 
    The following libraries or applications must be installed before
    running Kamailio with this module loaded:
      * None.
 
-3. Functions
+4. Functions
 
-   3.1. search(re)
-   3.2. search_body(re)
-   3.3. search_hf(hf, re, flags)
-   3.4. search_append(re, txt)
-   3.5. search_append_body(re, txt)
-   3.6. replace(re, txt)
-   3.7. replace_body(re, txt)
-   3.8. replace_all(re, txt)
-   3.9. replace_body_all(re, txt)
-   3.10. replace_body_atonce(re, txt)
-   3.11. subst('/re/repl/flags')
-   3.12. subst_uri('/re/repl/flags')
-   3.13. subst_user('/re/repl/flags')
-   3.14. subst_body('/re/repl/flags')
-   3.15. subst_hf(hf, subexp, flags)
-   3.16. set_body(txt,content_type)
-   3.17. set_reply_body(txt,content_type)
-   3.18. filter_body(content_type)
-   3.19. append_to_reply(txt)
-   3.20. append_hf(txt[, hdr])
-   3.21. insert_hf(txt[, hdr])
-   3.22. append_urihf(prefix, suffix)
-   3.23. is_present_hf(hf_name)
-   3.24. is_present_hf_re(hf_name_re)
-   3.25. append_time()
-   3.26. append_time_to_request()
-   3.27. is_method(name)
-   3.28. remove_hf(hname)
-   3.29. remove_hf_re(re)
-   3.30. has_body(), has_body(mime)
-   3.31. is_audio_on_hold()
-   3.32. is_privacy(privacy_type)
-   3.33. in_list(subject, list, separator)
-   3.34. cmp_str(str1, str2)
-   3.35. cmp_istr(str1, str2)
-   3.36. starts_with(str1, str2)
-   3.37. set_body_multipart([txt,content_type][,boundary])
-   3.38. append_body_part(txt,content_type[, content_disposition])
-   3.39. get_body_part(content_type, opv)
-   3.40. get_body_part_raw(content_type, opv)
-   3.41. remove_body_part(content_type)
+   4.1. search(re)
+   4.2. search_body(re)
+   4.3. search_hf(hf, re, flags)
+   4.4. search_append(re, txt)
+   4.5. search_append_body(re, txt)
+   4.6. replace(re, txt)
+   4.7. replace_body(re, txt)
+   4.8. replace_all(re, txt)
+   4.9. replace_body_all(re, txt)
+   4.10. replace_body_atonce(re, txt)
+   4.11. subst('/re/repl/flags')
+   4.12. subst_uri('/re/repl/flags')
+   4.13. subst_user('/re/repl/flags')
+   4.14. subst_body('/re/repl/flags')
+   4.15. subst_hf(hf, subexp, flags)
+   4.16. set_body(txt,content_type)
+   4.17. set_reply_body(txt,content_type)
+   4.18. filter_body(content_type)
+   4.19. append_to_reply(txt)
+   4.20. append_hf(txt[, hdr])
+   4.21. insert_hf(txt[, hdr])
+   4.22. append_urihf(prefix, suffix)
+   4.23. is_present_hf(hf_name)
+   4.24. is_present_hf_re(hf_name_re)
+   4.25. append_time()
+   4.26. append_time_to_request()
+   4.27. is_method(name)
+   4.28. remove_hf(hname)
+   4.29. remove_hf_re(re)
+   4.30. has_body(), has_body(mime)
+   4.31. is_audio_on_hold()
+   4.32. is_privacy(privacy_type)
+   4.33. in_list(subject, list, separator)
+   4.34. cmp_str(str1, str2)
+   4.35. cmp_istr(str1, str2)
+   4.36. starts_with(str1, str2)
+   4.37. set_body_multipart([txt,content_type][,boundary])
+   4.38. append_body_part(txt,content_type[, content_disposition])
+   4.39. get_body_part(content_type, opv)
+   4.40. get_body_part_raw(content_type, opv)
+   4.41. remove_body_part(content_type)
 
-3.1. search(re)
+4.1.  search(re)
 
    Searches for the re in the message.
 
@@ -289,7 +278,7 @@ From: medabeda
 if ( search("[Ss][Ii][Pp]") ) { /*....*/ };
 ...
 
-3.2. search_body(re)
+4.2.  search_body(re)
 
    Searches for the re in the body of the message.
 
@@ -304,7 +293,7 @@ if ( search("[Ss][Ii][Pp]") ) { /*....*/ };
 if ( search_body("[Ss][Ii][Pp]") ) { /*....*/ };
 ...
 
-3.3. search_hf(hf, re, flags)
+4.3.  search_hf(hf, re, flags)
 
    Searches for the re in the body of a header field.
 
@@ -323,7 +312,7 @@ if ( search_body("[Ss][Ii][Pp]") ) { /*....*/ };
 if ( search_hf("From", ":test@", "a") ) { /*....*/ };
 ...
 
-3.4. search_append(re, txt)
+4.4.  search_append(re, txt)
 
    Searches for the first match of re and appends txt after it.
 
@@ -339,7 +328,7 @@ if ( search_hf("From", ":test@", "a") ) { /*....*/ };
 search_append("[Oo]pen[Ss]er", " SIP Proxy");
 ...
 
-3.5. search_append_body(re, txt)
+4.5.  search_append_body(re, txt)
 
    Searches for the first match of re in the body of the message and
    appends txt after it.
@@ -356,7 +345,7 @@ search_append("[Oo]pen[Ss]er", " SIP Proxy");
 search_append_body("[Oo]pen[Ss]er", " SIP Proxy");
 ...
 
-3.6. replace(re, txt)
+4.6.  replace(re, txt)
 
    Replaces the first occurrence of re with txt.
 
@@ -372,7 +361,7 @@ search_append_body("[Oo]pen[Ss]er", " SIP Proxy");
 replace("openser", "Kamailio SIP Proxy");
 ...
 
-3.7. replace_body(re, txt)
+4.7.  replace_body(re, txt)
 
    Replaces the first occurrence of re in the body of the message with
    txt.
@@ -389,7 +378,7 @@ replace("openser", "Kamailio SIP Proxy");
 replace_body("openser", "Kamailio SIP Proxy");
 ...
 
-3.8. replace_all(re, txt)
+4.8.  replace_all(re, txt)
 
    Replaces all occurrence of re with txt.
 
@@ -405,7 +394,7 @@ replace_body("openser", "Kamailio SIP Proxy");
 replace_all("openser", "Kamailio SIP Proxy");
 ...
 
-3.9. replace_body_all(re, txt)
+4.9.  replace_body_all(re, txt)
 
    Replaces all occurrence of re in the body of the message with txt.
    Matching is done on a per-line basis.
@@ -422,7 +411,7 @@ replace_all("openser", "Kamailio SIP Proxy");
 replace_body_all("openser", "Kamailio SIP Proxy");
 ...
 
-3.10. replace_body_atonce(re, txt)
+4.10.  replace_body_atonce(re, txt)
 
    Replaces all occurrence of re in the body of the message with txt.
    Matching is done over the whole body.
@@ -441,7 +430,7 @@ if(has_body() && replace_body_atonce("^.+$", ""))
         remove_hf("Content-Type");
 ...
 
-3.11. subst('/re/repl/flags')
+4.11.  subst('/re/repl/flags')
 
    Replaces re with repl (sed or perl like).
 
@@ -467,7 +456,7 @@ if ( subst('/^To:(.*)sip:[^@]*@[a-zA-Z0-9.]+(.*)$/t:\1$avp(sip_address)\2/ig') )
 
 ...
 
-3.12. subst_uri('/re/repl/flags')
+4.12.  subst_uri('/re/repl/flags')
 
    Runs the re substitution on the message uri (like subst but works only
    on the uri)
@@ -495,7 +484,7 @@ if (subst_uri('/^sip:([0-9]+)@(.*)$/sip:$avp(uri_prefix)\1@\2;orig_uri=\0/i')){$
 
 ...
 
-3.13. subst_user('/re/repl/flags')
+4.13.  subst_user('/re/repl/flags')
 
    Runs the re substitution on the message uri (like subst_uri but works
    only on the user portion of the uri)
@@ -522,7 +511,7 @@ if (subst_user('/(.*)3642$/$avp(user_prefix)\13642/')){$
 
 ...
 
-3.14. subst_body('/re/repl/flags')
+4.14.  subst_body('/re/repl/flags')
 
    Replaces re with repl (sed or perl like) in the body of the message.
 
@@ -543,7 +532,7 @@ if ( subst_body('/^o=(.*) /o=$fU /') ) {};
 
 ...
 
-3.15. subst_hf(hf, subexp, flags)
+4.15.  subst_hf(hf, subexp, flags)
 
    Perl-like substitutions in the body of a header field.
 
@@ -563,7 +552,7 @@ if ( subst_body('/^o=(.*) /o=$fU /') ) {};
 if ( subst_hf("From", "/:test@/:best@/", "a") ) { /*....*/ };
 ...
 
-3.16. set_body(txt,content_type)
+4.16.  set_body(txt,content_type)
 
    Set body to a SIP message.
 
@@ -580,7 +569,7 @@ if ( subst_hf("From", "/:test@/:best@/", "a") ) { /*....*/ };
 set_body("test", "text/plain");
 ...
 
-3.17. set_reply_body(txt,content_type)
+4.17.  set_reply_body(txt,content_type)
 
    Set body to a SIP reply to be generated by Kamailio.
 
@@ -597,7 +586,7 @@ set_body("test", "text/plain");
 set_reply_body("test", "text/plain");
 ...
 
-3.18. filter_body(content_type)
+4.18.  filter_body(content_type)
 
    Filters multipart/mixed body by leaving out all other body parts except
    the first body part of given type.
@@ -620,7 +609,7 @@ if (has_body("multipart/mixed")) {
 }
 ...
 
-3.19. append_to_reply(txt)
+4.19.  append_to_reply(txt)
 
    Append txt as header to the reply.
 
@@ -636,7 +625,7 @@ append_to_reply("Foo: bar\r\n");
 append_to_reply("Foo: $rm at $Ts\r\n");
 ...
 
-3.20. append_hf(txt[, hdr])
+4.20.  append_hf(txt[, hdr])
 
    Appends 'txt' as header after first header field or after last 'hdr'
    header field.
@@ -655,7 +644,7 @@ append_hf("P-hint: VOICEMAIL\r\n");
 append_hf("From-username: $fU\r\n", "Call-ID");
 ...
 
-3.21. insert_hf(txt[, hdr])
+4.21.  insert_hf(txt[, hdr])
 
    Inserts 'txt' as header before the first header field or before first
    'hdr' header field if 'hdr' is given.
@@ -676,7 +665,7 @@ insert_hf("P-hint: VOICEMAIL\r\n", "Call-ID");
 insert_hf("To-username: $tU\r\n", "Call-ID");
 ...
 
-3.22. append_urihf(prefix, suffix)
+4.22.  append_urihf(prefix, suffix)
 
    Append header field name with original Request-URI in middle.
 
@@ -692,14 +681,14 @@ insert_hf("To-username: $tU\r\n", "Call-ID");
 append_urihf("CC-Diversion: ", "\r\n");
 ...
 
-3.23. is_present_hf(hf_name)
+4.23.  is_present_hf(hf_name)
 
    Return true if a header field is present in message.
 
 Note
 
    The function is also able to distinguish the compact names. For exmaple
-   "From" will match with "f"
+   “From” will match with “f”
 
    Meaning of the parameters is as follows:
      * hf_name - Header field name.(long or compact form)
@@ -712,7 +701,7 @@ Note
 if (is_present_hf("From")) log(1, "From HF Present");
 ...
 
-3.24. is_present_hf_re(hf_name_re)
+4.24.  is_present_hf_re(hf_name_re)
 
    Return true if a header field whose name matches regular expression
    'hf_name_re' is present in message.
@@ -728,12 +717,12 @@ if (is_present_hf("From")) log(1, "From HF Present");
 if (is_present_hf_re("^P-")) log(1, "There are headers starting with P-\n");
 ...
 
-3.25. append_time()
+4.25.  append_time()
 
    Adds a time header to the reply of the request. You must use it before
    functions that are likely to send a reply, e.g., save() from
-   'registrar' module. Header format is: "Date: %a, %d %b %Y %H:%M:%S
-   GMT", with the legend:
+   'registrar' module. Header format is: “Date: %a, %d %b %Y %H:%M:%S
+   GMT”, with the legend:
      * %a abbreviated week of day name (locale)
      * %d day of month as decimal number
      * %b abbreviated month name (locale)
@@ -752,10 +741,10 @@ if (is_present_hf_re("^P-")) log(1, "There are headers starting with P-\n");
 append_time();
 ...
 
-3.26. append_time_to_request()
+4.26.  append_time_to_request()
 
-   Adds a time header to the request. Header format is: "Date: %a, %d %b
-   %Y %H:%M:%S GMT", with the legend:
+   Adds a time header to the request. Header format is: “Date: %a, %d %b
+   %Y %H:%M:%S GMT”, with the legend:
      * %a abbreviated week of day name (locale)
      * %d day of month as decimal number
      * %b abbreviated month name (locale)
@@ -775,7 +764,7 @@ if(!is_present_hf("Date"))
     append_time_to_request();
 ...
 
-3.27. is_method(name)
+4.27.  is_method(name)
 
    Check if the method of the message matches the name. If name is a known
    method (invite, cancel, ack, bye, options, info, update, register,
@@ -812,9 +801,9 @@ if(is_method("OPTION|UPDATE"))
 }
 ...
 
-3.28. remove_hf(hname)
+4.28.  remove_hf(hname)
 
-   Remove from message all headers with name "hname". Header matching is
+   Remove from message all headers with name “hname”. Header matching is
    case-insensitive. Matches and removes also the compact header forms.
 
    Returns true if at least one header is found and removed.
@@ -837,10 +826,10 @@ remove_hf("Contact")
 remove_hf("m")
 ...
 
-3.29. remove_hf_re(re)
+4.29.  remove_hf_re(re)
 
    Remove from message all headers with name matching regular expression
-   "re"
+   “re”
 
    Returns true if at least one header is found and removed.
 
@@ -858,16 +847,16 @@ if(remove_hf_re("^P-"))
 }
 ...
 
-3.30. has_body(), has_body(mime)
+4.30.  has_body(), has_body(mime)
 
    The function returns true if the SIP message has a body attached. The
-   checked includes also the "Content-Length" header presence and value.
+   checked includes also the “Content-Length” header presence and value.
 
    If a parameter is given, the mime described will be also checked
-   against the "Content-Type" header.
+   against the “Content-Type” header.
 
    Meaning of the parameters is as follows:
-     * mime - mime to be checked against the "Content-Type" header. If not
+     * mime - mime to be checked against the “Content-Type” header. If not
        present or 0, this check will be disabled.
 
    This function can be used from REQUEST_ROUTE, ONREPLY_ROUTE,
@@ -881,7 +870,7 @@ if(has_body("application/sdp"))
 }
 ...
 
-3.31. is_audio_on_hold()
+4.31.  is_audio_on_hold()
 
    The function returns true if the SIP message has a body attached and at
    least one audio stream in on hold.
@@ -897,7 +886,7 @@ if(is_audio_on_hold())
 }
 ...
 
-3.32. is_privacy(privacy_type)
+4.32.  is_privacy(privacy_type)
 
    The function returns true if the SIP message has a Privacy header field
    that includes the given privacy_type among its privacy values. See
@@ -915,7 +904,7 @@ if(is_privacy("id"))
 }
 ...
 
-3.33. in_list(subject, list, separator)
+4.33.  in_list(subject, list, separator)
 
    Function checks if subject string is found in list string where list
    items are separated by separator string. Subject and list strings may
@@ -933,7 +922,7 @@ if (in_list("$var(subject)", "$var(list)", ",") {
 }
 ...
 
-3.34. cmp_str(str1, str2)
+4.34.  cmp_str(str1, str2)
 
    The function returns true if the two parameters matches as string case
    sensitive comparison.
@@ -949,7 +938,7 @@ if(cmp_str("$rU", "kamailio"))
 }
 ...
 
-3.35. cmp_istr(str1, str2)
+4.35.  cmp_istr(str1, str2)
 
    The function returns true if the two parameters matches as string case
    insensitive comparison.
@@ -965,7 +954,7 @@ if(cmp_istr("$rU@you", "kamailio@YOU"))
 }
 ...
 
-3.36. starts_with(str1, str2)
+4.36.  starts_with(str1, str2)
 
    The function returns true if the first string starts with the second
    string.
@@ -981,7 +970,7 @@ if (starts_with("$rU", "+358"))
 }
 ...
 
-3.37. set_body_multipart([txt,content_type][,boundary])
+4.37.  set_body_multipart([txt,content_type][,boundary])
 
    Set multipart body to a SIP message. If called with no parameters, will
    convert present body to multipart.
@@ -1016,7 +1005,7 @@ text
 --delimiter
 ...
 
-3.38. append_body_part(txt,content_type[, content_disposition])
+4.38.  append_body_part(txt,content_type[, content_disposition])
 
    Append a part on multipart body SIP message. Will use
    "unique-boundary-1" as boundary.
@@ -1050,7 +1039,7 @@ Content-Disposition: signal;handling=required
 --unique-boundary-1
 ...
 
-3.39. get_body_part(content_type, opv)
+4.39.  get_body_part(content_type, opv)
 
    Return the content of a multipart body SIP message, storing it in opv.
 
@@ -1068,7 +1057,7 @@ Content-Disposition: signal;handling=required
 get_body_part("application/vnd.cirpack.isdn-ext", "$var(pbody)");
 ...
 
-3.40. get_body_part_raw(content_type, opv)
+4.40.  get_body_part_raw(content_type, opv)
 
    Return the content of a multipart body SIP message, including headers
    and boundary string, storing it in opv.
@@ -1087,7 +1076,7 @@ get_body_part("application/vnd.cirpack.isdn-ext", "$var(pbody)");
 get_body_part("application/vnd.cirpack.isdn-ext", "$var(hbody)");
 ...
 
-3.41. remove_body_part(content_type)
+4.41.  remove_body_part(content_type)
 
    Remove a part on a multipart body SIP message.
 
@@ -1107,11 +1096,6 @@ get_body_part("application/vnd.cirpack.isdn-ext", "$var(hbody)");
 remove_body_part("application/vnd.cirpack.isdn-ext");
 ...
 
-4. Known Limitations
-
-   Search functions are applied to the original request, i.e., they ignore
-   all changes resulting from message processing in Kamailio script.
-
 Chapter 2. Developer Guide
 
    Table of Contents
@@ -1124,10 +1108,10 @@ Chapter 2. Developer Guide
 
    1.1. load_textops(*import_structure)
 
-1.1. load_textops(*import_structure)
+1.1.  load_textops(*import_structure)
 
    For programmatic use only--import the Textops API.
 
    Meaning of the parameters is as follows:
-     * import_structure - Pointer to the import structure - see "struct
-       textops_binds" in modules/textops/api.h
+     * import_structure - Pointer to the import structure - see “struct
+       textops_binds” in modules/textops/api.h

--- a/modules/textops/doc/textops_admin.xml
+++ b/modules/textops/doc/textops_admin.xml
@@ -23,18 +23,23 @@
 		Perl-like substitutions, checks for method type, header presence,
 		insert of new header and date, etc.
 	</para>
+	</section>
 	<section>
-		<title>Known Limitations</title>
-		<para>
-		search ignores folded lines. For example, 
+	<title>Known Limitations</title>
+	<para>
+		Search functions are applied to the original request,
+		i.e., they ignore all changes resulting from message
+		processing in &kamailio; script.
+	</para>
+	<para>
+		Search ignores folded lines. For example, 
 		search(<quote>(From|f):.*@foo.bar</quote>)
 		doesn't match the following From header field:
-		</para>
-		<programlisting format="linespecific">
+<programlisting format="linespecific">
 From: medabeda 
  &lt;sip:medameda@foo.bar&gt;;tag=1234
 </programlisting>
-	</section>
+	</para>
 	</section>
 
 	<section>
@@ -1571,14 +1576,6 @@ remove_body_part("application/vnd.cirpack.isdn-ext");
 		</example>
 	</section>
 
-	</section>
-	<section>
-		<title>Known Limitations</title>
-		<para>
-			Search functions are applied to the original request,
-			i.e., they ignore all changes resulting from message
-			processing in &kamailio; script.
-		</para>
 	</section>
 </chapter>
 

--- a/modules/xhttp_rpc/README
+++ b/modules/xhttp_rpc/README
@@ -22,22 +22,20 @@ Alex Balashov
    1. Admin Guide
 
         1. Overview
+        2. Limitations
+        3. Dependencies
 
-              1.1. Limitations
+              3.1. Kamailio Modules
+              3.2. External Libraries or Applications
 
-        2. Dependencies
+        4. Parameters
 
-              2.1. Kamailio Modules
-              2.2. External Libraries or Applications
+              4.1. xhttp_rpc_root (str)
+              4.2. xhttp_rpc_buf_size (str)
 
-        3. Parameters
+        5. Functions
 
-              3.1. xhttp_rpc_root (str)
-              3.2. xhttp_rpc_buf_size (str)
-
-        4. Functions
-
-              4.1. dispatch_xhttp_rpc()
+              5.1. dispatch_xhttp_rpc()
 
         5. Usage
 
@@ -52,28 +50,24 @@ Chapter 1. Admin Guide
    Table of Contents
 
    1. Overview
+   2. Limitations
+   3. Dependencies
 
-        1.1. Limitations
+        3.1. Kamailio Modules
+        3.2. External Libraries or Applications
 
-   2. Dependencies
+   4. Parameters
 
-        2.1. Kamailio Modules
-        2.2. External Libraries or Applications
+        4.1. xhttp_rpc_root (str)
+        4.2. xhttp_rpc_buf_size (str)
 
-   3. Parameters
+   5. Functions
 
-        3.1. xhttp_rpc_root (str)
-        3.2. xhttp_rpc_buf_size (str)
-
-   4. Functions
-
-        4.1. dispatch_xhttp_rpc()
+        5.1. dispatch_xhttp_rpc()
 
    5. Usage
 
 1. Overview
-
-   1.1. Limitations
 
    This module provides an HTTP transport layer implementation for the RPC
    management interface in a human-readable format.
@@ -81,7 +75,7 @@ Chapter 1. Admin Guide
    The xHTTP_RPC module uses the xHTTP module to handle HTTP requests.
    Read the documentation of the xHTTP module for more details.
 
-1.1. Limitations
+2. Limitations
 
      * This module does not implement asynchronous RPC commands. It is
        unlikely that asynchronous RPC commands will be executed from an
@@ -96,28 +90,28 @@ Chapter 1. Admin Guide
        command is not in the expected format, it will be dropped from the
        initial xhttp_rpc home page menu.
 
-2. Dependencies
+3. Dependencies
 
-   2.1. Kamailio Modules
-   2.2. External Libraries or Applications
+   3.1. Kamailio Modules
+   3.2. External Libraries or Applications
 
-2.1. Kamailio Modules
+3.1. Kamailio Modules
 
    The following modules must be loaded before this module:
      * xhttp - xHTTP.
 
-2.2. External Libraries or Applications
+3.2. External Libraries or Applications
 
    The following libraries or applications must be installed before
    running Kamailio with this module loaded:
      * None
 
-3. Parameters
+4. Parameters
 
-   3.1. xhttp_rpc_root (str)
-   3.2. xhttp_rpc_buf_size (str)
+   4.1. xhttp_rpc_root (str)
+   4.2. xhttp_rpc_buf_size (str)
 
-3.1. xhttp_rpc_root (str)
+4.1. xhttp_rpc_root (str)
 
    Specifies the root path for RPC http requests. The link to the RPC web
    interface must be constructed using the following pattern:
@@ -130,7 +124,7 @@ Chapter 1. Admin Guide
 modparam("xhttp_rpc", "xhttp_rpc_root", "http_rpc")
 ...
 
-3.2. xhttp_rpc_buf_size (str)
+4.2. xhttp_rpc_buf_size (str)
 
    Specifies the maximum length of the buffer (in bytes) used to write the
    RPC reply information in order to build the HTML response.
@@ -143,11 +137,9 @@ modparam("xhttp_rpc", "xhttp_rpc_root", "http_rpc")
 modparam("xhttp", "xhttp_rpc_buf_size", 1024)
 ...
 
-4. Functions
+5. Functions
 
-   4.1. dispatch_xhttp_rpc()
-
-4.1. dispatch_xhttp_rpc()
+5.1.  dispatch_xhttp_rpc()
 
    Handle the HTTP request and generate a response.
 

--- a/modules/xhttp_rpc/doc/xhttp_rpc_admin.xml
+++ b/modules/xhttp_rpc/doc/xhttp_rpc_admin.xml
@@ -18,11 +18,12 @@
 	<para>
 		This module provides an HTTP transport layer implementation for
 		the RPC management interface in a human-readable format.
-	<para>
 	</para>
+	<para>
 		The xHTTP_RPC module uses the xHTTP module to handle HTTP requests.
 		Read the documentation of the xHTTP module for more details.
 	</para>
+	</section>
 
 	<section>
 	<title>Limitations</title>
@@ -52,7 +53,6 @@
 	</para>
 	</listitem>
 	</itemizedlist>
-	</section>
 	</section>
 
 	<section>


### PR DESCRIPTION
I was reading READMEs in terminal and noticed that single sub-section can look confusing:
https://github.com/kamailio/kamailio/blob/master/modules/db_mongodb/README#L52

In comparison HTML layout does not contain such orphan section index:
http://kamailio.org/docs/modules/devel/modules/db_mongodb.html#idp19616368

This patch tries to improve confusing “Known limitations” subsections by making them independent sections.