### PR TITLE
TM fixes for DNS failover and branch_idx

### DIFF
--- a/modules/tm/t_fwd.c
+++ b/modules/tm/t_fwd.c
@@ -1022,6 +1022,7 @@ int add_uac_dns_fallback(struct cell *t, struct sip_msg* msg,
 			/* copy the onreply and onfailure routes */
 			t->uac[t->nr_of_outgoings].on_failure = old_uac->on_failure;
 			t->uac[t->nr_of_outgoings].on_reply = old_uac->on_reply;
+			t->uac[t->nr_of_outgoings].on_branch_failure = old_uac->on_branch_failure;
 
 			if (cfg_get(tm, tm_cfg, reparse_on_dns_failover)){
 				/* Reuse the old buffer and only replace the via header.

--- a/modules/tm/t_fwd.c
+++ b/modules/tm/t_fwd.c
@@ -1019,6 +1019,9 @@ int add_uac_dns_fallback(struct cell *t, struct sip_msg* msg,
 			/* copy the dns handle into the new uac */
 			dns_srv_handle_cpy(&t->uac[t->nr_of_outgoings].dns_h,
 								&old_uac->dns_h);
+			/* copy the onreply and onfailure routes */
+			t->uac[t->nr_of_outgoings].on_failure = old_uac->on_failure;
+			t->uac[t->nr_of_outgoings].on_reply = old_uac->on_reply;
 
 			if (cfg_get(tm, tm_cfg, reparse_on_dns_failover)){
 				/* Reuse the old buffer and only replace the via header.

--- a/modules/tm/t_reply.c
+++ b/modules/tm/t_reply.c
@@ -1352,6 +1352,7 @@ static enum rps t_should_relay_response( struct cell *Trans , int new_code,
 
 		drop_replies = failure_reply_mode;
 		replies_dropped = 0;
+		tm_ctx_set_branch_index(picked_branch);
 		/* run ON_FAILURE handlers ( route and callbacks) */
 		if (unlikely(has_tran_tmcbs( Trans, TMCB_ON_FAILURE_RO|TMCB_ON_FAILURE)
 						|| Trans->uac[picked_branch].on_failure )) {


### PR DESCRIPTION
Set the branch_idx for failure route

Make sure the configured on_failure/on_branch_failure/on_reply routes are copied to the new branches created for DNS failover.

These are eligible for 4.4 too.