### PR TITLE
kamailio-basic-kemi.cfg: add WITH_DB_TEXT

### DIFF
--- a/misc/examples/kemi/db_text/acc
+++ b/misc/examples/kemi/db_text/acc
@@ -1,0 +1,1 @@
+time(int) method(str) from_tag(str) to_tag(str) callid(str) sip_code(str) sip_reason(str) src_user(str) src_domain(str) src_ip(str) dst_ouser(str) dst_user(str) dst_domain(str)

--- a/misc/examples/kemi/db_text/address
+++ b/misc/examples/kemi/db_text/address
@@ -1,0 +1,1 @@
+id(int) grp(int) ip_addr(str) mask(str) port(int) tag(str)

--- a/misc/examples/kemi/db_text/bkp
+++ b/misc/examples/kemi/db_text/bkp
@@ -1,0 +1,1 @@
+src_user(str) src_domain(str) src_ip(str) dst_ouser(str) dst_user(str,null) dst_domain(str,null)

--- a/misc/examples/kemi/db_text/missed_calls
+++ b/misc/examples/kemi/db_text/missed_calls
@@ -1,0 +1,1 @@
+time(int) method(str) from_tag(str) to_tag(str) callid(str) sip_code(str) sip_reason(str) src_user(str) src_domain(str) src_ip(str) dst_ouser(str) dst_user(str) dst_domain(str)

--- a/misc/examples/kemi/db_text/subscriber
+++ b/misc/examples/kemi/db_text/subscriber
@@ -1,0 +1,4 @@
+username(str) password(str) domain(str) name(str) ha1(str,null) ha1b(str,null)
+kamailio:kamailio:kamailio.org:kamailio_user0:
+1:1:domain.com:user1:
+2:2:domain.com:user2:

--- a/misc/examples/kemi/db_text/trusted
+++ b/misc/examples/kemi/db_text/trusted
@@ -1,0 +1,1 @@
+id(int) src_ip(str) proto(str) from_pattern(str,null) ruri_pattern(str,null) tag(str,null) priority(int)

--- a/misc/examples/kemi/db_text/version
+++ b/misc/examples/kemi/db_text/version
@@ -1,0 +1,7 @@
+table_name(str) table_version(int)
+subscriber:3
+location:6
+aliases:6
+trusted:6
+address:6
+auth_db:6

--- a/misc/examples/kemi/kamailio-basic-kemi.cfg
+++ b/misc/examples/kemi/kamailio-basic-kemi.cfg
@@ -14,22 +14,25 @@
 # *** To run in debug mode:
 #     - define WITH_DEBUG
 #
-# *** To enable mysql:
-#     - define WITH_MYSQL
+# *** To enable db_text:
+#     - define WITH_DB_TEXT
+#
+# *** To enable db_mysql:
+#     - define WITH_DB_MYSQL
 #
 # *** To enable authentication execute:
-#     - enable mysql
+#     - enable db_mysql/db_text
 #     - define WITH_AUTH
 #     - add users using 'kamctl'
 #
 # *** To enable IP authentication execute:
-#     - enable mysql
+#     - enable db_mysql/db_text
 #     - enable authentication
 #     - define WITH_IPAUTH
 #     - add IP addresses with group id '1' to 'address' table
 #
 # *** To enable persistent user location execute:
-#     - enable mysql
+#     - enable db_mysql/db_text
 #     - define WITH_USRLOCDB
 #
 # *** To enable nat traversal execute:
@@ -44,7 +47,7 @@
 #     - define WITH_TLS
 #
 # *** To enhance accounting execute:
-#     - enable mysql
+#     - enable db_mysql/db_text
 #     - define WITH_ACCDB
 #     - add following columns to database
 #!ifdef ACCDB_COMMENT
@@ -62,7 +65,10 @@
   ALTER TABLE missed_calls ADD COLUMN dst_domain VARCHAR(128) NOT NULL DEFAULT '';
 #!endif
 
-#!define WITH_MYSQL
+#!substdef "!DB_TEXT_DIR!/root/kamailio/misc/examples/kemi/db_text!g"
+
+#!define WITH_DB_TEXT
+#!define WITH_DB_MYSQL
 #!define WITH_AUTH
 #!define WITH_IPAUTH
 #!define WITH_USRLOCDB
@@ -76,13 +82,18 @@ import_file "kamailio-local.cfg"
 ####### Defined Values #########
 
 # *** Value defines - IDs used later in config
-#!ifdef WITH_MYSQL
 # - database URL - used to connect to database server by modules such
 #       as: auth_db, acc, usrloc, a.s.o.
 #!ifndef DBURL
