### PR TITLE
sipcapture: Terminate the log line with a \n

### DIFF
--- a/modules/sipcapture/sipcapture.c
+++ b/modules/sipcapture/sipcapture.c
@@ -2825,7 +2825,7 @@ static int pv_parse_hep_name (pv_spec_p sp, str *in)
 	if(sp==NULL || in==NULL || in->len<=0)
 		return -1;
 
-        LM_ERR("REQUEST, PRE, %.*s", in->len, in->s);
+        LM_ERR("REQUEST, PRE, %.*s\n", in->len, in->s);
 
 	switch(in->len)
 	{


### PR DESCRIPTION
Add a newline to avoid the log of other messages starting behind
the REQUEST, PRE output.