### PR TITLE
Update jansson_path.c

### DIFF
--- a/src/modules/jansson/jansson_path.c
+++ b/src/modules/jansson/jansson_path.c
@@ -18,9 +18,9 @@
 #include "../../core/mod_fix.h"
 
 /* jansson private helper functions */
-void *jsonp_malloc(size_t size);
-void jsonp_free(void *ptr);
-char *jsonp_strdup(const char *str);
+static void *jsonp_malloc(size_t size);
+static void jsonp_free(void *ptr);
+static char *jsonp_strdup(const char *str);
 
 static json_malloc_t do_malloc = malloc;
 static json_free_t do_free = free;
@@ -252,21 +252,21 @@ fail:
 }
 
 /* jansson private helper functions */
-void *jsonp_malloc(size_t size) {
+static void *jsonp_malloc(size_t size) {
 	if(!size)
 		return NULL;
 
 	return (*do_malloc)(size);
 }
 
-void jsonp_free(void *ptr) {
+static void jsonp_free(void *ptr) {
 	if(!ptr)
 		return;
 
 	(*do_free)(ptr);
 }
 
-char *jsonp_strdup(const char *str) {
+static char *jsonp_strdup(const char *str) {
 	char *new_str;
 
 	new_str = jsonp_malloc(strlen(str) + 1); 


### PR DESCRIPTION
Hi Daniel, community!
in case of build on old debian (e.g. lenny) - statically linked libjansson has to be used, as a result build throw errors, cos libjansson has functions with the same names
proposed changes - fixed issues that I have with build on lenny 