### PR TITLE
app_python: fix compiler warning

### DIFF
--- a/src/modules/app_python/Makefile
+++ b/src/modules/app_python/Makefile
@@ -22,6 +22,8 @@ ifeq ($(OS), freebsd)
 LIBS+=-pthread
 endif
 
+# python2 https://www.python.org/dev/peps/pep-3123/
+DEFS+=-fno-strict-aliasing
 DEFS+=-I${PYTHON_INCDIR}
 DEFS+=-DKAMAILIO_MOD_INTERFACE
 


### PR DESCRIPTION
>    Add "-fno-strict-aliasing" to compilation flags
>
>    Fixes a slew of:
>      "dereferencing type-punned pointer will break strict-aliasing rules"
>    warnings from GCC for lines of the form:
>      Py_INCREF(Py_True);
>    and
>      Py_INCREF(Py_False);
>
>    due to the cast from PyIntObject* to PyObject*
>
>    GCC is technically correct here; see:
>      http://www.python.org/dev/peps/pep-3123/
>    though this is unlikely to lead to non-working machine code.