### PR TITLE
Fix execinfo error in ims_dialog module

### DIFF
--- a/src/modules/ims_dialog/dlg_hash.c
+++ b/src/modules/ims_dialog/dlg_hash.c
@@ -17,7 +17,7 @@
 #include "dlg_profile.h"
 #include "dlg_handlers.h"
 #include "dlg_db_handler.h"
-#include <execinfo.h>
+//#include <execinfo.h>
 
 #define MAX_LDG_LOCKS  2048
 #define MIN_LDG_LOCKS  2
@@ -70,6 +70,7 @@ static int dlg_hash_size_out = 4096;
 		}\
 	}while(0)
 
+#if 0
 inline static int backtrace2str(char* buf, int size)
 {
         void* bt[32];
@@ -87,6 +88,7 @@ inline static int backtrace2str(char* buf, int size)
         }
         return 0;
 }
+#endif
 
 /*!
  * \brief Initialize the global dialog table


### PR DESCRIPTION
Currently, ims_dialog includes execinfo.h to use backtrace in the
backtrace2str function. However, all calls to backtrace2str are
commented so disable this function through "if 0" and comment the
include on execinfo.h to allow the cross-compilation of the ims_dialog
module as some libc's don't always have this header (uclibc-ng, musl)

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>