### PR TITLE
Add support for Authentication-Info header in auth module

### DIFF
--- a/modules/auth/api.h
+++ b/modules/auth/api.h
@@ -99,8 +99,8 @@ auth_result_t pre_auth(struct sip_msg* msg, str* realm, hdr_types_t hftype,
  * marking authorized credentials and so on.
  */
 typedef auth_result_t (*post_auth_t)(struct sip_msg* msg,
-		struct hdr_field* hdr);
-auth_result_t post_auth(struct sip_msg* msg, struct hdr_field* hdr);
+		struct hdr_field* hdr, char* ha1);
+auth_result_t post_auth(struct sip_msg* msg, struct hdr_field* hdr, char* ha1);
 
 typedef int (*check_response_t)(dig_cred_t* cred, str* method, char* ha1);
 int auth_check_response(dig_cred_t* cred, str* method, char* ha1);

--- a/modules/auth/auth_mod.c
+++ b/modules/auth/auth_mod.c
@@ -137,6 +137,7 @@ static struct qp auth_qauthint = {
 /* Hash algorithm used for digest authentication, MD5 if empty */
 str auth_algorithm = {"", 0};
 int hash_hex_len;
+int add_authinfo_hdr = 0; /* should an Authentication-Info header be added on 200 OK responses? */
 
 calc_HA1_t calc_HA1;
 calc_response_t calc_response;
@@ -204,6 +205,7 @@ static param_export_t params[] = {
 	{"realm_prefix",           PARAM_STRING, &auth_realm_prefix.s   },
 	{"use_domain",             PARAM_INT,    &auth_use_domain       },
 	{"algorithm",              PARAM_STR,    &auth_algorithm        },
+	{"add_authinfo_hdr",       INT_PARAM,    &add_authinfo_hdr      },
 	{0, 0, 0}
 };
 
@@ -538,7 +540,7 @@ int pv_authenticate(struct sip_msg *msg, str *realm, str *passwd,
 	ret = auth_check_response(&(cred->digest), method, ha1);
 	if(ret==AUTHENTICATED) {
 		ret = AUTH_OK;
-		switch(post_auth(msg, h)) {
+		switch(post_auth(msg, h, ha1)) {
 			case AUTHENTICATED:
 				break;
 			default:

--- a/modules/auth/auth_mod.h
+++ b/modules/auth/auth_mod.h
@@ -44,6 +44,7 @@ extern str proxy_challenge_header;
 extern str www_challenge_header;
 extern struct qp auth_qop;
 extern str auth_algorithm;
+extern int add_authinfo_hdr; /* should an Authentication-Info header be added on 200 OK responses? */
 
 extern int hash_hex_len;
 extern calc_HA1_t calc_HA1;

--- a/modules/auth/challenge.h
+++ b/modules/auth/challenge.h
@@ -49,4 +49,6 @@ int get_challenge_hf(struct sip_msg* msg, int stale, str* realm,
 
 void strip_realm(str* _realm);
 
+int calc_new_nonce(char* nonce, int *nonce_len, int cfg, struct sip_msg* msg);
+
 #endif /* CHALLENGE_H */

--- a/modules/auth/doc/auth_params.xml
+++ b/modules/auth/doc/auth_params.xml
@@ -695,29 +695,55 @@ modparam("auth", "use_domain", 1)
 	</section>
 
 	<section id="auth.p.algorithm">
-	<title><varname>algorithm</varname> (string)</title>
-	<para>
-	   Configure hash algorithm used for digest authentication.
-	   Possible values are "MD5" or "SHA-256". If left empty MD5 is used.
-	   If specified, the specified algorithm is used and is also but in
-	   the 'algorithm' field of the challenge header.
-   </para>
-   <para>
-	   Warning: SHA-256 hash values take twice the space of MD5 hash values.
-	   So a buffer overflow might occur if this option is used in combination
-	   with another auth_* module that does not allocate at least 65 bytes to
-	   store hash values.
-	   SHA-256 can safely be used with the module auth_db as it allocates 256 bytes
-	   to store HA1 values.
-	</para>
-	<example>
-	   <title>use SHA-256 example</title>
-	   <programlisting>
+		<title><varname>algorithm</varname> (string)</title>
+		<para>
+			Configure hash algorithm used for digest authentication.
+			Possible values are "MD5" or "SHA-256". If left empty MD5 is used.
+			If specified, the specified algorithm is used and is also put in
+			the 'algorithm' field of the challenge header.
+		</para>
+		<para>
+			Warning: SHA-256 hash values take twice the space of MD5 hash values.
+			So a buffer overflow might occur if this option is used in combination
+			with another auth_* module that does not allocate at least 65 bytes to
+			store hash values.
+			SHA-256 can safely be used with the module auth_db as it allocates 256 bytes
+			to store HA1 values.
+		</para>
+		<example>
+			<title>use SHA-256 example</title>
+			<programlisting>
 ...
 modparam("auth", "algorithm", "SHA-256")
 ...
-	   </programlisting>
-	</example>
+			</programlisting>
+		</example>
+	</section>
+
+	<section id="auth.p.add_authinfo_hdr">
+		<title><varname>add_authinfo_hdr</varname> (boolean)</title>
+		<para>
+			Should an Authentication-Info header be added on 200 OK responses?
+			The Authentication-Info header offers mutual authentication.
+			The server proves to the client that it knows the user's secret.
+		</para>
+		<para>
+			The header also includes the next nonce which may be used by the client
+			in a future request.
+			If one_time_nonce is enabled, a new nonce is calculated for the next nonce.
+			Otherwise the current nonce is used for the next nonce.
+		</para>
+		<para>
+			The default value is 0 (no).
+		</para>
+		<example>
+			<title>add Authentication-Info header example</title>
+			<programlisting>
+...
+modparam("auth", "add_authinfo_hdr", yes)
+...
+			</programlisting>
+		</example>
 	</section>
 
 </section>

--- a/modules/auth/nonce.c
+++ b/modules/auth/nonce.c
@@ -178,7 +178,7 @@ inline static int calc_bin_nonce_md5(union bin_nonce* b_nonce, int cfg,
  *                  return error immediately. After a succesfull call it will
  *                  contain the size of nonce written into the buffer,
  *                  without the terminating 0.
- * @param cfg This is the value of one of the tree module parameters that
+ * @param cfg This is the value of one of the three module parameters that
  *            control which optional checks are enabled/disabled and which
  *            parts of the message will be included in the nonce string.
  * @param since Time when nonce was created, i.e. nonce is valid since <valid_since> up to <expires>

--- a/modules/auth/rfc2617.c
+++ b/modules/auth/rfc2617.c
@@ -110,7 +110,9 @@ void calc_response_md5(HASHHEX _ha1,      /* H(A1) */
 
 	/* calculate H(A2) */
 	MD5Init(&Md5Ctx);
-	MD5Update(&Md5Ctx, _method->s, _method->len);
+	if (_method) {
+		MD5Update(&Md5Ctx, _method->s, _method->len);
+	}
 	MD5Update(&Md5Ctx, ":", 1);
 	MD5Update(&Md5Ctx, _uri->s, _uri->len);
 

--- a/modules/auth/rfc2617_sha256.c
+++ b/modules/auth/rfc2617_sha256.c
@@ -115,7 +115,9 @@ void calc_response_sha256(HASHHEX_SHA256 _ha1,      /* H(A1) */
 
 	/* calculate H(A2) */
 	sr_SHA256_Init(&Sha256Ctx);
-	SHA256_Update(&Sha256Ctx, _method->s, _method->len);
+	if (_method) {
+		SHA256_Update(&Sha256Ctx, _method->s, _method->len);
+	}
 	SHA256_Update(&Sha256Ctx, ":", 1);
 	SHA256_Update(&Sha256Ctx, _uri->s, _uri->len);
 

--- a/modules/auth_db/authorize.c
+++ b/modules/auth_db/authorize.c
@@ -299,7 +299,7 @@ static int digest_authenticate_hdr(sip_msg_t* msg, str *realm,
 	ret = auth_api.check_response(&(cred->digest), method, ha1);
 	if(ret==AUTHENTICATED) {
 		ret = AUTH_OK;
-		switch(auth_api.post_auth(msg, h)) {
+		switch(auth_api.post_auth(msg, h, ha1)) {
 			case AUTHENTICATED:
 				generate_avps(msg, result);
 				break;

--- a/modules/auth_ephemeral/authorize.c
+++ b/modules/auth_ephemeral/authorize.c
@@ -101,7 +101,7 @@ static inline int do_auth(struct sip_msg *_m, struct hdr_field *_h, str *_realm,
 	ret = eph_auth_api.check_response(&cred->digest, _method, ha1);
 	if (ret == AUTHENTICATED)
 	{
-		if (eph_auth_api.post_auth(_m, _h) != AUTHENTICATED)
+		if (eph_auth_api.post_auth(_m, _h, ha1) != AUTHENTICATED)
 		{
 			return AUTH_ERROR;
 		}

--- a/modules/auth_radius/authorize.c
+++ b/modules/auth_radius/authorize.c
@@ -172,7 +172,7 @@ static inline int authorize(struct sip_msg* _msg, pv_elem_t* _realm,
     }
 
     if (res == 1) {
-	switch(auth_api.post_auth(_msg, h)) {
+	switch(auth_api.post_auth(_msg, h, NULL)) {
 	default:
 	    BUG("unexpected reply '%d'.\n",
 		auth_api.pre_auth(_msg, &domain, _hftype, &h, NULL));

--- a/modules/uid_auth_db/authorize.c
+++ b/modules/uid_auth_db/authorize.c
@@ -288,7 +288,7 @@ static inline int check_all_ha1(struct sip_msg* msg, struct hdr_field* hdr,
 					}
 
 					if (!check_response(dig, method, ha1)) {
-						if (auth_api.post_auth(msg, hdr) == AUTHENTICATED) {
+						if (auth_api.post_auth(msg, hdr, ha1) == AUTHENTICATED) {
 							generate_avps(*res, row);
 							return 0;
 						}
@@ -416,7 +416,7 @@ static inline int authenticate(struct sip_msg* msg, str* realm, authdb_table_inf
     
 	/* Recalculate response, it must be same to authorize successfully */
 	if (!check_response(&(cred->digest), &msg->first_line.u.request.method, ha1)) {
-		switch(auth_api.post_auth(msg, h)) {
+		switch(auth_api.post_auth(msg, h, ha1)) {
 		case ERROR:
 		case BAD_CREDENTIALS:
 			ret = -2; 


### PR DESCRIPTION
The Authentication-Info header is already supported by the ims_auth module. This pull requsts proposes an implementation for auth module.
The Authentication-Info header is added in the function "post_auth" (if "add_authinfo_hdr" is configured.)
Modules depending on "auth" are adapted slightly to offer the ha1 value to the function "post_auth".