### PR TITLE
presence: fix potential double free in shutdown routine

### DIFF
--- a/modules/presence/hash.c
+++ b/modules/presence/hash.c
@@ -318,9 +318,14 @@ int delete_shtable(shtable_t htable,unsigned int hash_code,subs_t* subs)
 		{
 			found= s->local_cseq +1;
 			ps->next= s->next;
-			if(s->contact.s!=NULL)
+			if(s->contact.s!=NULL) {
 				shm_free(s->contact.s);
-			shm_free(s);
+				s->contact.s = NULL;
+			}
+			if (s) {
+				shm_free(s);
+				s = NULL;
+			}
 			break;
 		}
 		ps= s;


### PR DESCRIPTION
Attempt to fix this (crash at shutdown) : 
I observed some of these while working with daemontools (svc) .

Program terminated with signal 6, Aborted.
#0  0x00007f43e6fd5125 in raise () from /lib/x86_64-linux-gnu/libc.so.6
(gdb) 
(gdb) 
(gdb) bt
#0  0x00007f43e6fd5125 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f43e6fd83a0 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x0000000000628b52 in qm_free (qm=0x7f43d547e000, p=0x7f43d57f5208, file=0x7f43e02d60a0 "presence: hash.c", func=0x7f43e02d69aa "delete_shtable", line=316)
    at mem/q_malloc.c:455
#3  0x00007f43e0244504 in delete_shtable (htable=0x7f43d5782e00, hash_code=431, subs=0x7fffda33b830) at hash.c:316
#4  0x00007f43d4507856 in free_subscriber (s=0x7f43d57f8390) at subscribe.c:391
#5  0x00007f43d44ec7db in free_impurecord (_r=0x7f43d57f1268) at impurecord.c:192
#6  0x00007f43d44e7ef3 in deinit_slot (_s=0x7f43d57ddc98) at hslot.c:172
#7  0x00007f43d451018d in free_udomain (_d=0x7f43d57db308) at udomain.c:136
#8  0x00007f43d44e6f23 in free_all_udomains () at dlist.c:361
#9  0x00007f43d45215db in destroy () at ul_mod.c:476
#10 0x000000000059bf98 in destroy_modules () at sr_module.c:817
#11 0x00000000004a113a in cleanup (show_status=1) at main.c:513
#12 0x00000000004a272e in shutdown_children (sig=15, show_status=1) at main.c:655
#13 0x00000000004a30d3 in handle_sigs () at main.c:685
#14 0x00000000004acbac in main_loop () at main.c:1705
#15 0x00000000004b21b2 in main (argc=14, argv=0x7fffda33c208) at main.c:2553
(gdb) bt full 
#0  0x00007f43e6fd5125 in raise () from /lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#1  0x00007f43e6fd83a0 in abort () from /lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#2  0x0000000000628b52 in qm_free (qm=0x7f43d547e000, p=0x7f43d57f5208, file=0x7f43e02d60a0 "presence: hash.c", func=0x7f43e02d69aa "delete_shtable", line=316)
    at mem/q_malloc.c:455
        f = 0x7f43d57f51d8
        size = 140736854210624
        next = 0x400
        prev = 0x7fffda33b750
        __FUNCTION__ = "qm_free"
#3  0x00007f43e0244504 in delete_shtable (htable=0x7f43d5782e00, hash_code=431, subs=0x7fffda33b830) at hash.c:316
        s = 0x7f43d57efba0
        ps = 0x7f43d57b1838
        found = 1
        __FUNCTION__ = "delete_shtable"
#4  0x00007f43d4507856 in free_subscriber (s=0x7f43d57f8390) at subscribe.c:391
        hash_code = 431
        subs = {pres_uri = {s = 0x7f43d57f84f2 "sip:214010000050069@ims.mnc001.mcc214.3gppnetwork.org1\300\300\300\300", len = 53}, to_user = {s = 0x0, len = 0}, 
          to_domain = {s = 0x0, len = 0}, from_user = {s = 0x0, len = 0}, from_domain = {s = 0x0, len = 0}, watcher_user = {s = 0x0, len = 0}, watcher_domain = {s = 0x0, 
            len = 0}, event = 0x0, event_id = {s = 0x0, len = 0}, to_tag = {
            s = 0x7f43d57f8462 "cb50c8efee1a044116f39e700af3e3ce-d61e55392518-578E4CA500085B76-8364E700tel:+12450069sip:172.17.140.164:5080;transport=udpudp:172.17.140.163:5060sip:214010000050069@ims.mnc001.mcc214.3gppnetwork.org1\300\300"..., len = 37}, from_tag = {
            s = 0x7f43d57f8487 "55392518-578E4CA500085B76-8364E700tel:+12450069sip:172.17.140.164:5080;transport=udpudp:172.17.140.163:5060sip:214010000050069@ims.mnc001.mcc214.3gppnetwork.org1\300\300\300\300", len = 34}, callid = {
            s = 0x7f43d57f8440 "69ADAB12-578E4CA500085B8C-8364E700cb50c8efee1a044116f39e700af3e3ce-d61e55392518-578E4CA500085B76-8364E700tel:+12450069sip:172.17.140.164:5080;transport=udpudp:172.17.140.163:5060sip:214010000050069@im"..., len = 34}, sockinfo_str = {s = 0x0, len = 0}, remote_cseq = 0, local_cseq = 0, contact = {s = 0x0, len = 0}, 
          local_contact = {s = 0x0, len = 0}, record_route = {s = 0x0, len = 0}, expires = 0, status = 0, reason = {s = 0x0, len = 0}, version = 0, send_on_cback = 0, 
          db_flag = 0, auth_rules_doc = 0x0, recv_event = 0, internal_update_flag = 0, updated = 0, updated_winfo = 0, next = 0x0}
        __FUNCTION__ = "free_subscriber"
