### PR TITLE
Add kpcre group

### DIFF
--- a/src/Makefile.groups
+++ b/src/Makefile.groups
@@ -277,8 +277,10 @@ module_group_ignore= $(sort $(filter-out $(module_group_default), $(mod_list_all
 
 # Standard modules in main pkg
 module_group_kstandard=$(mod_list_basic) $(mod_list_extra) \
-					  $(mod_list_db) $(mod_list_dbuid) \
-					  $(mod_list_pcre)
+					  $(mod_list_db) $(mod_list_dbuid)
+
+# pkg pcre module
+module_group_kpcre=$(mod_list_pcre)
 
 # pkg mysql module
 module_group_kmysql=$(mod_list_mysql)


### PR DESCRIPTION
Previously pcre was included into kstandard but pcre module depends on
pcre library so create its own group and remove it from kstandard as
standard modules should have no internal/external compile or link
dependencies

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>