### PR TITLE
ims_registar_scscf: Fix subscr data handling in SAA

### DIFF
--- a/modules/ims_registrar_scscf/cxdx_sar.c
+++ b/modules/ims_registrar_scscf/cxdx_sar.c
@@ -238,18 +238,23 @@ void async_cdp_callback(int is_timeout, void *param, AAAMessage *saa, long elaps
         }
 
         if (data->sar_assignment_type == AVP_IMS_SAR_REGISTRATION || data->sar_assignment_type == AVP_IMS_SAR_RE_REGISTRATION) {
-            if (build_p_associated_uri(s) != 0) {
-                LM_ERR("Unable to build p_associated_uri\n");
+            if (s) {
+                if (build_p_associated_uri(s) != 0) {
+                    LM_ERR("Unable to build p_associated_uri\n");
+                    rerrno = R_SAR_FAILED;
+                    goto error;
+                }
+            }
+
+        }
+
+        if (s) {
+            //here we update the contacts and also build the new contact header for the 200 OK reply
+            if (update_contacts_new(t->uas.request, data->domain, &data->public_identity, data->sar_assignment_type, &s, &ccf1, &ccf2, &ecf1, &ecf2, &data->contact_header) <= 0) {
+                LM_ERR("Error processing REGISTER\n");
                 rerrno = R_SAR_FAILED;
                 goto error;
             }
-        }
-
-        //here we update the contacts and also build the new contact header for the 200 OK reply
-        if (update_contacts(t->uas.request, data->domain, &data->public_identity, data->sar_assignment_type, &s, &ccf1, &ccf2, &ecf1, &ecf2, &data->contact_header) <= 0) {
-            LM_ERR("Error processing REGISTER\n");
-            rerrno = R_SAR_FAILED;
-            goto error;
         }
         
         if (data->contact_header) {


### PR DESCRIPTION
During re-registration, Diameter SAR message is sent to the HSS. It contains User-Data-Already-Available AVP, which by specification (TS 29.228, Table 6.1.2.1) instructs the HSS not to send subscription data. However when SAA is received without User-Data an error is generated. I think this behavior is not correct.

This patch modifies SAA handling so it doesn't try to update local ims subscription information, for the case where there is none received from the HSS.