### PR TITLE
core: fixed two double free() situations

### DIFF
--- a/data_lump_rpl.c
+++ b/data_lump_rpl.c
@@ -102,9 +102,12 @@ void free_lump_rpl(struct lump_rpl* lump)
 {
 	if (lump) {
 		if (!((lump->flags)&LUMP_RPL_NOFREE) && ((lump->flags)&LUMP_RPL_NODUP)
-		&& lump->text.s)
+		&& lump->text.s) {
 			pkg_free(lump->text.s);
+			lump->text.s = 0;
+		}
 		pkg_free(lump);
+		lump = 0;
 	}
 }
 

--- a/parser/hf.c
+++ b/parser/hf.c
@@ -215,6 +215,7 @@ void free_hdr_field_lst(struct hdr_field* hf)
 		hf=hf->next;
 		clean_hdr_field(foo);
 		pkg_free(foo);
+		foo = 0;
 	}
 }
 


### PR DESCRIPTION
I ran into these while testing with SIPP  and having memlog=1 :

kamailio[21826]: : <core> [mem/q_malloc.c:453]: qm_free(): BUG: qm_free: freeing already freed pointer (0x7f24869850f8), called
 from <core>: parser/contact/parse_contact.c: free_contact(109), first free <core>: parser/contact/parse_contact.c: free_contact(109) - aborting

kamailio[21540]: : <core> [mem/q_malloc.c:453]: qm_free(): BUG: qm_free: freeing already freed pointer (0x7f4161b971c0), called
 from <core>: data_lump_rpl.c: free_lump_rpl(107), first free <core>: data_lump_rpl.c: free_lump_rpl(107) - aborting

These two patches fix these two separate issues. 

