### PR TITLE
ipops: fix compilation under FreeBSD

### DIFF
--- a/modules/ipops/detailed_ip_type.c
+++ b/modules/ipops/detailed_ip_type.c
@@ -26,6 +26,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <arpa/inet.h>
+#if defined (__OS_freebsd)
+#include <sys/socket.h>
+#endif
 #include <string.h>
 #include <unistd.h>
 #include "../../dprint.h"


### PR DESCRIPTION
- unable to compile detailed_ip_type.c under FreeBSD needs extra header