### PR TITLE
modules/siptrace: remove duplicate HEP version check

### DIFF
--- a/src/modules/siptrace/siptrace.c
+++ b/src/modules/siptrace/siptrace.c
@@ -320,11 +320,6 @@ static int mod_init(void)
 		}
 	}
 
-	if(hep_version != 1 && hep_version != 2 && hep_version != 3) {
-		LM_ERR("unsupported version of HEP");
-		return -1;
-	}
-
 	trace_on_flag = (int*)shm_malloc(sizeof(int));
 	if(trace_on_flag==NULL) {
 		LM_ERR("no more shm memory left\n");


### PR DESCRIPTION
I think only this check is enough:
https://github.com/kamailio/kamailio/blob/f6396033763f1d55c11744ddb9774e112865400a/src/modules/siptrace/siptrace.c#L303-L306