### PR TITLE
core: use system MD5 on Solaris

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1832,7 +1832,7 @@ ifeq ($(CC_NAME), suncc)
 endif
 	OLD_SOLARIS= $(shell echo "$(OSREL)" | \
 				sed -e 's/^5\.[0-6][^0-9]*$$/yes/' )
-	LIBS+= -L$(LOCALBASE)/lib -lxnet -lsocket -lnsl
+	LIBS+= -L$(LOCALBASE)/lib -lxnet -lsocket -lnsl -lmd5
 ifeq	($(OLD_SOLARIS), yes)
 		LIBS+=-lposix4
 else

--- a/md5.c
+++ b/md5.c
@@ -22,6 +22,8 @@
 
 #include "md5.h"
 
+#ifndef __OS_solaris
+
 #define PUT_64BIT_LE(cp, value) do {					\
 	(cp)[7] = (value) >> 56;					\
 	(cp)[6] = (value) >> 48;					\
@@ -247,3 +249,5 @@ MD5Transform(u_int32_t state[4], const u_int8_t block[MD5_BLOCK_LENGTH])
 	state[2] += c;
 	state[3] += d;
 }
+
+#endif /* __OS_solaris */

--- a/md5.h
+++ b/md5.h
@@ -15,19 +15,14 @@
 #ifndef _MD5_H_
 #define _MD5_H_
 
+#ifndef __OS_solaris
+
 #define	MD5_BLOCK_LENGTH		64
 #define	MD5_DIGEST_LENGTH		16
 #define	MD5_DIGEST_STRING_LENGTH	(MD5_DIGEST_LENGTH * 2 + 1)
 
 /* Probably not the proper place, but will do for Debian: */
 #include <sys/types.h>
-
-/* fix types for Sun Solaris */
-#if defined(__SVR4) || defined(__sun)
-    typedef uint8_t u_int8_t;
-    typedef uint32_t u_int32_t;
-    typedef uint64_t u_int64_t;
-#endif
 
 typedef struct MD5Context {
 	u_int32_t state[4];			/* state */
@@ -48,5 +43,15 @@ static inline void MD5Update(MD5_CTX *ctx, const char *str, size_t len) {
 static inline void MD5Final(char buf[MD5_DIGEST_LENGTH], MD5_CTX *ctx) {
 	U_MD5Final((unsigned char *)buf, ctx);
 }
+
+#else /* __OS_solaris */
+#include <md5.h>
+
+#define U_MD5Update(ctx, input, len) \
+	MD5Update(ctx, input, len)
+#define U_MD5Final(digest, ctx) \
+	MD5Final(digest, ctx)
+
+#endif /* __OS_solaris */
 
 #endif /* _MD5_H_ */


### PR DESCRIPTION
- Allows use of SPARC optimized functions