### PR TITLE
rtpengine: really do allow unsigned setid

### DIFF
--- a/src/modules/rtpengine/rtpengine.h
+++ b/src/modules/rtpengine/rtpengine.h
@@ -75,7 +75,7 @@ struct rtpp_set_head {
 
 
 struct rtpp_node *get_rtpp_node(struct rtpp_set *rtpp_list, str *url);
-struct rtpp_set *get_rtpp_set(int set_id);
+struct rtpp_set *get_rtpp_set(unsigned int set_id);
 int add_rtpengine_socks(struct rtpp_set * rtpp_list, char * rtpproxy, unsigned int weight, int disabled, unsigned int ticks, int isDB);
 
 int rtpengine_delete_node(struct rtpp_node *rtpp_node);

--- a/src/modules/rtpengine/rtpengine_db.c
+++ b/src/modules/rtpengine/rtpengine_db.c
@@ -68,8 +68,8 @@ static int rtpp_load_db(void)
 	db_key_t query_cols[] = {&rtpp_setid_col, &rtpp_url_col, &rtpp_weight_col, &rtpp_disabled_col};
 
 	str url;
-	int setid, disabled;
-	unsigned int weight, ticks;
+	int disabled;
+	unsigned int setid, weight, ticks;
 
 	/* int weight, flags; */
 	int n_rows = 0;


### PR DESCRIPTION

## Motivation

1. DOC says `setid` in mysql should be `UNSIGNED INT`:
    http://www.kamailio.org/docs/modules/4.4.x/modules/rtpengine.html#rtpengine.p.table_name
    http://www.kamailio.org/docs/modules/4.4.x/modules/rtpengine.html#rtpengine.p.setid_col

2. kamailio did report invalid value if `setid` less than 0.

3. kamailio rtpengine module declares setid as `int setid`, thus we can not use setid more than 2147483647

This PR changes declaration of `setid` from `int` to `unsigned int`

## UNSURE (REVIEW NEEDED):

I'm not sure about:

should `int_val` in `fixup_set_ip` at [rtpengine.c#L910](https://github.com/kamailio/kamailio/blob/master/src/modules/rtpengine/rtpengine.c#L910) be declared as `unsigned int` as well?

not sure about the usage of `int pv_locate_name()` and `unsigned short str2s()` in the `fixup_set_ip()` function.

should we use `str2int` instead `str2s` ?


let me know if I'm on the wrong direction
