### PR TITLE
change answered elsewhere to call completed elsewhere

### DIFF
--- a/modules/tm/t_cancel.c
+++ b/modules/tm/t_cancel.c
@@ -43,7 +43,7 @@ typedef struct cancel_reason_map {
 } cancel_reason_map_t;
 
 static cancel_reason_map_t _cancel_reason_map[] = {
-	{ 200, str_init("Answered elsewhere") },
+	{ 200, str_init("Call completed elsewhere") },
 	{ 0, {0, 0} }
 };
 


### PR DESCRIPTION
"Call completed elsewhere", RFC3326, defines this as the string to send.

Author: Frank Carmickle <frank@silentcircle.com>