### PR TITLE
utils: introduced the ability to add User-Agent header in HTTP requests.

### DIFF
--- a/modules/utils/doc/utils_admin.xml
+++ b/modules/utils/doc/utils_admin.xml
@@ -192,6 +192,25 @@ modparam("utils", "xcap_table", "pres_xcap")
 				</programlisting>
 			</example>
 		</section>
+                <section id="utils.p.user_agent">
+                        <title><varname>user_agent</varname> (string)</title>
+                        <para>
+                        Defines User-Agent for HTTP requests.
+                        </para>
+                        <para>
+                        <emphasis>
+                                There is no default value, if none is defined then no User-Agent header is added.
+                        </emphasis>
+                        </para>
+                        <example>
+                        <title>Set <varname>user_agent</varname> parameter</title>
+                                <programlisting format="linespecific">
+...
+modparam("utils", "user_agent", "kamailio")
+...
+                                </programlisting>
+                        </example>
+                </section>
 	</section>
 
 	<section>

--- a/modules/utils/functions.c
+++ b/modules/utils/functions.c
@@ -168,6 +168,7 @@ int http_query(struct sip_msg* _m, char* _url, char* _dst, char* _post, char* _h
 
 	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, (long)1);
 	curl_easy_setopt(curl, CURLOPT_TIMEOUT, (long)http_query_timeout);
+	curl_easy_setopt(curl, CURLOPT_USERAGENT, user_agent);
 
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_function);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &stream);

--- a/modules/utils/utils.c
+++ b/modules/utils/utils.c
@@ -67,6 +67,7 @@ static char* mp_filter = "";
 static char* mp_proxy  = "";
 str xcap_table= str_init("xcap");
 str pres_db_url = {0, 0};
+str user_agent= str_init("");
 
 /* lock for configuration access */
 static gen_lock_t *conf_lock = NULL;
@@ -123,6 +124,7 @@ static cmd_export_t cmds[] = {
 static param_export_t params[] = {
 	{"pres_db_url", PARAM_STR, &pres_db_url},
 	{"xcap_table", PARAM_STR, &xcap_table},
+	{"user_agent", PARAM_STR, &user_agent},
 	{"http_query_timeout", INT_PARAM, &http_query_timeout},
 	{"http_response_trim", INT_PARAM, &http_response_trim},
 	{"http_response_mode", INT_PARAM, &http_response_mode},

--- a/modules/utils/utils.h
+++ b/modules/utils/utils.h
@@ -39,6 +39,7 @@
 extern int http_query_timeout;
 extern db1_con_t *pres_dbh;
 extern db_func_t pres_dbf;
+extern str user_agent;
 
 typedef struct {
 	char		*buf;


### PR DESCRIPTION
following commit will introduce possibility to add User-Agent header
for http_query by adding utils module parameter - user_agent,
if none is defined then no User-Agent header is added.