### PR TITLE
sca: add server_id column to sca_subscriptions table

### DIFF
--- a/lib/srdb1/schema/sca.xml
+++ b/lib/srdb1/schema/sca.xml
@@ -9,7 +9,7 @@
 
 <table id="sca_susbcriptions" xmlns:db="http://docbook.org/ns/docbook">
     <name>sca_subscriptions</name>
-    <version>1</version>
+    <version>2</version>
     <type db="mysql">&MYSQL_TABLE_TYPE;</type>
     <description>
         <db:para>This table is used by the sca module to store active subscriptions. At startup time, the sca module loads unexpired subscriptions into its subscription hash table. More information about the sca module can be found at: &KAMAILIO_MOD_DOC;sca.html
@@ -111,6 +111,14 @@
         <description>Cseq for SUBSCRIBEs sent from subscriber</description>
     </column>
 
+    <column id="server_id">
+        <name>server_id</name>
+        <type>int</type>
+        <size>11</size>
+        <default>0</default>
+        <description>The value of server_id from configuration file</description>
+    </column>
+
     <index>
 	<name>sca_subscriptions_idx</name>
 	<colref linkend="subscriber" />
@@ -122,6 +130,7 @@
 
     <index>
 	<name>sca_expires_idx</name>
+	<colref linkend="server_id" />
 	<colref linkend="expires" />
     </index>
 

--- a/modules/sca/sca_db.c
+++ b/modules/sca/sca_db.c
@@ -36,6 +36,7 @@ const str SCA_DB_TO_TAG_COL_NAME = STR_STATIC_INIT("to_tag");
 const str SCA_DB_RECORD_ROUTE_COL_NAME = STR_STATIC_INIT("record_route");
 const str SCA_DB_NOTIFY_CSEQ_COL_NAME = STR_STATIC_INIT("notify_cseq");
 const str SCA_DB_SUBSCRIBE_CSEQ_COL_NAME = STR_STATIC_INIT("subscribe_cseq");
+const str SCA_DB_SERVER_ID_COL_NAME = STR_STATIC_INIT("server_id");
 
 void sca_db_subscriptions_get_value_for_column(int column, db_val_t *row_values,
 		void *column_value)
@@ -63,6 +64,7 @@ void sca_db_subscriptions_get_value_for_column(int column, db_val_t *row_values,
 	case SCA_DB_SUBS_STATE_COL:
 	case SCA_DB_SUBS_NOTIFY_CSEQ_COL:
 	case SCA_DB_SUBS_SUBSCRIBE_CSEQ_COL:
+	case SCA_DB_SUBS_SERVER_ID_COL:
 		*((int *) column_value) = row_values[column].val.int_val;
 		break;
 
@@ -112,6 +114,7 @@ void sca_db_subscriptions_set_value_for_column(int column, db_val_t *row_values,
 	case SCA_DB_SUBS_STATE_COL:
 	case SCA_DB_SUBS_NOTIFY_CSEQ_COL:
 	case SCA_DB_SUBS_SUBSCRIBE_CSEQ_COL:
+	case SCA_DB_SUBS_SERVER_ID_COL:
 		row_values[column].val.int_val = *((int *) column_value);
 		row_values[column].type = DB1_INT;
 		row_values[column].nul = 0;
@@ -129,6 +132,7 @@ str **sca_db_subscriptions_columns(void)
 			(str *) &SCA_DB_RECORD_ROUTE_COL_NAME,
 			(str *) &SCA_DB_NOTIFY_CSEQ_COL_NAME,
 			(str *) &SCA_DB_SUBSCRIBE_CSEQ_COL_NAME,
+			(str *) &SCA_DB_SERVER_ID_COL_NAME,
 			NULL};
 
 	return (subs_columns);

--- a/modules/sca/sca_db.h
+++ b/modules/sca/sca_db.h
@@ -22,9 +22,9 @@
 
 #include "../../lib/srdb1/db.h"
 
-#define SCA_DB_SUBSCRIPTIONS_TABLE_VERSION	1
+#define SCA_DB_SUBSCRIPTIONS_TABLE_VERSION	2
 
-#define SCA_DB_SUBSCRIPTIONS_NUM_COLUMNS	12
+#define SCA_DB_SUBSCRIPTIONS_NUM_COLUMNS	13
 
 #define SCA_DB_DEFAULT_FETCH_ROW_COUNT		1000
 
@@ -41,6 +41,7 @@ enum {
 	SCA_DB_SUBS_RECORD_ROUTE_COL,
 	SCA_DB_SUBS_NOTIFY_CSEQ_COL,
 	SCA_DB_SUBS_SUBSCRIBE_CSEQ_COL,
+	SCA_DB_SUBS_SERVER_ID_COL,
 
 	SCA_DB_SUBS_BOUNDARY,
 };
@@ -78,6 +79,7 @@ extern const str SCA_DB_TO_TAG_COL_NAME;
 extern const str SCA_DB_RECORD_ROUTE_COL_NAME;
 extern const str SCA_DB_NOTIFY_CSEQ_COL_NAME;
 extern const str SCA_DB_SUBSCRIBE_CSEQ_COL_NAME;
+extern const str SCA_DB_SERVER_ID_COL_NAME;
 
 str **sca_db_subscriptions_columns(void);
 void sca_db_subscriptions_get_value_for_column(int, db_val_t *, void *);

--- a/modules/sca/sca_subscribe.c
+++ b/modules/sca/sca_subscribe.c
@@ -183,6 +183,8 @@ int sca_subscription_from_db_row_values(db_val_t *values, sca_subscription *sub)
 			values, &sub->dialog.notify_cseq);
 	sca_db_subscriptions_get_value_for_column(SCA_DB_SUBS_SUBSCRIBE_CSEQ_COL,
 			values, &sub->dialog.subscribe_cseq);
