### PR TITLE
xmlrpc: remove redeclaration of snprintf and vsnprintf

### DIFF
--- a/modules/xmlrpc/xmlrpc.c
+++ b/modules/xmlrpc/xmlrpc.c
@@ -146,13 +146,6 @@
 
 MODULE_VERSION
 
-#if defined (__OS_darwin) || defined (__OS_freebsd)
-/* redeclaration of functions from stdio.h throws errors */
-#else
-int snprintf(char *str, size_t size, const char *format, ...);
-int vsnprintf(char *str, size_t size, const char *format, va_list ap);
-#endif
-
 static int process_xmlrpc(sip_msg_t* msg);
 static int dispatch_rpc(sip_msg_t* msg, char* s1, char* s2);
 static int xmlrpc_reply(sip_msg_t* msg, char* code, char* reason);


### PR DESCRIPTION
compilation was failling with clang:

```
> CC (clang) [M xmlrpc.so]		xmlrpc.o
> xmlrpc.c:152:5: error: expected parameter declarator
> int snprintf(char *str, size_t size, const char *format, ...);
>     ^
> /usr/include/x86_64-linux-gnu/bits/stdio2.h:69:39: note: expanded from macro 'snprintf'
>   __builtin___snprintf_chk (str, len, __USE_FORTIFY_LEVEL - 1, __bos (str), \
>                                       ^
> /usr/include/features.h:329:31: note: expanded from macro '__USE_FORTIFY_LEVEL'
> #  define __USE_FORTIFY_LEVEL 2
>                               ^
> xmlrpc.c:152:5: error: expected ')'
> /usr/include/x86_64-linux-gnu/bits/stdio2.h:69:39: note: expanded from macro 'snprintf'
>   __builtin___snprintf_chk (str, len, __USE_FORTIFY_LEVEL - 1, __bos (str), \
>                                       ^
> /usr/include/features.h:329:31: note: expanded from macro '__USE_FORTIFY_LEVEL'
> #  define __USE_FORTIFY_LEVEL 2
>                               ^
> xmlrpc.c:152:5: note: to match this '('
> /usr/include/x86_64-linux-gnu/bits/stdio2.h:69:28: note: expanded from macro 'snprintf'
>   __builtin___snprintf_chk (str, len, __USE_FORTIFY_LEVEL - 1, __bos (str), \
>                            ^
> xmlrpc.c:152:5: error: conflicting types for '__builtin___snprintf_chk'
> int snprintf(char *str, size_t size, const char *format, ...);
>     ^
> /usr/include/x86_64-linux-gnu/bits/stdio2.h:69:3: note: expanded from macro 'snprintf'
>   __builtin___snprintf_chk (str, len, __USE_FORTIFY_LEVEL - 1, __bos (str), \
>   ^
> xmlrpc.c:152:5: note: '__builtin___snprintf_chk' is a builtin with type 'int (char *, unsigned long, int, unsigned long, const char *, ...)'
> /usr/include/x86_64-linux-gnu/bits/stdio2.h:69:3: note: expanded from macro 'snprintf'
>   __builtin___snprintf_chk (str, len, __USE_FORTIFY_LEVEL - 1, __bos (str), \
>   ^
> 3 errors generated.
```