### PR TITLE
carrieroute: fix double free related to hash_index

### DIFF
--- a/src/modules/carrierroute/cr_data.c
+++ b/src/modules/carrierroute/cr_data.c
@@ -589,11 +589,13 @@ static int rule_fixup_recursor(struct dtrie_node_t *node) {
 					if (rr->hash_index > rf->rule_num) {
 						LM_ERR("too large hash index %i, max is %i\n", rr->hash_index, rf->rule_num);
 						shm_free(rf->rules);
+						rf->rules = NULL;
 						return -1;
 					}
 					if (rf->rules[rr->hash_index - 1]) {
 						LM_ERR("duplicate hash index %i\n", rr->hash_index);
 						shm_free(rf->rules);
+						rf->rules = NULL;
 						return -1;
 					}
 					rf->rules[rr->hash_index - 1] = rr;

--- a/src/modules/carrierroute/cr_rule.c
+++ b/src/modules/carrierroute/cr_rule.c
@@ -251,6 +251,7 @@ void destroy_route_flags(struct route_flags *rf) {
 
 	if (rf->rules) {
 		shm_free(rf->rules);
+		rf->rules = NULL;
 	}
 	rs = rf->rule_list;
 	while (rs != NULL) {


### PR DESCRIPTION
- set freed pointer to NULL to avoid double free