### PR TITLE
db_text: implement fetch and memory constraints

### DIFF
--- a/modules/db_text/dbt_api.h
+++ b/modules/db_text/dbt_api.h
@@ -34,7 +34,11 @@
 /*
  * Retrieve result set
  */
-int dbt_get_result(db1_res_t** _r, dbt_result_p _dres);
+//int dbt_get_result(db1_res_t** _r, dbt_result_p _dres);
+int dbt_get_result(db1_res_t** _r, dbt_table_p _dres);
+int dbt_init_result(db1_res_t** _r, dbt_table_p _dres);
+int dbt_get_next_result(db1_res_t** _r, int offset, int rows);
+
 
 int dbt_use_table(db1_con_t* _h, const str* _t);
 

--- a/modules/db_text/dbt_lib.c
+++ b/modules/db_text/dbt_lib.c
@@ -40,6 +40,8 @@ static gen_lock_t *_dbt_cachesem = NULL;
 
 static dbt_tbl_cachel_p _dbt_cachetbl = NULL;
 
+extern int is_main;
+
 #define DBT_CACHETBL_SIZE	16
 
 /**
@@ -265,6 +267,7 @@ dbt_table_p dbt_db_get_table(dbt_cache_p _dc, const str *_s)
 	hash = core_hash(&_dc->name, _s, DBT_CACHETBL_SIZE);
 	hashidx = hash % DBT_CACHETBL_SIZE;
 		
+	if(!is_main)
 	lock_get(&_dbt_cachetbl[hashidx].sem);
 
 	_tbc = _dbt_cachetbl[hashidx].dtp;
@@ -380,7 +383,7 @@ int dbt_cache_destroy(void)
 /**
  *
  */
-int dbt_cache_print(int _f)
+int dbt_cache_print2(int _f, int _lock)
 {
 	int i;
 	dbt_table_p _tbc;
@@ -390,10 +393,12 @@ int dbt_cache_print(int _f)
 	
 	for(i=0; i< DBT_CACHETBL_SIZE; i++)
 	{
-		lock_get(&_dbt_cachetbl[i].sem);
+		if(_lock)
+			lock_get(&_dbt_cachetbl[i].sem);
 		_tbc = _dbt_cachetbl[i].dtp;
 		while(_tbc)
 		{
+			if(! (_tbc->flag & DBT_TBFL_TEMP)) {
 			if(_f)
 				fprintf(stdout, "\n--- Database [%.*s]\n", _tbc->dbname.len,
 								_tbc->dbname.s);
@@ -412,13 +417,20 @@ int dbt_cache_print(int _f)
 					dbt_table_update_flags(_tbc,DBT_TBFL_MODI, DBT_FL_UNSET, 0);
 				}
 			}
+			}
 			_tbc = _tbc->next;
 		}
-		lock_release(&_dbt_cachetbl[i].sem);
+		if(_lock)
+			lock_release(&_dbt_cachetbl[i].sem);
 	}
 	
 	return 0;
 }
+
+int dbt_cache_print(int _f)
+{
+	return dbt_cache_print2(_f, !is_main);
+}	
 
 int dbt_is_neq_type(db_type_t _t0, db_type_t _t1)
 {
@@ -461,3 +473,47 @@ int dbt_is_neq_type(db_type_t _t0, db_type_t _t1)
 	return 1;
 }
 
+static int tmp_table_number = 0;
+
+dbt_table_p dbt_db_get_temp_table(dbt_cache_p _dc)
+{
+	dbt_table_p _tbc = NULL;
+	str _s;
+	char buf[30];
+	int hash;
+	int hashidx;
+
+
+	if(!_dbt_cachetbl || !_dc) {
+		LM_ERR("invalid parameter\n");
+		return NULL;
+	}
+
+	sprintf(buf, "tmp-%i-%i", my_pid(), ++tmp_table_number);
+	_s.s = buf;
+	_s.len = strlen(buf);
+
+	hash = core_hash(&_dc->name, &_s, DBT_CACHETBL_SIZE);
+	hashidx = hash % DBT_CACHETBL_SIZE;
+
+	lock_get(&_dbt_cachetbl[hashidx].sem);
+
+	_tbc = _dbt_cachetbl[hashidx].dtp;
+
+
+
+	_tbc = dbt_table_new(&_s, &(_dc->name), NULL);
+
+	_tbc->hash = hash;
+	_tbc->next = _dbt_cachetbl[hashidx].dtp;
+	if(_dbt_cachetbl[hashidx].dtp)
+		_dbt_cachetbl[hashidx].dtp->prev = _tbc;
+
+	_dbt_cachetbl[hashidx].dtp = _tbc;
+
+	dbt_table_update_flags(_tbc, DBT_TBFL_TEMP, DBT_FL_SET, 0);
+
+
+	lock_release(&_dbt_cachetbl[hashidx].sem);
+	return _tbc;
+}

