### PR TITLE
presence: remove transaction creation from publ_notify_notifier() and mark_presentity_for_delete()

### DIFF
--- a/src/modules/presence/notify.c
+++ b/src/modules/presence/notify.c
@@ -1363,15 +1363,6 @@ int publ_notify_notifier(str pres_uri, pres_ev_t *event)
 	result_cols[r_to_tag_col=n_result_cols++] = &str_to_tag_col;
 	result_cols[r_from_tag_col=n_result_cols++] = &str_from_tag_col;
 
-	if (pa_dbf.start_transaction)
-	{
-		if (pa_dbf.start_transaction(pa_db, db_table_lock) < 0)
-		{
-			LM_ERR("in start_transaction\n");
-			goto error;
-		}
-	}
-
 	if(query_fn(pa_db, query_cols, 0, query_vals, result_cols,
 				n_query_cols, n_result_cols, 0, &result )< 0)
 	{
@@ -1400,25 +1391,10 @@ int publ_notify_notifier(str pres_uri, pres_ev_t *event)
 		set_updated(&subs);
 	}
 
-	if (pa_dbf.end_transaction)
-	{
-		if (pa_dbf.end_transaction(pa_db) < 0)
-		{
-			LM_ERR("in end_transaction\n");
-			goto error;
-		}
-	}
-
 	ret = RES_ROW_N(result);
 
 error:
 	if (result) pa_dbf.free_result(pa_db, result);
-
-	if (pa_dbf.abort_transaction)
-	{
-		if (pa_dbf.abort_transaction(pa_db) < 0)
-			LM_ERR("in abort_transaction\n");
-	}
 
 	return ret;
 }

--- a/src/modules/presence/presentity.c
+++ b/src/modules/presence/presentity.c
@@ -1568,15 +1568,6 @@ int mark_presentity_for_delete(presentity_t *pres)
 
 	result_cols[0] = &str_body_col;
 
-	if (pa_dbf.start_transaction)
-	{
-		if (pa_dbf.start_transaction(pa_db, db_table_lock) < 0)
-		{
-			LM_ERR("in start_transaction\n");
-			goto error;
-		}
-	}
-
 	if (query_fn(pa_db, query_cols, 0, query_vals, result_cols,
 				n_query_cols, 1, 0, &result) < 0)
 	{
@@ -1657,15 +1648,6 @@ int mark_presentity_for_delete(presentity_t *pres)
 		goto error;
 	}
 
-	if (pa_dbf.end_transaction)
-	{
-		if (pa_dbf.end_transaction(pa_db) < 0)
-		{
-			LM_ERR("in end_transaction\n");
-			goto error;
-		}
-	}
-
 	if (pa_dbf.affected_rows)
 		ret = pa_dbf.affected_rows(pa_db);
 	else
@@ -1676,12 +1658,6 @@ error:
 	free_notify_body(new_body, pres->event);
 	if (cur_body) pkg_free(cur_body);
 	if (result) pa_dbf.free_result(pa_db, result);
-
-	if (pa_dbf.abort_transaction)
-	{
-		if (pa_dbf.abort_transaction(pa_db) < 0)
-			LM_ERR("in abort_transaction\n");
-	}
 
 	return ret;
 }

--- a/src/modules/presence/publish.c
+++ b/src/modules/presence/publish.c
@@ -164,9 +164,22 @@ void msg_presentity_clean(unsigned int ticks,void *param)
 			}
 			else if (pres_notifier_processes > 0)
 			{
+				if (pa_dbf.start_transaction)
+				{
+					if (pa_dbf.start_transaction(pa_db, db_table_lock) < 0)
+					{
+						LM_ERR("in start_transaction\n");
+						goto error;
+					}
+				}
 				if ((num_watchers = publ_notify_notifier(uri, pres.event)) < 0)
 				{
 					LM_ERR("Updating watcher records\n");
+					if (pa_dbf.abort_transaction)
+					{
+						if (pa_dbf.abort_transaction(pa_db) < 0)
+							LM_ERR("in abort_transaction\n");
+					}
 					goto error;
 				}
 
@@ -175,6 +188,11 @@ void msg_presentity_clean(unsigned int ticks,void *param)
 					if (mark_presentity_for_delete(&pres) < 0)
 					{
 						LM_ERR("Marking presentity\n");
+						if (pa_dbf.abort_transaction)
+						{
+							if (pa_dbf.abort_transaction(pa_db) < 0)
+								LM_ERR("in abort_transaction\n");
+						}
 						goto error;
 					}
 				}
@@ -183,6 +201,14 @@ void msg_presentity_clean(unsigned int ticks,void *param)
 					if (delete_presentity(&pres) < 0)
 					{
 						LM_ERR("Deleting presentity\n");
+						goto error;
+					}
+				}
+				if (pa_dbf.end_transaction)
+				{
+					if (pa_dbf.end_transaction(pa_db) < 0)
+					{
+						LM_ERR("in end_transaction\n");
 						goto error;
 					}
 				}


### PR DESCRIPTION
* publ_notify_notifier() and mark_presentity_for_delete() are
  called inside a already created transaction
* adding transaction handle for msg_presentity_clean()
