### PR TITLE
db_mysql: Let the database convert the timestamp

### DIFF
--- a/src/modules/db_mysql/db_mysql.c
+++ b/src/modules/db_mysql/db_mysql.c
@@ -41,6 +41,7 @@ unsigned int my_connect_to = 2; /* 2 s by default */
 unsigned int my_send_to = 0; /*  enabled only for mysql >= 5.25  */
 unsigned int my_recv_to = 0; /* enabled only for mysql >= 5.25 */
 unsigned int my_retries = 1;    /* Number of retries when command fails */
+unsigned int my_server_timezone = 0; /* Use FROM_UNIXTIME() for date conversion */
 
 unsigned long my_client_ver = 0;
 
@@ -91,6 +92,7 @@ static param_export_t params[] = {
 	{"send_timeout",    PARAM_INT, &my_send_to},
 	{"receive_timeout", PARAM_INT, &my_recv_to},
 	{"retries",         PARAM_INT, &my_retries},
+	{"server_timezone", PARAM_INT, &my_server_timezone},
 
 	{"timeout_interval", INT_PARAM, &db_mysql_timeout_interval},
 	{"auto_reconnect",   INT_PARAM, &db_mysql_auto_reconnect},

--- a/src/modules/db_mysql/db_mysql.h
+++ b/src/modules/db_mysql/db_mysql.h
@@ -44,6 +44,7 @@ extern unsigned int my_send_to;
 extern unsigned int my_recv_to;
 extern unsigned long my_client_ver;
 extern unsigned int my_retries;
+extern unsigned int my_server_timezone;
 
 /** @} */
 

--- a/src/modules/db_mysql/doc/db_mysql_admin.xml
+++ b/src/modules/db_mysql/doc/db_mysql_admin.xml
@@ -74,6 +74,27 @@ modparam("db_mysql", "ping_interval", 600)
 </programlisting>
 		</example>
 	</section>
+	<section>
+		<title><varname>server_timezone</varname> (integer)</title>
+		<para>
+		Control if kamailio convers a time to string using the local timezone
+		or if MySQL will convert it using FROM_UNIXTIME. This option is useful
+		if kamailio and the database are configured for different timezones.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0 (use local conversion)
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>server_timezone</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("db_mysql", "server_timezone", 1)
+...
+</programlisting>
+		</example>
+	</section>
 		<section>
 		<title><varname>timeout_interval</varname> (integer)</title>
 		<para>

--- a/src/modules/db_mysql/km_val.c
+++ b/src/modules/db_mysql/km_val.c
@@ -29,6 +29,7 @@
 #include "../../lib/srdb1/db_ut.h"
 #include "km_val.h"
 #include "km_my_con.h"
+#include "db_mysql.h"
 
 
 /*!
@@ -45,6 +46,27 @@ int db_mysql_val2str(const db1_con_t* _c, const db_val_t* _v, char* _s, int* _le
 {
 	int l, tmp;
 	char* old_s;
+
+	switch(VAL_TYPE(_v)) {
+	case DB1_DATETIME:
+		if (my_server_timezone) {
+			/* Let MySQL handle timestamp to internal time representation */
+			if (!_s || !_len || !*_len) {
+				LM_ERR("Invalid parameter value\n");
+				return -1;
+			}
+			l = snprintf(_s, *_len, "FROM_UNIXTIME(%d)", VAL_INT(_v));
+			if (l < 0 || l >= *_len) {
+				LM_ERR("Error in snprintf\n");
+				return -1;
+			}
+			*_len  = l;
+			return 0;
+		}
+		break;
+	default:
+		break;
+	};
 
 	tmp = db_val2str(_c, _v, _s, _len);
 	if (tmp < 1)


### PR DESCRIPTION
Instead of using the time2str routines that go through timezone
conversion in kamailio, let MySQL do it. This helps with the
sipcapture module in case the system time is CET but the database
is operated in UTC. In these cases the micro_ts and date columns
would be offseted by the timezone difference and look-ups fail
to work.