### PR TITLE
Fix check_route_param()

### DIFF
--- a/modules/rr/loose.c
+++ b/modules/rr/loose.c
@@ -977,7 +977,9 @@ int check_route_param(struct sip_msg * msg, regex_t* re)
 		return -1;
 
 	/* include also the first ';' */
-	for( params=routed_params ; params.s[0]!=';' ; params.s--,params.len++ );
+	params=routed_params;
+	params.s--;
+	params.len++;
 
 	/* do the well-known trick to convert to null terminted */
 	bk = params.s[params.len];


### PR DESCRIPTION
Given that there are multiple Route sets , each with one param , check_route_param() function fails to search the proper param.s string . 
The condition params.s[0]!=';'  holds false and it stops the loop only when it encounters another ";" character which is not part of the Route header .

Eg: (these are not actual Route params, but this is what it is printing instead - this is part of my INVITE, and these headers are above Route ):
rr [loose.c:985]: check_route_param(): params are <;spi-s=424238335#015#012Require: sec-agree#015#012Proxy-Require: sec-agree#015#012Cont>

This patch is a functional workaround. 
Note I have also seen there routed_params.s not pointing to the actual params , so perhaps there might be another issue before reaching this code.   

