### PR TITLE
ims_registrar_scscf: Remove buggy AVP from SAR

### DIFF
--- a/modules/ims_registrar_scscf/cxdx_avp.c
+++ b/modules/ims_registrar_scscf/cxdx_avp.c
@@ -142,17 +142,6 @@ static inline str cxdx_get_avp(AAAMessage *msg,int avp_code,int vendor_id,
 		return avp->data;
 }
 
-inline int cxdx_add_call_id(AAAMessage *msg, str data) 
-{
-    return 
-	cxdx_add_avp(msg,data.s,data.len,
-		AVP_Call_Id,
-		AAA_AVP_FLAG_VENDOR_SPECIFIC,
-		50,
-		AVP_DUPLICATE_DATA,
-		__FUNCTION__);
-}
-
 /**
  * Creates and adds a Destination-Realm AVP.
  * @param msg - the Diameter message to add to.

--- a/modules/ims_registrar_scscf/cxdx_avp.h
+++ b/modules/ims_registrar_scscf/cxdx_avp.h
@@ -53,7 +53,6 @@ struct AAAMessage;
 struct AAA_AVP;
 struct sip_msg;
 
-inline int cxdx_add_call_id(AAAMessage *msg, str data);
 /**
  * Creates and adds a Destination-Realm AVP.
  * @param msg - the Diameter message to add to.

--- a/modules/ims_registrar_scscf/cxdx_sar.c
+++ b/modules/ims_registrar_scscf/cxdx_sar.c
@@ -345,7 +345,6 @@ int cxdx_send_sar(struct sip_msg *msg, str public_identity, str private_identity
     }
     if (!sar) goto error1;
 
-    if (!cxdx_add_call_id(sar, cscf_get_call_id(msg, &hdr))) goto error1;
     if (!cxdx_add_destination_realm(sar, cxdx_dest_realm)) goto error1;
 
     if (!cxdx_add_vendor_specific_appid(sar, IMS_vendor_id_3GPP, IMS_Cx, 0 /*IMS_Cx*/)) goto error1;


### PR DESCRIPTION
Remove buggy function to add
"Call-ID" AVP which actually doesn't exists
on SAR Diameter Message
According to TS129.229, it actually exists
"Call-ID-Sip-Header" AVP witch code 643
which is grouped into "Subscription-Info"
AVP. According to the same TS, this AVP
is used for restoration procedure.