### PR TITLE
Create ktls_no_curl

### DIFF
--- a/src/Makefile.groups
+++ b/src/Makefile.groups
@@ -87,7 +87,10 @@ mod_list_http_async=http_async_client
 mod_list_memcached=memcached
 
 # - modules depending on openssl library
-mod_list_tlsdeps=auth_identity crypto tls
+mod_list_tlsdeps=crypto tls
+
+# - modules depending on openssl (+curl) library
+mod_list_tlsdeps_curl=auth_identity
 
 # - modules depending on openssl library
 mod_list_outbound=outbound
@@ -201,7 +204,8 @@ mod_list_all=$(sort $(mod_list_basic) $(mod_list_extra) \
 			   $(mod_list_xmpp) $(mod_list_carrierroute) \
 			   $(mod_list_berkeley) $(mod_list_utils) \
 			   $(mod_list_memcached) \
-			   $(mod_list_tlsdeps) $(mod_list_websocket) \
+			   $(mod_list_tlsdeps) $(mod_list_tlsdeps_curl) \
+			   $(mod_list_websocket) \
 			   $(mod_list_snmpstats) $(mod_list_presence) \
 			   $(mod_list_lua) $(mod_list_python) \
 			   $(mod_list_geoip) $(mod_list_sqlite) \
@@ -243,7 +247,7 @@ module_group_standard=$(mod_list_basic) $(mod_list_extra) \
 module_group_common=$(mod_list_db) $(mod_list_dbuid) \
 					$(mod_list_pcre) $(mod_list_radius) \
 					$(mod_list_xmldeps) $(mod_list_presence) \
-					$(mod_list_tlsdeps)
+					$(mod_list_tlsdeps) $(mod_list_tlsdeps_curl)
 
 # For db use (db modules, excluding drivers)
 module_group_db=$(mod_list_db)
@@ -333,7 +337,10 @@ module_group_khttp_async=$(mod_list_http_async)
 module_group_kmemcached=$(mod_list_memcached)
 
 # pkg tls module
-module_group_ktls=$(mod_list_tlsdeps)
+module_group_ktls_basic=$(mod_list_tlsdeps)
+
+# pkg tls module with curl
+module_group_ktls=$(mod_list_tlsdeps) $(mod_list_tlsdeps_curl)
 
 # pkg websocket module
 module_group_kwebsocket=$(mod_list_websocket)


### PR DESCRIPTION
Create ktls_no_curl group to be able to compile ktls module when curl is
not available

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>