--- a/modules/db_text/dbt_lib.h
+++ b/modules/db_text/dbt_lib.h
@@ -35,6 +35,7 @@
 
 #define DBT_TBFL_ZERO	0
 #define DBT_TBFL_MODI	1
+#define DBT_TBFL_TEMP	2
 
 #define DBT_FL_IGN		-1
 #define DBT_FL_SET		0
@@ -50,6 +51,7 @@
 extern int db_mode; /* Database usage mode: 0 = no cache, 1 = cache */
 extern int empty_string; /* If TRUE, an empty string is an empty string, otherwise NULL */
 extern int _db_text_read_buffer_size; /* size of the buffer to allocate when reading file */
+extern int _db_text_max_result_rows; /* max result rows */
 
 typedef db_val_t dbt_val_t, *dbt_val_p;
 
@@ -109,6 +111,7 @@ typedef struct _dbt_cache
 int dbt_init_cache(void);
 int dbt_cache_destroy(void);
 int dbt_cache_print(int);
+int dbt_cache_print2(int, int);
 
 dbt_cache_p dbt_cache_get_db(str*);
 int dbt_cache_check_db(str*);
@@ -121,12 +124,13 @@ int dbt_cache_free(dbt_cache_p);
 dbt_column_p dbt_column_new(char*, int);
 dbt_row_p dbt_row_new(int);
 dbt_table_p dbt_table_new(const str*, const str*, const char*);
+dbt_table_p dbt_db_get_temp_table(dbt_cache_p _dc);
 
 int dbt_row_free(dbt_table_p, dbt_row_p);
 int dbt_column_free(dbt_column_p);
 int dbt_table_free_rows(dbt_table_p);
 int dbt_table_free(dbt_table_p);
-
+int dbt_db_del_table(dbt_cache_p _dc, const str *_s, int sync);
 
 int dbt_row_set_val(dbt_row_p, dbt_val_p, int, int);
 int dbt_row_update_val(dbt_row_p, dbt_val_p, int, int);

--- a/modules/db_text/dbt_res.h
+++ b/modules/db_text/dbt_res.h
@@ -34,6 +34,7 @@ typedef struct _dbt_result
 {
 	int nrcols;
 	int nrrows;
+	int last_row;
 	dbt_column_p colv;
 	dbt_row_p rows;
 } dbt_result_t, *dbt_result_p;
@@ -42,17 +43,22 @@ typedef struct _dbt_con
 {
 	dbt_cache_p con;
 	int affected;
+	dbt_table_p last_query;
 } dbt_con_t, *dbt_con_p;
 
 #define DBT_CON_CONNECTION(db_con) (((dbt_con_p)((db_con)->tail))->con)
+#define DBT_CON_TEMP_TABLE(db_con) (((dbt_con_p)((db_con)->tail))->last_query)
 
 dbt_result_p dbt_result_new(dbt_table_p, int*, int);
-int dbt_result_free(dbt_result_p);
+
+//int dbt_result_free(dbt_result_p);
+int dbt_result_free(db1_con_t* _h, dbt_table_p _dres);
+
 int dbt_row_match(dbt_table_p _dtp, dbt_row_p _drp, int* _lkey,
 				 db_op_t* _op, db_val_t* _v, int _n);
 int dbt_result_extract_fields(dbt_table_p _dtp, dbt_row_p _drp,
 				int* lres, dbt_result_p _dres);
-int dbt_result_print(dbt_result_p _dres);
+int dbt_result_print(dbt_table_p _dres);
 
 int* dbt_get_refs(dbt_table_p, db_key_t*, int);
 int dbt_cmp_val(dbt_val_p _vp, db_val_t* _v);