#5  0x00007f43d44ec7db in free_impurecord (_r=0x7f43d57f1268) at impurecord.c:192
        cbp = 0x418a10
        cbp_tmp = 0x7f43d5779680
        subscriber = 0x7f43d57f8390
        s_tmp = 0x0
        __FUNCTION__ = "free_impurecord"
#6  0x00007f43d44e7ef3 in deinit_slot (_s=0x7f43d57ddc98) at hslot.c:172
        ptr = 0x7f43d57f1268
#7  0x00007f43d451018d in free_udomain (_d=0x7f43d57db308) at udomain.c:136
        i = 219
        __FUNCTION__ = "free_udomain"
---Type <return> to continue, or q <return> to quit---
#8  0x00007f43d44e6f23 in free_all_udomains () at dlist.c:361
        ptr = 0x7f43d57db218
        __FUNCTION__ = "free_all_udomains"
#9  0x00007f43d45215db in destroy () at ul_mod.c:476
        __FUNCTION__ = "destroy"
#10 0x000000000059bf98 in destroy_modules () at sr_module.c:817
        t = 0x7f43e30097c0
        foo = 0x7f43e3009410
        __FUNCTION__ = "destroy_modules"
#11 0x00000000004a113a in cleanup (show_status=1) at main.c:513
        memlog = 32579
        __FUNCTION__ = "cleanup"
#12 0x00000000004a272e in shutdown_children (sig=15, show_status=1) at main.c:655
        __FUNCTION__ = "shutdown_children"
#13 0x00000000004a30d3 in handle_sigs () at main.c:685
        chld = -713157656
        chld_status = 0
        memlog = 0
        __FUNCTION__ = "handle_sigs"
#14 0x00000000004acbac in main_loop () at main.c:1705
        i = 1
        pid = 5816
        si = 0x0
        si_desc = "udp receiver child=0 sock=172.17.140.163:5060\000\000\000\000\302\063\332\377\177", '\000' <repeats 18 times>, "`\327\a\347C\177\000\000\060\000\000\000\060\000\000\000\220\337\f\343C\177\000\000\240\276\063\332\377\177\000\000(5K\325C\177\000\000\000\302\063\332\377\177\000\000\000\000\000\000\001\000\000"
        nrprocs = 1
        __FUNCTION__ = "main_loop"
#15 0x00000000004b21b2 in main (argc=14, argv=0x7fffda33c208) at main.c:2553
        cfg_stream = 0x1c03010
        c = -1
        r = 0
        tmp = 0x7fffda33df21 ""
        tmp_len = 0
        port = 0
        proto = 0
        options = 0x71c738 ":f:cm:M:dVIhEeb:l:L:n:vKrRDTN:W:w:t:u:g:P:G:SQ:O:a:A:"
        ret = -1
        seed = 2748507928
        rfd = 4
        debug_save = 0
        debug_flag = 0
---Type <return> to continue, or q <return> to quit---
        dont_fork_cnt = 2
        n_lst = 0x76
        p = 0x0
        st = {st_dev = 15, st_ino = 13169, st_nlink = 2, st_mode = 16832, st_uid = 0, st_gid = 0, __pad0 = 0, st_rdev = 0, st_size = 40, st_blksize = 4096, st_blocks = 0, 
          st_atim = {tv_sec = 1468413462, tv_nsec = 449607667}, st_mtim = {tv_sec = 1468244570, tv_nsec = 131567607}, st_ctim = {tv_sec = 1468244570, tv_nsec = 131567607}, 
          __unused = {0, 0, 0}}
        __FUNCTION__ = "main"


