### PR TITLE
cdp: Change debug level of peer state to DBG

### DIFF
--- a/modules/cdp/peermanager.c
+++ b/modules/cdp/peermanager.c
@@ -275,7 +275,7 @@ int peer_timer(time_t now,void *ptr)
 		}
 
 		if (p->activity+config->tc<=now){
-			LM_INFO("peer_timer(): Peer %.*s \tState %d \n",p->fqdn.len,p->fqdn.s,p->state);
+			LM_DBG("peer_timer(): Peer %.*s \tState %d \n",p->fqdn.len,p->fqdn.s,p->state);
 			switch (p->state){
 				/* initiating connection */
 				case Closed:


### PR DESCRIPTION
IMHO debug level of message telling the state
of the peer should be DBG. If any problem
occurs on peers proper message will be written
on log. This way we have lighter log