### PR TITLE
hep: Store ipstr in a static buffer for exporting to cfg

### DIFF
--- a/src/modules/sipcapture/hep.c
+++ b/src/modules/sipcapture/hep.c
@@ -879,7 +879,7 @@ int hepv3_get_chunk(struct sip_msg *msg, char *buf, unsigned int len, int req_ch
         int chunk_vendor=0, chunk_type=0, chunk_length=0;
         int total_length = 0;
         int ret = 0;
-        char ipstr[INET6_ADDRSTRLEN];        
+        static char ipstr[INET6_ADDRSTRLEN];
 
         if(memcmp(buf, "\x48\x45\x50\x33",4) && !memcmp(buf, "\x45\x45\x50\x31",4)) {
         


### PR DESCRIPTION
When using hep(0x003) and hep(0x004) the extracted ip address
would be written to the local ipstr buffer but when returning
to the script the buffer would already be partially overwritten.

Keep the data around long enough by storing the result in a
static buffer.