### PR TITLE
statsd: include usr_avp.h instead of usr_avp.c

### DIFF
--- a/src/modules/statsd/statsd.c
+++ b/src/modules/statsd/statsd.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 
 #include "../../core/sr_module.h"
-#include "../../core/usr_avp.c"
+#include "../../core/usr_avp.h"
 #include "../../core/pvar.h"
 #include "../../core/lvalue.h"
 #include "lib_statsd.h"


### PR DESCRIPTION
The start and stop function currently doesn't work since the AVP used by that function is not succesfully added because usr_avp is referenced wrongly. It does work when not compiled with `-Wl,-Bsymbolic-functions`, however that is the default under Ubuntu.