### PR TITLE
examples/scscf: minor fixes (logging)

### DIFF
--- a/examples/scscf/kamailio.cfg
+++ b/examples/scscf/kamailio.cfg
@@ -737,7 +737,7 @@ route[REG_MAR_REPLY]
                      send_reply("500", "MAR failed");
                      break;
              default:
-                     xlog("L_ERR", "Unknown return code from MAR, value is [$avp(s:uaa_return_code)]\n");
+                     xlog("L_ERR", "Unknown return code from MAR, value is [$avp(s:maa_return_code)]\n");
                      send_reply("500", "Unknown response code from MAR");
                      break;
      }
@@ -761,7 +761,7 @@ route[PRE_REG_SAR_REPLY]
                     xlog("L_ERR", "SAR error - error response sent from module\n");
                     break;
             default:
-                    xlog("L_ERR", "Unknown return code from SAR, value is [$avp(s:uaa_return_code)]\n");
+                    xlog("L_ERR", "Unknown return code from SAR, value is [$avp(s:saa_return_code)]\n");
                     break;
     }
     exit;
@@ -783,7 +783,7 @@ route[REG_SAR_REPLY]
                     xlog("L_ERR", "SAR error - error response sent from module\n");
                     break;
             default:
-                    xlog("L_ERR", "Unknown return code from SAR, value is [$avp(s:uaa_return_code)]\n");
+                    xlog("L_ERR", "Unknown return code from SAR, value is [$avp(s:saa_return_code)]\n");
                     break;
     }
     exit;
@@ -869,7 +869,7 @@ route[FINAL_ORIG]
 
 route[CHARGING_CCR_ORIG_REPLY]
 {
-        xlog("L_DBG","saa_return code is $avp(s:cca_return_code)\n");
+        xlog("L_DBG","cca_return code is $avp(s:cca_return_code)\n");
 
         switch ($avp(s:cca_return_code)){
             case 1: #success
@@ -1039,7 +1039,7 @@ route[FINAL_TERM] {
 
 route[CHARGING_CCR_TERM_REPLY]
 {
-        xlog("L_DBG","saa_return code is $avp(s:cca_return_code)\n");
+        xlog("L_DBG","cca_return code is $avp(s:cca_return_code)\n");
 
         switch ($avp(s:cca_return_code)){
             case 1: #success


### PR DESCRIPTION
The real return code of MAA/SAA is not shown in the logs in case of unknown error.
 
