### PR TITLE
corex: fix compiler warning #612

### DIFF
--- a/modules/corex/corex_mod.c
+++ b/modules/corex/corex_mod.c
@@ -349,7 +349,12 @@ static int w_file_read(sip_msg_t *msg, char *fn, char *vn)
 		fclose(f);
 		return -1;
 	}
-	fread(content, fsize, 1, f);
+	if(fread(content, fsize, 1, f) != fsize) {
+		if(ferror(f)) {
+			LM_ERR("error reading from file: %.*s\n",
+				fname.len, fname.s);
+		}
+	}
 	fclose(f);
 	content[fsize] = 0;
 


### PR DESCRIPTION
* show error message if error in read file

> CC (clang) [M corex.so]     corex_mod.o
> corex_mod.c:352:2: warning: ignoring return value of function declared with warn_unused_result attribute [-Wunused-result]
>         fread(content, fsize, 1, f);
>        ^~~~~ ~~~~~~~~~~~~~~~~~~~~
> 1 warning generated.