### PR TITLE
Add missing modules to the spec file for CentOS 6

### DIFF
--- a/pkg/kamailio/centos/6/kamailio.spec
+++ b/pkg/kamailio/centos/6/kamailio.spec
@@ -53,8 +53,17 @@ Group:		System Environment/Daemons
 Requires:	openssl, kamailio = %ver
 BuildRequires:	openssl-devel
 
-%description auth-ephemeral
+%description 	auth-ephemeral
 Functions for authentication using ephemeral credentials.
+
+
+%package	auth-xkeys
+Summary:	Functions for authentication using shared keys.
+Group:		System Environment/Daemons
+Requires:	kamailio = %ver
+
+%description 	auth-xkeys
+Functions for authentication using shared keys.
 
 
 %package	bdb
@@ -95,6 +104,15 @@ BuildRequires:	pcre-devel
 
 %description	dialplan
 String translations based on rules for Kamailio.
+
+
+%package	dmq_userloc
+Summary:	User location (usrloc) records replication between multiple servers via DMQ module for Kamailio.
+Group:		System Environment/Daemons
+Requires:	kamailio = %ver
+
+%description	dmq_userloc
+User location (usrloc) records replication between multiple servers via DMQ module.
 
 
 %package	dnssec
@@ -299,6 +317,15 @@ BuildRequires:	pcre-devel
 PCRE mtaching operations for Kamailio.
 
 
+%package	rtjson
+Summary:	SIP routing based on JSON specifications.
+Group:		System Environment/Daemons
+Requires:	kamailio = %ver
+
+%description	rtjson
+SIP routing based on JSON specifications.
+
+
 %package	sctp
 Summary:	SCTP transport for Kamailio.
 Group:		System Environment/Daemons
@@ -319,6 +346,15 @@ BuildRequires:	net-snmp-devel
 SNMP management interface (scalar statistics) for Kamailio.
 
 
+%package	statsd
+Summary:	Send commands to statsd server.
+Group:		System Environment/Daemons
+Requires:	kamailio = %ver
+
+%description	statsd
+Send commands to statsd server.
+
+
 %package	sqlite
 Summary:	SQLite database connectivity for Kamailio.
 Group:		System Environment/Daemons
@@ -337,6 +373,15 @@ BuildRequires:	openssl-devel
 
 %description	tls
 TLS transport for Kamailio.
+
+
+%package	tcpops
+Summary:	On demand and per socket control to the TCP options.
+Group:		System Environment/Daemons
+Requires:	kamailio = %ver
+
+%description	tcpops
+On demand and per socket control to the TCP options.
 
 
 %package	unixodbc
@@ -789,6 +834,12 @@ fi
 %{_libdir}/kamailio/modules/auth_ephemeral.so
 
 
+%files		auth-xkeys
+%defattr(-,root,root)
+%doc %{_docdir}/kamailio/modules/README.auth_xkeys
+%{_libdir}/kamailio/modules/auth_xkeys.so
+
+
 %files		bdb
 %defattr(-,root,root)
 %doc %{_docdir}/kamailio/modules/README.db_berkeley
@@ -816,6 +867,12 @@ fi
 %defattr(-,root,root)
 %doc %{_docdir}/kamailio/modules/README.dialplan
 %{_libdir}/kamailio/modules/dialplan.so
+
+
+%files		dmq_userloc
+%defattr(-,root,root)
+%doc %{_docdir}/kamailio/modules/README.dmq_usrloc
+%{_libdir}/kamailio/modules/dmq_usrloc.so
 
 
 %files		dnssec
@@ -850,7 +907,7 @@ fi
 %doc %{_docdir}/kamailio/modules/README.ims_isc
 %doc %{_docdir}/kamailio/modules/README.ims_qos
 #%doc %{_docdir}/kamailio/modules/README.ims_registrar_pcscf
-#%doc %{_docdir}/kamailio/modules/README.ims_registrar_scscf
+%doc %{_docdir}/kamailio/modules/README.ims_registrar_scscf
 %doc %{_docdir}/kamailio/modules/README.ims_usrloc_pcscf
 #%doc %{_docdir}/kamailio/modules/README.ims_usrloc_scscf
 %{_libdir}/kamailio/modules/cdp.so
@@ -1045,6 +1102,12 @@ fi
 %{_libdir}/kamailio/modules/regex.so
 
 
+%files		rtjson
+%defattr(-,root,root)
+%doc %{_docdir}/kamailio/modules/README.rtjson
+%{_libdir}/kamailio/modules/rtjson.so
+
+
 %files		sctp
 %defattr(-,root,root)
 %doc %{_docdir}/kamailio/modules/README.sctp
