### PR TITLE
ims_qos, ima_registrar_pcscf: fixes for de-registration and adding a flow to registration

### DIFF
--- a/modules/ims_qos/README
+++ b/modules/ims_qos/README
@@ -2,8 +2,8 @@ The IMS QoS Module
 
 Dragos Vingarzan
 
-   FhG Fokus
-   <Dragos.Vingarzan@fokus.fraunhofer.de>
+   Core Network Dynamics (ex FhG Fokus)
+   <dragos@corenetdynamics.com>
 
 Jason Penton
 
@@ -25,6 +25,8 @@ Carsten Bock
    Copyright © 2012 Smile Communications
 
    Copyright © 2015 ng-voice GmbH
+
+   Copyright © 2016 Core Network Dynamics GmbH
      __________________________________________________________________
 
    Table of Contents
@@ -42,16 +44,17 @@ Carsten Bock
               3.1. rx_dest_realm (string)
               3.2. rx_forced_peer (string)
               3.3. rx_auth_expiry (integer)
-              3.4. cdp_event_latency (integer)
-              3.5. cdp_event_threshold (integer)
-              3.6. cdp_event_latency_log (integer)
-              3.7. authorize_video_flow (integer)
-              3.8. cdp_event_list_size_threshold (integer)
-              3.9. audio_default_bandwidth (integer)
-              3.10. video_default_bandwidth (integer)
-              3.11. early_qosrelease_reason (String)
-              3.12. confirmed_qosrelease_headers (String)
-              3.13. regex_sdp_ip_prefix_to_maintain_in_fd (String)
+              3.4. af_signaling_ip (string)
+              3.5. cdp_event_latency (integer)
+              3.6. cdp_event_threshold (integer)
+              3.7. cdp_event_latency_log (integer)
+              3.8. authorize_video_flow (integer)
+              3.9. cdp_event_list_size_threshold (integer)
+              3.10. audio_default_bandwidth (integer)
+              3.11. video_default_bandwidth (integer)
+              3.12. early_qosrelease_reason (String)
+              3.13. confirmed_qosrelease_headers (String)
+              3.14. regex_sdp_ip_prefix_to_maintain_in_fd (String)
 
         4. Functions
 
@@ -69,18 +72,19 @@ Carsten Bock
    1.1. rx_dest_realm parameter usage
    1.2. rx_forced_peer parameter usage
    1.3. rx_auth_expiry parameter usage
-   1.4. cdp_event_latency parameter usage
-   1.5. cdp_event_threshold parameter usage
-   1.6. cdp_event_latency_log parameter usage
-   1.7. authorize_video_flow parameter usage
-   1.8. cdp_event_list_size_threshold parameter usage
-   1.9. audio_default_bandwidth parameter usage
-   1.10. video_default_bandwidth parameter usage
-   1.11. early_qosrelease_reason parameter usage
-   1.12. confirmed_qosrelease_headers parameter usage
-   1.13. regex_sdp_ip_prefix_to_maintain_in_fd parameter usage
-   1.14. Rx_AAR_Register
-   1.15. Rx_AAR
+   1.4. rx_auth_expiry parameter usage
+   1.5. cdp_event_latency parameter usage
+   1.6. cdp_event_threshold parameter usage
+   1.7. cdp_event_latency_log parameter usage
+   1.8. authorize_video_flow parameter usage
+   1.9. cdp_event_list_size_threshold parameter usage
+   1.10. audio_default_bandwidth parameter usage
+   1.11. video_default_bandwidth parameter usage
+   1.12. early_qosrelease_reason parameter usage
+   1.13. confirmed_qosrelease_headers parameter usage
+   1.14. regex_sdp_ip_prefix_to_maintain_in_fd parameter usage
+   1.15. Rx_AAR_Register
+   1.16. Rx_AAR
 
 Chapter 1. Admin Guide
 
@@ -97,16 +101,17 @@ Chapter 1. Admin Guide
         3.1. rx_dest_realm (string)
         3.2. rx_forced_peer (string)
         3.3. rx_auth_expiry (integer)
