### PR TITLE
app_perl: Make sv2int_str() static

### DIFF
--- a/src/modules/app_perl/kamailioxs.xs
+++ b/src/modules/app_perl/kamailioxs.xs
@@ -402,7 +402,7 @@ char *pv_sprintf(struct sip_msg *m, char *fmt) {
  * - strflag: flag mask to be or-applied for string match
  */
 
-inline int sv2int_str(SV *val, int_str *is,
+static inline int sv2int_str(SV *val, int_str *is,
 		      unsigned short *flags, unsigned short strflag) {
 	char *s;
 	STRLEN len;


### PR DESCRIPTION
The function is only called from the xs file, and C11’s inline
semantics mean that gcc-5 and later miscompile this file when
no optimization is specified.

Signed-off-by: James Cloos <cloos@jhcloos.com>