### PR TITLE
sipcapture: remove workaround of correlation_id

### DIFF
--- a/modules/sipcapture/sipcapture.c
+++ b/modules/sipcapture/sipcapture.c
@@ -2307,7 +2307,6 @@ int receive_logging_json_msg(char * buf, unsigned int len, struct hep_generic_re
 	if(correlation_id) {
 		corrtmp.s = correlation_id;
 		corrtmp.len = strlen(correlation_id);
-		if(!strncmp(log_table, "rtcp_capture",12)) corrtmp.len--;
 	}
 
 	db_keys[0] = &date_column;
@@ -2482,7 +2481,6 @@ static int report_capture(struct sip_msg *msg, str *_table, str* _corr,  str *_d
 	else if(correlation_id) {
 		corrtmp.s = correlation_id;
 		corrtmp.len = strlen(correlation_id);
-		if(!strncmp(_table->s, "rtcp_capture",12)) corrtmp.len--;
 	}
 
 	db_keys[0] = &date_column;


### PR DESCRIPTION
- Compatible with Asterisk >= 10

(cherry picked from commit 6cb0bec7d2491ed3365dc237fc1d8608af246c3a)