### PR TITLE
pike: fixed rpc array

### DIFF
--- a/modules/pike/pike_top.c
+++ b/modules/pike/pike_top.c
@@ -33,7 +33,6 @@
 static struct TopListItem_t *top_list_root = 0;
 static struct TopListItem_t *top_list_iter = 0;
 
-#define PIKE_BUFF_SIZE	128
 static char buff[PIKE_BUFF_SIZE];
 
 struct TopListItem_t *pike_top_get_root() { return top_list_root; }

--- a/modules/pike/pike_top.h
+++ b/modules/pike/pike_top.h
@@ -24,6 +24,8 @@
 #include "ip_tree.h"
 #include "../../ip_addr.h"
 
+#define PIKE_BUFF_SIZE  128
+
 struct TopListItem_t {
 	int             addr_len;
 	unsigned char   ip_addr[45];	/*!< Make room for IPv6 */


### PR DESCRIPTION
- added array structure when returning multiple addresses instead of concatenated strings
- fixed buffer overflow on incorrect buffer size allocation