+	sca_db_subscriptions_get_value_for_column(SCA_DB_SUBS_SERVER_ID_COL,
+			values, &sub->server_id);
 
 	return (0);
 }
@@ -221,6 +223,8 @@ int sca_subscription_to_db_row_values(sca_subscription *sub, db_val_t *values)
 			values, &notify_cseq);
 	sca_db_subscriptions_set_value_for_column(SCA_DB_SUBS_SUBSCRIBE_CSEQ_COL,
 			values, &subscribe_cseq);
+	sca_db_subscriptions_set_value_for_column(SCA_DB_SUBS_SERVER_ID_COL,
+			values, &sub->server_id);
 
 	return (0);
 }
@@ -228,6 +232,9 @@ int sca_subscription_to_db_row_values(sca_subscription *sub, db_val_t *values)
 int sca_subscriptions_restore_from_db(sca_mod *scam)
 {
 	db1_con_t *db_con;
+	db_key_t query_columns[1];
+	db_val_t query_values[1];
+	db_op_t query_ops[1];
 	db_key_t result_columns[SCA_DB_SUBSCRIPTIONS_NUM_COLUMNS];
 	db1_res_t *result = NULL;
 	db_row_t *rows = NULL;
@@ -238,6 +245,7 @@ int sca_subscriptions_restore_from_db(sca_mod *scam)
 	int num_rows;
 	int i;
 	int idx;
+	int q_count = 0;
 	int rc = -1;
 	time_t now = time(NULL);
 
@@ -261,8 +269,13 @@ int sca_subscriptions_restore_from_db(sca_mod *scam)
 		result_columns[i] = column_names[i];
 	}
 
