### PR TITLE
sms: fix compiler warning #612

### DIFF
--- a/modules/sms/libsms_modem.c
+++ b/modules/sms/libsms_modem.c
@@ -74,7 +74,9 @@ int put_command( struct modem *mdm, char* cmd, int cmd_len, char* answer,
 	LM_DBG("-<%d>-->[%.*s] \n",cmd_len,cmd_len,cmd);
 #endif
 	/* send the command to the modem */
-	write(mdm->fd,cmd,cmd_len);
+	if (write(mdm->fd,cmd,cmd_len)<0) {
+		LM_ERR("write error: %s\n", strerror(errno));
+	}
 	tcdrain(mdm->fd);
 
 	/* read from the modem */


### PR DESCRIPTION
* show error message if error in write

> CC (clang) [M sms.so]       libsms_modem.o
> libsms_modem.c:77:2: warning: ignoring return value of function declared with warn_unused_result attribute [-Wunused-result]
>        write(mdm->fd,cmd,cmd_len);
>        ^~~~~ ~~~~~~~~~~~~~~~~~~~
>1 warning generated.