### PR TITLE
sca: fix sca_call_info_update() [to|from] optional parameters

### DIFF
--- a/modules/sca/sca.c
+++ b/modules/sca/sca.c
@@ -425,12 +425,30 @@ static int sca_call_info_update_1_f(sip_msg_t* msg, char* p1) {
 	return sca_call_info_update(msg, p1, NULL, NULL);
 }
 static int sca_call_info_update_2_f(sip_msg_t* msg, char* p1, char* p2) {
-	return sca_call_info_update(msg, p1, p2, NULL);
+	str uri_to = STR_NULL;
+	if(get_str_fparam(&uri_to, msg, (gparam_p)p2)!=0)
+	{
+		LM_ERR("unable to get value from param pvar_to\n");
+		return -1;
+	}
+	return sca_call_info_update(msg, p1, &uri_to, NULL);
 }
 static int sca_call_info_update_3_f(sip_msg_t* msg,
 	char* p1, char* p2, char * p3)
 {
-	return sca_call_info_update(msg, p1, p2, p3);
+	str uri_to = STR_NULL;
+	str uri_from = STR_NULL;
+	if(get_str_fparam(&uri_to, msg, (gparam_p)p2)!=0)
+	{
+		LM_ERR("unable to get value from param pvar_to\n");
+		return -1;
+	}
+	if(get_str_fparam(&uri_from, msg, (gparam_p)p3)!=0)
+	{
+		LM_ERR("unable to get value from param pvar_from\n");
+		return -1;
+	}
+	return sca_call_info_update(msg, p1, &uri_to, &uri_from);
 }
 
 int fixup_ciu(void **param, int param_no)

--- a/modules/sca/sca_call_info.h
+++ b/modules/sca/sca_call_info.h
@@ -59,7 +59,7 @@ typedef struct _sca_call_info sca_call_info;
 
 extern const str SCA_CALL_INFO_HEADER_STR;
 
-int sca_call_info_update(sip_msg_t *, char *, char *, char *);
+int sca_call_info_update(sip_msg_t *, char *, str*, str*);
 void sca_call_info_sl_reply_cb(void *);
 void sca_call_info_ack_cb(struct cell *, int, struct tmcb_params *);
 

--- a/modules/sca/sca_util.c
+++ b/modules/sca/sca_util.c
@@ -178,60 +178,28 @@ int sca_get_msg_to_header(sip_msg_t *msg, struct to_body **to)
 	return (0);
 }
 
-int sca_get_pv_from_header(sip_msg_t *msg, struct to_body **from, pv_spec_t *sp)
+/*
+ * caller needs to call free_to for *body
+ */
+int sca_build_to_body_from_uri(sip_msg_t *msg, struct to_body **body, str *uri)
 {
-	struct to_body parsed_from;
-	pv_value_t pv_val;
-
 	assert(msg != NULL);
-	assert(from != NULL);
-	assert(sp != NULL);
+	assert(body != NULL);
+	assert(uri != NULL);
 
-	if (pv_get_spec_value(msg, sp, &pv_val) < 0) {
-		LM_ERR("can't get value from to_pvar\n");
-		return (-1);
+	*body = pkg_malloc(sizeof(struct to_body));
+	if(*body == NULL) {
+		LM_ERR("cannot allocate pkg memory\n");
+		return(-1);
 	}
-	if (pv_val.flags & PV_VAL_STR) {
-		parse_to(pv_val.rs.s, pv_val.rs.s + pv_val.rs.len + 1, &parsed_from);
-		if (parsed_from.error != PARSE_OK) {
-			LM_ERR("Bad From value from from_pvar\n");
-			return (-1);
-		}
-		*from = &parsed_from;
-		return (0);
-	}
-	else {
-		LM_ERR("value from from_pvar is not a string\n");
-	}
-	return (-1);
-}
 
-int sca_get_pv_to_header(sip_msg_t *msg, struct to_body **to, pv_spec_t *sp)
-{
-	struct to_body parsed_to;
-	pv_value_t pv_val;
-
-	assert(msg != NULL);
-	assert(to != NULL);
-	assert(sp != NULL);
-
-	if (pv_get_spec_value(msg, sp, &pv_val) < 0) {
-		LM_ERR("can't get value from to_pvar\n");
-		return (-1);
+	parse_to(uri->s, uri->s + uri->len + 1, *body);
+	if ((*body)->error != PARSE_OK) {
+		LM_ERR("Bad uri value[%.*s]\n", STR_FMT(uri));
+		free_to(*body);
+		return(-1);
 	}
-	if (pv_val.flags & PV_VAL_STR) {
-		parse_to(pv_val.rs.s, pv_val.rs.s + pv_val.rs.len + 1, &parsed_to);
-		if (parsed_to.error != PARSE_OK) {
-			LM_ERR("Bad To value from to_pvar\n");
-			return (-1);
-		}
-		*to = &parsed_to;
-		return (0);
-	}
-	else {
-		LM_ERR("value from to_pvar is not a string\n");
-	}
-	return (-1);
+	return (0);
 }
 
 /*

--- a/modules/sca/sca_util.h
+++ b/modules/sca/sca_util.h
@@ -46,8 +46,7 @@ int sca_get_msg_from_header(sip_msg_t *, struct to_body **);
 // convenient To header parsing and extraction
 int sca_get_msg_to_header(sip_msg_t *, struct to_body **);
 
-int sca_get_pv_from_header(sip_msg_t *, struct to_body **, pv_spec_t *);
-int sca_get_pv_to_header(sip_msg_t *, struct to_body **, pv_spec_t *);
+int sca_build_to_body_from_uri(sip_msg_t *, struct to_body **, str *);
 
 // count number of characters requiring escape as defined by escape_common
 int sca_uri_display_escapes_count(str *);


### PR DESCRIPTION
* use str values
* need to build struct to_body and free memory afterwards