### PR TITLE
Reuse PERLLDOPTS in db_perlvdb

### DIFF
--- a/src/modules/db_perlvdb/Makefile
+++ b/src/modules/db_perlvdb/Makefile
@@ -4,7 +4,11 @@
 include ../../Makefile.defs
 auto_gen=
 NAME=db_perlvdb.so
-LIBS:=$(shell perl -MExtUtils::Embed -e ldopts)
+ifeq ($(PERLLDOPTS),)
+	LIBS:=$(shell perl -MExtUtils::Embed -e ldopts)
+else
+	LIBS+=$(PERLLDOPTS)
+endif
 PERL_DEFS:=$(shell perl -MExtUtils::Embed -e ccopts)
 DEFS+=$(PERL_DEFS)
 


### PR DESCRIPTION
PERLLDOPTS is already used in app_perl module.
Reuse this variable in db_perlvdb module instead of always setting LIBS
to (shell perl -MExtUtils::Embed -e ldopts)
Indeed, this will not work when cross-compiling (the value will be
retrieved for the host perl and not the target perl)

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>