### PR TITLE
presence: add new parameter `subscribe_expires_offset`

### DIFF
--- a/modules/presence/doc/presence_admin.xml
+++ b/modules/presence/doc/presence_admin.xml
@@ -341,6 +341,27 @@ modparam("presence", "expires_offset", 10)
 		</example>
 
 </section>
+
+	<section id="presence.p.add_expires_offset">
+		<title><varname>add_expires_offset</varname> (int)</title>
+		<para>
+		Add expires_offset value to expires before inserting into db/htable
+		</para>
+		<para>
+		<emphasis>Default value is <quote>0</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>add_expires_offset</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("presence", "add_expires_offset", 1)
+...
+</programlisting>
+		</example>
+
+</section>
+
        <section id="presence.p.max_expires">
                <title><varname>max_expires</varname> (int)</title>
                <para>

--- a/modules/presence/presence.c
+++ b/modules/presence/presence.c
@@ -145,6 +145,7 @@ char prefix='a';
 int startup_time=0;
 str db_url = {0, 0};
 int expires_offset = 0;
+uint32_t add_expires_offset = 0;
 uint32_t min_expires= 0;
 int min_expires_action= 1;
 uint32_t max_expires= 3600;
@@ -207,6 +208,7 @@ static param_export_t params[]={
 	{ "force_delete",           INT_PARAM, &pres_force_delete },
 	{ "to_tag_pref",            PARAM_STRING, &to_tag_pref },
 	{ "expires_offset",         INT_PARAM, &expires_offset },
+	{ "add_expires_offset",     INT_PARAM, &add_expires_offset },
 	{ "max_expires",            INT_PARAM, &max_expires },
 	{ "min_expires",            INT_PARAM, &min_expires },
 	{ "min_expires_action",     INT_PARAM, &min_expires_action },

--- a/modules/presence/presence.h
+++ b/modules/presence/presence.h
@@ -71,6 +71,7 @@ extern int pid;
 extern int startup_time;
 extern char *to_tag_pref;
 extern int expires_offset;
+extern uint32_t add_expires_offset;
 extern str server_address;
 extern uint32_t min_expires;
 extern int min_expires_action;

--- a/modules/presence/subscribe.c
+++ b/modules/presence/subscribe.c
@@ -617,6 +617,11 @@ int update_subscription(struct sip_msg* msg, subs_t* subs, int to_tag_gen,
 			}
 			return 1;
 		}
+
+		if (add_expires_offset > 0) {
+			subs->expires = subs->expires + expires_offset;
+		}
+
 		/* if subscriptions are stored in memory, update them */
 		if(subs_dbmode != DB_ONLY)
 		{


### PR DESCRIPTION
 * defaults to 0
 * adds X seconds to expires before being stored in htable or database
 * causes subscribes to not be removed prematurely