### PR TITLE
presence: allow control of subscription deletion

### DIFF
--- a/src/modules/presence/doc/presence_admin.xml
+++ b/src/modules/presence/doc/presence_admin.xml
@@ -780,6 +780,14 @@ modparam("presence", "subs_remove_match", 1)
 			the priority of the presence document is based on timestamp,
 			so newer documents have higher priority.</para>
         </listitem>
+        <listitem>
+			<para><emphasis>delete_subscription</emphasis> - integer value to 
+			give extra control of deleting the subscription after processing of
+			event_route[presence:notify-reply]. If value = 1, it deletes the subscription.
+			If xavp_cfg parameter is set but this attribute is not in the avp,
+			the subscription is not deleted. this does apply for code 404 and 481
+			where subscription is deleted.</para>
+        </listitem>
      </itemizedlist>
     <para>
         Default value is <emphasis>empty</emphasis> (not set).

--- a/src/modules/presence/notify.c
+++ b/src/modules/presence/notify.c
@@ -1818,6 +1818,23 @@ void run_notify_reply_event(struct cell *t, struct tmcb_params *ps)
 
 }
 
+int pres_get_delete_sub(void)
+{
+       sr_xavp_t *vavp = NULL;
+       str vname = str_init("delete_subscription");
+
+       if(pres_xavp_cfg.s==NULL || pres_xavp_cfg.len<=0) {
+               return 0;
+       }
+
+       vavp = xavp_get_child_with_ival(&pres_xavp_cfg, &vname);
+       if(vavp!=NULL) {
+               return (int)vavp->val.v.i;
+       }
+
+       return 0;
+}
+
 void p_tm_callback( struct cell *t, int type, struct tmcb_params *ps)
 {
 	subs_t* subs;
@@ -1835,7 +1852,10 @@ void p_tm_callback( struct cell *t, int type, struct tmcb_params *ps)
 
 	run_notify_reply_event(t, ps);
 
-	if(ps->code == 404 || ps->code == 481 || (ps->code == 408 && timeout_rm_subs)) {
+        if(ps->code == 404
+	   || ps->code == 481
+	   || (ps->code == 408 && timeout_rm_subs)
+	   || pres_get_delete_sub()) {
 		delete_subs(&subs->pres_uri, &subs->event->name,
 				&subs->to_tag, &subs->from_tag, &subs->callid);
 	}


### PR DESCRIPTION
use the configuration xavp to control subscription deletion after notify
searches for `delete_subscription` value in the configuration xavp