### PR TITLE
tm: reset T_ASYNC_CONTINUE flag in t_suspend

### DIFF
--- a/src/modules/tm/t_suspend.c
+++ b/src/modules/tm/t_suspend.c
@@ -143,7 +143,8 @@ int t_suspend(struct sip_msg *msg,
 	*hash_index = t->hash_index;
 	*label = t->label;
 
-
+	/* reset the continue flag to be able to suspend in a failure route */
+	t->flags &= ~T_ASYNC_CONTINUE;
 
 	/* backup some extra info that can be used in continuation logic */
 	t->async_backup.backup_route = get_route_type();


### PR DESCRIPTION
Related to http://lists.sip-router.org/pipermail/sr-users/2017-January/095772.html
Resetting the flag in t_suspend allows adding new branches in a failure route while suspending the transaction.