### PR TITLE
dialog: set DLG_FLAG_CHANGED for changed dialog variables

### DIFF
--- a/modules/dialog/dlg_var.c
+++ b/modules/dialog/dlg_var.c
@@ -186,7 +186,7 @@ int set_dlg_variable_unsafe(struct dlg_cell *dlg, str *key, str *val)
 				/* replace the current it with var and free the it */
 				var->next = it->next;
 				/* Take the previous vflags: */
-				var->vflags = it->vflags & DLG_FLAG_CHANGED;
+				var->vflags = it->vflags | DLG_FLAG_CHANGED;
 				if (it_prev) it_prev->next = var;
 				else *var_list = var;				  
 			}


### PR DESCRIPTION
i've noticed, some dialog variables  are not saved to DB

improper flag setting has been the cause of the not DB saving in some scenarios