### PR TITLE
modules/ims_auth, modules/ims_registrar_scscf: fix condition for priv…

### DIFF
--- a/modules/ims_auth/pvt_message.c
+++ b/modules/ims_auth/pvt_message.c
@@ -82,7 +82,7 @@ struct sip_msg* get_request_from_tx(struct cell *t) {
         (which we cannot assume) then we would pollute the shm_msg t->uas.request if we did any parsing on it. Instead, we need to 
         make a private copy of the message and free it when we are done 
          */
-        if (_pv_treq.T != t || t->uas.request != _pv_treq.tmsgp) {
+	if (_pv_treq.label != t->label || _pv_treq.index != t->hash_index) {		
             /* make a copy */
             if (_pv_treq.buf == NULL || _pv_treq.buf_size < t->uas.request->len + 1) {
                 if (_pv_treq.buf != NULL)
@@ -90,8 +90,8 @@ struct sip_msg* get_request_from_tx(struct cell *t) {
                 if (_pv_treq.tmsgp)
                     free_sip_msg(&_pv_treq.msg);
                 _pv_treq.tmsgp = NULL;
-                _pv_treq.id = 0;
-                _pv_treq.T = NULL;
+                _pv_treq.index = 0;
+                _pv_treq.label = 0;
                 _pv_treq.buf_size = t->uas.request->len + 1;
                 _pv_treq.buf = (char*) pkg_malloc(_pv_treq.buf_size * sizeof (char));
                 if (_pv_treq.buf == NULL) {
@@ -108,8 +108,8 @@ struct sip_msg* get_request_from_tx(struct cell *t) {
             _pv_treq.msg.len = t->uas.request->len;
             _pv_treq.msg.buf = _pv_treq.buf;
             _pv_treq.tmsgp = t->uas.request;
-            _pv_treq.id = t->uas.request->id;
-            _pv_treq.T = t;
+            _pv_treq.index = t->hash_index;
+            _pv_treq.label = t->label;
 
 
             if (pv_t_copy_msg(t->uas.request, &_pv_treq.msg) != 0) {
@@ -117,7 +117,8 @@ struct sip_msg* get_request_from_tx(struct cell *t) {
                 _pv_treq.buf_size = 0;
                 _pv_treq.buf = NULL;
                 _pv_treq.tmsgp = NULL;
-                _pv_treq.T = NULL;
+                _pv_treq.index = 0;
+                _pv_treq.label = 0;
                 return 0;
             }
         }

--- a/modules/ims_auth/pvt_message.h
+++ b/modules/ims_auth/pvt_message.h
@@ -47,12 +47,13 @@
 
 
 #include "../../parser/msg_parser.h"
+#include "../tm/tm_load.h"
 
 struct _pv_req_data {
-    struct cell *T;
     struct sip_msg msg;
     struct sip_msg *tmsgp;
-    unsigned int id;
+    unsigned int index;
+    unsigned int label;
     char *buf;
     int buf_size;
 };

--- a/modules/ims_registrar_scscf/pvt_message.c
+++ b/modules/ims_registrar_scscf/pvt_message.c
@@ -84,7 +84,7 @@ struct sip_msg* get_request_from_tx(struct cell *t) {
         (which we cannot assume) then we would pollute the shm_msg t->uas.request if we did any parsing on it. Instead, we need to 
         make a private copy of the message and free it when we are done 
          */
-        if ((_pv_treq.T != t || t->uas.request != _pv_treq.tmsgp)) { 
+	if (_pv_treq.label != t->label || _pv_treq.index != t->hash_index) {		
             /* make a copy */
             if (_pv_treq.buf == NULL || _pv_treq.buf_size < t->uas.request->len + 1) {
                 if (_pv_treq.buf != NULL)
@@ -92,8 +92,8 @@ struct sip_msg* get_request_from_tx(struct cell *t) {
                 if (_pv_treq.tmsgp)
                     free_sip_msg(&_pv_treq.msg);
                 _pv_treq.tmsgp = NULL;
-                _pv_treq.id = 0;
-                _pv_treq.T = NULL;
+                _pv_treq.index = 0;
+                _pv_treq.label = 0;
                 _pv_treq.buf_size = t->uas.request->len + 1;
                 _pv_treq.buf = (char*) pkg_malloc(_pv_treq.buf_size * sizeof (char));
                 if (_pv_treq.buf == NULL) {
@@ -110,8 +110,8 @@ struct sip_msg* get_request_from_tx(struct cell *t) {
             _pv_treq.msg.len = t->uas.request->len;
             _pv_treq.msg.buf = _pv_treq.buf;
             _pv_treq.tmsgp = t->uas.request;
-            _pv_treq.id = t->uas.request->id;
-            _pv_treq.T = t;
+            _pv_treq.index = t->hash_index;
+            _pv_treq.label = t->label;
 
 
             if (pv_t_copy_msg(t->uas.request, &_pv_treq.msg) != 0) {
@@ -119,7 +119,8 @@ struct sip_msg* get_request_from_tx(struct cell *t) {
                 _pv_treq.buf_size = 0;
                 _pv_treq.buf = NULL;
                 _pv_treq.tmsgp = NULL;
-                _pv_treq.T = NULL;
+                _pv_treq.index = 0;
+                _pv_treq.label = 0;
                 return 0;
             }
         }

--- a/modules/ims_registrar_scscf/pvt_message.h
+++ b/modules/ims_registrar_scscf/pvt_message.h
@@ -49,12 +49,13 @@
 
 
 #include "../../parser/msg_parser.h"
+#include "../tm/tm_load.h"
 
 struct _pv_req_data {
-    struct cell *T;
     struct sip_msg msg;
     struct sip_msg *tmsgp;
-    unsigned int id;
+    unsigned int index;
+    unsigned int label;
     char *buf;
     int buf_size;
 };


### PR DESCRIPTION
…ate copy of the msg

I've been facing recently some inconsistent replies generated from the two modules. Those replies didn't belong to the current request, but to some old transaction. The issue is due to the check made to decide if the current private copy of the message is consistent with the current transaction: due to memory reallocation there are chances that the check gives a false negative, bringing an old message to be used as a base for the reply. Using transaction's index and label is safer IMO.