### PR TITLE
rr: default to port 5060 if port is omitted in route header

### DIFF
--- a/modules/rr/loose.c
+++ b/modules/rr/loose.c
@@ -827,8 +827,9 @@ static inline int after_loose(struct sip_msg* _m, int preloaded)
 			}
 
 			if (!use_ob) {
-				si = grep_sock_info( &puri.host, puri.port_no, puri.proto);
-				if (si) {
+				if ((si = grep_sock_info( &puri.host, puri.port_no?puri.port_no:proto_default_port(puri.proto), puri.proto)) != 0) {
+					set_force_socket(_m, si);
+				} else if ((si = grep_sock_info( &puri.host, puri.port_no, puri.proto)) != 0) {
 					set_force_socket(_m, si);
 				} else {
 					if (enable_socket_mismatch_warning)

--- a/socket_info.h
+++ b/socket_info.h
@@ -44,6 +44,8 @@
 int socket2str(char* s, int* len, struct socket_info* si);
 int socketinfo2str(char* s, int* len, struct socket_info* si, int mode);
 
+/* Helper macro that results in the default port based on the protocol */
+#define proto_default_port(proto) ((proto==PROTO_TLS)?SIPS_PORT:SIP_PORT)
 
 /* struct socket_info is defined in ip_addr.h */
 


### PR DESCRIPTION
When using double route headers the selection of the outgoing
socket is only done on IP address if the port is omitted in that
route header. This fix defaults the port to 5060 so the correct
listen socket is chosen. When no socket is found it will fallback
to the current behaviour keeping backwards compatibility.

If backwards compatibility is not required the extra 'if else' could be removed. I'm not sure if `loose_route()` is being used in this way so I opted for keeping backwards compatibility.