### PR TITLE
presence: delay aux_body_processing until after subscription has been updated

### DIFF
--- a/src/modules/presence/notify.c
+++ b/src/modules/presence/notify.c
@@ -1278,7 +1278,7 @@ error:
 
 int publ_notify(presentity_t* p, str pres_uri, str* body, str* offline_etag, str* rules_doc)
 {
-	str *notify_body = NULL, *aux_body = NULL;
+	str *notify_body = NULL;
 	subs_t* subs_array= NULL, *s= NULL;
 	int ret_code= -1;
 
@@ -1305,22 +1305,13 @@ int publ_notify(presentity_t* p, str pres_uri, str* body, str* offline_etag, str
 	while(s)
 	{
 		s->auth_rules_doc= rules_doc;
-		if (p->event->aux_body_processing) {
-			aux_body = p->event->aux_body_processing(s, notify_body?notify_body:body);
-		}
 
-		if(notify(s, NULL, aux_body?aux_body:(notify_body?notify_body:body), 0)< 0 )
+		if(notify(s, NULL, notify_body?notify_body:body, 0, p->event->aux_body_processing)< 0 )
 		{
 			LM_ERR("Could not send notify for %.*s\n",
 					p->event->name.len, p->event->name.s);
 		}
 
-		if(aux_body!=NULL) {
-			if(aux_body->s)	{
-				p->event->aux_free_body(aux_body->s);
-			}
-			pkg_free(aux_body);
-		}
 		s= s->next;
 	}
 	ret_code= 0;
@@ -1468,7 +1459,7 @@ int query_db_notify(str* pres_uri, pres_ev_t* event, subs_t* watcher_subs )
 				aux_body = event->aux_body_processing(s, notify_body);
 			}
 
-			if(notify(s, watcher_subs, aux_body?aux_body:notify_body, 0)< 0 )
+			if(notify(s, watcher_subs, aux_body?aux_body:notify_body, 0, 0)< 0 )
 			{
 				LM_ERR("Could not send notify for [event]=%.*s\n",
 						event->name.len, event->name.s);
@@ -1681,8 +1672,11 @@ error:
 }
 
 
-int notify(subs_t* subs, subs_t * watcher_subs,str* n_body,int force_null_body)
+int notify(subs_t* subs, subs_t * watcher_subs,str* n_body,int force_null_body, aux_body_processing_t* aux_body_processing)
 {
+
+	str* aux_body = NULL;
+
 	/* update first in hash table and the send Notify */
 	if(subs->expires!= 0 && subs->status != TERMINATED_STATUS)
 	{
@@ -1719,10 +1713,28 @@ int notify(subs_t* subs, subs_t * watcher_subs,str* n_body,int force_null_body)
 		force_null_body = 1;
 	}
 
-	if(send_notify_request(subs, watcher_subs, n_body, force_null_body)< 0)
+	if (!force_null_body && aux_body_processing)
+	{
+		aux_body = aux_body_processing(subs, n_body);
+	}
+
+	if(send_notify_request(subs, watcher_subs, aux_body?aux_body:n_body, force_null_body)< 0)
 	{
 		LM_ERR("sending Notify not successful\n");
+		if(aux_body!=NULL) {
+			if(aux_body->s) {
+				subs->event->aux_free_body(aux_body->s);
+			}
+			pkg_free(aux_body);
+		}
 		return -1;
+	}
+
+	if(aux_body!=NULL) {
+		if(aux_body->s) {
+			subs->event->aux_free_body(aux_body->s);
+		}
+		pkg_free(aux_body);
 	}
 	return 0;
 }
@@ -2745,7 +2757,7 @@ static int notifier_notify(subs_t *sub, int *updated, int *end_transaction)
 			goto done;
 	}
 
-	if (notify(sub, NULL, nbody, 0) < 0)
+	if (notify(sub, NULL, nbody, 0, 0) < 0)
 	{
 		LM_ERR("could not send notify\n");
 		goto error;

--- a/src/modules/presence/notify.h
+++ b/src/modules/presence/notify.h
@@ -116,7 +116,7 @@ int publ_notify_notifier(str pres_uri, pres_ev_t *event);
 int set_updated(subs_t *sub);
 int set_wipeer_subs_updated(str *pres_uri, pres_ev_t *event, int full);
 
-int notify(subs_t* subs, subs_t* watcher_subs, str* n_body,int force_null_body);
+int notify(subs_t* subs, subs_t* watcher_subs, str* n_body,int force_null_body, aux_body_processing_t* aux_body_processing);
 
 int send_notify_request(subs_t* subs, subs_t * watcher_subs,
 		str* n_body,int force_null_body);

--- a/src/modules/presence/presence.c
+++ b/src/modules/presence/presence.c
@@ -1032,7 +1032,7 @@ send_notify:
 
 		while(s)
 		{
-			if(notify(s, NULL, NULL, 0)< 0)
+			if(notify(s, NULL, NULL, 0, 0)< 0)
 			{
 				LM_ERR( "sending Notify request\n");
 				goto done;

--- a/src/modules/presence/subscribe.c
+++ b/src/modules/presence/subscribe.c
@@ -610,7 +610,7 @@ int update_subscription(struct sip_msg* msg, subs_t* subs, int to_tag_gen,
 				*sent_reply= 1;
 			}
 
-			if(notify(subs, NULL, NULL, 0)< 0)
+			if(notify(subs, NULL, NULL, 0, 0)< 0)
 			{
 				LM_ERR("Could not send notify\n");
 				goto error;
@@ -697,7 +697,7 @@ int update_subscription(struct sip_msg* msg, subs_t* subs, int to_tag_gen,
 			}
 			if(subs->send_on_cback== 0)
 			{
-				if(notify(subs, NULL, NULL, 0)< 0)
+				if(notify(subs, NULL, NULL, 0, 0)< 0)
 				{
 					LM_ERR("Could not send notify\n");
 					goto error;
@@ -706,7 +706,7 @@ int update_subscription(struct sip_msg* msg, subs_t* subs, int to_tag_gen,
 		}
 		else
 		{
-			if(send_fast_notify && (notify(subs, NULL, NULL, 0)< 0))
+			if(send_fast_notify && (notify(subs, NULL, NULL, 0, 0)< 0))
 			{
 				LM_ERR("Could not send notify\n");
 				goto error;
@@ -724,7 +724,7 @@ int update_subscription(struct sip_msg* msg, subs_t* subs, int to_tag_gen,
 		}
 		*sent_reply= 1;
 
-		if(send_fast_notify && (notify(subs, NULL, NULL, 0 )< 0))
+		if(send_fast_notify && (notify(subs, NULL, NULL, 0, 0)< 0))
 		{
 			LM_ERR("sending notify request\n");
 			goto error;


### PR DESCRIPTION
Fixes out-of-sequence version when subs_db_mode <> 3 and fast_notify is enabled.

Version is incremented only when copy is updated in memory. Therefore, currently:

On SUBSCRIBE, subscription is updated first, so NOTIFY body contains newly incremented version.

But on PUBLISH, aux_body_processing is called first, so NOTIFY body contains previously stored version.