### PR TITLE
Add kam_rand() macro for portability

### DIFF
--- a/main.c
+++ b/main.c
@@ -118,6 +118,7 @@
 #include "dst_blacklist.h"
 #endif
 #include "rand/fastrand.h" /* seed */
+#include "rand/kam_rand.h"
 
 #include "stats.h"
 #include "counters.h"
@@ -2103,10 +2104,10 @@ try_again:
 	}
 	seed+=getpid()+time(0);
 	LM_DBG("seeding PRNG with %u\n", seed);
-	srand(seed);
-	fastrand_seed(rand());
-	srandom(rand()+time(0));
-	LM_DBG("test random numbers %u %lu %u\n", rand(), random(), fastrand());
+	kam_srand(seed);
+	fastrand_seed(kam_rand());
+	srandom(kam_rand()+time(0));
+	LM_DBG("test random numbers %u %lu %u\n", kam_rand(), random(), fastrand());
 
 	/*register builtin  modules*/
 	register_builtin_modules();

--- a/modules/auth/auth_mod.c
+++ b/modules/auth/auth_mod.c
@@ -40,6 +40,7 @@
 #include "../../lvalue.h"
 #include "../../mod_fix.h"
 #include "../../kemi.h"
+#include "../../rand/kam_rand.h"
 #include "../../modules/sl/sl.h"
 #include "auth_mod.h"
 #include "challenge.h"
@@ -248,14 +249,14 @@ static inline int generate_random_secret(void)
 	/* srandom(time(0));  -- seeded by core */
 
 	for(i = 0; i < RAND_SECRET_LEN; i++) {
-		sec_rand1[i] = 32 + (int)(95.0 * rand() / (RAND_MAX + 1.0));
+		sec_rand1[i] = 32 + (int)(95.0 * kam_rand() / (KAM_RAND_MAX + 1.0));
 	}
 
 	secret1.s = sec_rand1;
 	secret1.len = RAND_SECRET_LEN;
 
 	for(i = 0; i < RAND_SECRET_LEN; i++) {
-		sec_rand2[i] = 32 + (int)(95.0 * rand() / (RAND_MAX + 1.0));
+		sec_rand2[i] = 32 + (int)(95.0 * kam_rand() / (KAM_RAND_MAX + 1.0));
 	}
 
 	secret2.s = sec_rand2;

--- a/modules/carrierroute/cr_func.c
+++ b/modules/carrierroute/cr_func.c
@@ -40,6 +40,7 @@
 #include "../../mem/mem.h"
 #include "../../qvalue.h"
 #include "../../dset.h"
+#include "../../rand/kam_rand.h"
 #include "cr_map.h"
 #include "cr_rule.h"
 #include "cr_domain.h"
