### PR TITLE
db_unixodbc: detect DB disconnection with generic HY000 status

### DIFF
--- a/modules/db_unixodbc/dbase.c
+++ b/modules/db_unixodbc/dbase.c
@@ -138,7 +138,8 @@ static int db_unixodbc_submit_query(const db1_con_t* _h, const str* _s)
 
 		/* Connection broken */
 		if( !strncmp((char*)sqlstate,"08003",5) ||
-		    !strncmp((char*)sqlstate,"08S01",5)
+		    !strncmp((char*)sqlstate,"08S01",5) ||
+		    !strncmp((char*)sqlstate,"HY000",5)   /* ODBC 3 General error */
 		    )
 		{
 			ret = reconnect(_h);


### PR DESCRIPTION
With Oracle DB, if the DB is restarted, db_unixodbc doesn't detect the problem as the error returned by
db_unixodbc_extract_error() is:

Jul  1 06:07:15 newvm1 /usr/sbin/kamailio[2770]: ERROR: db_unixodbc [connection.c:220]: db_unixodbc_extract_error(): unixodbc:SQLExecDirect=HY000:1:3114:[Oracle][ODBC][Ora]ORA-03114: not connected to ORACLE#012

Before, only status 08003 and 08S01 where checked to reconnect to the DB. Now, SQLSTATE HY000 (General error) is checked to trigger a reconnection.