### PR TITLE
bugfix in topoh module

### DIFF
--- a/modules/topoh/th_msg.c
+++ b/modules/topoh/th_msg.c
@@ -954,6 +954,9 @@ int th_add_hdr_cookie(sip_msg_t *msg)
 struct via_param *th_get_via_cookie(sip_msg_t *msg, struct via_body *via)
 {
 	struct via_param *p;
+        if (!via) {
+            return NULL;
+        }
 	for(p=via->param_lst; p; p=p->next)
 	{
 		if(p->name.len==th_cookie_name.len


### PR DESCRIPTION
Avoid crash (dereferencing null pointer) if there is no VIA header in sip message