### PR TITLE
erlang: allow user to set ERLANG_xxxDIR

### DIFF
--- a/src/modules/erlang/Makefile
+++ b/src/modules/erlang/Makefile
@@ -10,9 +10,12 @@ ERLANG=$(shell which erl)
 ifneq ($(ERLANG),)
 ERLANG_LIBDIR=$(shell $(ERLANG) -noshell -eval 'io:format("~n~s/lib~n", [[code:lib_dir("erl_interface")]]).' -s erlang halt | tail -n 1)
 ERLANG_INCDIR=$(shell $(ERLANG) -noshell -eval 'io:format("~n~s/include~n", [[code:lib_dir("erl_interface")]]).' -s erlang halt | tail -n 1)
-else
+endif
+
+ifeq ($(ERLANG_LIBDIR)$(ERLANG_INCDIR),)
 $(error Not found Erlang)
 endif
+
 LIBS=-L$(ERLANG_LIBDIR) -lei -lpthread
 
 DEFS+=-I$(ERLANG_INCDIR)


### PR DESCRIPTION
If erl is not installed on the system or can not be used (for example
when cross-compiling), then erlang module will use the values set by the
user in ERLANG_INCDIR and ERLANG_LIBDIR instead of returning en error

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>