### PR TITLE
sipcapture: Added exported pseudo-variable $hep(dst_ip) and updated README

### DIFF
--- a/src/modules/sipcapture/README
+++ b/src/modules/sipcapture/README
@@ -55,12 +55,17 @@ Alexandr Dubovikov
               4.1. sip_capture([table])
               4.2. report_capture([table],[data])
 
-        5. RPC Commands
+        5. Exported pseudo-variables
 
-              5.1. sipcapture.status param
+              5.1. $hep(src_ip)
+              5.2. $hep(dst_ip)
 
-        6. Database setup
-        7. Limitations
+        6. RPC Commands
+
+              6.1. sipcapture.status param
+
+        7. Database setup
+        8. Limitations
 
    List of Examples
 
@@ -125,12 +130,16 @@ Chapter 1. Admin Guide
         4.1. sip_capture([table])
         4.2. report_capture([table],[data])
 
-   5. RPC Commands
+   5. Exported pseudo-variables
+        5.1. $hep(src_ip)
+        5.2. $hep(dst_ip)
 
-        5.1. sipcapture.status param
+   6. RPC Commands
 
-   6. Database setup
-   7. Limitations
+        6.1. sipcapture.status param
+
+   7. Database setup
+   8. Limitations
 
 1. Overview
 
@@ -505,11 +514,26 @@ report_capture("report_data");
 report_capture("report_data", "{\"MOS\":4.1,\"PACKET_LOST\":100"});
 ...
 
-5. RPC Commands
+5. Exported pseudo-variables
 
-   5.1. sipcapture.status param
+   5.1. $hep(src_ip)
+   5.2. $hep(dst_ip)
 
-5.1.  sipcapture.status param
+   Exported pseudo-variables are listed in the next sections.
+
+5.1. $hep(src_ip)
+
+   Returns the current HEP's message original source IP address.
+
+5.2. $hep(dst_ip)
+
+   Returns the current HEP's message original destination IP address.
+
+6. RPC Commands
+
+   6.1. sipcapture.status param
+
+6.1.  sipcapture.status param
 
    Name: sipcapture.status
 
@@ -527,7 +551,7 @@ kamcmd sipcapture.status off
 kamcmd sipcapture.status check
 ...
 
-6. Database setup
+7. Database setup
 
    Before running Kamailio with the sipcapture module, you have to setup
    the database tables where the module will store the data. For that, if
@@ -537,7 +561,7 @@ kamcmd sipcapture.status check
    find the complete database documentation on the project webpage,
    http://www.kamailio.org/docs/db-tables/kamailio-db-devel.html.
 
-7. Limitations
+8. Limitations
 
      * 1. Only one capturing mode on RAW socket is supported: IPIP or
        monitoring/mirroring port. Don't activate both at the same time.

--- a/src/modules/sipcapture/sipcapture.c
+++ b/src/modules/sipcapture/sipcapture.c
@@ -2773,6 +2773,7 @@ static int pv_parse_hep_name (pv_spec_p sp, str *in)
 		case 6:
 		{
 			if(!strncmp(in->s, "src_ip", 6)) sp->pvp.pvn.u.isname.name.n = 2;
+			else if(!strncmp(in->s, "dst_ip", 6)) sp->pvp.pvn.u.isname.name.n = 3;
 			else goto error;
 		}
 		case 7:
@@ -2813,6 +2814,10 @@ static int pv_get_hep(struct sip_msg *msg, pv_param_t *param, pv_value_t *res)
 						sizeof(sc_buf_ip)-1);
 				sc_buf_ip[sc_buf_ip_len]=0;
 				return pv_get_strlval(msg, param, res, sc_buf_ip, sc_buf_ip_len);
+		case 3:
+			sc_buf_ip_len=ip_addr2sbuf(&msg->rcv.dst_ip, sc_buf_ip, sizeof(sc_buf_ip)-1);
+			sc_buf_ip[sc_buf_ip_len]=0;
+			return pv_get_strlval(msg, param, res, sc_buf_ip, sc_buf_ip_len);
 		default:
 		        return  hepv3_get_chunk(msg, msg->buf, msg->len, param->pvn.u.isname.name.n, param, res);
 	}


### PR DESCRIPTION
Added a new exported pseudo-variable to expose HEP's message's original source ip address.
Added an "Exported pseudo-variabled" to the README file to document $hep(src_ip) and $hep(dst_ip).