### PR TITLE
sca: fix core when HDR_CSEQ not parsed

### DIFF
--- a/modules/sca/sca.c
+++ b/modules/sca/sca.c
@@ -70,6 +70,10 @@ static int sca_mod_init(void);
 static int sca_child_init(int);
 static void sca_mod_destroy(void);
 static int sca_set_config(sca_mod *);
+static int sca_call_info_update_0_f(sip_msg_t* msg);
+static int sca_call_info_update_1_f(sip_msg_t* msg, char*);
+static int sca_call_info_update_2_f(sip_msg_t* msg, char* , char*);
+static int sca_call_info_update_3_f(sip_msg_t* msg, char* , char*, char *);
 int fixup_ciu(void **, int);
 int fixup_free_ciu(void **param, int param_no);
 
@@ -79,13 +83,13 @@ int fixup_free_ciu(void **param, int param_no);
 static cmd_export_t cmds[] = {
 		{"sca_handle_subscribe", (cmd_function)sca_handle_subscribe, 0, NULL, 0,
 				REQUEST_ROUTE},
-		{"sca_call_info_update", (cmd_function)sca_call_info_update, 0, NULL, 0,
+		{"sca_call_info_update", (cmd_function)sca_call_info_update_0_f, 0, NULL, 0,
 				REQUEST_ROUTE | FAILURE_ROUTE | ONREPLY_ROUTE},
-		{"sca_call_info_update", (cmd_function)sca_call_info_update, 1,
+		{"sca_call_info_update", (cmd_function)sca_call_info_update_1_f, 1,
 			fixup_ciu, fixup_free_ciu, REQUEST_ROUTE | FAILURE_ROUTE | ONREPLY_ROUTE},
-		{"sca_call_info_update", (cmd_function)sca_call_info_update, 2,
+		{"sca_call_info_update", (cmd_function)sca_call_info_update_2_f, 2,
 			fixup_ciu, fixup_free_ciu, REQUEST_ROUTE | FAILURE_ROUTE | ONREPLY_ROUTE},
-		{"sca_call_info_update", (cmd_function)sca_call_info_update, 3,
+		{"sca_call_info_update", (cmd_function)sca_call_info_update_3_f, 3,
 			fixup_ciu, fixup_free_ciu, REQUEST_ROUTE | FAILURE_ROUTE | ONREPLY_ROUTE},
 		{ 0, 0, 0, 0, 0, 0 }
 };
@@ -406,6 +410,21 @@ void sca_mod_destroy(void)
 	}
 
 	sca_db_disconnect();
+}
+
+static int sca_call_info_update_0_f(sip_msg_t* msg) {
+	return sca_call_info_update(msg, NULL, NULL, NULL);
+}
+static int sca_call_info_update_1_f(sip_msg_t* msg, char* p1) {
+	return sca_call_info_update(msg, p1, NULL, NULL);
+}
+static int sca_call_info_update_2_f(sip_msg_t* msg, char* p1, char* p2) {
+	return sca_call_info_update(msg, p1, p2, NULL);
+}
+static int sca_call_info_update_3_f(sip_msg_t* msg,
+	char* p1, char* p2, char * p3)
+{
+	return sca_call_info_update(msg, p1, p2, p3);
 }
 
 int fixup_ciu(void **param, int param_no)

--- a/modules/sca/sca_call_info.c
+++ b/modules/sca/sca_call_info.c
@@ -1842,6 +1842,12 @@ int sca_call_info_update(sip_msg_t *msg, char *p1, char *p2, char *p3)
 		}
 	}
 	if (i >= n_dispatch) {
+		if(msg->cseq==NULL && ((parse_headers(msg, HDR_CSEQ_F, 0)==-1) ||
+			(msg->cseq==NULL)))
+		{
+			LM_ERR("no CSEQ header\n");
+			return (1);
+		}
 		LM_DBG("BUG: sca module does not support Call-Info headers "
 				"in %.*s requests\n", STR_FMT(&get_cseq(msg)->method));
 		return (1);


### PR DESCRIPTION
> Program terminated with signal SIGSEGV, Segmentation fault.
> #0  0x00007f1820227bae in sca_call_info_update (msg=0x7f1828635930, p1=0x0, p2=0x0, p3=0x7f1828635930 "\001") at sca_call_info.c:1845
> 1845			LM_DBG("BUG: sca module does not support Call-Info headers "
> (gdb) p msg->cseq
> $1 = (struct hdr_field *) 0x0
> (gdb) p msg->first_line.u.request->method
> $2 = {
>  s = 0xa33540 <buf> "SUBSCRIBE sip:30@127.0.0.1:5060 SIP/2.0\r\nVia: SIP/2.0/UDP 172.17.0.2:5061;branch=z9hG4bK-2884-1-0\r\nFrom: sipp <sip:sipp@172.17.0.2:5061>;tag=2884SIPpTag001\r\nTo: sut <sip:30@127.0.0.1:5060>\r\nCall-ID: 1"..., len = 9}