### PR TITLE
Read all 12 columns from uacreg if the database does not have DB_CAP_…

### DIFF
--- a/modules/uac/uac_reg.c
+++ b/modules/uac/uac_reg.c
@@ -1172,7 +1172,7 @@ int uac_reg_load_db(void)
 		}
 	} else {
 		if((ret=reg_dbf.query(reg_db_con, NULL, NULL, NULL, db_cols,
-						0, 10, 0, &db_res))!=0
+						0, 12, 0, &db_res))!=0
 				|| RES_ROW_N(db_res)<=0 )
 		{
 			reg_dbf.free_result(reg_db_con, db_res);


### PR DESCRIPTION
When the database does not have DB_CAP_FETCH capability, only 10 columns are being read from uacreg instead of 12, so the flags and reg_delay columns are being omitted.