### PR TITLE
presence: fix crush if dialog id is NULL

### DIFF
--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -691,7 +691,7 @@ int update_presentity(struct sip_msg* msg, presentity_t* presentity, str* body,
 			}
 
 			check_if_dialog(*body, &is_dialog, &dialog_id);
-			if (is_dialog == 1) {
+			if ( dialog_id ) {
 				if (delete_presentity_if_dialog_id_exists(presentity, dialog_id) < 0) {
 					goto error;
 				}


### PR DESCRIPTION
- check dialog_id is not NULL before call delete_presentity_if_dialog_id_exists

sometimes after  check_if_dialog(str body, int *is_dialog, char **dialog_id) it is possible
is_dialog==1
dialog_id==NULL

#0  __strcmp_sse42 () at ../sysdeps/x86_64/multiarch/strcmp.S:260
#1  0x00007feb2e446603 in delete_presentity_if_dialog_id_exists (presentity=0x7feb545c8ca8, dialog_id=0x0) at presentity.c:419
