### PR TITLE
Sipcapture fixes

### DIFF
--- a/modules/sipcapture/hep.c
+++ b/modules/sipcapture/hep.c
@@ -38,7 +38,7 @@
 
 static int count = 0;
 
-struct hep_timehdr* heptime;
+struct hep_timeinfo* heptime;
 
 /* HEPv2 HEPv3 */
 int hepv2_received(char *buf, unsigned int len, struct receive_info *ri);
@@ -101,7 +101,7 @@ int hepv2_received(char *buf, unsigned int len, struct receive_info *ri){
         struct hep_iphdr *hepiph = NULL;
 
 	struct hep_timehdr* heptime_tmp = NULL;
-        memset(heptime, 0, sizeof(struct hep_timehdr));
+        memset(heptime, 0, sizeof(struct hep_timeinfo));
 
         struct hep_ip6hdr *hepip6h = NULL;
             	        
@@ -263,7 +263,7 @@ int parsing_hepv3_message(char *buf, unsigned int len) {
 	memset(hg, 0, sizeof(struct hep_generic_recv));
 
 	
-        memset(heptime, 0, sizeof(struct hep_timehdr));	
+        memset(heptime, 0, sizeof(struct hep_timeinfo));	
 	        
 
 	/* HEADER */
@@ -395,7 +395,7 @@ int parsing_hepv3_message(char *buf, unsigned int len) {
                                 case 12:
                                         hg->capt_id  = (hep_chunk_uint32_t *) (tmp);
                                         i+=chunk_length;
-                                        heptime->captid = ntohs(hg->capt_id->data);
+                                        heptime->captid = ntohl(hg->capt_id->data);
                                         totelem++;
                                         break;
 
@@ -487,7 +487,7 @@ int parsing_hepv3_message(char *buf, unsigned int len) {
 	/*TIME*/ 
         heptime->tv_sec = hg->time_sec->data;
         heptime->tv_usec = hg->time_usec->data;
-        heptime->captid = ntohs(hg->capt_id->data);
+        heptime->captid = ntohl(hg->capt_id->data);
           
 
         if(payload != NULL ) {
@@ -541,7 +541,7 @@ int hepv3_message_parse(char *buf, unsigned int len, sip_msg_t* msg) {
 	memset(hg, 0, sizeof(struct hep_generic_recv));
 
 	
-        memset(heptime, 0, sizeof(struct hep_timehdr));	
+        memset(heptime, 0, sizeof(struct hep_timeinfo));	
 	        
 
 	/* HEADER */
@@ -669,7 +669,7 @@ int hepv3_message_parse(char *buf, unsigned int len, sip_msg_t* msg) {
                                 case 12:
                                         hg->capt_id  = (hep_chunk_uint32_t *) (tmp);
                                         i+=chunk_length;
-                                        heptime->captid = ntohs(hg->capt_id->data);
+                                        heptime->captid = ntohl(hg->capt_id->data);
                                         totelem++;
                                         break;
 
@@ -731,7 +731,7 @@ int hepv3_message_parse(char *buf, unsigned int len, sip_msg_t* msg) {
 	/*TIME*/ 
         heptime->tv_sec = hg->time_sec->data;
         heptime->tv_usec = hg->time_usec->data;
-        heptime->captid = ntohs(hg->capt_id->data);
+        heptime->captid = ntohl(hg->capt_id->data);
 
 done:
           
@@ -758,7 +758,7 @@ int hepv2_message_parse(char *buf, unsigned int len, sip_msg_t* msg) {
         struct hep_iphdr *hepiph = NULL;
 
 	struct hep_timehdr* heptime_tmp = NULL;
-        memset(heptime, 0, sizeof(struct hep_timehdr));
+        memset(heptime, 0, sizeof(struct hep_timeinfo));
 
         struct hep_ip6hdr *hepip6h = NULL;
             	        

--- a/modules/sipcapture/hep.h
+++ b/modules/sipcapture/hep.h
@@ -74,6 +74,12 @@ struct hep_timehdr{
    u_int16_t captid;          /* Capture ID node */
 };
 
+struct hep_timeinfo{
+   u_int32_t tv_sec;         /* seconds */
+   u_int32_t tv_usec;        /* useconds */
+   u_int32_t captid;          /* Capture ID node */
+};
+
 struct hep_ip6hdr {
         struct in6_addr hp6_src;        /* source address */
         struct in6_addr hp6_dst;        /* destination address */

--- a/modules/sipcapture/sipcapture.c
+++ b/modules/sipcapture/sipcapture.c
@@ -1680,7 +1680,7 @@ static int sip_capture(struct sip_msg *msg, str *_table, _capture_mode_data_t * 
 
 	if(heptime && heptime->tv_sec != 0) {
 		sco.tmstamp = (unsigned long long)heptime->tv_sec*1000000+heptime->tv_usec; /* micro ts */
-		snprintf(tmp_node, 100, "%.*s:%i", capture_node.len, capture_node.s, heptime->captid);
+		snprintf(tmp_node, 100, "%.*s:%lu", capture_node.len, capture_node.s, (unsigned long)heptime->captid);
 		sco.node.s = tmp_node;
 		sco.node.len = strlen(tmp_node);
 	}
@@ -2380,7 +2380,7 @@ int receive_logging_json_msg(char * buf, unsigned int len, struct hep_generic_re
 
 	if(heptime && heptime->tv_sec != 0) {
 		sco.tmstamp = (unsigned long long)heptime->tv_sec*1000000+heptime->tv_usec; /* micro ts */
-		snprintf(tmp_node, 100, "%.*s:%i", capture_node.len, capture_node.s, heptime->captid);
+		snprintf(tmp_node, 100, "%.*s:%lu", capture_node.len, capture_node.s, (unsigned long)heptime->captid);
 		sco.node.s = tmp_node;
 		sco.node.len = strlen(tmp_node);
 		epoch_time_as_time_t = heptime->tv_sec;;
@@ -2550,7 +2550,7 @@ static int report_capture(struct sip_msg *msg, str *_table, str* _corr,  str *_d
 
 	if(heptime && heptime->tv_sec != 0) {
 		sco.tmstamp = (unsigned long long)heptime->tv_sec*1000000+heptime->tv_usec; /* micro ts */
-		snprintf(tmp_node, 100, "%.*s:%i", capture_node.len, capture_node.s, heptime->captid);
+		snprintf(tmp_node, 100, "%.*s:%lu", capture_node.len, capture_node.s, (unsigned long)heptime->captid);
 		sco.node.s = tmp_node;
 		sco.node.len = strlen(tmp_node);
 		epoch_time_as_time_t = heptime->tv_sec;;

--- a/modules/sipcapture/sipcapture.c
+++ b/modules/sipcapture/sipcapture.c
@@ -2372,11 +2372,11 @@ int receive_logging_json_msg(char * buf, unsigned int len, struct hep_generic_re
 	/*source ip*/
 	sco.source_ip.s = ipstr_src;
 	sco.source_ip.len = strlen(ipstr_src);
-	sco.source_port = hg->src_port->data;
+	sco.source_port = ntohs(hg->src_port->data);
 
 	sco.destination_ip.s = ipstr_dst;
 	sco.destination_ip.len = strlen(ipstr_dst);
-	sco.destination_port = hg->dst_port->data;
+	sco.destination_port = ntohs(hg->dst_port->data);
 
 	if(heptime && heptime->tv_sec != 0) {
 		sco.tmstamp = (unsigned long long)heptime->tv_sec*1000000+heptime->tv_usec; /* micro ts */


### PR DESCRIPTION
Two fixes in this PR.
The first is to perform the ntohs also on hep messaging carrying payload other than SIP.
The scond is to take in count the definition of captid chunk in HEPv3 (uint32 BE) different from the one for HEPv2 (uint16 LE).