### PR TITLE
TCP closed event route improvement

### DIFF
--- a/modules/tcpops/doc/eventroutes.xml
+++ b/modules/tcpops/doc/eventroutes.xml
@@ -8,28 +8,73 @@
 
 ]>
 <section id="tcpops.ex.event_routes">
-    <title>Event routes</title>
-    <section>
-        <title>
-            <function moreinfo="none">tcp:closed</function>
-        </title>
-        <para>
-			This route is called when a socket is closed by the remote party,
-			or reset, or timeout. The corresponding <emphasis>$conid</emphasis>
-			variable will be available in the event route. 
-        </para>
-        <para>
-			Whether this route is always called, never, or on a per socket basis
-			is controlled by the <emphasis>closed_event</emphasis> parameter.
-        </para>
-        <para>
-    		<programlisting  format="linespecific">
+	<title>Event routes</title>
+		<para>The 3 following routes are called when a socket is closed.</para>
+		<para>
+			The corresponding
+			<emphasis>$conid</emphasis>
+			,
+			<emphasis>$Ri</emphasis>
+			,
+			<emphasis>$Rp</emphasis>
+			,
+			<emphasis>$si</emphasis>
+			,
+			<emphasis>$sp</emphasis>
+			and
+			<emphasis>$proto</emphasis>
+			variable will be available in the event routes.
+		</para>
+		<para>
+			Whether these routes are always called, never, or on a per socket
+			basis is controlled by the
+			<emphasis>closed_event</emphasis>
+			parameter.
+		</para>
+	<section>
+		<title>
+			<function moreinfo="none">tcp:closed</function>
+		</title>
+		<para>
+			Called for each "normal" TCP socket closure by the other side (FIN,ACK).
+		</para>
+	</section>
+	<section>
+		<title>
+			<function moreinfo="none">tcp:timeout</function>
+		</title>
+		<para>
+			Called for connection timeouts (unanswered keepalives).
+		</para>
+	</section>
+	<section>
+		<title>
+			<function moreinfo="none">tcp:reset</function>
+		</title>
+		<para>
+			Called if the connection is reset by peer (RST).
+		</para>
+	</section>
+	<section>
+		<title>
+			<function moreinfo="none">Example</function>
+		</title>
+		<para>
+			<programlisting format="linespecific">
 ...
 event_route[tcp:closed] {
-    xlog("L_INFO", "TCP connection closed ($conid)\n");
+	xlog("L_INFO", "$proto connection closed ($conid)\n");
+}
+
+event_route[tcp:timeout] {
+	xlog("L_INFO", "$proto connection timed out ($conid)\n");
+}
+
+event_route[tcp:reset] {
+	xlog("L_INFO", "$proto connection reset by peer ($conid)\n");
 }
 ...
-  	    	</programlisting>
-    	</para>
+			</programlisting>
+		</para>
 	</section>
 </section>

--- a/modules/tcpops/tcpops.h
+++ b/modules/tcpops/tcpops.h
@@ -28,6 +28,7 @@
 #include "../../events.h"
 
 extern int tcp_closed_event;
+extern int tcp_closed_routes[_TCP_CLOSED_REASON_MAX];
 
 int tcpops_get_current_fd(int conid, int *fd);
 int tcpops_acquire_fd_from_tcpmain(int conid, int *fd);

--- a/modules/tcpops/tcpops_mod.c
+++ b/modules/tcpops/tcpops_mod.c
@@ -118,11 +118,17 @@ static int mod_init(void)
 		return -1;
 	}
 
-	if (tcp_closed_event /* register event only if tcp_closed_event != 0 */
-		&& (sr_event_register_cb(SREV_TCP_CLOSED, tcpops_handle_tcp_closed) != 0))
-	{
-		LM_ERR("problem registering tcpops_handle_tcp_closed call-back\n");
-		return -1;
+	if (tcp_closed_event) {
+		/* register event only if tcp_closed_event != 0 */
+		if (sr_event_register_cb(SREV_TCP_CLOSED, tcpops_handle_tcp_closed) != 0) {
+			LM_ERR("problem registering tcpops_handle_tcp_closed call-back\n");
+			return -1;
+		}
+
+		/* get event routes */
+		tcp_closed_routes[TCP_CLOSED_EOF] = route_get(&event_rt, "tcp:closed");
+		tcp_closed_routes[TCP_CLOSED_TIMEOUT] = route_get(&event_rt, "tcp:timeout");
+		tcp_closed_routes[TCP_CLOSED_RESET] = route_get(&event_rt, "tcp:reset");
 	}
 
 	return 0;

--- a/tcp_conn.h
+++ b/tcp_conn.h
@@ -335,6 +335,19 @@ typedef struct tcp_event_info {
 	struct tcp_connection *con;
 } tcp_event_info_t;
 
+enum tcp_closed_reason {
+	TCP_CLOSED_EOF = 0,
+	TCP_CLOSED_TIMEOUT,
+	TCP_CLOSED_RESET,
+
+	_TCP_CLOSED_REASON_MAX /* /!\ keep this one always at the end */
+};
+
+typedef struct tcp_closed_event_info {
+	enum tcp_closed_reason reason;
+	struct tcp_connection *con;
+} tcp_closed_event_info_t;
+
 typedef struct ws_event_info {
 	int type;
 	char *buf;


### PR DESCRIPTION
This patch for the **tcpops** module (+ some core modifications) improves the original **tcp:closed** event route handling by triggering different event routes, depending on the reason why the connection was closed:

- **tcp:closed** for "normal" closure by the other side (FIN,ACK)
- **tcp:timeout** for timeouts (unanswered keepalives)
- **tcp:reset** if reset by peer (RST)

It will break the compatibility with older scripts, as some events will require new event routes to be caught.

I'll modify the documentation accordingly if/when this is accepted.