### PR TITLE
presence: fix multiple double free on shutdown caught with memlog=1

### DIFF
--- a/modules/presence/hash.c
+++ b/modules/presence/hash.c
@@ -101,6 +101,7 @@ void destroy_shtable(shtable_t htable, int hash_size)
 		lock_destroy(&htable[i].lock);
 		free_subs_list(htable[i].entries->next, SHM_MEM_TYPE, 1);
 		shm_free(htable[i].entries);
+		htable[i].entries = NULL;
 	}
 	shm_free(htable);
 	htable= NULL;
@@ -345,15 +346,21 @@ void free_subs_list(subs_t* s_array, int mem_type, int ic)
 		s_array= s_array->next;
 		if(mem_type & PKG_MEM_TYPE)
 		{
-			if(ic)
+			if(ic) {
 				pkg_free(s->contact.s);
+				s->contact.s = NULL;
+			}
 			pkg_free(s);
+			s = NULL;
 		}
 		else
 		{
-			if(ic)
+			if(ic) {
 				shm_free(s->contact.s);
+				s->contact.s = NULL;
+			}
 			shm_free(s);
+			s = NULL;
 		}
 	}
 	


### PR DESCRIPTION
These small changes fix the bug shown below and another potential one. 

kamailio[3062]: : <core> [mem/q_malloc.c:453]: qm_free(): BUG: qm_free: freeing already freed pointer (0x7facf958dc08), called from presence: hash.c: delete_shtable(316), first free presence: hash.c: free_subs_list(349) - aborting

It's the double free apocalypse day :)
