### PR TITLE
lib/srutils: fix gcc warning GH#612

### DIFF
--- a/lib/srutils/sha256.c
+++ b/lib/srutils/sha256.c
@@ -610,7 +610,7 @@ void sr_SHA256_Final(sha2_byte digest[], SHA256_CTX* context) {
 			*context->buffer = 0x80;
 		}
 		/* Set the bit count: */
-		*(sha2_word64*)&context->buffer[SHA256_SHORT_BLOCK_LENGTH] = context->bitcount;
+		MEMCPY_BCOPY(&(context->buffer[SHA256_SHORT_BLOCK_LENGTH]), &(context->bitcount), sizeof(sha2_word64));
 
 		/* Final transform: */
 		SHA256_Transform(context, (sha2_word32*)context->buffer);
@@ -927,8 +927,8 @@ void SHA512_Last(SHA512_CTX* context) {
 		*context->buffer = 0x80;
 	}
 	/* Store the length of input data (in bits): */
-	*(sha2_word64*)&context->buffer[SHA512_SHORT_BLOCK_LENGTH] = context->bitcount[1];
-	*(sha2_word64*)&context->buffer[SHA512_SHORT_BLOCK_LENGTH+8] = context->bitcount[0];
+	MEMCPY_BCOPY(&(context->buffer[SHA512_SHORT_BLOCK_LENGTH+0]), &(context->bitcount[1]), sizeof(sha2_word64));
+	MEMCPY_BCOPY(&(context->buffer[SHA512_SHORT_BLOCK_LENGTH+8]), &(context->bitcount[0]), sizeof(sha2_word64));
 
 	/* Final transform: */
 	SHA512_Transform(context, (sha2_word64*)context->buffer);


### PR DESCRIPTION
Attempt to fix #612 

> sha256.c: In function 'sr_SHA256_Final':
> sha256.c:613:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
>    *(sha2_word64*)&context->buffer[SHA256_SHORT_BLOCK_LENGTH] = context->bitcount;
>    ^
> sha256.c: In function 'SHA512_Last':
> sha256.c:930:2: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
>    *(sha2_word64*)&context->buffer[SHA512_SHORT_BLOCK_LENGTH] = context->bitcount[1];
>    ^
> sha256.c:931:2: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
>  *(sha2_word64*)&context->buffer[SHA512_SHORT_BLOCK_LENGTH+8] = context->bitcount[0];
>  ^