### PR TITLE
core: initialize dns cache used memory

### DIFF
--- a/src/core/dns_cache.c
+++ b/src/core/dns_cache.c
@@ -347,6 +347,9 @@ int init_dns_cache()
 		ret=E_OUT_OF_MEM;
 		goto error;
 	}
+
+	*dns_cache_mem_used=0;
+
 #ifdef DNS_LU_LST
 	dns_last_used_lst=shm_malloc(sizeof(*dns_last_used_lst));
 	if (dns_last_used_lst==0){


### PR DESCRIPTION
Without the initialization the used memory counter can have random values thus breaking the dns cache.