### PR TITLE
Free database column name as part of database result cleanup

### DIFF
--- a/lib/srdb1/db_res.c
+++ b/lib/srdb1/db_res.c
@@ -81,6 +81,9 @@ int db_free_columns(db1_res_t* _r)
 	for(col = 0; col < RES_COL_N(_r); col++) {
 		if (RES_NAMES(_r)[col]!=NULL) {
 			LM_DBG("freeing RES_NAMES[%d] at %p\n", col, RES_NAMES(_r)[col]);
+			if (RES_NAMES(_r)[col]->s != NULL) {
+				pkg_free(RES_NAMES(_r)[col]->s);
+			}
 			pkg_free((str *)RES_NAMES(_r)[col]);
 			RES_NAMES(_r)[col] = NULL;
 		}

--- a/modules/db_berkeley/km_bdb_res.c
+++ b/modules/db_berkeley/km_bdb_res.c
@@ -79,8 +79,13 @@ int bdb_get_columns(table_p _tp, db1_res_t* _res, int* _lres, int _nc)
 		LM_DBG("allocate %lu bytes for RES_NAMES[%d] at %p\n",
 			(unsigned long)sizeof(str), col, RES_NAMES(_res)[col]);
 
-		/* The pointer that is here returned is part of the result structure. */
-		RES_NAMES(_res)[col]->s = cp->name.s;
+		RES_NAMES(_res)[col]->s = pkg_malloc(strlen(cp->name.s)+1);
+		if (! RES_NAMES(_res)[col]->s) {
+			LM_ERR("no private memory left\n");
+			db_free_columns(_res);
+			return -4;
+		}
+		strcpy(RES_NAMES(_res)[col]->s, cp->name.s);
 		RES_NAMES(_res)[col]->len = cp->name.len;
 
 		LM_DBG("RES_NAMES(%p)[%d]=[%.*s]\n", RES_NAMES(_res)[col]

--- a/modules/db_mongodb/mongodb_dbase.c
+++ b/modules/db_mongodb/mongodb_dbase.c
@@ -395,8 +395,13 @@ int db_mongodb_get_columns(const db1_con_t* _h, db1_res_t* _r)
 		LM_DBG("allocate %lu bytes for RES_NAMES[%d] at %p\n",
 				(unsigned long)sizeof(str), col, RES_NAMES(_r)[col]);
 
-		/* pointer linked here is part of the result structure */
-		RES_NAMES(_r)[col]->s = (char*)colname;
+		RES_NAMES(_r)[col]->s = pkg_malloc(strlen(colname)+1);
+		if (! RES_NAMES(_r)[col]->s) {
+			LM_ERR("no private memory left\n");
+			db_free_columns(_r);
+			return -4;
+		}
+		strcpy(RES_NAMES(_r)[col]->s, colname);
 		RES_NAMES(_r)[col]->len = strlen(colname);
 
 		switch(coltype) {

--- a/modules/db_mysql/km_res.c
+++ b/modules/db_mysql/km_res.c
@@ -83,8 +83,13 @@ int db_mysql_get_columns(const db1_con_t* _h, db1_res_t* _r)
 		LM_DBG("allocate %lu bytes for RES_NAMES[%d] at %p\n",
 				(unsigned long)sizeof(str), col, RES_NAMES(_r)[col]);
 
-		/* The pointer that is here returned is part of the result structure. */
-		RES_NAMES(_r)[col]->s = fields[col].name;
+		RES_NAMES(_r)[col]->s = pkg_malloc(strlen(fields[col].name)+1);
+		if (! RES_NAMES(_r)[col]->s) {
+			LM_ERR("no private memory left\n");
+			db_free_columns(_r);
+			return -4;
+		}
+		strcpy(RES_NAMES(_r)[col]->s, fields[col].name);
 		RES_NAMES(_r)[col]->len = strlen(fields[col].name);
 
 		LM_DBG("RES_NAMES(%p)[%d]=[%.*s]\n", RES_NAMES(_r)[col], col,

--- a/modules/db_postgres/km_res.c
+++ b/modules/db_postgres/km_res.c
@@ -126,8 +126,14 @@ int db_postgres_get_columns(const db1_con_t* _h, db1_res_t* _r)
 				RES_NAMES(_r)[col]);
 
 		/* The pointer that is here returned is part of the result structure. */
-		RES_NAMES(_r)[col]->s = PQfname(CON_RESULT(_h), col);
-		RES_NAMES(_r)[col]->len = strlen(PQfname(CON_RESULT(_h), col));
+		RES_NAMES(_r)[col]->s = pkg_malloc(strlen(PQfname(CON_RESULT(_h), col))+1);
+		if (! RES_NAMES(_r)[col]->s) {
+			LM_ERR("no private memory left\n");
+			db_free_columns(_r);
+			return -4;
+		}
+		strcpy(RES_NAMES(_r)[col]->s, PQfname(CON_RESULT(_h), col));
+		RES_NAMES(_r)[col]->len = strlen(RES_NAMES(_r)[col]->s);
 
 		LM_DBG("RES_NAMES(%p)[%d]=[%.*s]\n", RES_NAMES(_r)[col], col,
 				RES_NAMES(_r)[col]->len, RES_NAMES(_r)[col]->s);

--- a/modules/db_text/dbt_api.c
+++ b/modules/db_text/dbt_api.c
@@ -73,7 +73,14 @@ static int dbt_get_columns(db1_res_t* _r, dbt_result_p _dres)
 		LM_DBG("allocate %d bytes for RES_NAMES[%d] at %p\n",
 				(int)sizeof(str), col,
 				RES_NAMES(_r)[col]);
-		RES_NAMES(_r)[col]->s = _dres->colv[col].name.s;
+
+		RES_NAMES(_r)[col]->s = pkg_malloc(strlen(_dres->colv[col].name.s)+1);
+		if (! RES_NAMES(_r)[col]->s) {
+			LM_ERR("no private memory left\n");
+			db_free_columns(_r);
+			return -4;
+		}
+		strcpy(RES_NAMES(_r)[col]->s, _dres->colv[col].name.s);
 		RES_NAMES(_r)[col]->len = _dres->colv[col].name.len;
 
 		switch(_dres->colv[col].type)

--- a/modules/db_unixodbc/res.c
+++ b/modules/db_unixodbc/res.c
@@ -93,7 +93,13 @@ int db_unixodbc_get_columns(const db1_con_t* _h, db1_res_t* _r)
 			// FIXME should we fail here completly?
 		}
 		/* The pointer that is here returned is part of the result structure. */
-		RES_NAMES(_r)[col]->s = columnname;
+		RES_NAMES(_r)[col]->s = pkg_malloc(strlen(columnname)+1);
+		if (! RES_NAMES(_r)[col]->s) {
+			LM_ERR("no private memory left\n");
+			db_free_columns(_r);
+			return -4;
+		}
+		strcpy(RES_NAMES(_r)[col]->s, columnname);
 		RES_NAMES(_r)[col]->len = namelength;
 
 		LM_DBG("RES_NAMES(%p)[%d]=[%.*s]\n", RES_NAMES(_r)[col], col,

--- a/modules/xmlrpc/xmlrpc.c
+++ b/modules/xmlrpc/xmlrpc.c
@@ -145,7 +145,7 @@
 
 MODULE_VERSION
 
-#if defined (__OS_darwin) || defined (__OS_freebsd)
+#if defined (__OS_darwin) || defined (__OS_freebsd) || defined (__clang__)
 /* redeclaration of functions from stdio.h throws errors */
 #else
 int snprintf(char *str, size_t size, const char *format, ...);


### PR DESCRIPTION
The column name is currently not free'd. Some db bankends copy this
data so that memory is leaked. Some store internal database pointers
and those shouldn't be free'd. One returns a pointer to a stack
variable which shouldn't be done.

The patch cleans up all db backends to copy the column name and frees
that column name as part of the database result cleanup function.

Author: Chris Double <doublec@silentcircle.com>