### PR TITLE
websocket: X-Forwarded-For and X-Real-IP support

### DIFF
--- a/src/modules/websocket/ws_conn.h
+++ b/src/modules/websocket/ws_conn.h
@@ -62,6 +62,8 @@ typedef struct ws_connection
 	int      run_event;
 
 	str frag_buf;
+
+	char real_src_ip[IP_ADDR_MAX_STR_SIZE]; /* to track X-Forwarded-For header for websocket */
 } ws_connection_t;
 
 typedef struct


### PR DESCRIPTION
New feature to get the real source IP when kamailio websocket is behind a load balancer transmitting X-Forwarded-For and/or X-Real-IP headers:
Detect HTTP headers X-Forwarded-For and X-Real-IP during the Websocket handshake.
The pseudo variable $ws_real_src_ip is populated during ws_handshake() or null if not set.
$ws_real_src_ip is readonly.