### PR TITLE
pua_dialoginfo: Add flags to disable caller and/or callee PUBLISH when required

### DIFF
--- a/src/modules/pua_dialoginfo/doc/pua_dialoginfo_admin.xml
+++ b/src/modules/pua_dialoginfo/doc/pua_dialoginfo_admin.xml
@@ -358,6 +358,44 @@ modparam("pua_dialoginfo", "send_publish_flag", 8)
 </programlisting>
 		</example>
 		</section>
+
+	<section>
+		<title><varname>disable_caller_publish_flag</varname> (int)</title>
+		<para>
+			This message flag indicates whether to send caller (initiator) PUBLISH requests or not.
+			If set, PUBLISH requests are not sent for the caller (initiator).
+		</para>
+		<para>
+			<emphasis>Default value is <quote>-1</quote>.</emphasis>
+		</para>
+		<example>
+			<title>Set <varname>disable_caller_publish_flag</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("pua_dialoginfo", "disable_caller_publish_flag", 9)
+...
+</programlisting>
+		</example>
+		</section>
+
+	<section>
+		<title><varname>disable_callee_publish_flag</varname> (int)</title>
+		<para>
+			This message flag indicates whether to send callee (recipient) PUBLISH requests or not.
+			If set, PUBLISH requests are not sent for the callee (recipient).
+		</para>
+		<para>
+			<emphasis>Default value is <quote>-1</quote>.</emphasis>
+		</para>
+		<example>
+			<title>Set <varname>disable_callee_publish_flag</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("pua_dialoginfo", "disable_callee_publish_flag", 10)
+...
+</programlisting>
+		</example>
+		</section>
 	
 		<section>
 		<title><varname>use_pubruri_avps</varname> (int)</title>


### PR DESCRIPTION
- Added 2 new flags, disable_caller_publish_flag and disable_callee_publish_flag
- Wrapped each call to dialog_publish_multi to first check if the flag is set

This is actually quite a strange usecase. It's useful when calls do not route internally on Kamailio but are always forced out through a B2BUA which routes back to Kamailio for eventual delivery to the phone. In this case, you can disable callee (recipient) notifications for the outbound call leg from Phone->Kamailio->B2BUA and caller (initiator) notifications for the inbound leg from B2BUA->Kamailio->Phone.

In this case, you don't get notifications for 2 dialogs for each party on the call - rather 1 dialog per party. For a BLF phone, this doesn't really change anything however when BLF notifications are used to trigger events in other systems, it can be helpful to de-duplicate the messages.

I can't imagine there will be a queue of people wanting to use this... but it's implemented in such a way that behavior won't change unless the flags are defined and implemented.