### PR TITLE
pv: add the $env() PV class to read env vars

### DIFF
--- a/src/modules/pv/pv.c
+++ b/src/modules/pv/pv.c
@@ -208,6 +208,8 @@ static pv_export_t mod_pvs[] = {
 	{{"duri", (sizeof("duri")-1)}, /* */
 		PVT_DSTURI, pv_get_dsturi, pv_set_dsturi,
 		0, 0, 0, 0},
+	{{"env", (sizeof("env")-1)}, PVT_OTHER, pv_get_env, 0,
+		pv_parse_env_name, 0, 0, 0},
 	{{"err.class", (sizeof("err.class")-1)}, /* */
 		PVT_OTHER, pv_get_errinfo_attr, 0,
 		0, 0, 0, 0},

--- a/src/modules/pv/pv_core.c
+++ b/src/modules/pv/pv_core.c
@@ -50,6 +50,8 @@
 #include "pv_core.h"
 #include "pv_svar.h"
 
+#include <string.h>
+#include <stdlib.h>
 
 static str str_udp    = { "UDP", 3 };
 static str str_5060   = { "5060", 4 };
@@ -3233,3 +3235,44 @@ int pv_get_msg_attrs(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 			return pv_get_null(msg, param, res);
 	}
 }
+
+int pv_parse_env_name(pv_spec_p sp, str *in)
+{
+	if(in->s==NULL || in->len<=0)
+		return -1;
+
+	char *csname;
+
+	csname = pkg_malloc(in->len + 1);
+
+	if (csname == NULL) {
+		LM_ERR("no more pkg memory");
+		return -1;
+	}
+
+	memcpy(csname, in->s, in->len);
+	csname[in->len] = '\0';
+
+	sp->pvp.pvn.u.dname = (void*)csname;
+	sp->pvp.pvn.type = PV_NAME_OTHER;
+	return 0;
+}
+
+int pv_get_env(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
+{
+	char *val;
+	char *csname = (char *) param->pvn.u.dname;
+
+	if (csname) {
+		val = getenv(csname);
+
+		if (val) {
+			return pv_get_strzval(msg, param, res, val);
+		} else {
+			return pv_get_null(msg, param, res);
+		}
+	} else {
+		return pv_get_null(msg, param, res);
+	}
+}
+

--- a/src/modules/pv/pv_core.c
+++ b/src/modules/pv/pv_core.c
@@ -3238,10 +3238,10 @@ int pv_get_msg_attrs(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 
 int pv_parse_env_name(pv_spec_p sp, str *in)
 {
+	char *csname;
+
 	if(in->s==NULL || in->len<=0)
 		return -1;
-
-	char *csname;
 
 	csname = pkg_malloc(in->len + 1);
 
@@ -3268,11 +3268,8 @@ int pv_get_env(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 
 		if (val) {
 			return pv_get_strzval(msg, param, res, val);
-		} else {
-			return pv_get_null(msg, param, res);
 		}
-	} else {
-		return pv_get_null(msg, param, res);
 	}
+	return pv_get_null(msg, param, res);
 }
 

--- a/src/modules/pv/pv_core.h
+++ b/src/modules/pv/pv_core.h
@@ -334,5 +334,9 @@ int pv_parse_msg_attrs_name(pv_spec_p sp, str *in);
 
 int pv_get_msg_attrs(sip_msg_t *msg, pv_param_t *param,
 		pv_value_t *res);
+
+int pv_parse_env_name(pv_spec_p sp, str *in);
+
+int pv_get_env(sip_msg_t *msg, pv_param_t *param, pv_value_t *res);
 #endif
 


### PR DESCRIPTION
this allows kamailio to have read-only (for now) access to environment variables