### PR TITLE
Packaging: Add new http package for Debian

### DIFF
--- a/Makefile.groups
+++ b/Makefile.groups
@@ -81,10 +81,10 @@ mod_list_carrierroute=carrierroute
 mod_list_berkeley=db_berkeley
 
 # - modules depending on curl library
-mod_list_utils=utils http_client
+mod_list_utils=utils
 
 # - modules depending on curl and libevent2 library
-mod_list_http_async=http_async_client
+mod_list_http_client=http_async_client http_client
 
 # - modules depending on purple library
 mod_list_purple=purple
@@ -220,7 +220,7 @@ mod_list_all=$(sort $(mod_list_basic) $(mod_list_extra) \
 			   $(mod_list_mongodb) $(mod_list_cnxcc) \
 			   $(mod_list_jansson) $(mod_list_geoip2) \
 			   $(mod_list_erlang) $(mod_list_systemd) \
-			   $(mod_list_http_async) $(mod_list_nsq))
+			   $(mod_list_http_client) $(mod_list_nsq))
 
 
 
@@ -325,7 +325,7 @@ module_group_kldap=$(mod_list_ldap)
 module_group_kutils=$(mod_list_utils)
 
 # pkg https_async module
-module_group_khttp_async=$(mod_list_http_async)
+module_group_khttp=$(mod_list_http_client)
 
 # pkg purple module
 module_group_kpurple=$(mod_list_purple)

--- a/pkg/kamailio/deb/debian/control
+++ b/pkg/kamailio/deb/debian/control
@@ -499,8 +499,6 @@ Description: Provides a set utility functions for Kamailio
  .
  Provides a set of utility functions for Kamailio, which are not related
  to the server configuration.
- .
- Includes http client (http_client) module too
 
 Package: kamailio-sctp-modules
 Architecture: linux-any
@@ -669,6 +667,20 @@ Description: extra modules for Kamailio
  per second even on low-budget hardware.
  .
  This package provides: gzcompress uuid ev jansson janssonrpc-c http_async
+
+Package: kamailio-http-modules
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: kamailio (= ${binary:Version}),
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: http modules for Kamailio
+ Kamailio is a very fast and flexible SIP (RFC3261)
+ proxy server. Written entirely in C, Kamailio can handle thousands calls
+ per second even on low-budget hardware.
+ .
+ This package provides: http_client http_async_client
 
 Package: kamailio-nth
 Architecture: any

--- a/pkg/kamailio/deb/debian/rules
+++ b/pkg/kamailio/deb/debian/rules
@@ -34,7 +34,7 @@ EXTRA_EXCLUDED_MODULES=bdb dbtext oracle pa iptrtpproxy
 # Note: the order is important (should be in dependency order, the one
 # on which other depend first)
 PACKAGE_GROUPS=mysql postgres berkeley unixodbc radius presence \
-			   ldap xml perl utils lua memcached \
+			   ldap xml perl utils http lua memcached \
 			   snmpstats carrierroute xmpp cpl redis python geoip\
 			   sqlite json mono ims sctp java \
 			   purple tls outbound websocket autheph dnssec kazoo cnxcc \

--- a/pkg/kamailio/deb/jessie/control
+++ b/pkg/kamailio/deb/jessie/control
@@ -498,8 +498,6 @@ Description: Provides a set utility functions for Kamailio
  .
  Provides a set of utility functions for Kamailio, which are not related
  to the server configuration.
- .
- Includes http client (http_client) module too
 
 Package: kamailio-sctp-modules
 Architecture: linux-any
@@ -668,6 +666,20 @@ Description: extra modules for Kamailio
  per second even on low-budget hardware.
  .
  This package provides: gzcompress uuid ev jansson janssonrpc-c http_async
+
+Package: kamailio-http-modules
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: kamailio (= ${binary:Version}),
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: http modules for Kamailio
+ Kamailio is a very fast and flexible SIP (RFC3261)
+ proxy server. Written entirely in C, Kamailio can handle thousands calls
+ per second even on low-budget hardware.
+ .
+ This package provides: http_client http_async_client
 
 Package: kamailio-nth
 Architecture: any

