### PR TITLE
core: added mcast to select interface for multicast

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -427,6 +427,7 @@ RT_TIMER2_PRIO		"rt_timer2_prio"|"rt_stimer_prio"
 RT_TIMER2_POLICY	"rt_timer2_policy"|"rt_stimer_policy"
 MCAST_LOOPBACK		"mcast_loopback"
 MCAST_TTL		"mcast_ttl"
+MCAST		"mcast"
 TOS			"tos"
 PMTU_DISCOVERY	"pmtu_discovery"
 KILL_TIMEOUT	"exit_timeout"|"ser_kill_timeout"
@@ -894,6 +895,8 @@ IMPORTFILE      "import_file"
 									return MCAST_LOOPBACK; }
 <INITIAL>{MCAST_TTL}		{	count(); yylval.strval=yytext;
 									return MCAST_TTL; }
+<INITIAL>{MCAST}		{	count(); yylval.strval=yytext;
+									return MCAST; }
 <INITIAL>{TOS}			{	count(); yylval.strval=yytext;
 									return TOS; }
 <INITIAL>{PMTU_DISCOVERY}		{	count(); yylval.strval=yytext;

--- a/cfg.y
+++ b/cfg.y
@@ -465,6 +465,7 @@ extern char *default_routename;
 %token RT_TIMER2_POLICY
 %token MCAST_LOOPBACK
 %token MCAST_TTL
+%token MCAST
 %token TOS
 %token PMTU_DISCOVERY
 %token KILL_TIMEOUT
@@ -1479,6 +1480,21 @@ assign_stm:
 		#endif
 	}
 	| MCAST_TTL EQUAL error { yyerror("number expected"); }
+	| MCAST EQUAL ID {
+		#ifdef USE_MCAST
+			mcast=$3;
+		#else
+			warn("no multicast support compiled in");
+		#endif
+	}
+	| MCAST EQUAL STRING {
+		#ifdef USE_MCAST
+			mcast=$3;
+		#else
+			warn("no multicast support compiled in");
+		#endif
+	}
+	| MCAST EQUAL error { yyerror("string expected"); }
 	| TOS EQUAL NUMBER { tos=$3; }
 	| TOS EQUAL ID { if (strcasecmp($3,"IPTOS_LOWDELAY")) {
 			tos=IPTOS_LOWDELAY;

--- a/globals.h
+++ b/globals.h
@@ -136,6 +136,7 @@ extern str version_table;
 #ifdef USE_MCAST
 extern int mcast_loopback;
 extern int mcast_ttl;
+extern char* mcast;
 #endif /* USE_MCAST */
 
 extern int auto_bind_ipv6;

--- a/ip_addr.h
+++ b/ip_addr.h
@@ -116,6 +116,9 @@ struct socket_info{
 	int workers; /* number of worker processes for this socket */
 	int workers_tcpidx; /* index of workers in tcp children array */
 	struct advertise_info useinfo; /* details to be used in SIP msg */
+#ifdef USE_MCAST
+	str mcast; /* name of interface that should join multicast group*/
+#endif /* USE_MCAST */
 };
 
 

--- a/main.c
+++ b/main.c
@@ -411,6 +411,7 @@ int reply_to_via=0;
 #ifdef USE_MCAST
 int mcast_loopback = 0;
 int mcast_ttl = -1; /* if -1, don't touch it, use the default (usually 1) */
+char* mcast = 0;
 #endif /* USE_MCAST */
 
 int tos = IPTOS_LOWDELAY;

--- a/socket_info.c
+++ b/socket_info.c
@@ -712,6 +712,14 @@ static struct socket_info* new_sock2list(char* name, struct name_lst* addr_l,
 		si->workers = socket_workers;
 		socket_workers = 0;
 	}
+#ifdef USE_MCAST
+	if (mcast!=0) {
+		si->mcast.len=strlen(mcast);
+		si->mcast.s=(char*)pkg_malloc(si->mcast.len+1);
+		strcpy(si->mcast.s, mcast);
+		mcast = 0;
+	}
+#endif /* USE_MCAST */
 	sock_listadd(list, si);
 	return si;
 error:


### PR DESCRIPTION
You can now define a mcast parameter before a listen parameter that
contains a multicast address. After each listen parameter mcast gets
reset. mcast must contain the name of an interface, eg `eth1`.

Issue GH#813