### PR TITLE
lib/srdb1: fix compiler warning

### DIFF
--- a/lib/srdb1/db_ut.c
+++ b/lib/srdb1/db_ut.c
@@ -53,8 +53,8 @@
 #ifndef __OS_solaris
 	#undef _XOPEN_SOURCE
 	#undef _XOPEN_SOURCE_EXTENDED
-#else
-	#undef _XOPEN_SOURCE_EXTENDED 1   /* solaris */
+#else  /* solaris */
+	#undef _XOPEN_SOURCE_EXTENDED
 #endif
 
 #include <limits.h>


### PR DESCRIPTION
Came up when trying to compile with OmniOS distribution