-        3.4. cdp_event_latency (integer)
-        3.5. cdp_event_threshold (integer)
-        3.6. cdp_event_latency_log (integer)
-        3.7. authorize_video_flow (integer)
-        3.8. cdp_event_list_size_threshold (integer)
-        3.9. audio_default_bandwidth (integer)
-        3.10. video_default_bandwidth (integer)
-        3.11. early_qosrelease_reason (String)
-        3.12. confirmed_qosrelease_headers (String)
-        3.13. regex_sdp_ip_prefix_to_maintain_in_fd (String)
+        3.4. af_signaling_ip (string)
+        3.5. cdp_event_latency (integer)
+        3.6. cdp_event_threshold (integer)
+        3.7. cdp_event_latency_log (integer)
+        3.8. authorize_video_flow (integer)
+        3.9. cdp_event_list_size_threshold (integer)
+        3.10. audio_default_bandwidth (integer)
+        3.11. video_default_bandwidth (integer)
+        3.12. early_qosrelease_reason (String)
+        3.13. confirmed_qosrelease_headers (String)
+        3.14. regex_sdp_ip_prefix_to_maintain_in_fd (String)
 
    4. Functions
 
@@ -150,16 +155,17 @@ Chapter 1. Admin Guide
    3.1. rx_dest_realm (string)
    3.2. rx_forced_peer (string)
    3.3. rx_auth_expiry (integer)
-   3.4. cdp_event_latency (integer)
-   3.5. cdp_event_threshold (integer)
-   3.6. cdp_event_latency_log (integer)
-   3.7. authorize_video_flow (integer)
-   3.8. cdp_event_list_size_threshold (integer)
-   3.9. audio_default_bandwidth (integer)
-   3.10. video_default_bandwidth (integer)
-   3.11. early_qosrelease_reason (String)
-   3.12. confirmed_qosrelease_headers (String)
-   3.13. regex_sdp_ip_prefix_to_maintain_in_fd (String)
+   3.4. af_signaling_ip (string)
+   3.5. cdp_event_latency (integer)
+   3.6. cdp_event_threshold (integer)
+   3.7. cdp_event_latency_log (integer)
+   3.8. authorize_video_flow (integer)
+   3.9. cdp_event_list_size_threshold (integer)
+   3.10. audio_default_bandwidth (integer)
+   3.11. video_default_bandwidth (integer)
+   3.12. early_qosrelease_reason (String)
+   3.13. confirmed_qosrelease_headers (String)
+   3.14. regex_sdp_ip_prefix_to_maintain_in_fd (String)
 
 3.1. rx_dest_realm (string)
 
@@ -200,19 +206,34 @@ modparam("ims_qos", "rx_forced_peer", "pcrf.ims.smilecoms.com")
 modparam("ims_qos", "rx_auth_expiry", 14400)
 ...
 
-3.4. cdp_event_latency (integer)
+3.4. af_signaling_ip (string)
+
+   Defines the IP address to use in the flow description for the media
+   flow of the SIP registration. This is known in EPC as the AF-Signaling
+   path and usually would create a dedicated bearer for the SIP signaling
+   between the UE IP and the P-CSCF IP. Usually set this value to the IP
+   address of the P-CSCF.
+
+   Default value is 127.0.0.1 - dummy value.
+
+   Example 1.4. rx_auth_expiry parameter usage
+...
+modparam("ims_qos", "af_signaling_ip", "192.168.1.45")
+...
+
+3.5. cdp_event_latency (integer)
 
    This is a flag to determine whether or slow CDP responses should be
    reported in the log file. 1 is enabled and 0 is disabled.
 
    Default value is 1.
 
-   Example 1.4. cdp_event_latency parameter usage
+   Example 1.5. cdp_event_latency parameter usage
 ...
 modparam("ims_qos", "cdp_event_latency", 1)
 ...
 
-3.5. cdp_event_threshold (integer)
+3.6. cdp_event_threshold (integer)
 
    This time in milliseconds is the limit we should report a CDP response
    as slow. i.e. if a CDP response exceeds this limit it will be reported
@@ -221,12 +242,12 @@ modparam("ims_qos", "cdp_event_latency", 1)
 
    Default value is 500.
 
-   Example 1.5. cdp_event_threshold parameter usage
+   Example 1.6. cdp_event_threshold parameter usage
 ...
 modparam("ims_qos", "cdp_event_threshold", 500)
 ...
 
-3.6. cdp_event_latency_log (integer)
+3.7. cdp_event_latency_log (integer)
 
    This time log level at which we should report slow CDP responses. 0 is
    ERROR, 1 is WARN, 2 is INFO and 3 is DEBUG. This is only relevant is
