### PR TITLE
presence: use sockinfo from subs to init uac

### DIFF
--- a/src/modules/presence/notify.c
+++ b/src/modules/presence/notify.c
@@ -5,7 +5,6 @@
  *
  * This file is part of Kamailio, a free SIP server.
  *
- * Kamailio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version
@@ -1625,6 +1624,9 @@ jump_over_body:
 
 	set_uac_req(&uac_r, &met, &str_hdr, notify_body, td, TMCB_LOCAL_COMPLETED,
 			p_tm_callback, (void*)cb_param);
+	if (subs->sockinfo_str.len) {
+		 uac_r.ssock = &subs->sockinfo_str;
+	}
 	result = tmb.t_request_within(&uac_r);
 	_pres_subs_last_sub = backup_subs;
 	if(result< 0)


### PR DESCRIPTION
for deployments with multiple ports where UAs subscribe to specific port and expect the notify from that port