--- a/pkg/kamailio/deb/jessie/rules
+++ b/pkg/kamailio/deb/jessie/rules
@@ -34,7 +34,7 @@ EXTRA_EXCLUDED_MODULES=bdb dbtext oracle pa iptrtpproxy mi_xmlrpc
 # Note: the order is important (should be in dependency order, the one
 # on which other depend first)
 PACKAGE_GROUPS=mysql postgres berkeley unixodbc radius presence \
-			   ldap xml perl utils lua memcached \
+			   ldap xml perl utils http lua memcached \
 			   snmpstats carrierroute xmpp cpl redis python geoip\
 			   sqlite json mono ims sctp java \
 			   purple tls outbound websocket autheph dnssec kazoo cnxcc \

--- a/pkg/kamailio/deb/precise/control
+++ b/pkg/kamailio/deb/precise/control
@@ -494,8 +494,6 @@ Description: Provides a set utility functions for Kamailio
  .
  Provides a set of utility functions for Kamailio, which are not related
  to the server configuration.
- .
- Includes http client (http_client) module too
 
 Package: kamailio-sctp-modules
 Architecture: linux-any
@@ -608,6 +606,20 @@ Description: extra modules for Kamailio
  per second even on low-budget hardware.
  .
  This package provides: gzcompress uuid ev jansson janssonrpc-c http_async
+
+Package: kamailio-http-modules
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: kamailio (= ${binary:Version}),
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: http modules for Kamailio
+ Kamailio is a very fast and flexible SIP (RFC3261)
+ proxy server. Written entirely in C, Kamailio can handle thousands calls
+ per second even on low-budget hardware.
+ .
+ This package provides: http_client http_async_client
 
 Package: kamailio-nth
 Architecture: any

--- a/pkg/kamailio/deb/precise/rules
+++ b/pkg/kamailio/deb/precise/rules
@@ -33,7 +33,7 @@ EXTRA_EXCLUDED_MODULES=bdb dbtext oracle pa iptrtpproxy mi_xmlrpc dnssec kazoo c
 # Note: the order is important (should be in dependency order, the one
 # on which other depend first)
 PACKAGE_GROUPS=mysql postgres berkeley unixodbc radius presence \
-			   ldap xml perl utils lua memcached \
+			   ldap xml perl utils http lua memcached \
 			   snmpstats carrierroute xmpp cpl redis python geoip\
 			   sqlite json mono ims sctp java \
 			   purple tls outbound websocket autheph \

--- a/pkg/kamailio/deb/sid/control
+++ b/pkg/kamailio/deb/sid/control
@@ -498,8 +498,6 @@ Description: Provides a set utility functions for Kamailio
  .
  Provides a set of utility functions for Kamailio, which are not related
  to the server configuration.
- .
- Includes http client (http_client) module too
 
 Package: kamailio-sctp-modules
 Architecture: linux-any
@@ -668,6 +666,20 @@ Description: extra modules for Kamailio
  per second even on low-budget hardware.
  .
  This package provides: gzcompress uuid ev jansson janssonrpc-c http_async
+
+Package: kamailio-http-modules
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: kamailio (= ${binary:Version}),
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: http modules for Kamailio
+ Kamailio is a very fast and flexible SIP (RFC3261)
+ proxy server. Written entirely in C, Kamailio can handle thousands calls
+ per second even on low-budget hardware.
+ .
+ This package provides: http_client http_async_client
 
 Package: kamailio-nth
 Architecture: any

--- a/pkg/kamailio/deb/sid/rules
+++ b/pkg/kamailio/deb/sid/rules
@@ -34,7 +34,7 @@ EXTRA_EXCLUDED_MODULES=bdb dbtext oracle pa iptrtpproxy mi_xmlrpc
 # Note: the order is important (should be in dependency order, the one
 # on which other depend first)
 PACKAGE_GROUPS=mysql postgres berkeley unixodbc radius presence \
