### PR TITLE
Fix memory leak when converting body to multipart with set_body_multipart();

### DIFF
--- a/modules/textops/textops.c
+++ b/modules/textops/textops.c
@@ -1763,6 +1763,8 @@ int set_multibody_helper(struct sip_msg* msg, char* p1, char* p2, char* p3)
 	}
 	pkg_free(nbb);
 	if(nc.s!=NULL) pkg_free(nc.s);
+	if(convert && nb.s!=NULL) pkg_free(nb.s);
+	if(convert && oc.s!=NULL) pkg_free(oc.s);
 	LM_DBG("set flag FL_BODY_MULTIPART\n");
 	msg->msg_flags |= FL_BODY_MULTIPART;
 	return 1;

--- a/msg_translator.c
+++ b/msg_translator.c
@@ -1688,7 +1688,7 @@ int get_boundary(struct sip_msg* msg, str* boundary)
 		msg->content_type->body.len);
 	if (params.s == NULL)
 	{
-		LM_ERR("Content-Type hdr has no params\n");
+		LM_INFO("Content-Type hdr has no params <%.*s>\n", msg->content_type->body.len, msg->content_type->body.s);
 		return -1;
 	}
 	params.len = msg->content_type->body.len -
@@ -1749,7 +1749,10 @@ int check_boundaries(struct sip_msg *msg, struct dest_info *send_info)
 		}
 		tmp.s = buf.s;
 		t = tmp.len = buf.len;
-		if(get_boundary(msg, &ob)!=0) return -1;
+		if(get_boundary(msg, &ob)!=0) {
+                        if(tmp.s) pkg_free(tmp.s);
+                        return -1;
+                }
 		if(str_append(&ob, &bsuffix, &b)!=0) {
 			LM_ERR("Can't append suffix to boundary\n");
 			goto error;


### PR DESCRIPTION
Hi, All.

I have some problems with pkg_memory leak.

After each call used private memory of the "udp receiver" process
increases at 2500 bytes.
On test environment I have set it to 2Mbyte, but it is full after 700 calls.

I need to modify SDP in invite and other packets.
When I do in script

```
if(has_body("application/sdp"))
   set_body_multipart();
   if (msg_apply_changes())
    {
       xlog("L_INFO", "ISUP 1 Changes Applied Succesfully");
    }
}

record_route();
dlg_manage
route(RELAY);
```

I make test this on kamailio 4.3.5 and 4.4.0 - same issue.

After discussion in mailing list with Daniel-Constantin Mierla, I have done debugging memory usage by process and found 3 points where memory hase not freeing after execution.

This patch solves it for me.