### PR TITLE
core: avoid overrun-buffer-arg

### DIFF
--- a/src/core/dns_cache.c
+++ b/src/core/dns_cache.c
@@ -2362,6 +2362,7 @@ inline static struct hostent* dns_entry2he(struct dns_hash_entry* e)
 	int af, len;
 	struct dns_rr* rr;
 	unsigned char rr_no;
+	unsigned char *ip;
 	ticks_t now;
 	int i;
 
@@ -2389,7 +2390,15 @@ inline static struct hostent* dns_entry2he(struct dns_hash_entry* e)
 	for(i=0; rr && (i<DNS_HE_MAX_ADDR); i++,
 							rr=dns_entry_get_rr(e, &rr_no, now)){
 				p_addr[i]=&address[i*len];
-				memcpy(p_addr[i], ((struct a_rdata*)rr->rdata)->ip, len);
+				switch(e->type){
+					case T_A:
+						ip = ((struct a_rdata*)rr->rdata)->ip;
+						break;
+					case T_AAAA:
+						ip = ((struct aaaa_rdata*)rr->rdata)->ip6;
+						break;
+				}
+				memcpy(p_addr[i], ip, len);
 	}
 	if (i==0){
 		LM_DBG("no good records found (%d) for %.*s (%d)\n",


### PR DESCRIPTION
> Overrunning array ((struct a_rdata *)rr->rdata)->ip of 4 bytes
> by passing it to a function which accesses it at byte offset 15
> using argument len (which evaluates to 16)