-			   ldap xml perl utils lua memcached \
+			   ldap xml perl utils http lua memcached \
 			   snmpstats carrierroute xmpp cpl redis python geoip\
 			   sqlite json mono ims sctp java \
 			   purple tls outbound websocket autheph dnssec kazoo cnxcc \

--- a/pkg/kamailio/deb/squeeze/control
+++ b/pkg/kamailio/deb/squeeze/control
@@ -420,8 +420,6 @@ Description: Provides a set utility functions for Kamailio
  .
  Provides a set of utility functions for Kamailio, which are not related
  to the server configuration.
- .
- Includes http client (http_client) module too
 
 Package: kamailio-tls-modules
 Architecture: linux-any
@@ -498,6 +496,20 @@ Description: extra modules for Kamailio
  per second even on low-budget hardware.
  .
  This package provides: gzcompress uuid ev http_async
+
+Package: kamailio-http-modules
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: kamailio (= ${binary:Version}),
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: http modules for Kamailio
+ Kamailio is a very fast and flexible SIP (RFC3261)
+ proxy server. Written entirely in C, Kamailio can handle thousands calls
+ per second even on low-budget hardware.
+ .
+ This package provides: http_client http_async_client
 
 Package: kamailio-nth
 Architecture: any

--- a/pkg/kamailio/deb/squeeze/rules
+++ b/pkg/kamailio/deb/squeeze/rules
@@ -31,7 +31,7 @@ EXTRA_EXCLUDED_MODULES=bdb dbtext oracle pa iptrtpproxy java dnssec sctp purple 
 # Note: the order is important (should be in dependency order, the one
 # on which other depend first)
 PACKAGE_GROUPS=mysql postgres berkeley unixodbc radius presence \
-			   ldap xml perl utils lua memcached \
+			   ldap xml perl utils http lua memcached \
 			   snmpstats carrierroute xmpp cpl python geoip\
 			   sqlite json ims \
 			   tls outbound websocket autheph \

--- a/pkg/kamailio/deb/stretch/control
+++ b/pkg/kamailio/deb/stretch/control
@@ -498,8 +498,6 @@ Description: Provides a set utility functions for Kamailio
  .
  Provides a set of utility functions for Kamailio, which are not related
  to the server configuration.
- .
- Includes http client (http_client) module too
 
 Package: kamailio-sctp-modules
 Architecture: linux-any
@@ -668,6 +666,20 @@ Description: extra modules for Kamailio
  per second even on low-budget hardware.
  .
  This package provides: gzcompress uuid ev jansson janssonrpc-c http_async
+
+Package: kamailio-http-modules
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: kamailio (= ${binary:Version}),
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: http modules for Kamailio
+ Kamailio is a very fast and flexible SIP (RFC3261)
+ proxy server. Written entirely in C, Kamailio can handle thousands calls
+ per second even on low-budget hardware.
+ .
+ This package provides: http_client http_async_client
 
 Package: kamailio-nth
 Architecture: any

--- a/pkg/kamailio/deb/stretch/rules
+++ b/pkg/kamailio/deb/stretch/rules
@@ -34,7 +34,7 @@ EXTRA_EXCLUDED_MODULES=bdb dbtext oracle pa iptrtpproxy mi_xmlrpc
 # Note: the order is important (should be in dependency order, the one
 # on which other depend first)
 PACKAGE_GROUPS=mysql postgres berkeley unixodbc radius presence \
-			   ldap xml perl utils lua memcached \
+			   ldap xml perl utils http lua memcached \
 			   snmpstats carrierroute xmpp cpl redis python geoip\
 			   sqlite json mono ims sctp java \
 			   purple tls outbound websocket autheph dnssec kazoo cnxcc \

--- a/pkg/kamailio/deb/trusty/control
+++ b/pkg/kamailio/deb/trusty/control
@@ -496,8 +496,6 @@ Description: Provides a set utility functions for Kamailio
  .
  Provides a set of utility functions for Kamailio, which are not related
  to the server configuration.