+	query_columns[q_count] = (str *) &SCA_DB_SERVER_ID_COL_NAME;
+	query_ops[q_count] = OP_EQ;
+	SCA_DB_BIND_INT_VALUE(server_id, &SCA_DB_SERVER_ID_COL_NAME, query_columns,
+		query_values, q_count);
+
 	rc = db_fetch_query(scam->db_api, SCA_DB_DEFAULT_FETCH_ROW_COUNT, db_con,
-			NULL, NULL, NULL, result_columns, 0,
+			query_columns, query_ops, query_values, result_columns, q_count,
 			SCA_DB_SUBSCRIPTIONS_NUM_COLUMNS, 0, &result);
 	switch (rc) {
 	default:
@@ -439,14 +452,20 @@ static int sca_subscription_db_insert_subscriber(db1_con_t *db_con,
 
 int sca_subscription_db_delete_expired(db1_con_t *db_con)
 {
-	db_key_t delete_columns[1];
-	db_val_t delete_values[1];
-	db_op_t delete_ops[1];
+	db_key_t delete_columns[2];
+	db_val_t delete_values[2];
+	db_op_t delete_ops[2];
 	time_t now = time(NULL);
 	int kv_count = 0;
 
-	delete_columns[0] = (str *) &SCA_DB_EXPIRES_COL_NAME;
-	delete_ops[0] = OP_LT;
+	delete_columns[kv_count] = (str *) &SCA_DB_SERVER_ID_COL_NAME;
+	delete_ops[kv_count] = OP_EQ;
+
+	SCA_DB_BIND_INT_VALUE(server_id, &SCA_DB_SERVER_ID_COL_NAME, delete_columns,
+			delete_values, kv_count);
+
+	delete_columns[kv_count] = (str *) &SCA_DB_EXPIRES_COL_NAME;
+	delete_ops[kv_count] = OP_LT;
 
 	SCA_DB_BIND_INT_VALUE(now, &SCA_DB_EXPIRES_COL_NAME, delete_columns,
 			delete_values, kv_count);
@@ -657,6 +676,8 @@ sca_subscription *sca_subscription_create(str *aor, int event, str *subscriber,
 	sub->dialog.to_tag.s = sub->dialog.id.s + call_id->len + from_tag->len;
 	sub->dialog.to_tag.len = to_tag->len;
 
+	sub->server_id = server_id;
+
 	return (sub);
 
 	error: if (sub != NULL) {
@@ -706,7 +727,7 @@ void sca_subscription_print(void *value)
 
 	LM_DBG("%.*s %s (%d) %.*s, expires: %ld, index: %d, "
 			"dialog %.*s;%.*s;%.*s, record_route: %.*s, "
-			"notify_cseq: %d, subscribe_cseq: %d\n",
+			"notify_cseq: %d, subscribe_cseq: %d, server_id: %d\n",
 			STR_FMT(&sub->target_aor),
 			sca_event_name_from_type(sub->event),
 			sub->event,
@@ -718,7 +739,8 @@ void sca_subscription_print(void *value)
 			SCA_STR_EMPTY(&sub->rr) ? 4 : sub->rr.len,
 			SCA_STR_EMPTY(&sub->rr) ? "null" : sub->rr.s,
 			sub->dialog.notify_cseq,
-			sub->dialog.subscribe_cseq);
+			sub->dialog.subscribe_cseq,
+			sub->server_id);
 }
 
 int sca_subscription_save_unsafe(sca_mod *scam, sca_subscription *sub,
@@ -1094,6 +1116,7 @@ int sca_subscription_from_request(sca_mod *scam, sip_msg_t *msg, int event_type,
 
 	req_sub->dialog.subscribe_cseq = 0;
 	req_sub->dialog.notify_cseq = 0;
+	req_sub->server_id = server_id;
 
 	free_to_params(&tmp_to);
 

--- a/modules/sca/sca_subscribe.h
+++ b/modules/sca/sca_subscribe.h
@@ -48,6 +48,7 @@ struct _sca_subscription {
 	str rr; // Record-Route header values
 
 	int db_cmd_flag; // track whether to INSERT or UPDATE
+	int server_id; // server
 };
 typedef struct _sca_subscription sca_subscription;
 

--- a/utils/kamctl/db_berkeley/kamailio/sca_subscriptions
+++ b/utils/kamctl/db_berkeley/kamailio/sca_subscriptions
@@ -1,5 +1,5 @@
 METADATA_COLUMNS
-id(int) subscriber(str) aor(str) event(int) expires(int) state(int) app_idx(int) call_id(str) from_tag(str) to_tag(str) record_route(str) notify_cseq(int) subscribe_cseq(int)
+id(int) subscriber(str) aor(str) event(int) expires(int) state(int) app_idx(int) call_id(str) from_tag(str) to_tag(str) record_route(str) notify_cseq(int) subscribe_cseq(int) server_id(int)
 METADATA_KEY
 
 METADATA_READONLY
@@ -7,4 +7,4 @@ METADATA_READONLY
 METADATA_LOGFLAGS
 0
 METADATA_DEFAULTS
-NIL|NIL|NIL|0|0|0|0|NIL|NIL|NIL|NIL|NIL|NIL
+NIL|NIL|NIL|0|0|0|0|NIL|NIL|NIL|NIL|NIL|NIL|0

--- a/utils/kamctl/db_berkeley/kamailio/version
+++ b/utils/kamctl/db_berkeley/kamailio/version
@@ -107,7 +107,7 @@ rtpengine|1
 rtpproxy|
 rtpproxy|1
 sca_subscriptions|
-sca_subscriptions|1
+sca_subscriptions|2
 silo|
 silo|8
 sip_trace|

--- a/utils/kamctl/db_sqlite/sca-create.sql
+++ b/utils/kamctl/db_sqlite/sca-create.sql
@@ -12,11 +12,12 @@ CREATE TABLE sca_subscriptions (
     record_route TEXT,
     notify_cseq INTEGER NOT NULL,
     subscribe_cseq INTEGER NOT NULL,
+    server_id INTEGER DEFAULT 0 NOT NULL,
     CONSTRAINT sca_subscriptions_sca_subscriptions_idx UNIQUE (subscriber, call_id, from_tag, to_tag)
 );
 
-CREATE INDEX sca_subscriptions_sca_expires_idx ON sca_subscriptions (expires);
+CREATE INDEX sca_subscriptions_sca_expires_idx ON sca_subscriptions (server_id, expires);
 CREATE INDEX sca_subscriptions_sca_subscribers_idx ON sca_subscriptions (subscriber, event);
 
-INSERT INTO version (table_name, table_version) values ('sca_subscriptions','1');
+INSERT INTO version (table_name, table_version) values ('sca_subscriptions','2');
 

--- a/utils/kamctl/dbtext/kamailio/sca_subscriptions
+++ b/utils/kamctl/dbtext/kamailio/sca_subscriptions
@@ -1,1 +1,1 @@
-id(int,auto) subscriber(string) aor(string) event(int) expires(int) state(int) app_idx(int) call_id(string) from_tag(string) to_tag(string) record_route(string,null) notify_cseq(int) subscribe_cseq(int) 
+id(int,auto) subscriber(string) aor(string) event(int) expires(int) state(int) app_idx(int) call_id(string) from_tag(string) to_tag(string) record_route(string,null) notify_cseq(int) subscribe_cseq(int) server_id(int) 

--- a/utils/kamctl/dbtext/kamailio/version
+++ b/utils/kamctl/dbtext/kamailio/version
@@ -48,7 +48,7 @@ rls_presentity:1
 rls_watchers:3
 rtpengine:1
 rtpproxy:1
-sca_subscriptions:1
+sca_subscriptions:2
 silo:8
 sip_trace:4
 speed_dial:2

--- a/utils/kamctl/mysql/sca-create.sql
+++ b/utils/kamctl/mysql/sca-create.sql
@@ -12,11 +12,12 @@ CREATE TABLE `sca_subscriptions` (
     `record_route` TEXT,
     `notify_cseq` INT(11) NOT NULL,
     `subscribe_cseq` INT(11) NOT NULL,
+    `server_id` INT(11) DEFAULT 0 NOT NULL,
     CONSTRAINT sca_subscriptions_idx UNIQUE (`subscriber`, `call_id`, `from_tag`, `to_tag`)
 );
 
-CREATE INDEX sca_expires_idx ON sca_subscriptions (`expires`);
+CREATE INDEX sca_expires_idx ON sca_subscriptions (`server_id`, `expires`);
 CREATE INDEX sca_subscribers_idx ON sca_subscriptions (`subscriber`, `event`);
 
-INSERT INTO version (table_name, table_version) values ('sca_subscriptions','1');
+INSERT INTO version (table_name, table_version) values ('sca_subscriptions','2');
 

--- a/utils/kamctl/oracle/sca-create.sql
+++ b/utils/kamctl/oracle/sca-create.sql
@@ -12,6 +12,7 @@ CREATE TABLE sca_subscriptions (
     record_route CLOB,
     notify_cseq NUMBER(10),
     subscribe_cseq NUMBER(10),
+    server_id NUMBER(10) DEFAULT 0 NOT NULL,
     CONSTRAINT ORA_sca_subscriptions_idx  UNIQUE (subscriber, call_id, from_tag, to_tag)
 );
 
@@ -23,8 +24,8 @@ END sca_subscriptions_tr;
 /
 BEGIN map2users('sca_subscriptions'); END;
 /
-CREATE INDEX ORA_sca_expires_idx  ON sca_subscriptions (expires);
+CREATE INDEX ORA_sca_expires_idx  ON sca_subscriptions (server_id, expires);
 CREATE INDEX ORA_sca_subscribers_idx  ON sca_subscriptions (subscriber, event);
 
-INSERT INTO version (table_name, table_version) values ('sca_subscriptions','1');
+INSERT INTO version (table_name, table_version) values ('sca_subscriptions','2');
 

--- a/utils/kamctl/postgres/sca-create.sql
+++ b/utils/kamctl/postgres/sca-create.sql
@@ -12,11 +12,12 @@ CREATE TABLE sca_subscriptions (
     record_route TEXT,
     notify_cseq INTEGER NOT NULL,
     subscribe_cseq INTEGER NOT NULL,
+    server_id INTEGER DEFAULT 0 NOT NULL,
     CONSTRAINT sca_subscriptions_sca_subscriptions_idx UNIQUE (subscriber, call_id, from_tag, to_tag)
 );
 
-CREATE INDEX sca_subscriptions_sca_expires_idx ON sca_subscriptions (expires);
+CREATE INDEX sca_subscriptions_sca_expires_idx ON sca_subscriptions (server_id, expires);
 CREATE INDEX sca_subscriptions_sca_subscribers_idx ON sca_subscriptions (subscriber, event);
 
-INSERT INTO version (table_name, table_version) values ('sca_subscriptions','1');
+INSERT INTO version (table_name, table_version) values ('sca_subscriptions','2');
 

--- a/utils/kamctl/xhttp_pi/pi_framework.xml
+++ b/utils/kamctl/xhttp_pi/pi_framework.xml
@@ -709,6 +709,7 @@
 		<column><field>record_route</field><type>DB1_BLOB</type></column>
 		<column><field>notify_cseq</field><type>DB1_INT</type></column>
 		<column><field>subscribe_cseq</field><type>DB1_INT</type></column>
+		<column><field>server_id</field><type>DB1_INT</type></column>
 	</db_table>
 	<!-- Declaration of sip_trace table-->
 	<db_table id="sip_trace">
@@ -3701,6 +3702,7 @@
 				<col><field>record_route</field></col>
 				<col><field>notify_cseq</field></col>
 				<col><field>subscribe_cseq</field></col>
+				<col><field>server_id</field></col>
 			</query_cols>
 		</cmd>
 		<cmd><cmd_name>add</cmd_name>
@@ -3719,6 +3721,7 @@
 				<col><field>record_route</field></col>
 				<col><field>notify_cseq</field></col>
 				<col><field>subscribe_cseq</field></col>
+				<col><field>server_id</field></col>
 			</query_cols>
 		</cmd>
 		<cmd><cmd_name>update</cmd_name>
@@ -3740,6 +3743,7 @@
 				<col><field>record_route</field></col>
 				<col><field>notify_cseq</field></col>
 				<col><field>subscribe_cseq</field></col>
+				<col><field>server_id</field></col>
 			</query_cols>
 		</cmd>
 		<cmd><cmd_name>delete</cmd_name>

--- a/utils/kamctl/xhttp_pi/sca-mod
+++ b/utils/kamctl/xhttp_pi/sca-mod
@@ -17,6 +17,7 @@
 				<col><field>record_route</field></col>
 				<col><field>notify_cseq</field></col>
 				<col><field>subscribe_cseq</field></col>
+				<col><field>server_id</field></col>
 			</query_cols>
 		</cmd>
 		<cmd><cmd_name>add</cmd_name>
@@ -35,6 +36,7 @@
 				<col><field>record_route</field></col>
 				<col><field>notify_cseq</field></col>
 				<col><field>subscribe_cseq</field></col>
+				<col><field>server_id</field></col>
 			</query_cols>
 		</cmd>
 		<cmd><cmd_name>update</cmd_name>
@@ -56,6 +58,7 @@
 				<col><field>record_route</field></col>
 				<col><field>notify_cseq</field></col>
 				<col><field>subscribe_cseq</field></col>
+				<col><field>server_id</field></col>
 			</query_cols>
 		</cmd>
 		<cmd><cmd_name>delete</cmd_name>

--- a/utils/kamctl/xhttp_pi/sca-table
+++ b/utils/kamctl/xhttp_pi/sca-table
@@ -15,4 +15,5 @@
 		<column><field>record_route</field><type>DB1_BLOB</type></column>
 		<column><field>notify_cseq</field><type>DB1_INT</type></column>
 		<column><field>subscribe_cseq</field><type>DB1_INT</type></column>
+		<column><field>server_id</field><type>DB1_INT</type></column>
 	</db_table>


### PR DESCRIPTION
In order to have more than one server with the same DB ``sca`` module has to have a ``server_id`` column to partition subscriptions

version bumped to ``2``

See #782
