### PR TITLE
modules/tm documentation improvements

### DIFF
--- a/modules/tm/doc/functions.xml
+++ b/modules/tm/doc/functions.xml
@@ -815,9 +815,8 @@ route {
 	</title>
 	<para>
 		Returns true if the failure route is executed for a branch that did
-		timeout. It can be used from 
-		<emphasis>failure_route</emphasis> and
-		<emphasis>branch-failure</emphasis> event route.
+		timeout. It can be used from FAILURE_ROUTE and BRANCH_FAILURE_ROUTE
+		event route.
 	</para>
 	<example>
 	    <title><function>t_branch_timeout</function> usage</title>
@@ -840,9 +839,8 @@ failure_route[0]{
 	<para>
 		Returns true if the failure route is executed for a branch that did
 		receive at least one reply in the past (the "current" reply is not 
-		taken into account). It can be used from
-		<emphasis>failure_route</emphasis>  and
-		<emphasis>branch-failure</emphasis> event route.
+		taken into account). It can be used from FAILURE_ROUTE and
+		BRANCH_FAILURE_ROUTE event route.
 	</para>
 	<example>
 	    <title><function>t_branch_replied</function> usage</title>
@@ -1318,7 +1316,7 @@ if (!t_next_contacts()) {
 		was empty and thus there was
 		nothing to do, and returns -1 in case of an error (see
 		syslog).
-		This function can be used from a BRANCH_FAILURE event route.
+		This function can be used from a BRANCH_FAILURE_ROUTE event route.
 		</para>
 		<example>
 		<title><function>t_next_contact_flow</function> usage</title>

--- a/modules/tm/doc/functions.xml
+++ b/modules/tm/doc/functions.xml
@@ -35,6 +35,35 @@
 		Returns a negative value on failure -- you may still want to send a
 	    negative reply upstream statelessly not to leave upstream UAC in lurch.
 	</para>
+
+	<para>In case of error, the function returns the following codes:</para>
+	<itemizedlist>
+		<listitem>
+		<para><emphasis>-1</emphasis> - generic internal error
+		</para>
+		</listitem>
+		<listitem>
+		<para><emphasis>-2</emphasis> - bad message (parsing errors)
+		</para>
+		</listitem>
+		<listitem>
+		<para><emphasis>-3</emphasis> - no destination available (no branches were
+			added or request already cancelled)
+		</para>
+		</listitem>
+		<listitem>
+		<para><emphasis>-4</emphasis> - bad destination (unresolvable address)
+		</para>
+		</listitem>
+		<listitem>
+		<para><emphasis>-5</emphasis> - destination filtered (black listed)
+		</para>
+		</listitem>
+		<listitem>
+		<para><emphasis>-6</emphasis> - generic send failed
+		</para>
+		</listitem>
+	</itemizedlist>
 	<example>
 	    <title><function>t_relay</function> usage</title>
 	    <programlisting>


### PR DESCRIPTION
t_relay() return values copied from 1.5.x documentation:
http://kamailio.org/docs/modules/1.5.x/tm.html#id2514020

In route naming CAPITALS seem more common than <emphasis> (tm, tmx, sl, corex).