### PR TITLE
dmq_usrloc: fix deadlock

### DIFF
--- a/src/modules/dmq_usrloc/usrloc_sync.c
+++ b/src/modules/dmq_usrloc/usrloc_sync.c
@@ -62,8 +62,6 @@ static int add_contact(str aor, ucontact_info_t* ci)
 		return -1;
 	}
 
-	dmq_ul.lock_udomain(_d, &aor);
-
 	LM_DBG("aor: %.*s\n", aor.len, aor.s);
 	LM_DBG("ci->ruid: %.*s\n", ci->ruid.len, ci->ruid.s);
 	LM_DBG("aorhash: %i\n", dmq_ul.get_aorhash(&aor));
@@ -72,6 +70,7 @@ static int add_contact(str aor, ucontact_info_t* ci)
 		// Search by ruid, if possible
 		res = dmq_ul.get_urecord_by_ruid(_d, dmq_ul.get_aorhash(&aor), &ci->ruid, &r, &c);
 		if (res == 0) {
+			dmq_ul.lock_udomain(_d, &aor);
 			LM_DBG("Found contact\n");
 			dmq_ul.update_ucontact(r, c, ci);
 			LM_DBG("Release record\n");
@@ -81,6 +80,8 @@ static int add_contact(str aor, ucontact_info_t* ci)
 			return 0;
 		}
 	}
+
+	dmq_ul.lock_udomain(_d, &aor);
 	res = dmq_ul.get_urecord(_d, &aor, &r);
 	if (res < 0) {
 		LM_ERR("failed to retrieve record from usrloc\n");

--- a/src/modules/dmq_usrloc/usrloc_sync.c
+++ b/src/modules/dmq_usrloc/usrloc_sync.c
@@ -70,7 +70,6 @@ static int add_contact(str aor, ucontact_info_t* ci)
 		// Search by ruid, if possible
 		res = dmq_ul.get_urecord_by_ruid(_d, dmq_ul.get_aorhash(&aor), &ci->ruid, &r, &c);
 		if (res == 0) {
-			dmq_ul.lock_udomain(_d, &aor);
 			LM_DBG("Found contact\n");
 			dmq_ul.update_ucontact(r, c, ci);
 			LM_DBG("Release record\n");


### PR DESCRIPTION
caused by acquiring the same lock twice using get_urecord_by_ruid and lock_udomain