### PR TITLE
http_client Terminate exported commands list

### DIFF
--- a/modules/http_client/http_client.c
+++ b/modules/http_client/http_client.c
@@ -142,6 +142,7 @@ static cmd_export_t cmds[] = {
 		fixup_free_curl_get_redirect,
 		REQUEST_ROUTE|ONREPLY_ROUTE|FAILURE_ROUTE|BRANCH_ROUTE},
 	{"bind_http_client",  (cmd_function)bind_httpc_api,  0, 0, 0, 0},
+	{0,0,0,0,0,0}
 };
 
 


### PR DESCRIPTION
The list of exported functions was not terminated, which caused a
segfault in find_mod_export_record() when reading outside the list.