### PR TITLE
ims_qos: create a proper flow description for the SIP signaling

### DIFF
--- a/modules/ims_qos/mod.c
+++ b/modules/ims_qos/mod.c
@@ -135,6 +135,9 @@ str rx_dest_realm = str_init("ims.smilecoms.com");
 /* Only used if we want to force the Rx peer usually this is configured at a stack level and the first request uses realm routing */
 str rx_forced_peer = str_init("");
 
+/* P-CSCF IP address to generate the flows for the UE<->PCSCF signaling path */
+str rx_pcscf_ip = str_init("192.168.1.45");
+
 /* commands wrappers and fixups */
 static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *id, int id_type);
 static int w_rx_aar_register(struct sip_msg *msg, char *route, char* str1, char *bar);
@@ -182,6 +185,7 @@ static cmd_export_t cmds[] = {
 
 static param_export_t params[] = {
 		{ "rx_dest_realm", PARAM_STR, &rx_dest_realm},
+		{ "rx_pcscf_ip", PARAM_STR, &rx_pcscf_ip},
 		{ "rx_forced_peer", PARAM_STR, &rx_forced_peer},
 		{ "rx_auth_expiry", INT_PARAM, &rx_auth_expiry},
 		{ "cdp_event_latency", INT_PARAM, &cdp_event_latency}, /*flag: report slow processing of CDP callback events or not */

--- a/modules/ims_qos/rx_avp.h
+++ b/modules/ims_qos/rx_avp.h
@@ -76,13 +76,13 @@ int rx_add_avp(AAAMessage *m, char *d, int len, int avp_code,
 
 int rx_add_vendor_specific_application_id_group(AAAMessage *msg, unsigned int vendorid, unsigned int auth_app_id);
 int rx_add_destination_realm_avp(AAAMessage *msg, str data);
-inline int rx_add_subscription_id_avp(AAAMessage *msg, str identifier, int identifier_type);
-inline int rx_add_auth_application_id_avp(AAAMessage *msg, unsigned int data);
+int rx_add_subscription_id_avp(AAAMessage *msg, str identifier, int identifier_type);
+int rx_add_auth_application_id_avp(AAAMessage *msg, unsigned int data);
 
-inline int rx_add_media_component_description_avp(AAAMessage *msg, int number, str *media_description, str *ipA, str *portA, str *ipB, str *portB, str *transport, 
+int rx_add_media_component_description_avp(AAAMessage *msg, int number, str *media_description, str *ipA, str *portA, str *ipB, str *portB, str *transport, 
         str *raw_payload, str *rpl_raw_payload, enum dialog_direction dlg_direction);
 
-inline int rx_add_media_component_description_avp_register(AAAMessage *msg);
+int rx_add_media_component_description_avp_register(AAAMessage *msg);
 
 AAA_AVP *rx_create_media_subcomponent_avp(int number, char *proto, str *ipA, str *portA, str *ipB, str *portB);
 
@@ -90,9 +90,9 @@ AAA_AVP *rx_create_media_subcomponent_avp_register();
 
 AAA_AVP* rx_create_codec_data_avp(str *raw_sdp_stream, int number, int direction);
 
-inline int rx_get_result_code(AAAMessage *msg, unsigned int *data);
+int rx_get_result_code(AAAMessage *msg, unsigned int *data);
 unsigned int rx_get_abort_cause(AAAMessage *msg);
 
-inline int rx_add_specific_action_avp(AAAMessage *msg, unsigned int data);
+int rx_add_specific_action_avp(AAAMessage *msg, unsigned int data);
 
 #endif /*__PCC_AVP_H*/


### PR DESCRIPTION
- before there was just an empty one in the AAR
- re-using the function typically used for the RTP media
- fixing then that function to not just hard-code protocol 17 (UDP) for everything
- now supporting also 6 (TCP) and IP (IP has no protocol number, we use just the
magic word "ip" (see RFC 3588 IPFilterRule for more details)
- adding the IP of the P-CSCF as a parameter to the module, as this is required
in the flow (UE IP <-> P-CSCF IP)
- also some inline/static fixes to function for avoiding warnings on gcc >=5