### PR TITLE
lib/binrpc modules/ctl utils/kamcmd : set UNIX_PATH_MAX to lowest common value

### DIFF
--- a/lib/binrpc/binrpc_api.c
+++ b/lib/binrpc/binrpc_api.c
@@ -53,7 +53,7 @@
 #define binrpc_free internal_free
 
 #ifndef UNIX_PATH_MAX
-#define UNIX_PATH_MAX 108
+#define UNIX_PATH_MAX 104
 #endif
 
 #ifndef INT2STR_MAX_LEN

--- a/modules/ctl/init_socks.c
+++ b/modules/ctl/init_socks.c
@@ -37,7 +37,7 @@
 #include <fcntl.h>
 
 #ifndef UNIX_PATH_MAX
-#define UNIX_PATH_MAX 108
+#define UNIX_PATH_MAX 104
 #endif
 
 

--- a/utils/kamcmd/kamcmd.c
+++ b/utils/kamcmd/kamcmd.c
@@ -82,7 +82,7 @@
 
 
 #ifndef UNIX_PATH_MAX
-#define UNIX_PATH_MAX 100
+#define UNIX_PATH_MAX 104
 #endif
 
 static char id[]="$Id$";


### PR DESCRIPTION
sockaddr_un.sun_path[] seem to be either 104 or 108 in following Unices:
104 - NetBSD, OpenBSD, FreeBSD, DragonFly BSD, MINIX, XNU(Apple OS X)
108 - illumos, Solaris, Linux