### PR TITLE
db_unixodbc: some ODBC drivers do not support ODBC replace query

### DIFF
--- a/modules/db_unixodbc/connection.h
+++ b/modules/db_unixodbc/connection.h
@@ -63,6 +63,7 @@ struct my_con
 	SQLHDBC dbc;			/*!< Connection representation */
 	char** row;			/*!< Actual row in the result */
 	time_t timestamp;		/*!< Timestamp of last query */
+	int statement_res;		/*!< ODBC real statement result */
 };
 
 /*
@@ -74,6 +75,7 @@ struct my_con
 #define CON_TIMESTAMP(db_con)  (((struct my_con*)((db_con)->tail))->timestamp)
 #define CON_ID(db_con) 		(((struct my_con*)((db_con)->tail))->id)
 #define CON_ENV(db_con)		(((struct my_con*)((db_con)->tail))->env)
+#define CON_QUERY_RESULT(db_con) (((struct my_con*)((db_con)->tail))->statement_res)
 
 #define MAX_CONN_STR_LEN 2048
 

--- a/modules/db_unixodbc/db_unixodbc.c
+++ b/modules/db_unixodbc/db_unixodbc.c
@@ -37,6 +37,7 @@
 int ping_interval = 5 * 60; /* Default is 5 minutes */
 int auto_reconnect = 1;     /* Default is enabled */
 int use_escape_common = 0;  /* Enable common escaping */
+int replace_query = 1;      /* Enable ODBC replace query */
 
 MODULE_VERSION
 
@@ -59,6 +60,7 @@ static param_export_t params[] = {
 	{"ping_interval",     INT_PARAM, &ping_interval},
 	{"auto_reconnect",    INT_PARAM, &auto_reconnect},
 	{"use_escape_common", INT_PARAM, &use_escape_common},
+	{"replace_query", INT_PARAM, &replace_query},
 	{0, 0, 0}
 };
 
@@ -95,7 +97,10 @@ int db_unixodbc_bind_api(db_func_t *dbb)
 	dbb->insert           = db_unixodbc_insert;
 	dbb->delete           = db_unixodbc_delete; 
 	dbb->update           = db_unixodbc_update;
-	dbb->replace          = db_unixodbc_replace;
+	if (replace_query)
+		dbb->replace      = db_unixodbc_replace;
+	else
+		dbb->replace      = db_unixodbc_update_or_insert;
 
 	return 0;
 }

--- a/modules/db_unixodbc/dbase.h
+++ b/modules/db_unixodbc/dbase.h
@@ -93,6 +93,13 @@ int db_unixodbc_replace(const db1_con_t* handle, const db_key_t* keys, const db_
 		const int n, const int _un, const int _m);
 
 /*
+ * Just like insert, but update the row if it exists or insert it if not. This function is used when
+ * the odbc replace query is not supported.
+ */
+int db_unixodbc_update_or_insert(const db1_con_t* handle, const db_key_t* keys, const db_val_t* vals,
+		const int n, const int _un, const int _m);
+
+/*
  * Store name of table that will be used by
  * subsequent database functions
  */

--- a/modules/db_unixodbc/doc/db_unixodbc_admin.xml
+++ b/modules/db_unixodbc/doc/db_unixodbc_admin.xml
@@ -131,6 +131,25 @@ modparam("db_unixodbc", "use_escape_common", 1)
 </programlisting>
 		</example>
 	</section>
+       <section>
+                <title><varname>replace_query</varname> (int)</title>
+                <para>
+                Tells if the ODBC replace query is supported by the DB odbc driver.
+                </para>
+                <para>
+                <emphasis>
+                        Default value is <quote>1</quote> seconds.
+                </emphasis>
+                </para>
+                <example>
+                <title>Set the <quote>replace_query</quote> parameter</title>
+                <programlisting format="linespecific">
+...
+modparam("db_unixodbc", "replace_query", 0)
+...
+</programlisting>
+                </example>
+        </section>
     </section>
 
 	<section>
@@ -199,6 +218,17 @@ shell>safe_mysqld --user=mysql --socket=/var/lib/mysql/mysql.sock
 	The connector search the socket in /var/lib/mysql/mysql.sock and not 
 	in /tmp/mysql.sock
 	</para>
+
+	<para>
+	REMARK: Oracle ODBC driver doesn't support ODBC query. To disable its usage
+	and replace the replace query by an update or insert query, use the parameter:
+	</para>
+        <programlisting format="linespecific">
+....
+modparam("db_unixodbc", "replace_query", 0)
+....
+</programlisting>
+
 	</section>
 
 	</section>


### PR DESCRIPTION
unix ODBC offers the possibilty to do an update or insert in one replace query. Unfortunately, Oracle unixODBC driver doesn't support this feature. Modifications have been done in the db_unixodbc module to allow to replace the query by 2 queries : update and if not exist, insert. This can be controlled by a new parameter replace_query, set to '1' by default in order to be backward compatible.