### PR TITLE
db_postgres: rename ntohll and htonll functions

### DIFF
--- a/modules/db_postgres/pg_fld.c
+++ b/modules/db_postgres/pg_fld.c
@@ -89,23 +89,19 @@ union ull {
 	uint32_t ui32[2];
 };
 
-#if !defined(__OS_darwin) || (defined(__OS_darwin) && !defined(NTOHLL))
-static inline uint64_t htonll(uint64_t in)
+static inline uint64_t _htonll(uint64_t in)
 {
 	union ull* p = (union ull*)&in;
 	
 	return ((uint64_t)htonl(p->ui32[0]) << 32) + (uint64_t)htonl(p->ui32[1]);
 }
-#endif
 
 
-#if !defined(__OS_darwin) || (defined(__OS_darwin) && !defined(NTOHLL))
-static inline uint64_t ntohll(uint64_t in)
+static inline uint64_t _ntohll(uint64_t in)
 {
 	union ull* p = (union ull*)&in;
 	return ((uint64_t)ntohl(p->ui32[0]) << 32) + (uint64_t)ntohl(p->ui32[1]);
 }
-#endif
 
 
 static inline void db_int2pg_int4(struct pg_params* dst, int i, 
@@ -141,7 +137,7 @@ static inline void db_int2pg_timestamp(struct pg_params* dst, int i,
 	} else {
 		pfld->v.dbl = (double)src->v.int4 - (double)PG_EPOCH_TIME;
 	}
-	pfld->v.int8 = htonll(pfld->v.int8);
+	pfld->v.int8 = _htonll(pfld->v.int8);
 
 	dst->fmt[i] = 1;
 	dst->val[i] = pfld->v.byte;
@@ -204,7 +200,7 @@ static inline void db_float2pg_float8(struct pg_params* dst, int i, db_fld_t* sr
 {
 	struct pg_fld* pfld = DB_GET_PAYLOAD(src);
 	pfld->v.dbl = src->v.flt;
-	pfld->v.int8 = htonll(pfld->v.int8);
+	pfld->v.int8 = _htonll(pfld->v.int8);
 
 	dst->fmt[i] = 1;
 	dst->val[i] = pfld->v.byte;
@@ -215,7 +211,7 @@ static inline void db_float2pg_float8(struct pg_params* dst, int i, db_fld_t* sr
 static inline void db_double2pg_float8(struct pg_params* dst, int i, db_fld_t* src)
 {
 	struct pg_fld* pfld = DB_GET_PAYLOAD(src);
-	pfld->v.int8 = htonll(src->v.int8);
+	pfld->v.int8 = _htonll(src->v.int8);
 
 	dst->fmt[i] = 1;
 	dst->val[i] = pfld->v.byte;
@@ -682,7 +678,7 @@ static inline int pg_int4_2_db_int(db_fld_t* fld, char* val, int len)
 
 static inline int pg_int8_2_db_int(db_fld_t* fld, char* val, int len)
 {
-	fld->v.int8 = (int64_t)ntohll(*((int64_t*)val));
+	fld->v.int8 = (int64_t)_ntohll(*((int64_t*)val));
 	return 0;
 }
 
@@ -728,10 +724,10 @@ static inline int pg_timestamp2db_int(db_fld_t* fld, char* val, int len,
 {
 	if (flags & PG_INT8_TIMESTAMP) {
 		/* int8 format */
-		fld->v.int4 = (int64_t)ntohll(((int64_t*)val)[0]) / (int64_t)1000000 + PG_EPOCH_TIME;
+		fld->v.int4 = (int64_t)_ntohll(((int64_t*)val)[0]) / (int64_t)1000000 + PG_EPOCH_TIME;
 	} else {
 		/* double format */
-		fld->v.int4 = PG_EPOCH_TIME + ntohll(((int64_t*)val)[0]);
+		fld->v.int4 = PG_EPOCH_TIME + _ntohll(((int64_t*)val)[0]);
 	}
 	return 0;
 }
@@ -771,7 +767,7 @@ static inline int pg_float42db_double(db_fld_t* fld, char* val, int len)
 
 static inline int pg_float82db_double(db_fld_t* fld, char* val, int len)
 {
-	fld->v.int8 = ntohll(*(uint64_t*)val);
+	fld->v.int8 = _ntohll(*(uint64_t*)val);
 	return 0;
 }
 


### PR DESCRIPTION
- fix namespace conflict on platforms where these are present in system libs

closes #665 