### PR TITLE
sca: add onhold_bflag module parameter

### DIFF
--- a/modules/sca/doc/sca_admin.xml
+++ b/modules/sca/doc/sca_admin.xml
@@ -262,6 +262,28 @@ modparam( "sca", "db_update_interval", 120 )
 		</programlisting>
 		</example>
 	</section>
+
+	<section id="sca.p.onhold_bflag">
+		<title><varname>onhold_bflag</varname> (integer)</title>
+		<para>
+		<para>
+		Which branch flag should be used by the module to identify if the call
+		is on-hold instead of parsing the sdp.
+		</para>
+		<para>
+		<emphasis>
+			Default value is -1 (disabled).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>onhold_bflag</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("sca", "onhold_bflag", 15)
+...
+</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>

--- a/modules/sca/sca.c
+++ b/modules/sca/sca.c
@@ -125,6 +125,7 @@ int hash_table_size = -1;
 int call_info_max_expires = 3600;
 int line_seize_max_expires = 15;
 int purge_expired_interval = 120;
+int onhold_bflag = -1;
 
 static param_export_t params[] = {
 		{"outbound_proxy", PARAM_STR, &outbound_proxy},
@@ -136,6 +137,7 @@ static param_export_t params[] = {
 		{"call_info_max_expires", INT_PARAM, &call_info_max_expires},
 		{"line_seize_max_expires", INT_PARAM, &line_seize_max_expires},
 		{"purge_expired_interval", INT_PARAM, &purge_expired_interval},
+		{"onhold_bflag", INT_PARAM, &onhold_bflag},
 		{NULL, 0, NULL},
 };
 
@@ -265,6 +267,11 @@ static int sca_set_config(sca_mod *scam)
 	scam->cfg->call_info_max_expires = call_info_max_expires;
 	scam->cfg->line_seize_max_expires = line_seize_max_expires;
 	scam->cfg->purge_expired_interval = purge_expired_interval;
+	if(onhold_bflag > 31) {
+		LM_ERR("sca_set_config: onhold_bflag value > 31\n");
+		return (-1);
+	}
+	scam->cfg->onhold_bflag = onhold_bflag;
 
 	return (0);
 }

--- a/modules/sca/sca.h
+++ b/modules/sca/sca.h
@@ -37,6 +37,7 @@ struct _sca_config {
 	int call_info_max_expires;
 	int line_seize_max_expires;
 	int purge_expired_interval;
+	int onhold_bflag;
 };
 typedef struct _sca_config sca_config;
 

--- a/modules/sca/sca_util.c
+++ b/modules/sca/sca_util.c
@@ -18,11 +18,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA. 02110-1301 USA
  */
 #include "sca_common.h"
-
+#include "sca.h"
 #include <assert.h>
 
 #include "sca_util.h"
-
+#include "../../dset.h"
 #include "../../parser/sdp/sdp.h"
 
 int sca_get_msg_method(sip_msg_t *msg)
@@ -419,6 +419,10 @@ int sca_call_is_held(sip_msg_t *msg)
 	int is_held = 0;
 	int rc;
 
+	if(sca->cfg->onhold_bflag >= 0) {
+		LM_DBG("sca_call_is_held: skip parse_sdp and use onhold_bflag\n");
+		return isbflagset(0, (flag_t)sca->cfg->onhold_bflag);
+	}
 	rc = parse_sdp(msg);
 	if (rc < 0) {
 		LM_ERR("sca_call_is_held: parse_sdp body failed\n");


### PR DESCRIPTION
* disable by default (-1)
* will skip parsing the sdp for on hold discovery and it will
  use the value of the bflag

Fix #773