- .
- Includes http client (http_client) module too
 
 Package: kamailio-sctp-modules
 Architecture: linux-any
@@ -652,6 +650,20 @@ Description: extra modules for Kamailio
  per second even on low-budget hardware.
  .
  This package provides: gzcompress uuid ev jansson janssonrpc-c http_async
+
+Package: kamailio-http-modules
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: kamailio (= ${binary:Version}),
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: http modules for Kamailio
+ Kamailio is a very fast and flexible SIP (RFC3261)
+ proxy server. Written entirely in C, Kamailio can handle thousands calls
+ per second even on low-budget hardware.
+ .
+ This package provides: http_client http_async_client
 
 Package: kamailio-nth
 Architecture: any

--- a/pkg/kamailio/deb/trusty/rules
+++ b/pkg/kamailio/deb/trusty/rules
@@ -34,7 +34,7 @@ EXTRA_EXCLUDED_MODULES=bdb dbtext oracle pa iptrtpproxy mi_xmlrpc systemd
 # Note: the order is important (should be in dependency order, the one
 # on which other depend first)
 PACKAGE_GROUPS=mysql postgres berkeley unixodbc radius presence \
-			   ldap xml perl utils lua memcached \
+			   ldap xml perl utils http lua memcached \
 			   snmpstats carrierroute xmpp cpl redis python geoip\
 			   sqlite json mono ims sctp java \
 			   purple tls outbound websocket autheph dnssec kazoo cnxcc \

--- a/pkg/kamailio/deb/wheezy/control
+++ b/pkg/kamailio/deb/wheezy/control
@@ -478,8 +478,6 @@ Description: Provides a set utility functions for Kamailio
  .
  Provides a set of utility functions for Kamailio, which are not related
  to the server configuration.
- .
- Includes http client (http_client) module too
 
 Package: kamailio-sctp-modules
 Architecture: linux-any
@@ -592,6 +590,20 @@ Description: extra modules for Kamailio
  per second even on low-budget hardware.
  .
  This package provides: gzcompress uuid ev jansson janssonrpc-c http_async
+
+Package: kamailio-http-modules
+Architecture: linux-any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: kamailio (= ${binary:Version}),
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: http modules for Kamailio
+ Kamailio is a very fast and flexible SIP (RFC3261)
+ proxy server. Written entirely in C, Kamailio can handle thousands calls
+ per second even on low-budget hardware.
+ .
+ This package provides: http_client http_async_client
 
 Package: kamailio-nth
 Architecture: any

--- a/pkg/kamailio/deb/wheezy/rules
+++ b/pkg/kamailio/deb/wheezy/rules
@@ -33,7 +33,7 @@ EXTRA_EXCLUDED_MODULES=bdb dbtext oracle pa iptrtpproxy purple mi_xmlrpc dnssec 
 # Note: the order is important (should be in dependency order, the one
 # on which other depend first)
 PACKAGE_GROUPS=mysql postgres berkeley unixodbc radius presence \
-			   ldap xml perl utils lua memcached \
+			   ldap xml perl utils http lua memcached \
 			   snmpstats carrierroute xmpp cpl redis python geoip\
 			   sqlite json mono ims sctp java \
 			   tls outbound websocket autheph \


### PR DESCRIPTION
The new module contains the http_client and http_async_client module.

A few difficulties with this change:

1. Modules are right now grouped by lib dependencies. This caused the http_client module to end up in the kamailio-utils-modules package. No one would ever search for it there.
2. I tried to package a kamailio-http_async-modules package, but this isn't a valid Debian package name. But when renaming it into kamailio-http-modules, it felt wrong to include just the async http client and leave the http_client module stuck in the utils package, where no one would look for it. So I moved the http_client package, too.
3. The package depends on libevent, which is actually just a dependency of http_async_client. http_client would compile without. I don't know whether this breaks any policies.