### PR TITLE
modules/presence_conference: Fix compilation on FreeBSD

### DIFF
--- a/modules/presence_conference/pidf.c
+++ b/modules/presence_conference/pidf.c
@@ -34,23 +34,21 @@
 /**
  * make strptime available
  * use 600 for 'Single UNIX Specification, Version 3'
- * _XOPEN_SOURCE creates conflict in header definitions in Solaris
  */
-#ifndef __OS_solaris
-	#define _XOPEN_SOURCE 600          /* glibc2 on linux, bsd */
+#ifdef __OS_linux
+	#define _XOPEN_SOURCE 600          /* glibc2 on linux */
 	#define _BSD_SOURCE 1				/* needed on linux to "fix" the effect
 										  of the above define on
 										  features.h/unistd.h syscall() */
    #define _DEFAULT_SOURCE 1			/* _BSD_SOURCE is deprecated */
-   #define _DARWIN_C_SOURCE 1
-#else
-	#define _XOPEN_SOURCE_EXTENDED 1   /* solaris */
 #endif
-
+#ifdef __OS_darwin
+   #define _DARWIN_C_SOURCE 1
+#endif
+#ifdef __OS_solaris
+   #define _XOPEN_SOURCE_EXTENDED 1
+#endif
 #include <time.h>
-
-#undef _XOPEN_SOURCE
-#undef _XOPEN_SOURCE_EXTENDED
 
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Fixes compilation on FreeBSD where no special feature request is needed 