### PR TITLE
db_postgress: insert_update() with DO NOTHING

### DIFF
--- a/src/modules/db_postgres/db_postgres.c
+++ b/src/modules/db_postgres/db_postgres.c
@@ -90,6 +90,7 @@ int db_postgres_bind_api(db_func_t *dbb)
 	dbb->raw_query        = db_postgres_raw_query;
 	dbb->free_result      = db_postgres_free_result;
 	dbb->insert           = db_postgres_insert;
+	dbb->insert_update    = db_postgres_insert_update;
 	dbb->delete           = db_postgres_delete; 
 	dbb->update           = db_postgres_update;
 	dbb->replace          = db_postgres_replace;

--- a/src/modules/db_postgres/db_postgres.h
+++ b/src/modules/db_postgres/db_postgres.h
@@ -38,4 +38,6 @@ int pg_init_lock_set(int sz);
 
 void pg_destroy_lock_set(void);
 
+int pg_alloc_buffer(void);
+
 #endif /* _KM_DB_POSTGRES_H */

--- a/src/modules/db_postgres/km_dbase.h
+++ b/src/modules/db_postgres/km_dbase.h
@@ -91,6 +91,11 @@ int db_postgres_raw_query(const db1_con_t* _h, const str* _s, db1_res_t** _r);
 int db_postgres_insert(const db1_con_t* _h, const db_key_t* _k, const db_val_t* _v,
 		const int _n);
 
+/*
+ * Insert and update ON CONFLICT
+ */
+int db_postgres_insert_update(const db1_con_t* _h, const db_key_t* _k, const db_val_t* _v,
+		const int _n);
 
 /*
  * Delete a row from table

--- a/src/modules/db_postgres/km_pg_con.c
+++ b/src/modules/db_postgres/km_pg_con.c
@@ -116,6 +116,10 @@ struct pg_con* db_postgres_new_connection(struct db_id* id)
 		goto err;
 	}
 
+	if (PQserverVersion(ptr->con) <  90500) {
+		LM_WARN("server version < 9.5 does not support insert_update\n");
+	}
+
 	ptr->connected = 1;
 	ptr->timestamp = time(0);
 	ptr->id = id;

--- a/src/modules/db_postgres/pg_mod.c
+++ b/src/modules/db_postgres/pg_mod.c
@@ -534,6 +534,10 @@ int pg_test(void)
 
 int mod_register(char *path, int *dlflags, void *p1, void *p2)
 {
+	if(!pg_alloc_buffer()) {
+		LM_ERR("failed too allocate buffer");
+		return -1;
+	}
 	if(db_api_init()<0)
 		return -1;
 	return 0;


### PR DESCRIPTION
Why is insert_update doing nothing in Kamailio db insert_update ?

As explained in the following article the design of "UPSERT" in
PostgreSQL requires to be explicit about the constraint on which
we accept to do update modification to Kamailio database framework/API
would be required to expose which specific key constraint should be
handled as an update

http://pgeoghegan.blogspot.com/2015/10/avoid-naming-constraint-directly-when.html

In this first step, DO NOTHING is providing the simple feature to ignore
error on insert when facing a constraint violation