### PR TITLE
sqlops: Increase size of static escape buffer

### DIFF
--- a/src/modules/sqlops/sql_trans.c
+++ b/src/modules/sqlops/sql_trans.c
@@ -31,7 +31,7 @@
 
 #include "sql_trans.h"
 
-#define TR_BUFFER_SIZE 2048
+#define TR_BUFFER_SIZE 8192
 
 
 static int _tr_eval_sql_val(pv_value_t *val)


### PR DESCRIPTION
The code assumes that all characters require escaping and the
maximum input string length right now is 1023. When the ss7ops
module is used the length of a IAM is longer than this. Increase
the static buffer to 8k. This increases the memory usage of each
process by 7168 bytes.