@@ -1060,6 +1123,12 @@ fi
 %{_datadir}/snmp/mibs/KAMAILIO-SIP-COMMON-MIB
 %{_datadir}/snmp/mibs/KAMAILIO-SIP-SERVER-MIB
 %{_datadir}/snmp/mibs/KAMAILIO-TC
+
+
+%files		statsd
+%defattr(-,root,root)
+%{_docdir}/kamailio/modules/README.statsd
+%{_libdir}/kamailio/modules/statsd.so
 
 
 %files		sqlite
@@ -1078,6 +1147,12 @@ fi
 %doc %{_docdir}/kamailio/modules/README.tls
 %{_libdir}/kamailio/modules/auth_identity.so
 %{_libdir}/kamailio/modules/tls.so
+
+
+%files		tcpops
+%defattr(-,root,root)
+%doc %{_docdir}/kamailio/modules/README.tcpops
+%{_libdir}/kamailio/modules/tcpops.so
 
 
 %files		unixodbc

--- a/pkg/kamailio/centos/6/kamailio.spec
+++ b/pkg/kamailio/centos/6/kamailio.spec
@@ -86,6 +86,16 @@ BuildRequires:	epel-release, libconfuse-devel
 The carrierroute module for Kamailio.
 
 
+%package	cnxcc
+Summary:	Module which provides a mechanism to limit call duration based on credit information parameters for Kamailio.
+Group:		System Environment/Daemons
+Requires:	libevent, hiredis, kamailio = %ver
+BuildRequires:	libevent-devel, hiredis-devel
+
+%description	cnxcc
+Module which provides a mechanism to limit call duration based on credit information parameters for Kamailio.
+
+
 %package	cpl
 Summary:	CPL (Call Processing Language) interpreter for Kamailio.
 Group:		System Environment/Daemons
@@ -466,7 +476,7 @@ make cfg prefix=/usr cfg_prefix=$RPM_BUILD_ROOT basedir=$RPM_BUILD_ROOT \
 make
 make every-module skip_modules="app_mono db_cassandra db_oracle iptrtpproxy \
 	jabber ndb_cassandra osp" \
-	group_include="kstandard kautheph kberkeley kcarrierroute kcpl \
+	group_include="kstandard kautheph kberkeley kcarrierroute kcnxcc kcpl \
 	kdnssec kgeoip kgzcompress kims kjava kjson kldap klua kmemcached \
 	kmi_xmlrpc kmysql koutbound kperl kpostgres kpresence kpurple kpython \
 	kradius kredis ksctp ksnmpstats ksqlite ktls kunixodbc kutils \
@@ -484,7 +494,7 @@ make utils
 make install
 make install-modules-all skip_modules="app_mono db_cassandra db_oracle \
 	iptrtpproxy jabber osp" \
-	group_include="kstandard kautheph kberkeley kcarrierroute kcpl \
+	group_include="kstandard kautheph kberkeley kcarrierroute kcnxcc kcpl \
 	kdnssec kgeoip kgzcompress kims kjava kjson kldap klua kmemcached \
 	kmi_xmlrpc kmysql koutbound kperl kpostgres kpresence kpurple kpython \
 	kradius kredis ksctp ksnmpstats ksqlite ktls kunixodbc kutils \
@@ -555,7 +565,6 @@ fi
 %doc %{_docdir}/kamailio/modules/README.cfg_db
 %doc %{_docdir}/kamailio/modules/README.cfg_rpc
 %doc %{_docdir}/kamailio/modules/README.cfgutils
-%doc %{_docdir}/kamailio/modules/README.cnxcc
 %doc %{_docdir}/kamailio/modules/README.corex
 %doc %{_docdir}/kamailio/modules/README.counters
 %doc %{_docdir}/kamailio/modules/README.ctl
@@ -699,7 +708,6 @@ fi
 %{_libdir}/kamailio/modules/cfg_db.so
 %{_libdir}/kamailio/modules/cfg_rpc.so
 %{_libdir}/kamailio/modules/cfgutils.so
-%{_libdir}/kamailio/modules/cnxcc.so
 %{_libdir}/kamailio/modules/corex.so
 %{_libdir}/kamailio/modules/counters.so
 %{_libdir}/kamailio/modules/ctl.so
@@ -856,6 +864,11 @@ fi
 %{_docdir}/kamailio/modules/README.carrierroute
 %{_libdir}/kamailio/modules/carrierroute.so
 
+
+%files		cnxcc
+%defattr(-,root,root)
+%{_docdir}/kamailio/modules/README.cnxcc
+%{_libdir}/kamailio/modules/cnxcc.so
 
 %files		cpl
 %defattr(-,root,root)


### PR DESCRIPTION
Some modules (auth-xkeys, dmq_userloc, rtjson, statsd, tcpops) are missing from the spec file for CentOS 6, which causes errors during rpmbuild process. These modules are added as separate packages in this branch.