### PR TITLE
fix compiler warnings

### DIFF
--- a/lib/srdb1/db_ut.c
+++ b/lib/srdb1/db_ut.c
@@ -43,6 +43,7 @@
 	#define _BSD_SOURCE 1              /* needed on linux to "fix" the effect
 										* of the above define on
 										* features.h/unistd.h syscall() */
+	#define _DEFAULT_SOURCE 1         /* _BSD_SOURCE is deprecated */
 #else
 	#define _XOPEN_SOURCE_EXTENDED 1   /* solaris */
 #endif

--- a/modules/db2_ldap/ld_fld.c
+++ b/modules/db2_ldap/ld_fld.c
@@ -35,6 +35,7 @@
 #define _SVID_SOURCE 1 /* timegm */
 
 #define _BSD_SOURCE /* snprintf */
+#define _DEFAULT_SOURCE 1 /* _BSD_SOURCE is deprecated */
 
 #include "ld_fld.h"
 

--- a/modules/db_mysql/my_cmd.c
+++ b/modules/db_mysql/my_cmd.c
@@ -29,6 +29,7 @@
 #endif
 #define _XOPEN_SOURCE_EXTENDED 1    /* solaris */
 #define _SVID_SOURCE 1 /* timegm */
+#define _DEFAULT_SOURCE 1 /* _SVID_SOURCE is deprecated */
 
 #include "my_cmd.h"
 

--- a/modules/presence_conference/pidf.c
+++ b/modules/presence_conference/pidf.c
@@ -41,6 +41,7 @@
 	#define _BSD_SOURCE 1				/* needed on linux to "fix" the effect
 										  of the above define on
 										  features.h/unistd.h syscall() */
+   #define _DEFAULT_SOURCE 1			/* _BSD_SOURCE is deprecated */
    #define _DARWIN_C_SOURCE 1
 #else
 	#define _XOPEN_SOURCE_EXTENDED 1   /* solaris */

--- a/modules/presence_dialoginfo/pidf.c
+++ b/modules/presence_dialoginfo/pidf.c
@@ -41,6 +41,7 @@
 	#define _BSD_SOURCE 1				/* needed on linux to "fix" the effect
 										  of the above define on
 										  features.h/unistd.h syscall() */
+	#define _DEFAULT_SOURCE 1			/* _BSD_SOURCE is deprecated */
 #elif defined __OS_solaris
 	#define _XOPEN_SOURCE_EXTENDED 1   /* solaris */
 #endif

--- a/modules/presence_xml/pidf.c
+++ b/modules/presence_xml/pidf.c
@@ -42,6 +42,7 @@
 	#define _BSD_SOURCE 1				/* needed on linux to "fix" the effect
 										  of the above define on
 										  features.h/unistd.h syscall() */
+	#define _DEFAULT_SOURCE 1         /* _BSD_SOURCE is deprecated */
    #define _DARWIN_C_SOURCE 1
 #else
 	#define _XOPEN_SOURCE_EXTENDED 1   /* solaris */

--- a/modules/xmlrpc/xmlrpc.c
+++ b/modules/xmlrpc/xmlrpc.c
@@ -24,6 +24,7 @@
 #endif
 #define _XOPEN_SOURCE_EXTENDED 1  /* solaris */
 #define _SVID_SOURCE 1            /* timegm */
+#define _DEFAULT_SOURCE 1         /* _SVID_SOURCE is deprecated */
 
 #include <strings.h>
 #include <time.h>


### PR DESCRIPTION
> CC (gcc) [L libsrdb1.so.1.0]    db_ut.o
> In file included from /usr/include/time.h:27:0,
>                  from db_ut.c:50:
> /usr/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
>  # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"