### PR TITLE
pv: Use memcpy to copy len bytes instead of strcpy

### DIFF
--- a/modules/pv/pv_svar.c
+++ b/modules/pv/pv_svar.c
@@ -70,7 +70,7 @@ script_var_t* add_var(str *name, int vtype)
 		return 0;
 	}
 	it->name.len = name->len;
-	strncpy(it->name.s, name->s, name->len);
+	memcpy(it->name.s, name->s, name->len);
 	it->name.s[it->name.len] = '\0';
 
 	if(vtype==VAR_TYPE_NULL) {
@@ -133,7 +133,7 @@ script_var_t* set_var_value(script_var_t* var, int_str *value, int flags)
 			}
 			var->v.flags |= VAR_VAL_STR;
 		}
-		strncpy(var->v.value.s.s, value->s.s, value->s.len);
+		memcpy(var->v.value.s.s, value->s.s, value->s.len);
 		var->v.value.s.len = value->s.len;
 		var->v.value.s.s[value->s.len] = '\0';
 	} else {


### PR DESCRIPTION
The sipcapture plugin stores bytes with VAR_VAL_STR and when
copying the data it would end up being truncated. Use memcpy
instead of strncpy and assume that the original string already
has the NUL termination (or not as with the hep plugin).

Config example:

	$var(payload) = hep(0x00f)