### PR TITLE
modules/siptrace: fix parsing of unsecure ws uris

### DIFF
--- a/modules/siptrace/siptrace.c
+++ b/modules/siptrace/siptrace.c
@@ -1854,7 +1854,7 @@ static int pipport2su (char *pipport, union sockaddr_union *tmp_su, unsigned int
 	if(strncmp(pipport, "udp:",4) == 0) *proto = IPPROTO_UDP;
 	else if(strncmp(pipport, "tcp:",4) == 0) *proto = IPPROTO_TCP;
 	else if(strncmp(pipport, "tls:",4) == 0) *proto = IPPROTO_IDP; /* fake proto type */
-	else if(strncmp(pipport, "ws:",3) == 0) *proto = IPPROTO_IDP; /* fake proto type */
+	else if(strncmp(pipport, "ws:",3) == 0) cutlen = 3, *proto = IPPROTO_IDP; /* fake proto type */
 	else if(strncmp(pipport, "wss:",4) == 0) *proto = IPPROTO_IDP; /* fake proto type */
 #ifdef USE_SCTP
 	else if(strncmp(pipport, "sctp:",5) == 0) cutlen = 5, *proto = IPPROTO_SCTP;


### PR DESCRIPTION
due to missing adaption of cutlen, the first decimal number of the ip address is cut off when using 'ws:' uris