### PR TITLE
pkg/kamailio/deb/jessie: change default location

### DIFF
--- a/pkg/kamailio/deb/jessie/kamailio.init
+++ b/pkg/kamailio/deb/jessie/kamailio.init
@@ -14,14 +14,14 @@
 
 . /lib/lsb/init-functions
 
-PATH=/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/sbin/kamailio
+PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
+DAEMON=/usr/local/sbin/kamailio
 NAME=`basename "$0"`
 DESC="Kamailio SIP Server"
 HOMEDIR=/var/run/$NAME
 PIDFILE=$HOMEDIR/$NAME.pid
 DEFAULTS=/etc/default/$NAME
-CFGFILE=/etc/$NAME/kamailio.cfg
+CFGFILE=/usr/local/etc/$NAME/kamailio.cfg
 RUN_KAMAILIO=no
 USER=kamailio
 GROUP=kamailio

--- a/pkg/kamailio/deb/jessie/kamailio.service
+++ b/pkg/kamailio/deb/jessie/kamailio.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
-Environment='CFGFILE=/etc/kamailio/kamailio.cfg'
+Environment='CFGFILE=/usr/local/etc/kamailio/kamailio.cfg'
 Environment='SHM_MEMORY=64'
 Environment='PKG_MEMORY=8'
 Environment='USER=kamailio'
@@ -14,7 +14,7 @@ EnvironmentFile=-/etc/default/kamailio.d/*
 # PIDFile requires a full absolute path
 PIDFile=/var/run/kamailio/kamailio.pid
 # ExecStart requires a full absolute path
-ExecStart=/usr/sbin/kamailio -P /var/run/kamailio/kamailio.pid -f $CFGFILE -m $SHM_MEMORY -M $PKG_MEMORY -u $USER -g $GROUP
+ExecStart=/usr/local/sbin/kamailio -P /var/run/kamailio/kamailio.pid -f $CFGFILE -m $SHM_MEMORY -M $PKG_MEMORY -u $USER -g $GROUP
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
- default config file is /usr/local/etc/kamailio. kamailio.init CFGFILE should match installed location.
- kamailio is installed in /usr/local/sbin. kamailio.init PATH should have /usr/local/bin:/usr/local/sbin.
- kamailio is installed in /usr/local/sbin. kamailio.init DAEMON should match installed location.
- CFGFILE and ExecStart should match installed locations of kamailio.cfg and kamailio