@@ -234,12 +255,12 @@ modparam("ims_qos", "cdp_event_threshold", 500)
 
    Default value is 0.
 
-   Example 1.6. cdp_event_latency_log parameter usage
+   Example 1.7. cdp_event_latency_log parameter usage
 ...
 modparam("ims_qos", "cdp_event_latency_log", 1)
 ...
 
-3.7. authorize_video_flow (integer)
+3.8. authorize_video_flow (integer)
 
    This is a flag that specifies whether or not to authorize video flows.
    1 means video flows will be authorized over Rx and 0 means video flows
@@ -247,48 +268,48 @@ modparam("ims_qos", "cdp_event_latency_log", 1)
 
    Default value is 1.
 
-   Example 1.7. authorize_video_flow parameter usage
+   Example 1.8. authorize_video_flow parameter usage
 ...
 modparam("ims_qos", "authorize_video_flow", 0)
 ...
 
-3.8. cdp_event_list_size_threshold (integer)
+3.9. cdp_event_list_size_threshold (integer)
 
    This is a threshold on the size of the cdp event list. Once the queue
    exceeds this length a warning is logged. 0 disables this feature
 
    Default value is 0.
 
-   Example 1.8. cdp_event_list_size_threshold parameter usage
+   Example 1.9. cdp_event_list_size_threshold parameter usage
 ...
 modparam("ims_qos", "cdp_event_list_size_threshold", 10)
 ...
 
-3.9. audio_default_bandwidth (integer)
+3.10. audio_default_bandwidth (integer)
 
    This parameters defines the default bandwidth for Audio, if no
    "b=AS"-Parameter is found in the SDP.
 
    Default value is 64 (64 kBit)
 
-   Example 1.9. audio_default_bandwidth parameter usage
+   Example 1.10. audio_default_bandwidth parameter usage
 ...
 modparam("ims_qos", "audio_default_bandwidth", 32)
 ...
 
-3.10. video_default_bandwidth (integer)
+3.11. video_default_bandwidth (integer)
 
    This parameters defines the default bandwidth for Video, if no
    "b=AS"-Parameter is found in the SDP.
 
    Default value is 128 (128 kBit)
 
-   Example 1.10. video_default_bandwidth parameter usage
+   Example 1.11. video_default_bandwidth parameter usage
 ...
 modparam("ims_qos", "video_default_bandwidth", 256)
 ...
 
-3.11. early_qosrelease_reason (String)
+3.12. early_qosrelease_reason (String)
 
    This sets the default Reason, when a call is terminated in early stage
    due to QoS-failure.
@@ -296,12 +317,12 @@ modparam("ims_qos", "video_default_bandwidth", 256)
    Default value is "QoS released", an call in early stage would be
    released with "488 QoS released".
 
-   Example 1.11. early_qosrelease_reason parameter usage
+   Example 1.12. early_qosrelease_reason parameter usage
 ...
 modparam("ims_qos", "early_qosrelease_reason", "Sorry - QoS failed")
 ...
 
-3.12. confirmed_qosrelease_headers (String)
+3.13. confirmed_qosrelease_headers (String)
 
    These headers are added to the BYE-Message, when an confirmed call is
    terminated due to a QoS failure.
@@ -310,12 +331,12 @@ modparam("ims_qos", "early_qosrelease_reason", "Sorry - QoS failed")
 
    The headers must end with CRLF.
 
-   Example 1.12. confirmed_qosrelease_headers parameter usage
+   Example 1.13. confirmed_qosrelease_headers parameter usage
 ...
 modparam("ims_qos", "confirmed_qosrelease_headers", "X-Reason: QoS failed\r\n")
 ...
 
-3.13. regex_sdp_ip_prefix_to_maintain_in_fd (String)
+3.14. regex_sdp_ip_prefix_to_maintain_in_fd (String)
 
    The flow-description AVP is typically populated using IP:port
    information present in the SDP. Certain (buggy) UEs can change ports
@@ -327,7 +348,7 @@ modparam("ims_qos", "confirmed_qosrelease_headers", "X-Reason: QoS failed\r\n")
 
    Default value is "", no IPs replaced
 
