### PR TITLE
siptrace: new hlog() function to send logs to homer

### DIFF
--- a/src/modules/siptrace/doc/siptrace.xml
+++ b/src/modules/siptrace/doc/siptrace.xml
@@ -33,6 +33,11 @@
 		<surname>Vacca</surname>
 		<email>giacomo.vacca@gmail.com</email>
 	</editor>
+	<editor>
+		<firstname>Camille</firstname>
+		<surname>Oudot</surname>
+		<email>camille.oudot@orange.com</email>
+	</editor>
 	</authorgroup>
 	<copyright>
 	    <year>2010</year>

--- a/src/modules/siptrace/doc/siptrace_admin.xml
+++ b/src/modules/siptrace/doc/siptrace_admin.xml
@@ -557,6 +557,40 @@ sip_trace("sip:10.1.1.2:5085", "$ci-abc");
 		</example>
 	</section>
 
+	<section id="siptrace.f.hlog">
+		<title>
+		<function moreinfo="none">hlog([correlation_id,] message)</function>
+		</title>
+		<para>
+		Sends a log event as a HEP3 packet to the homer host configured in
+		<emphasis>duplicate_uri</emphasis>.
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+			<listitem>
+			<para><emphasis>correlation_id</emphasis> (optional) - Homer correlation
+			ID for this event. If this parameter is not set, the current message's
+			call-id will be used. (This parameter may contain PVs)
+			</para>
+			</listitem>
+			<listitem>
+			<para><emphasis>message</emphasis> - The text to send to Homer as log
+			event. (This parameter may contain PVs)
+			</para>
+			</listitem>
+		</itemizedlist>
+		<example>
+		<title><function>hlog()</function> usage</title>
+		<programlisting format="linespecific">
+...
+hlog("[cfg:$cfg(line)] This is a log from kamailio to Homer");
+...
+hlog("$hdr(P-MyID)", "Another one with a custom correlation ID");
+...
+</programlisting>
+		</example>
+	</section>
+
 	</section>
 
     <section>


### PR DESCRIPTION
This adds the `hlog()` function to the siptrace module, that sends a HEP3 LOG event packet to the URI configured in the module.

Usage:
```
...
hlog("[cfg:$cfg(line)] This is a log from kamailio to Homer");
...
hlog("$hdr(P-MyID)", "Another one with a custom correlation ID");
...
```