### PR TITLE
cdp: fix occasional segfault on process exit

### DIFF
--- a/modules/cdp/diameter_peer.c
+++ b/modules/cdp/diameter_peer.c
@@ -411,6 +411,9 @@ void diameter_peer_destroy()
 	int pid,status;
 	handler *h;
 
+	if (!shutdownx_lock) {
+		return;
+	}
 	lock_get(shutdownx_lock);
 	if (*shutdownx) {
 		/* already other process is cleaning stuff */


### PR DESCRIPTION
this may happen at kamailio shutdown : 

Program terminated with signal 11, Segmentation fault.
#0  0x00007fb66a73e591 in atomic_cmpxchg_int (var=0x0, old=0, new_v=1) at ../../mem/../atomic/atomic_x86.h:233
233	ATOMIC_FUNC_CMPXCHG(cmpxchg, "cmpxchgl %2, %1", int , int)
(gdb) bt
#0  0x00007fb66a73e591 in atomic_cmpxchg_int (var=0x0, old=0, new_v=1) at ../../mem/../atomic/atomic_x86.h:233
#1  0x00007fb66a73e5e0 in futex_get (lock=0x0) at ../../mem/../futexlock.h:99
#2  0x00007fb66a743183 in diameter_peer_destroy () at diameter_peer.c:416
#3  0x00007fb66a745272 in cdp_exit () at mod.c:244
#4  0x000000000059bf98 in destroy_modules () at sr_module.c:817
#5  0x00000000004a113a in cleanup (show_status=0) at main.c:513
#6  0x00000000004a272e in shutdown_children (sig=15, show_status=0) at main.c:655
#7  0x00000000004b255d in main (argc=12, argv=0x7ffcdbd4bac8) at main.c:2568
(gdb) bt full 
#0  0x00007fb66a73e591 in atomic_cmpxchg_int (var=0x0, old=0, new_v=1) at ../../mem/../atomic/atomic_x86.h:233
        ret = 48
#1  0x00007fb66a73e5e0 in futex_get (lock=0x0) at ../../mem/../futexlock.h:99
        v = 0
        i = 1024
#2  0x00007fb66a743183 in diameter_peer_destroy () at diameter_peer.c:416
        pid = 1786325736
        status = 32694
        h = 0x7fb660289560
        __FUNCTION__ = "diameter_peer_destroy"
#3  0x00007fb66a745272 in cdp_exit () at mod.c:244
        __llevel = 2
        __FUNCTION__ = "cdp_exit"
#4  0x000000000059bf98 in destroy_modules () at sr_module.c:817
        t = 0x7fb66f3a6010
        foo = 0x7fb66f3a5d40
        __FUNCTION__ = "destroy_modules"
#5  0x00000000004a113a in cleanup (show_status=0) at main.c:513
        memlog = 32764
        __FUNCTION__ = "cleanup"
#6  0x00000000004a272e in shutdown_children (sig=15, show_status=0) at main.c:655
        __FUNCTION__ = "shutdown_children"
#7  0x00000000004b255d in main (argc=12, argv=0x7ffcdbd4bac8) at main.c:2568
        cfg_stream = 0x1706010
        c = -1
        r = 0
        tmp = 0x7ffcdbd4bf2f ""
        tmp_len = 0
        port = 0
        proto = 0
        options = 0x71c738 ":f:cm:M:dVIhEeb:l:L:n:vKrRDTN:W:w:t:u:g:P:G:SQ:O:a:A:"
        ret = -1
        seed = 1767645291
        rfd = 4
        debug_save = 0
        debug_flag = 0
        dont_fork_cnt = 0
        n_lst = 0x76
        p = 0x7ffcdbd4b9ce ""
        st = {st_dev = 0, st_ino = 0, st_nlink = 0, st_mode = 0, st_uid = 0, st_gid = 0, __pad0 = 0, st_rdev = 0, st_size = 0, st_blksize = 0, st_blocks = 0, st_atim = {
            tv_sec = 0, tv_nsec = 0}, st_mtim = {tv_sec = 0, tv_nsec = 0}, st_ctim = {tv_sec = 0, tv_nsec = 0}, __unused = {0, 0, 0}}
---Type <return> to continue, or q <return> to quit---
        __FUNCTION__ = "main"
(gdb) 

Patch provides a quick fix so that it will not dump core.
