### PR TITLE
Use portable endian macros

### DIFF
--- a/md5.c
+++ b/md5.c
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 #include <string.h>
 
+#include "endianness.h"
 #include "md5.h"
 
 #ifndef __OS_solaris
@@ -159,7 +160,7 @@ MD5Transform(u_int32_t state[4], const u_int8_t block[MD5_BLOCK_LENGTH])
 {
 	u_int32_t a, b, c, d, in[MD5_BLOCK_LENGTH / 4];
 
-#ifndef WORDS_BIGENDIAN
+#ifndef __IS_BIG_ENDIAN
 	memcpy(in, block, sizeof(in));
 #else
 	for (a = 0; a < MD5_BLOCK_LENGTH / 4; a++) {

--- a/modules/acc/diam_message.h
+++ b/modules/acc/diam_message.h
@@ -38,6 +38,7 @@
 
 #include "../../str.h"
 #include "../../mem/mem.h"
+#include "../../endianness.h"
 
 #define ad_malloc	pkg_malloc
 #define ad_free		pkg_free
@@ -68,7 +69,7 @@
 
 /* message codes
  */
-#ifndef WORDS_BIGENDIAN
+#ifndef __IS_BIG_ENDIAN
 	#define AS_MSG_CODE      0x12010000
 	#define AC_MSG_CODE      0x0f010000
 	#define CE_MSG_CODE      0x01010000

--- a/modules/auth_diameter/diameter_msg.h
+++ b/modules/auth_diameter/diameter_msg.h
@@ -29,6 +29,7 @@
 
 #include "../../str.h"
 #include "../../mem/mem.h"
+#include "../../endianness.h"
 
 #define ad_malloc	pkg_malloc
 #define ad_free		pkg_free
@@ -59,7 +60,7 @@
 
 /* message codes
  */
-#ifndef WORDS_BIGENDIAN
+#ifndef __IS_BIG_ENDIAN
 	#define AS_MSG_CODE      0x12010000
 	#define AC_MSG_CODE      0x0f010000
 	#define CE_MSG_CODE      0x01010000
@@ -69,7 +70,6 @@
 	#define ST_MSG_CODE      0x13010000
 	#define MASK_MSG_CODE    0xffffff00
 #else
-	#error BIG endian detected!!
 	#define AS_MSG_CODE      0x00000112
 	#define AC_MSG_CODE      0x0000010f
 	#define CE_MSG_CODE      0x00000101

--- a/modules/cdp/diameter.h
+++ b/modules/cdp/diameter.h
@@ -47,6 +47,7 @@
 
 #include "utils.h"
 #include <ctype.h>
+#include "../../endianness.h"
 
 #include "diameter_code_result.h"
 #include "diameter_code_avp.h"
@@ -104,7 +105,7 @@
 	AVP_VENDOR_ID_SIZE*(((_flags_)&AAA_AVP_FLAG_VENDOR_SPECIFIC)!=0) )
 
 /* mesage codes */
-#ifndef WORDS_BIGENDIAN
+#ifndef __IS_BIG_ENDIAN
 	#define AS_MSG_CODE      0x12010000
 	#define AC_MSG_CODE      0x0f010000
 	#define CE_MSG_CODE      0x01010000

--- a/modules/xmpp/sha.c
+++ b/modules/xmpp/sha.c
@@ -49,6 +49,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <string.h>
+#include "../../endianness.h"
 
 #ifndef MACOS
 #  include <sys/stat.h>
@@ -104,7 +105,7 @@ sha_hash(int *data, int *hash)
 
   for (t=0; t<16; t++) 
     {
-#ifndef WORDS_BIGENDIAN
+#ifndef __IS_BIG_ENDIAN
       W[t]=switch_endianness(data[t]);
 #else 
       W[t]=data[t];
@@ -244,7 +245,7 @@ char *shahash(const char *str)
 				for (i=0; i<14; i++) 
 					((int*)read_buffer)[i]=0;
 			}      
-#ifndef WORDS_BIGENDIAN
+#ifndef __IS_BIG_ENDIAN
 			for (i=0; i<8; i++) 
 			{
 				read_buffer[56+i]=(char)(length>>(56-(i*8))) & 0xff;


### PR DESCRIPTION
Not all platforms define WORDS_BIGENDIAN on big endian archs. This fixes #739 
