### PR TITLE
Nathelper/nat_traversal: branch=0

### DIFF
--- a/modules/nat_traversal/nat_traversal.c
+++ b/modules/nat_traversal/nat_traversal.c
@@ -1508,6 +1508,8 @@ ClientNatTest(struct sip_msg *msg, unsigned int tests)
 
 
 #define FROM_PREFIX "sip:keepalive@"
+#define MAX_BRANCHID 9999999
+#define MIN_BRANCHID 1000000
 
 static void
 send_keepalive(NAT_Contact *contact)
@@ -1536,7 +1538,7 @@ send_keepalive(NAT_Contact *contact)
 
     len = snprintf(buffer, sizeof(buffer),
                    "%s %s SIP/2.0\r\n"
-                   "Via: SIP/2.0/UDP %.*s:%d;branch=0\r\n"
+                   "Via: SIP/2.0/UDP %.*s:%d;branch=z9hG4bK%ld\r\n"
                    "From: %s;tag=%x\r\n"
                    "To: %s\r\n"
                    "Call-ID: %s-%x-%x@%.*s\r\n"
@@ -1546,6 +1548,7 @@ send_keepalive(NAT_Contact *contact)
                    keepalive_params.method, contact->uri,
                    contact->socket->address_str.len,
                    contact->socket->address_str.s, contact->socket->port_no,
+                   (long)(rand()/(float)RAND_MAX * (MAX_BRANCHID-MIN_BRANCHID) + MIN_BRANCHID),
                    from_uri, keepalive_params.from_tag++,
                    contact->uri, keepalive_params.callid_prefix,
                    keepalive_params.callid_counter++, get_ticks(),

--- a/modules/nathelper/sip_pinger.h
+++ b/modules/nathelper/sip_pinger.h
@@ -116,6 +116,9 @@ static inline char* build_sipping(str *curi, struct socket_info* s, str *path,
 								str *ruid, unsigned int aorhash, int *len_p)
 {
 #define s_len(_s) (sizeof(_s)-1)
+#define MAX_BRANCHID 9999999
+#define MIN_BRANCHID 1000000
+#define LEN_BRANCHID 7  /* NOTE: this must be sync with the MX and MIN values !! */
 	static char buf[MAX_SIPPING_SIZE];
 	char *p;
 	int len;
@@ -135,7 +138,7 @@ static inline char* build_sipping(str *curi, struct socket_info* s, str *path,
 	if ( sipping_method.len + 1 + curi->len + s_len(" SIP/2.0"CRLF) +
 		s_len("Via: SIP/2.0/UDP ") + vaddr.len +
 				((s->address.af==AF_INET6)?2:0) +
-				1 + vport.len + s_len(";branch=0") +
+				1 + vport.len + s_len(";branch=z9hG4bK") + LEN_BRANCHID +
 		(path->len ? (s_len(CRLF"Route: ") + path->len) : 0) +
 		s_len(CRLF"From: ") +  sipping_from.len + s_len(";tag=") +
 				ruid->len + 1 + 8 + 1 + 8 +
@@ -164,13 +167,16 @@ static inline char* build_sipping(str *curi, struct socket_info* s, str *path,
 	}
 	*(p++) = ':';
 	append_str( p, vport.s, vport.len);
+	append_fix( p, ";branch=z9hG4bK");
+	int2bstr(
+		(long)(rand()/(float)RAND_MAX * (MAX_BRANCHID-MIN_BRANCHID) + MIN_BRANCHID),
+		p+LEN_BRANCHID-INT2STR_MAX_LEN+1, NULL);
+	p += LEN_BRANCHID;
 	if (path->len) {
-		append_fix( p, ";branch=0"CRLF"Route: ");
+		append_fix( p, CRLF"Route: ");
 		append_str( p, path->s, path->len);
-		append_fix( p, CRLF"From: ");
-	} else {
-		append_fix( p, ";branch=0"CRLF"From: ");
 	}
+	append_fix( p, CRLF"From: ");
 	append_str( p, sipping_from.s, sipping_from.len);
 	append_fix( p, ";tag=");
 	append_str( p, ruid->s, ruid->len);


### PR DESCRIPTION
It was noitced "branch=0" in sip-pinging requests, that seems not RFC compliant:

> OPTIONS sip:0004*202@192.168.5.61:5062 SIP/2.0.
> Via: SIP/2.0/UDP xxx.xxx.xxx.xxx:5060;branch=0.
> From: sip:ping@myhost.ru;tag=uloc-5756b445-45e2-53b-223ff654-6ad81121.
> To: sip:0004*202@192.168.5.61:5062.
> Call-ID: 935a5981-9d632e71-c6c3075@xxx.xxx.xxx.xxx.
> CSeq: 1 OPTIONS.
> Content-Length: 0.

this issue is a google search result: https://github.com/OpenSIPS/opensips/issues/145
so this patch is just a copy 	of [varunvairavan](https://github.com/varunvairavan) patch