@@ -62,6 +68,10 @@ int dbt_parse_orderbyclause(db_key_t **_o_k, char **_o_op, int *_o_n, db_key_t _
 int dbt_mangle_columnselection(int **_lres, int *_nc, int *_o_nc, int *_o_l, int _o_n);
 int dbt_sort_result(dbt_result_p _dres, int *_o_l, char *_o_op, int _o_n, int *_lres, int _nc);
 void dbt_project_result(dbt_result_p _dres, int _o_nc);
+
+int dbt_qsort_compare_temp(const void *_a, const void *_b);
+int dbt_sort_result_temp(dbt_row_p *_res, int count, int *_o_l, char *_o_op, int _o_n);
+dbt_row_p dbt_result_extract_results(dbt_table_p _dtp, dbt_row_p* pRows, int _nrows, int* _lres, int _ncols);
 
 #endif
 

--- a/modules/db_text/dbt_tb.c
+++ b/modules/db_text/dbt_tb.c
@@ -137,7 +137,7 @@ dbt_table_p dbt_table_new(const str *_tbname, const str *_dbname, const char *pa
 {
 	struct stat s;
 	dbt_table_p dtp = NULL;
-	if(!_tbname || !_dbname || !path)
+	if(!_tbname || !_dbname)
 		return NULL;
 	
 	dtp = (dbt_table_p)shm_malloc(sizeof(dbt_table_t));
@@ -175,7 +175,7 @@ dbt_table_p dbt_table_new(const str *_tbname, const str *_dbname, const char *pa
 	dtp->nrrows = dtp->nrcols = dtp->auto_val = 0;
 	dtp->auto_col = -1;
 	dtp->mt = 0;
-	if(stat(path, &s) == 0)
+	if(path && stat(path, &s) == 0)
 	{
 		dtp->mt = s.st_mtime;
 		LM_DBG("mtime is %d\n", (int)s.st_mtime);

--- a/modules/db_text/dbtext.c
+++ b/modules/db_text/dbtext.c
@@ -38,6 +38,7 @@ static int mod_init(void);
 static void destroy(void);
 
 #define DEFAULT_DB_TEXT_READ_BUFFER_SIZE 16384
+#define DEFAULT_MAX_RESULT_ROWS 100000;
 
 /*
  * Module parameter variables
@@ -45,6 +46,7 @@ static void destroy(void);
 int db_mode = 0;  /* Database usage mode: 0 = cache, 1 = no cache */
 int empty_string = 0;  /* Treat empty string as "" = 0, 1 = NULL */
 int _db_text_read_buffer_size = DEFAULT_DB_TEXT_READ_BUFFER_SIZE;
+int _db_text_max_result_rows = DEFAULT_MAX_RESULT_ROWS;
 
 int dbt_bind_api(db_func_t *dbb);
 
@@ -64,6 +66,7 @@ static param_export_t params[] = {
 	{"db_mode", INT_PARAM, &db_mode},
 	{"emptystring", INT_PARAM, &empty_string},
 	{"file_buffer_size", INT_PARAM, &_db_text_read_buffer_size},
+	{"max_result_rows", INT_PARAM, &_db_text_max_result_rows},
 	{0, 0, 0}
 };
 
@@ -108,7 +111,7 @@ static int mod_init(void)
 static void destroy(void)
 {
 	LM_DBG("destroy ...\n");
-	dbt_cache_print(0);
+	dbt_cache_print2(0, 0);
 	dbt_cache_destroy();
 }
 
@@ -125,6 +128,7 @@ int dbt_bind_api(db_func_t *dbb)
 	dbb->init        = dbt_init;
 	dbb->close       = dbt_close;
 	dbb->query       = (db_query_f)dbt_query;
+	dbb->fetch_result = (db_fetch_result_f) dbt_fetch_result;
 	dbb->free_result = dbt_free_result;
 	dbb->insert      = (db_insert_f)dbt_insert;
 	dbb->delete      = (db_delete_f)dbt_delete; 
@@ -132,7 +136,7 @@ int dbt_bind_api(db_func_t *dbb)
 	dbb->replace     = (db_replace_f)dbt_replace;
 	dbb->affected_rows = (db_affected_rows_f) dbt_affected_rows;
 	dbb->raw_query   = (db_raw_query_f) dbt_raw_query;
-	dbb->cap         = DB_CAP_ALL | DB_CAP_AFFECTED_ROWS | DB_CAP_RAW_QUERY | DB_CAP_REPLACE;
+	dbb->cap         = DB_CAP_ALL | DB_CAP_AFFECTED_ROWS | DB_CAP_RAW_QUERY | DB_CAP_REPLACE | DB_CAP_FETCH;
 
 	return 0;
 }

--- a/modules/db_text/dbtext.h
+++ b/modules/db_text/dbtext.h
@@ -56,6 +56,10 @@ int dbt_free_result(db1_con_t* _h, db1_res_t* _r);
 int dbt_query(db1_con_t* _h, db_key_t* _k, db_op_t* _op, db_val_t* _v, 
 			db_key_t* _c, int _n, int _nc, db_key_t _o, db1_res_t** _r);
 
+/*
+ * fetch result
+ */
+int dbt_fetch_result(db1_con_t* _h, db1_res_t** _r, const int nrows);
 
 /*
  * Raw SQL query


### PR DESCRIPTION
when dealing with large db_text files, pkg_memory is not suitable for
operating the database.

implementing fetch allows modules like presence & registrar & usrloc
to query large tables without constraints on pkg_memory.

creates tmp tables in shared memory for query results