-   Example 1.13. regex_sdp_ip_prefix_to_maintain_in_fd parameter usage
+   Example 1.14. regex_sdp_ip_prefix_to_maintain_in_fd parameter usage
 ...
 modparam("ims_qos", "regex_sdp_ip_prefix_to_maintain_in_fd", "10.21.0.1")
 ...
@@ -362,7 +383,7 @@ modparam("ims_qos", "regex_sdp_ip_prefix_to_maintain_in_fd", "10.21.0.1")
    p.s. this is executed asynchronously. See example on how to retrieve
    return value
 
-   Example 1.14. Rx_AAR_Register
+   Example 1.15. Rx_AAR_Register
 ...
 if(Rx_AAR_Register("REG_AAR_REPLY","location")==0){
     exit;
@@ -404,7 +425,7 @@ route[REG_AAR_REPLY]
    p.s. this is executed asynchronously. See example on how to retrieve
    return value
 
-   Example 1.15. Rx_AAR
+   Example 1.16. Rx_AAR
 ...
 if(Rx_AAR("ORIG_SESSION_AAR_REPLY","orig","",-1)==0){
     exit;

--- a/modules/ims_qos/doc/ims_qos.xml
+++ b/modules/ims_qos/doc/ims_qos.xml
@@ -16,10 +16,10 @@
         <surname/>
 
         <affiliation>
-          <orgname>FhG Fokus</orgname>
+          <orgname>Core Network Dynamics (ex FhG Fokus)</orgname>
         </affiliation>
 
-        <email>Dragos.Vingarzan@fokus.fraunhofer.de</email>
+        <email>dragos@corenetdynamics.com</email>
       </author>
 
       <author>
@@ -70,6 +70,10 @@
     <copyright>
       <year>2015</year>
       <holder>ng-voice GmbH</holder>
+    </copyright>
+    <copyright>
+      <year>2016</year>
+      <holder>Core Network Dynamics GmbH</holder>
     </copyright>
   </bookinfo>
 

--- a/modules/ims_qos/doc/ims_qos_admin.xml
+++ b/modules/ims_qos/doc/ims_qos_admin.xml
@@ -122,6 +122,29 @@ modparam("ims_qos", "rx_auth_expiry", 14400)
     </section>
 
     <section>
+      <title><varname>af_signaling_ip</varname> (string)</title>
+
+      <para>Defines the IP address to use in the flow description for the
+      media flow of the SIP registration. This is known in EPC as the 
+      AF-Signaling path and usually would create a dedicated bearer for the SIP
+      signaling between the UE IP and the P-CSCF IP. 
+      
+      Usually set this value to the IP address of the P-CSCF.</para>
+
+      <para><emphasis> Default value is 127.0.0.1 - dummy value. </emphasis></para>
+
+      <example>
+        <title><varname>rx_auth_expiry</varname> parameter usage</title>
+
+        <programlisting format="linespecific">
+...
+modparam("ims_qos", "af_signaling_ip", "192.168.1.45")
+...
+        </programlisting>
+      </example>
+    </section>
+    
+    <section>
       <title><varname>cdp_event_latency</varname> (integer)</title>
 
       <para>This is a flag to determine whether or slow CDP responses should

--- a/modules/ims_qos/mod.c
+++ b/modules/ims_qos/mod.c
@@ -135,6 +135,9 @@ str rx_dest_realm = str_init("ims.smilecoms.com");
 /* Only used if we want to force the Rx peer usually this is configured at a stack level and the first request uses realm routing */
 str rx_forced_peer = str_init("");
 
+/* P-CSCF IP address to generate the flows for the UE<->PCSCF signaling path */
+str rx_pcscf_ip = str_init("192.168.1.45");
+
 /* commands wrappers and fixups */
 static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *id, int id_type);
 static int w_rx_aar_register(struct sip_msg *msg, char *route, char* str1, char *bar);
@@ -182,6 +185,7 @@ static cmd_export_t cmds[] = {
 
 static param_export_t params[] = {
 		{ "rx_dest_realm", PARAM_STR, &rx_dest_realm},
+		{ "rx_pcscf_ip", PARAM_STR, &rx_pcscf_ip},
 		{ "rx_forced_peer", PARAM_STR, &rx_forced_peer},
 		{ "rx_auth_expiry", INT_PARAM, &rx_auth_expiry},
 		{ "cdp_event_latency", INT_PARAM, &cdp_event_latency}, /*flag: report slow processing of CDP callback events or not */

--- a/modules/ims_qos/mod.c
+++ b/modules/ims_qos/mod.c
@@ -3,23 +3,23 @@
  *
  * Copyright (C) 2012 Smile Communications, jason.penton@smilecoms.com
  * Copyright (C) 2012 Smile Communications, richard.good@smilecoms.com
- * 
+ *
  * The initial version of this code was written by Dragos Vingarzan
  * (dragos(dot)vingarzan(at)fokus(dot)fraunhofer(dot)de and the
  * Fruanhofer Institute. It was and still is maintained in a separate
  * branch of the original SER. We are therefore migrating it to
  * Kamailio/SR and look forward to maintaining it from here on out.
  * 2011/2012 Smile Communications, Pty. Ltd.
- * ported/maintained/improved by 
+ * ported/maintained/improved by
  * Jason Penton (jason(dot)penton(at)smilecoms.com and
- * Richard Good (richard(dot)good(at)smilecoms.com) as part of an 
+ * Richard Good (richard(dot)good(at)smilecoms.com) as part of an
  * effort to add full IMS support to Kamailio/SR using a new and
  * improved architecture
- * 
+ *
  * NB: Alot of this code was originally part of OpenIMSCore,
- * FhG Fokus. 
+ * FhG Fokus.
  * Copyright (C) 2004-2006 FhG Fokus
- * Thanks for great work! This is an effort to 
+ * Thanks for great work! This is an effort to
  * break apart the various CSCF functions into logically separate
  * components. We hope this will drive wider use. We also feel
  * that in this way the architecture is more complete and thereby easier
@@ -37,10 +37,10 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- * 
+ *
  */
 
 #include <stdio.h>
@@ -136,7 +136,7 @@ str rx_dest_realm = str_init("ims.smilecoms.com");
 str rx_forced_peer = str_init("");
 
 /* P-CSCF IP address to generate the flows for the UE<->PCSCF signaling path */
-str rx_pcscf_ip = str_init("192.168.1.45");
+str af_signaling_ip = str_init("127.0.0.1");
 
 /* commands wrappers and fixups */
 static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *id, int id_type);
@@ -185,9 +185,9 @@ static cmd_export_t cmds[] = {
 
 static param_export_t params[] = {
 		{ "rx_dest_realm", PARAM_STR, &rx_dest_realm},
-		{ "rx_pcscf_ip", PARAM_STR, &rx_pcscf_ip},
 		{ "rx_forced_peer", PARAM_STR, &rx_forced_peer},
 		{ "rx_auth_expiry", INT_PARAM, &rx_auth_expiry},
+		{ "af_signaling_ip", PARAM_STR, &af_signaling_ip}, /* IP of this P-CSCF, to be used in the flow for the AF-signaling */
 		{ "cdp_event_latency", INT_PARAM, &cdp_event_latency}, /*flag: report slow processing of CDP callback events or not */
 		{ "cdp_event_threshold", INT_PARAM, &cdp_event_threshold}, /*time in ms above which we should report slow processing of CDP callback event*/
 		{ "cdp_event_latency_log", INT_PARAM, &cdp_event_latency_loglevel}, /*log-level to use to report slow processing of CDP callback event*/
@@ -720,8 +720,8 @@ static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *c_id, int
 
 
 		/*  we may need the request message from here on.. if there are headers we need that were not parsed in the original request
-			(which we cannot assume) then we would pollute the shm_msg t->uas.request if we did any parsing on it. Instead, we need to 
-			make a private copy of the message and free it when we are done 
+			(which we cannot assume) then we would pollute the shm_msg t->uas.request if we did any parsing on it. Instead, we need to
+			make a private copy of the message and free it when we are done
 		 */
 		if ((_pv_treq.T != t || t->uas.request != _pv_treq.tmsgp)
 				&& t->uas.request->id != _pv_treq.id) {
@@ -947,7 +947,7 @@ static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *c_id, int
 								identifier_type = AVP_Subscription_Id_Type_SIP_URI; //default is END_USER_SIP_URI
 						}
 				}
-				//IP 
+				//IP
 				//if its mo we use request SDP
 				//if its mt we use reply SDP
 				if (dlg_direction == DLG_MOBILE_ORIGINATING) {
@@ -965,9 +965,9 @@ static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *c_id, int
 						}
 						ip = sdp_session->ip_addr;
 						ip_version = sdp_session->pf;
-						
+
 						LM_DBG("IP retrieved from Request SDP to use for framed IP address: [%.*s]", ip.len, ip.s);
-						
+
 						if (ip.len <= 0) {
 								LM_DBG("Request SDP connection IP could not be retrieved, so we use SDP stream IP");
 								sdp_stream = get_sdp_stream(orig_sip_request_msg, 0, 0);
@@ -975,7 +975,7 @@ static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *c_id, int
 										LM_ERR("Missing SDP stream information from request\n");
 										goto error;
 								}
-								
+
 								ip = sdp_stream->ip_addr;
 								if (ip.len <= 0) {
 										LM_ERR("Request SDP IP information could not be retrieved");
@@ -986,11 +986,11 @@ static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *c_id, int
 										LM_ERR("check_ip_version returned 0 \n");
 										goto error;
 								}
-								
+
 						}
-						
+
 						free_sdp((sdp_info_t**) (void*) &t->uas.request->body);
-						
+
 				} else {
 						LM_DBG("terminating direction\n");
 						//get ip from reply sdp (we use first SDP session)
@@ -1006,9 +1006,9 @@ static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *c_id, int
 						}
 						ip = sdp_session->ip_addr;
 						ip_version = sdp_session->pf;
-						
+
 						LM_DBG("IP retrieved from Reply SDP to use for framed IP address: [%.*s]", ip.len, ip.s);
-						
+
 						if (ip.len <= 0) {
 								LM_DBG("Reply SDP connection IP could not be retrieved, so we use SDP stream IP");
 								sdp_stream = get_sdp_stream(msg, 0, 0);
@@ -1016,7 +1016,7 @@ static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *c_id, int
 										LM_ERR("Missing SDP stream information from reply\n");
 										goto error;
 								}
-								
+
 								ip = sdp_stream->ip_addr;
 								if (ip.len <= 0) {
 										LM_ERR("Reply SDP IP information could not be retrieved");
@@ -1027,9 +1027,9 @@ static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *c_id, int
 										LM_ERR("check_ip_version returned 0 \n");
 										goto error;
 								}
-								
+
 						}
-						
+
 						free_sdp((sdp_info_t**) (void*) &msg->body);
 				}
 
@@ -1254,7 +1254,7 @@ static int w_rx_aar_register(struct sip_msg *msg, char* route, char* str1, char*
 				goto error;
 		}
 
-		//we use the received IP address for the framed_ip_address 
+		//we use the received IP address for the framed_ip_address
 		recv_ip.s = ip_addr2a(&msg->rcv.src_ip);
 		recv_ip.len = strlen(ip_addr2a(&msg->rcv.src_ip));
 

--- a/modules/ims_qos/rx_aar.c
+++ b/modules/ims_qos/rx_aar.c
@@ -3,23 +3,23 @@
  *
  * Copyright (C) 2012 Smile Communications, jason.penton@smilecoms.com
  * Copyright (C) 2012 Smile Communications, richard.good@smilecoms.com
- * 
+ *
  * The initial version of this code was written by Dragos Vingarzan
  * (dragos(dot)vingarzan(at)fokus(dot)fraunhofer(dot)de and the
  * Fruanhofer Institute. It was and still is maintained in a separate
  * branch of the original SER. We are therefore migrating it to
  * Kamailio/SR and look forward to maintaining it from here on out.
  * 2011/2012 Smile Communications, Pty. Ltd.
- * ported/maintained/improved by 
+ * ported/maintained/improved by
  * Jason Penton (jason(dot)penton(at)smilecoms.com and
- * Richard Good (richard(dot)good(at)smilecoms.com) as part of an 
+ * Richard Good (richard(dot)good(at)smilecoms.com) as part of an
  * effort to add full IMS support to Kamailio/SR using a new and
  * improved architecture
- * 
+ *
  * NB: Alot of this code was originally part of OpenIMSCore,
- * FhG Fokus. 
+ * FhG Fokus.
  * Copyright (C) 2004-2006 FhG Fokus
- * Thanks for great work! This is an effort to 
+ * Thanks for great work! This is an effort to
  * break apart the various CSCF functions into logically separate
  * components. We hope this will drive wider use. We also feel
  * that in this way the architecture is more complete and thereby easier
@@ -37,10 +37,10 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- * 
+ *
  *
  *
  * History:
@@ -77,7 +77,7 @@ extern struct ims_qos_counters_h ims_qos_cnts_h;
 
 extern int authorize_video_flow;
 
-extern str rx_pcscf_ip;
+extern str af_signaling_ip;
 
 str IMS_Serv_AVP_val = {"IMS Services", 12};
 str IMS_Em_Serv_AVP_val = {"Emergency IMS Call", 18};
@@ -409,7 +409,7 @@ int add_media_components_using_current_flow_description(AAAMessage* aar, rx_auth
                 add_flow = 0;
             }
         }
-	
+
 	if(add_flow) {
             rx_add_media_component_description_avp(aar, flow_description->stream_num,
                     &flow_description->media, &flow_description->req_sdp_ip_addr,
@@ -467,7 +467,7 @@ int add_media_components(AAAMessage* aar, struct sip_msg *req,
 
             if (!rpl_sdp_session)
                 LM_ERR("Missing SDP session information from rpl\n");
-            
+
 			goto error;
         }
 
@@ -495,7 +495,7 @@ int add_media_components(AAAMessage* aar, struct sip_msg *req,
                     }
 
 			if(add_flow) {
-					
+
 						str ipA = req_sdp_session->ip_addr;
 						str ipB = rpl_sdp_session->ip_addr;
 
@@ -507,7 +507,7 @@ int add_media_components(AAAMessage* aar, struct sip_msg *req,
 										goto error;
 								}
 						}
-						
+
 						if (ipB.len <= 0) {
 								LM_DBG("Reply SDP connection IP could not be retrieved, so we use SDP 1st stream IP");
 								ipB = rpl_sdp_stream->ip_addr;
@@ -516,7 +516,7 @@ int add_media_components(AAAMessage* aar, struct sip_msg *req,
 										goto error;
 								}
 						}
-						
+
 						//add this to auth session data
                         add_flow_description((rx_authsessiondata_t*) auth->u.auth.generic_data, sdp_stream_num + 1,
                                 &req_sdp_stream->media, &ipA,
@@ -544,9 +544,9 @@ int add_media_components(AAAMessage* aar, struct sip_msg *req,
     free_sdp((sdp_info_t**) (void*) &rpl->body);
 
 	return 1;
-	
+
 	error:
-	
+
     return 0;
 }
 
@@ -569,7 +569,7 @@ int rx_send_aar_update_no_video(AAASession* auth) {
     str recv_ip;
     uint16_t ip_version;
 
-    //we get ip and identifier for the auth session data 
+    //we get ip and identifier for the auth session data
     rx_authsessiondata_t* p_session_data = 0;
     p_session_data = (rx_authsessiondata_t*) auth->u.auth.generic_data;
     identifier = p_session_data->identifier;
@@ -730,7 +730,7 @@ int rx_send_aar(struct sip_msg *req, struct sip_msg *res,
     str ip;
     uint16_t ip_version;
 
-    //we get ip and identifier for the auth session data 
+    //we get ip and identifier for the auth session data
     rx_authsessiondata_t* p_session_data = 0;
     p_session_data = (rx_authsessiondata_t*) auth->u.auth.generic_data;
     identifier = p_session_data->identifier;
@@ -904,7 +904,7 @@ int rx_send_aar_register(struct sip_msg *msg, AAASession* auth, saved_transactio
     str ip;
     uint16_t ip_version;
 
-    //we get ip and identifier for the auth session data 
+    //we get ip and identifier for the auth session data
     rx_authsessiondata_t* p_session_data = 0;
     p_session_data = (rx_authsessiondata_t*) auth->u.auth.generic_data;
     identifier = p_session_data->identifier;
@@ -968,7 +968,7 @@ int rx_send_aar_register(struct sip_msg *msg, AAASession* auth, saved_transactio
     /* Add media component description avp for register*/
     rx_add_media_component_description_avp(aar, 1,
                &media, &saved_t_data->via_host,
-               &port_from, &rx_pcscf_ip,
+               &port_from, &af_signaling_ip,
                &port_to, &protocol,
                &raw_stream,
                &raw_stream, DLG_MOBILE_REGISTER);

--- a/modules/ims_qos/rx_avp.h
+++ b/modules/ims_qos/rx_avp.h
@@ -76,13 +76,13 @@ int rx_add_avp(AAAMessage *m, char *d, int len, int avp_code,
 
 int rx_add_vendor_specific_application_id_group(AAAMessage *msg, unsigned int vendorid, unsigned int auth_app_id);
 int rx_add_destination_realm_avp(AAAMessage *msg, str data);
-inline int rx_add_subscription_id_avp(AAAMessage *msg, str identifier, int identifier_type);
-inline int rx_add_auth_application_id_avp(AAAMessage *msg, unsigned int data);
+int rx_add_subscription_id_avp(AAAMessage *msg, str identifier, int identifier_type);
+int rx_add_auth_application_id_avp(AAAMessage *msg, unsigned int data);
 
-inline int rx_add_media_component_description_avp(AAAMessage *msg, int number, str *media_description, str *ipA, str *portA, str *ipB, str *portB, str *transport, 
+int rx_add_media_component_description_avp(AAAMessage *msg, int number, str *media_description, str *ipA, str *portA, str *ipB, str *portB, str *transport, 
         str *raw_payload, str *rpl_raw_payload, enum dialog_direction dlg_direction);
 
-inline int rx_add_media_component_description_avp_register(AAAMessage *msg);
+int rx_add_media_component_description_avp_register(AAAMessage *msg);
 
 AAA_AVP *rx_create_media_subcomponent_avp(int number, char *proto, str *ipA, str *portA, str *ipB, str *portB);
 
@@ -90,9 +90,9 @@ AAA_AVP *rx_create_media_subcomponent_avp_register();
 
 AAA_AVP* rx_create_codec_data_avp(str *raw_sdp_stream, int number, int direction);
 
-inline int rx_get_result_code(AAAMessage *msg, unsigned int *data);
+int rx_get_result_code(AAAMessage *msg, unsigned int *data);
 unsigned int rx_get_abort_cause(AAAMessage *msg);
 
-inline int rx_add_specific_action_avp(AAAMessage *msg, unsigned int data);
+int rx_add_specific_action_avp(AAAMessage *msg, unsigned int data);
 
 #endif /*__PCC_AVP_H*/

--- a/modules/ims_registrar_pcscf/save.c
+++ b/modules/ims_registrar_pcscf/save.c
@@ -183,9 +183,9 @@ static inline int update_contacts(struct sip_msg *req,struct sip_msg *rpl, udoma
 					LM_DBG("contact already exists and is in state (%d) : [%s]\n",pcontact->reg_state, reg_state_to_string(pcontact->reg_state));
 					if ((expires-local_time_now)<=0) { //remove contact - de-register
 						LM_DBG("This is a de-registration for contact <%.*s>\n", c->uri.len, c->uri.s);
-//						if (ul.delete_pcontact(_d, &c->uri, &ci.received_host, ci.received_port, pcontact) != 0) {
-//							LM_ERR("failed to delete pcscf contact <%.*s>\n", c->uri.len, c->uri.s);
-//						}
+						if (ul.delete_pcontact(_d, pcontact) != 0) {
+							LM_ERR("failed to delete pcscf contact <%.*s>\n", c->uri.len, c->uri.s);
+						}
                                                 //TODO_LATEST replace above
 					} else { //update contact
 						LM_DBG("Updating contact: <%.*s>, old expires: %li, new expires: %i which is in %i seconds\n", c->uri.len, c->uri.s,


### PR DESCRIPTION
ims_qos: create a proper flow description for the SIP signaling
- before there was just an empty one in the AAR
- re-using the function typically used for the RTP media
- fixing then that function to not just hard-code protocol 17 (UDP) for everything
- now supporting also 6 (TCP) and IP (IP has no protocol number, we use just the
magic word "ip" (see RFC 3588 IPFilterRule for more details)
- adding the IP of the P-CSCF as a parameter to the module, as this is required
in the flow (UE IP <-> P-CSCF IP)
- also some inline/static fixes to function for avoiding warnings on gcc >=5

ims_registrar_pcscf: fixed removal of contacts on de-registration
- the code was there, but I guess some API changes resulted in temporary
commented-out code; this uses the new parameters and seems to fix the
issue.