+#!ifdef WITH_DB_MYSQL
 #!define DBURL "mysql://kamailio:kamailiorw@localhost/kamailio"
+#!else
+#!ifdef WITH_DB_TEXT
+#!define DBURL "text://DB_TEXT_DIR"
 #!endif
 #!endif
+#!endif
+
 #!define MULTIDOMAIN 0
 
 # - flags
@@ -157,13 +168,20 @@ tcp_connection_lifetime=3605
 
 # set paths to location of modules (to sources or installation folders)
 #!ifdef WITH_SRCPATH
-mpath="modules"
+mpath="./src/modules"
 #!else
 mpath="/usr/local/lib/kamailio/modules/"
 #!endif
 
-#!ifdef WITH_MYSQL
+#!ifdef WITH_DB_MYSQL
 loadmodule "db_mysql.so"
+#!else
+#!ifdef WITH_DB_TEXT
+loadmodule "db_text.so"
+modparam("db_text", "db_mode", 1)   # check for file changes
+modparam("db_text", "emptystring", 1)
+modparam("db_text", "file_buffer_size", 16384)
+#!endif
 #!endif
 
 loadmodule "jsonrpcs.so"
@@ -295,7 +313,11 @@ modparam("acc", "db_extra",
 modparam("usrloc", "preload", "location")
 #!ifdef WITH_USRLOCDB
 modparam("usrloc", "db_url", DBURL)
+#!ifdef WITH_DB_TEXT
+modparam("usrloc", "db_mode", 0) # in memory
+#!else
 modparam("usrloc", "db_mode", 2)
+#!endif
 modparam("usrloc", "use_domain", MULTIDOMAIN)
 #!endif
 
@@ -307,6 +329,7 @@ modparam("auth_db", "calculate_ha1", yes)
 modparam("auth_db", "password_column", "password")
 modparam("auth_db", "load_credentials", "")
 modparam("auth_db", "use_domain", MULTIDOMAIN)
+modparam("auth", "nonce_count", 1)
 
 # ----- permissions params -----
 #!ifdef WITH_IPAUTH
@@ -354,22 +377,40 @@ modparam("pike", "remove_latency", 4)
 modparam("htable", "htable", "ipban=>size=8;autoexpire=300;")
 #!endif
 
+
 #!ifdef WITH_CFGPYTHON
+#!ifdef WITH_SRCPATH
+modparam("app_python", "script_name", "./misc/examples/kemi/kamailio-basic-kemi-python.py")
+#!else
 modparam("app_python", "script_name", "/usr/local/etc/kamailio/kamailio-basic-kemi-python.py")
+#!endif
 cfgengine "python"
 #!else
 
 #!ifdef WITH_CFGLUA
+#!ifdef WITH_SRCPATH
+modparam("app_lua", "load", "./misc/examples/kemi/kamailio-basic-kemi-lua.lua")
+#!else
 modparam("app_lua", "load", "/usr/local/etc/kamailio/kamailio-basic-kemi-lua.lua")
+#!endif
 cfgengine "lua"
 #!else
 
 #!ifdef WITH_CFGJSDT
-modparam("app_jsdt", "load", "/usr/local/etc/kamailio/kamailio-basic-kemi-jsdt.js")
-cfgengine "lua"
+#!ifdef WITH_SRCPATH
+modparam("app_jsdt", "load", "./misc/examples/kemi/kamailio-basic-kemi-jsdt.js")
 #!else
-cfgengine "native"
+modparam("app_jsdt", "load", "/usr/local/etc/kamailio/kamailio-basic-kemi-jsdt.js")
+#!endif
+cfgengine "lua"
+
+#!else
+#!ifdef WITH_SRCPATH
+include_file "./misc/examples/kemi/kamailio-basic-kemi-native.cfg"
+#!else
 include_file "/usr/local/etc/kamailio/kamailio-basic-kemi-native.cfg"
+#!endif
+cfgengine "native"
 #!endif
 
 #!endif


### PR DESCRIPTION
This is for the people out there (me included) who don't want to install mysql to play with kamailio:
- comment out ``#!define WITH_DB_MYSQL`` (still used by default)
- set the right ``DB_TEXT_DIR``, to match ``kamailio_path/misc/examples/kemi/db_text`` (absolute path is needed; I tried with relative path and it did not work)
- add users/passwords by editing ``kamailio_path/misc/examples/kemi/db_text/subscriber`` file

Hope it's helpful. Enjoy!