@@ -510,7 +511,7 @@ static int rewrite_on_rule(struct route_flags *rf_head, flag_t flags, str * dest
 						 * was previously tried */
 
 						do {
-							int rule_no = rand() % rf->rule_num;
+							int rule_no = kam_rand() % rf->rule_num;
 							//LM_DBG("CR: trying rule_no=%d \n", rule_no);
 							for (rr = rf->rule_list; (rule_no > 0) && (rr->next!=NULL) ; rule_no-- , rr = rr->next) {}
 						} while (cr_uri_already_used(rr->host, used_dests, no_dests));

--- a/modules/carrierroute/prime_hash.c
+++ b/modules/carrierroute/prime_hash.c
@@ -30,10 +30,10 @@
 #include "../../parser/parse_to.h"
 #include "../../parser/parse_from.h"
 #include "../../crc.h"
+#include "../../rand/kam_rand.h"
 
 #include <ctype.h>
 #include <stdio.h> /* for snprintf */
-#include <stdlib.h> /* for rand */
 
 #include "prime_hash.h"
 
@@ -153,7 +153,7 @@ static int determine_fromto_user (struct to_body *fromto, str *source_string) {
 
 static int determine_fromrand(str* source_string){
 
-	snprintf(&cr_randbuf[0], CR_RANDBUF_S , "%d", rand());
+	snprintf(&cr_randbuf[0], CR_RANDBUF_S , "%d", kam_rand());
 
 	LM_NOTICE("randbuf is %s\n", cr_randbuf);
 	source_string->s = cr_randbuf;

--- a/modules/cdp/peermanager.c
+++ b/modules/cdp/peermanager.c
@@ -84,10 +84,10 @@ int peer_manager_init(dp_config *config)
 	msg_id_lock = lock_alloc();
 	msg_id_lock = lock_init(msg_id_lock);
 
-	srand((unsigned int)time(0));
-	*hopbyhop_id = rand();
+	kam_srand((unsigned int)time(0));
+	*hopbyhop_id = kam_rand();
 	*endtoend_id = (time(0)&0xFFF)<<20;
-	*endtoend_id |= rand() & 0xFFFFF;
+	*endtoend_id |= kam_rand() & 0xFFFFF;
 
 	for(i=0;i<config->peers_cnt;i++){
 		p = new_peer(config->peers[i].fqdn,config->peers[i].realm,config->peers[i].port,config->peers[i].src_addr);

--- a/modules/cdp/session.c
+++ b/modules/cdp/session.c
@@ -172,8 +172,8 @@ int cdp_sessions_init(int hash_size)
 		LOG_NO_MEM("shm",sizeof(unsigned int));
 		goto error;
 	}
-	srand((unsigned int)time(0));
-	*session_id1 = rand();
+	kam_srand((unsigned int)time(0));
+	*session_id1 = kam_rand();
 	*session_id1 <<= 16;
 	*session_id1 += time(0)&0xFFFF;
 	*session_id2 = 0;

--- a/modules/cdp/utils.h
+++ b/modules/cdp/utils.h
@@ -50,6 +50,7 @@
 #include "../../mem/shm_mem.h"
 #include "../../locking.h"
 #include "../../pt.h"
+#include "../../rand/kam_rand.h"
 #include "sem.h"
 
 #ifndef LOG_NO_MEM

--- a/modules/cfgutils/cfgutils.c
+++ b/modules/cfgutils/cfgutils.c
@@ -74,6 +74,7 @@
 #include "../../route.h"
 #include "../../rpc_lookup.h"
 #include "../../kemi.h"
+#include "../../rand/kam_rand.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -736,7 +737,7 @@ static int rand_event(struct sip_msg *bar, char *foo1, char *foo2)
 	if ((*probability) == 0) return -1;
 	if ((*probability) == 100) return 1;
 
-	tmp = ((double) rand() / RAND_MAX);
+	tmp = ((double) kam_rand() / KAM_RAND_MAX);
 	LM_DBG("generated random %f\n", tmp);
 	if (tmp < ((double) (*probability) / 100)) {
 		LM_DBG("return true\n");
@@ -758,7 +759,7 @@ static int pv_get_random_val(struct sip_msg *msg, pv_param_t *param,
 	if(msg==NULL || res==NULL)
 		return -1;
 
-	n = rand();
+	n = kam_rand();
 	ch = int2str(n , &l);
 	res->rs.s = ch;
 	res->rs.len = l;

--- a/modules/dialog/dlg_hash.c
+++ b/modules/dialog/dlg_hash.c
@@ -36,6 +36,7 @@
 #include "../../hashes.h"
 #include "../../lib/kmi/mi.h"
 #include "../../lib/kcore/statistics.h"
+#include "../../rand/kam_rand.h"
 #include "dlg_timer.h"
 #include "dlg_var.h"
 #include "dlg_hash.h"
@@ -298,7 +299,7 @@ int init_dlg_table(unsigned int size)
 			LM_ERR("failed to init lock for slot: %d\n", i);
 			goto error1;
 		}
-		d_table->entries[i].next_id = rand() % (3*size);
+		d_table->entries[i].next_id = kam_rand() % (3*size);
 	}
 
 	return 0;

--- a/modules/dispatcher/dispatch.c
+++ b/modules/dispatcher/dispatch.c
@@ -472,10 +472,10 @@ void shuffle_uint100array(unsigned int* arr){
 	int k;
 	int j;
 	unsigned int t;
-	srand(time(0));
+	kam_srand(time(0));
 	for (j=0; j<100; j++)
 	{
-		k = j + (rand() % (100-j));
+		k = j + (kam_rand() % (100-j));
 		t = arr[j];
 		arr[j] = arr[k];
 		arr[k] = t;
@@ -1897,7 +1897,7 @@ int ds_select_dst_limit(sip_msg_t *msg, int set, int alg, unsigned int limit, in
 			}
 			break;
 		case 6: /* random selection */
-			hash = rand() % idx->nr;
+			hash = kam_rand() % idx->nr;
 			break;
 		case 7: /* hash on PV value */
 			if (ds_hash_pvar(msg, &hash)!=0)

--- a/modules/dispatcher/dispatch.h
+++ b/modules/dispatcher/dispatch.h
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include "../../pvar.h"
 #include "../../parser/msg_parser.h"
+#include "../../rand/kam_rand.h"
 #include "../../modules/tm/tm_load.h"
 
 

--- a/modules/dispatcher/dispatcher.c
+++ b/modules/dispatcher/dispatcher.c
@@ -571,7 +571,7 @@ static int mod_init(void)
  */
 static int child_init(int rank)
 {
-	srand((11+rank)*getpid()*7);
+	kam_srand((11+rank)*getpid()*7);
 
 	return 0;
 }

--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -47,6 +47,7 @@
 #include "../../parser/parse_uri.h"
 #include "../../dset.h"
 #include "../../rpc_lookup.h"
+#include "../../rand/kam_rand.h"
 
 #include "dr_load.h"
 #include "prefix_tree.h"
@@ -403,7 +404,7 @@ static int dr_child_init(int rank)
 		LM_ERR("cannot select table \"%.*s\"\n", drg_table.len, drg_table.s);
 		return -1;
 	}
-	srand(getpid()+time(0)+rank);
+	kam_srand(getpid()+time(0)+rank);
 	return 0;
 }
 
@@ -774,7 +775,7 @@ again:
 			} else {
 				if(i-j==2)
 				{
-					local_gwlist[t++]   = j + rand()%2;
+					local_gwlist[t++]   = j + kam_rand()%2;
 					if(sort_order==1)
 					{
 						local_gwlist[t++] = j + (local_gwlist[j]-j+1)%2;
@@ -783,11 +784,11 @@ again:
 						 *  local_gwlist[j+1]);*/
 					}
 				} else {
-					local_gwlist[t++]   = j + rand()%(i-j);
+					local_gwlist[t++]   = j + kam_rand()%(i-j);
 					if(sort_order==1)
 					{
 						do{
-							local_gwlist[t] = j + rand()%(i-j);
+							local_gwlist[t] = j + kam_rand()%(i-j);
 						}while(local_gwlist[t]==local_gwlist[t-1]);
 						t++;
 
@@ -824,7 +825,7 @@ again:
 						}
 					}
 					while ( dr_already_choosen(rt_info, local_gwlist, t-1, local_gwlist[t-1]) ) {
-						local_gwlist[t-1]   = j + rand()%(i-j);
+						local_gwlist[t-1]   = j + kam_rand()%(i-j);
 					}
 				}
 				LM_DBG("The %d gateway is %.*s [%d]\n", t, rt_info->pgwl[local_gwlist[t-1]].pgw->ip.len,

--- a/modules/ims_auth/authorize.c
+++ b/modules/ims_auth/authorize.c
@@ -57,6 +57,7 @@
 #include "../../usr_avp.h"
 #include "../../mod_fix.h"
 #include "../../mem/mem.h"
+#include "../../rand/kam_rand.h"
 #include "../cdp/diameter.h"
 #include "../cdp/diameter_ims_code_result.h"
 
@@ -933,7 +934,7 @@ int authenticate(struct sip_msg* msg, char* _realm, char* str2, int is_proxy_aut
             int i;
             char y[NONCE_LEN];
             for (i = 0; i < NONCE_LEN; i++)
-                y[i] = (unsigned char) ((int) (256.0 * rand() / (RAND_MAX + 1.0)));
+                y[i] = (unsigned char) ((int) (256.0 * kam_rand() / (KAM_RAND_MAX + 1.0)));
 
             if (unlikely((av->authenticate.len < 2 * NONCE_LEN))) {
                 if (av->authenticate.s) {
@@ -1222,7 +1223,7 @@ auth_vector * new_auth_vector(int item_number, str auth_scheme, str authenticate
             int i;
             char y[NONCE_LEN];
             for (i = 0; i < NONCE_LEN; i++)
-                y[i] = (unsigned char) ((int) (256.0 * rand() / (RAND_MAX + 1.0)));
+                y[i] = (unsigned char) ((int) (256.0 * kam_rand() / (KAM_RAND_MAX + 1.0)));
             x->authenticate.len = 2 * NONCE_LEN;
             x->authenticate.s = shm_malloc(x->authenticate.len);
             if (!x->authenticate.s) {

--- a/modules/ims_charging/ro_session_hash.c
+++ b/modules/ims_charging/ro_session_hash.c
@@ -117,7 +117,7 @@ int init_ro_session_table(unsigned int size) {
 
     for (i = 0; i < size; i++) {
         memset(&(ro_session_table->entries[i]), 0, sizeof (struct ro_session_entry));
-        ro_session_table->entries[i].next_id = rand() % (3*size);
+        ro_session_table->entries[i].next_id = kam_rand() % (3*size);
         ro_session_table->entries[i].lock_idx = i % ro_session_table->locks_no;
     }
 

--- a/modules/ims_charging/ro_session_hash.h
+++ b/modules/ims_charging/ro_session_hash.h
@@ -10,6 +10,7 @@
 
 #include "ro_timer.h"
 #include "../../mem/shm_mem.h"
+#include "../../rand/kam_rand.h"
 #include "ims_charging_stats.h"
 #include <stdlib.h>
 

--- a/modules/ims_dialog/dlg_hash.c
+++ b/modules/ims_dialog/dlg_hash.c
@@ -11,6 +11,7 @@
 #include "../../dprint.h"
 #include "../../ut.h"
 #include "../../lib/kmi/mi.h"
+#include "../../rand/kam_rand.h"
 #include "dlg_timer.h"
 #include "dlg_var.h"
 #include "dlg_hash.h"
@@ -130,7 +131,7 @@ int init_dlg_table(unsigned int size) {
 
     for (i = 0; i < size; i++) {
         memset(&(d_table->entries[i]), 0, sizeof (struct dlg_entry));
-        d_table->entries[i].next_id = rand() % (3*size);
+        d_table->entries[i].next_id = kam_rand() % (3*size);
         d_table->entries[i].lock_idx = i % d_table->locks_no;
     }
 

--- a/modules/ims_registrar_scscf/reg_mod.h
+++ b/modules/ims_registrar_scscf/reg_mod.h
@@ -51,6 +51,7 @@
 #include "../../parser/msg_parser.h"
 #include "../../qvalue.h"
 #include "../../usr_avp.h"
+#include "../../rand/kam_rand.h"
 #include "../ims_usrloc_scscf/usrloc.h"
 #include "../../modules/sl/sl.h"
 #include "../../modules/tm/tm_load.h"

--- a/modules/ims_registrar_scscf/registrar_notify.c
+++ b/modules/ims_registrar_scscf/registrar_notify.c
@@ -109,7 +109,7 @@ static inline int randomize_expires(int expires, int range) {
 
     int range_min = expires - (float) range / 100 * expires;
 
-    return range_min + (float) (rand() % 100) / 100 * (expires - range_min);
+    return range_min + (float) (kam_rand() % 100) / 100 * (expires - range_min);
 }
 
 int notify_init() {

--- a/modules/ims_registrar_scscf/save.c
+++ b/modules/ims_registrar_scscf/save.c
@@ -96,7 +96,7 @@ static inline int randomize_expires(int expires, int range) {
 
     int range_min = expires - (float) range / 100 * expires;
 
-    return range_min + (float) (rand() % 100) / 100 * (expires - range_min);
+    return range_min + (float) (kam_rand() % 100) / 100 * (expires - range_min);
 }
 
 /*! \brief

--- a/modules/ims_registrar_scscf/sip_msg.c
+++ b/modules/ims_registrar_scscf/sip_msg.c
@@ -53,7 +53,7 @@ static inline int get_expire_val(void) {
 		return expires;
 	/* select a random value in the range */
 	return expires - (float) range / 100 * expires
-			+ (float) (rand() % 100) / 100 * 2 * (float) range / 100 * expires;
+			+ (float) (kam_rand() % 100) / 100 * 2 * (float) range / 100 * expires;
 }
 
 /*! \brief

--- a/modules/iptrtpproxy/iptrtpproxy.c
+++ b/modules/iptrtpproxy/iptrtpproxy.c
@@ -48,6 +48,7 @@
 #include "../../select_buf.h"
 #include "../../script_cb.h"
 #include "../../cfg_parser.h"
+#include "../../rand/kam_rand.h"
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -1438,7 +1439,7 @@ ERR("RTPPROXY_DEBUG: session_count: %d, reuse_existing_count: %d\n", global_sdp_
 
 					} else if (ok_stamp == 0) {
 						/* not yet acquired, highest */
-						w = 100000000 + (rand() & 0xFFFF);  /* randomize not yet asked or being hartbeated */
+						w = 100000000 + (kam_rand() & 0xFFFF);  /* randomize not yet asked or being hartbeated */
 					} else {
 						/* middle */
 						w = 1000;

--- a/modules/lcr/lcr_mod.c
+++ b/modules/lcr/lcr_mod.c
@@ -64,6 +64,7 @@
 #include "../../socket_info.h"
 #include "../../pvar.h"
 #include "../../mod_fix.h"
+#include "../../rand/kam_rand.h"
 #include "hash.h"
 #include "lcr_rpc.h"
 #include "../../rpc_lookup.h"
@@ -1992,7 +1993,7 @@ static int load_gws(struct sip_msg* _m, int argc, action_u_t argv[])
 		matched_gws[gw_index].prefix_len = pl->prefix_len;
 		matched_gws[gw_index].priority = t->priority;
 		matched_gws[gw_index].weight = t->weight *
-		    (rand() >> 8);
+		    (kam_rand() >> 8);
 		matched_gws[gw_index].duplicate = 0;
 		LM_DBG("added matched_gws[%d]=[%u, %u, %u, %u]\n",
 		       gw_index, t->gw_index, pl->prefix_len,

--- a/modules/nat_traversal/nat_traversal.c
+++ b/modules/nat_traversal/nat_traversal.c
@@ -65,6 +65,7 @@
 #include "../../parser/parse_expires.h"
 #include "../../parser/contact/parse_contact.h"
 #include "../../lib/kcore/statistics.h"
+#include "../../rand/kam_rand.h"
 #include "../dialog/dlg_load.h"
 #include "../../modules/tm/tm_load.h"
 #include "../../modules/sl/sl.h"
@@ -1548,7 +1549,7 @@ send_keepalive(NAT_Contact *contact)
                    keepalive_params.method, contact->uri,
                    contact->socket->address_str.len,
                    contact->socket->address_str.s, contact->socket->port_no,
-                   (long)(rand()/(float)RAND_MAX * (MAX_BRANCHID-MIN_BRANCHID) + MIN_BRANCHID),
+                   (long)(kam_rand()/(float)KAM_RAND_MAX * (MAX_BRANCHID-MIN_BRANCHID) + MIN_BRANCHID),
                    from_uri, keepalive_params.from_tag++,
                    contact->uri, keepalive_params.callid_prefix,
                    keepalive_params.callid_counter++, get_ticks(),
@@ -1799,9 +1800,9 @@ mod_init(void)
     }
     if (strcasecmp(keepalive_params.method, "NOTIFY")==0)
         keepalive_params.event_header = "Event: keep-alive\r\n";
-    snprintf(keepalive_params.callid_prefix, 20, "%x", rand());
-    keepalive_params.callid_counter = rand();
-    keepalive_params.from_tag = rand();
+    snprintf(keepalive_params.callid_prefix, 20, "%x", kam_rand());
+    keepalive_params.callid_counter = kam_rand();
+    keepalive_params.from_tag = kam_rand();
 
 #ifdef STATISTICS
     // we need the statistics initialized before restoring the keepalive state

--- a/modules/nsq/reader.c
+++ b/modules/nsq/reader.c
@@ -2,6 +2,7 @@
 #include "utlist.h"
 #include "http.h"
 #include "../../dprint.h"
+#include "../../rand/kam_rand.h"
 
 extern int nsq_max_in_flight;
 
@@ -68,7 +69,7 @@ static void nsq_reader_lookupd_poll_cb(EV_P_ struct ev_timer *w, int revents)
     if (count == 0)
 	idx = 0;
     else
-	idx = rand() % count;
+	idx = kam_rand() % count;
 
 
     i = 0;
@@ -167,6 +168,6 @@ int nsq_reader_connect_to_nsqd(struct NSQReader *rdr, const char *address, int p
 void nsq_run(struct ev_loop *loop)
 {
 	//LM_ERR("nsq_run()!\n");
-    srand(time(NULL));
+    kam_srand(time(NULL));
     ev_loop(loop, 0);
 }

--- a/modules/pipelimit/pipelimit.c
+++ b/modules/pipelimit/pipelimit.c
@@ -52,6 +52,7 @@
 #include "../../modules/sl/sl.h"
 #include "../../lib/kmi/mi.h"
 #include "../../rpc_lookup.h"
+#include "../../rand/kam_rand.h"
 
 #include "pl_ht.h"
 #include "pl_db.h"
@@ -499,7 +500,7 @@ static int pl_drop(struct sip_msg * msg, unsigned int low, unsigned int high)
 				hdr.len = snprintf(hdr.s, 63, "Retry-After: %d\r\n", low);
 			} else {
 				hdr.len = snprintf(hdr.s, 63, "Retry-After: %d\r\n", 
-					low + rand() % (high - low + 1));
+					low + kam_rand() % (high - low + 1));
 			}
 
 			if (add_lump_rpl(msg, hdr.s, hdr.len, LUMP_RPL_HDR)==0) {

--- a/modules/presence/presence.c
+++ b/modules/presence/presence.c
@@ -56,6 +56,7 @@
 #include "../../mem/mem.h"
 #include "../../mem/shm_mem.h"
 #include "../../usr_avp.h"
+#include "../../rand/kam_rand.h"
 #include "../../modules/tm/tm_load.h"
 #include "../../modules/sl/sl.h"
 #include "../../pt.h"
@@ -1481,7 +1482,7 @@ static int update_pw_dialogs_dbonlymode(subs_t* subs, subs_t** subs_array)
 	db_vals[n_update_cols].nul = 0;
 	if (subs->callid.len == 0 || subs->from_tag.len == 0)
 	{
-		db_vals[n_update_cols].val.int_val = (int) ((rand() / (RAND_MAX + 1.0)) *
+		db_vals[n_update_cols].val.int_val = (int) ((kam_rand() / (KAM_RAND_MAX + 1.0)) *
 				(pres_waitn_time * pres_notifier_poll_rate
 				 * pres_notifier_processes));
 	} else {

--- a/modules/registrar/sip_msg.c
+++ b/modules/registrar/sip_msg.c
@@ -33,6 +33,7 @@
 #include "../../parser/parse_expires.h"
 #include "../../ut.h"
 #include "../../qvalue.h"
+#include "../../rand/kam_rand.h"
 #include "registrar.h"                     /* Module parameters */
 #include "regtime.h"                     /* act_time */
 #include "rerrno.h"
@@ -56,7 +57,7 @@ static inline int randomize_expires( int expires, int range )
 
 	range_min = expires - (float)range/100 * expires;
 
-	return range_min + (float)(rand()%100)/100 * ( expires - range_min );
+	return range_min + (float)(kam_rand()%100)/100 * ( expires - range_min );
 }
 
 

--- a/modules/rls/notify.c
+++ b/modules/rls/notify.c
@@ -37,6 +37,7 @@
 #include "../../parser/parse_cseq.h"
 #include "../../parser/contact/parse_contact.h"
 #include "../../parser/parse_rr.h"
+#include "../../rand/kam_rand.h"
 #include "../../modules/tm/dlg.h"
 #include "../presence/utils_func.h"
 #include "../presence/hash.h"
@@ -1112,7 +1113,7 @@ char* generate_string(int length)
 		
 	for(i=0; i<length; i++) 
 	{
-		r= rand() % ('z'- 'A') + 'A';
+		r= kam_rand() % ('z'- 'A') + 'A';
 		if(r>'Z' && r< 'a')
 		r= '0'+ (r- 'Z');
 
@@ -1128,7 +1129,7 @@ char* generate_cid(char* uri, int uri_len)
 	static char cid[512];
 	int len;
 
-	len= sprintf(cid, "%d.%.*s.%d", (int)time(NULL), uri_len, uri, rand());
+	len= sprintf(cid, "%d.%.*s.%d", (int)time(NULL), uri_len, uri, kam_rand());
 	cid[len]= '\0';
 	
 	return cid;

--- a/modules/sipcapture/sipcapture.c
+++ b/modules/sipcapture/sipcapture.c
@@ -74,6 +74,7 @@
 #include "../../resolve.h"
 #include "../../receive.h"
 #include "../../mod_fix.h"
+#include "../../rand/kam_rand.h"
 #include "sipcapture.h"
 #include "hash_mode.h"
 #include "hep.h"
@@ -807,7 +808,7 @@ static int mod_init(void)
 	}
 #endif
 
-	srand(time(NULL));
+	kam_srand(time(NULL));
 
 
 	if(db_insert_mode) {
@@ -1481,7 +1482,7 @@ static int sip_capture_store(struct _sipcapture_object *sco, str *dtable, _captu
 		}
 		else if (c->mtmode == mode_random )
 		{
-			ii = rand() % c->no_tables;
+			ii = kam_rand() % c->no_tables;
 			LM_DBG("rand idx is:%d\n", ii);
 		}
 		else if (c->mtmode == mode_round_robin)

--- a/modules/tm/callid.c
+++ b/modules/tm/callid.c
@@ -36,6 +36,7 @@
 #include "../../pt.h"
 #include "../../socket_info.h"
 #include "../../srapi.h"
+#include "../../rand/kam_rand.h"
 #include "callid.h"
 
 /**
@@ -81,16 +82,16 @@ int init_callid(void)
 		return -1;
 	}
 	
-	for(rand_bits = 1, i = RAND_MAX; i; i >>= 1, rand_bits++);  /* how long are the rand()s ? */
+	for(rand_bits = 1, i = KAM_RAND_MAX; i; i >>= 1, rand_bits++);  /* how long are the rand()s ? */
 	i = callid_prefix.len * 4 / rand_bits; /* how many rands() fit in the ULONG ? */
 
 	     /* now fill in the callid with as many random
 	      * numbers as you can + 1 */
-       	callid_nr = rand(); /* this is the + 1 */
+       	callid_nr = kam_rand(); /* this is the + 1 */
 
 	while(i--) {
 		callid_nr <<= rand_bits;
-		callid_nr |= rand();
+		callid_nr |= kam_rand();
 	}
 
 	i = snprintf(callid_prefix.s, callid_prefix.len + 1, "%0*lx", callid_prefix.len, callid_nr);

--- a/modules/tm/h_table.c
+++ b/modules/tm/h_table.c
@@ -36,6 +36,7 @@
 #include "../../globals.h"
 #include "../../error.h"
 #include "../../char_msg_val.h"
+#include "../../rand/kam_rand.h"
 #include "defs.h"
 #include "t_reply.h"
 #include "t_cancel.h"
@@ -270,7 +271,7 @@ static inline void init_synonym_id( struct sip_msg *p_msg, char *hash )
 		   anything
 		*/
 		/* HACK : not long enough */
-		myrand=rand();
+		myrand=kam_rand();
 		c = hash;
 		size=MD5_LEN;
 		memset(c, '0', size );
@@ -480,7 +481,7 @@ struct s_table* init_hash_table()
 	for(  i=0 ; i<TABLE_ENTRIES; i++ )
 	{
 		init_entry_lock( _tm_table, (_tm_table->entries)+i );
-		_tm_table->entries[i].next_label = rand();
+		_tm_table->entries[i].next_label = kam_rand();
 		/* init cell list */
 		clist_init(&_tm_table->entries[i], next_c, prev_c);
 	}

--- a/modules/tm/uac.c
+++ b/modules/tm/uac.c
@@ -36,6 +36,7 @@
 #include "../../socket_info.h"
 #include "../../compiler_opt.h"
 #include "../../parser/parse_cseq.h"
+#include "../../rand/kam_rand.h"
 #include "config.h"
 #include "ut.h"
 #include "h_table.h"
@@ -75,7 +76,7 @@ int uac_init(void)
 	str src[3];
 	struct socket_info *si;
 
-	if (RAND_MAX < TABLE_ENTRIES) {
+	if (KAM_RAND_MAX < TABLE_ENTRIES) {
 		LOG(L_WARN, "Warning: uac does not spread "
 		    "across the whole hash table\n");
 	}

--- a/modules/tsilo/ts_hash.c
+++ b/modules/tsilo/ts_hash.c
@@ -35,6 +35,7 @@
 #include "../../hashes.h"
 #include "../../lib/kmi/mi.h"
 #include "../../lib/kcore/statistics.h"
+#include "../../rand/kam_rand.h"
 #include "ts_hash.h"
 #include "ts_handlers.h"
 
@@ -111,7 +112,7 @@ int init_ts_table(unsigned int size)
 
 	for( i=0 ; i<size; i++ ) {
 		memset( &(t_table->entries[i]), 0, sizeof(struct ts_entry) );
-		t_table->entries[i].next_id = rand() % (3*size);
+		t_table->entries[i].next_id = kam_rand() % (3*size);
 		t_table->entries[i].lock_idx = i % t_table->locks_no;
 	}
 

--- a/modules/usrloc/ul_mi.c
+++ b/modules/usrloc/ul_mi.c
@@ -35,6 +35,7 @@
 #include "../../qvalue.h"
 #include "../../ip_addr.h"
 #include "../../dset.h"
+#include "../../rand/kam_rand.h"
 #include "ul_mi.h"
 #include "dlist.h"
 #include "udomain.h"
@@ -67,7 +68,7 @@ static void set_mi_ul_cid(void)
 	if(mi_ul_cid.s!=NULL) return;
 
 	for(i=0; i<19; i++) {
-        mi_ul_cid_buf[i] = charset[rand()%(sizeof(charset) - 1)];
+        mi_ul_cid_buf[i] = charset[kam_rand()%(sizeof(charset) - 1)];
     }
     memcpy(mi_ul_cid_buf+i, "@kamailio.mi", sizeof("@kamailio.mi"));
     mi_ul_cid.s = mi_ul_cid_buf;

--- a/modules/xmpp/util.c
+++ b/modules/xmpp/util.c
@@ -28,11 +28,11 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <stdlib.h>
 
 #include "xmpp.h"
 #include "../../parser/parse_uri.h"
 #include "../../parser/parse_param.h"
+#include "../../rand/kam_rand.h"
 
 extern param_t *_xmpp_gwmap_list;
 
@@ -271,7 +271,7 @@ char *random_secret(void)
 	int i, r;
 
         for (i = 0; i < 40; i++) {
-            r = (int) (36.0 * rand() / RAND_MAX);
+            r = (int) (36.0 * kam_rand() / KAM_RAND_MAX);
             secret[i] = (r >= 0 && r <= 9) ? (r + 48) : (r + 87);
         }
         secret[40] = '\0';

--- a/modules/xprint/xp_lib.c
+++ b/modules/xprint/xp_lib.c
@@ -51,6 +51,7 @@
 #include "../../resolve.h"
 #include "../../qvalue.h"
 #include "../../usr_avp.h"
+#include "../../rand/kam_rand.h"
 
 #include "../../parser/parse_from.h"
 #include "../../parser/parse_uri.h"
@@ -1929,13 +1930,13 @@ int xl_child_init(int rank)
 {
 	int i, x, rb, cb;
 
-	for (i=RAND_MAX, rb=0; i; rb++, i>>=1);
+	for (i=KAM_RAND_MAX, rb=0; i; rb++, i>>=1);
 
 	cb=x=0; /* x asiignment to make gcc happy */
 	for (i=0; i<UNIQUE_ID_LEN; i++) {
 		if (!cb) {
 			cb=rb;
-			x=rand();
+			x=kam_rand();
 		}
 		UNIQUE_ID[i]=fourbits2char[x&0x0F];
 		x>>=rb;

--- a/msg_translator.c
+++ b/msg_translator.c
@@ -103,6 +103,7 @@
 #include "parser/parse_param.h"
 #include "forward.h"
 #include "str_list.h"
+#include "rand/kam_rand.h"
 
 #define append_str_trans(_dest,_src,_len,_msg) \
 	append_str( (_dest), (_src), (_len) );
@@ -520,7 +521,7 @@ static inline int lump_check_opt(	struct lump *l,
 				return 1;
 			}
 		case COND_IF_RAND:
-			if(rand()>=RAND_MAX/2) {
+			if(kam_rand()>=KAM_RAND_MAX/2) {
 				LUMP_SET_COND_TRUE(l);
 				return 1;
 			} else return 0;

--- a/pt.c
+++ b/pt.c
@@ -26,6 +26,7 @@
 #include "sr_module.h"
 #include "socket_info.h"
 #include "rand/fastrand.h"
+#include "rand/kam_rand.h"
 #ifdef PKG_MALLOC
 #include "mem/mem.h"
 #endif
@@ -284,7 +285,7 @@ int fork_process(int child_id, char *desc, int make_sock)
 	
 	
 	child_process_no = *process_count;
-	new_seed1=rand();
+	new_seed1=kam_rand();
 	new_seed2=random();
 	pid = fork();
 	if (pid<0) {
@@ -300,8 +301,8 @@ int fork_process(int child_id, char *desc, int make_sock)
 #ifdef USE_TCP
 		close_extra_socks(child_id, process_no);
 #endif /* USE_TCP */
-		srand(new_seed1);
-		fastrand_seed(rand());
+		kam_srand(new_seed1);
+		fastrand_seed(kam_rand());
 		srandom(new_seed2+time(0));
 		shm_malloc_on_fork();
 #ifdef PROFILING
@@ -419,7 +420,7 @@ int fork_tcp_process(int child_id, char *desc, int r, int *reader_fd_1)
 	
 	
 	child_process_no = *process_count;
-	new_seed1=rand();
+	new_seed1=kam_rand();
 	new_seed2=random();
 	pid = fork();
 	if (pid<0) {
@@ -442,8 +443,8 @@ int fork_tcp_process(int child_id, char *desc, int r, int *reader_fd_1)
 			}
 		}
 		daemon_status_on_fork_cleanup();
-		srand(new_seed1);
-		fastrand_seed(rand());
+		kam_srand(new_seed1);
+		fastrand_seed(kam_rand());
 		srandom(new_seed2+time(0));
 		shm_malloc_on_fork();
 #ifdef PROFILING

--- a/rand/kam_rand.h
+++ b/rand/kam_rand.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2016 Spencer Thomason
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef __KAM_RAND_H__
+#define __KAM_RAND_H__
+
+#include <limits.h>
+#include <stdlib.h>
+
+#if RAND_MAX < INT_MAX
+#define KAM_RAND_MAX ((int) (0x7FFFFFFF)) /* (1<<31) - 1 */
+#define kam_rand(x) ((int)random(x))
+#define kam_srand(x) srandom(x)
+#else
+#define KAM_RAND_MAX RAND_MAX
+#define kam_rand(x) rand(x)
+#define kam_srand(x) srand(x)
+#endif
+
+#endif

--- a/select_core.c
+++ b/select_core.c
@@ -57,6 +57,7 @@
 #include "sr_module.h"
 #include "resolve.h"
 #include "forward.h"
+#include "rand/kam_rand.h"
 
 #define RETURN0_res(x) {*res=(x);return 0;}
 #define TRIM_RET0_res(x) {*res=(x);trim(res);return 0;} 
@@ -1508,11 +1509,11 @@ int select_sys_unique(str* res, select_t* s, struct sip_msg* msg) {
 		uniq_id[UNIQUE_ID_PID_LEN+1+UNIQUE_ID_TIME_LEN] = '-';
 
 		/* init random part */
-		for (i = RAND_MAX, rb=0; i; rb++, i>>=1);
+		for (i = KAM_RAND_MAX, rb=0; i; rb++, i>>=1);
 		for (i = UNIQUE_ID_FIX_LEN, cb = 0, x = 0; i < UNIQUE_ID_FIX_LEN+UNIQUE_ID_RAND_LEN; i++) {
 			if (!cb) {
 				cb = rb;
-				x = rand();
+				x = kam_rand();
 			}
 			uniq_id[i] = fourbits2char[x & 0x0F];
 			x >>= rb;


### PR DESCRIPTION
Many platforms with 4 byte integers define RAND_MAX as INT_MAX but some (Solaris and derivatives for example), RAND_MAX is only 32767 but INT_MAX is 2147483647.  This change allows falling back to the posix random() and srandom() variants with casts to int if both int and long are 4 bytes, then defining a consistent KAM_RAND_MAX of 2147483647.  If both INT_MAX and RAND_MAX are 2 bytes, then we are stuck with ANSI rand().