### PR TITLE
db_postgres insert_update and usrloc params

### DIFF
--- a/src/modules/db_postgres/db_postgres.c
+++ b/src/modules/db_postgres/db_postgres.c
@@ -90,6 +90,7 @@ int db_postgres_bind_api(db_func_t *dbb)
 	dbb->raw_query        = db_postgres_raw_query;
 	dbb->free_result      = db_postgres_free_result;
 	dbb->insert           = db_postgres_insert;
+	dbb->insert_update    = db_postgres_insert_update;
 	dbb->delete           = db_postgres_delete; 
 	dbb->update           = db_postgres_update;
 	dbb->replace          = db_postgres_replace;

--- a/src/modules/db_postgres/db_postgres.h
+++ b/src/modules/db_postgres/db_postgres.h
@@ -38,4 +38,6 @@ int pg_init_lock_set(int sz);
 
 void pg_destroy_lock_set(void);
 
+int pg_alloc_buffer(void);
+
 #endif /* _KM_DB_POSTGRES_H */

--- a/src/modules/db_postgres/km_dbase.h
+++ b/src/modules/db_postgres/km_dbase.h
@@ -35,6 +35,16 @@
 #include "../../lib/srdb1/db_op.h"
 #include "../../lib/srdb1/db_val.h"
 
+/*
+ * Storage for all the unique constraints found by insert_update
+ */
+typedef struct db_pg_constraint_list {
+	struct db_pg_constraint_list* next;
+	struct db_pg_constraint_list* prev;
+	str database;
+	str table;
+	str unique;
+} pg_constraint_t;
 
 /*
  * Initialize database connection
@@ -91,6 +101,11 @@ int db_postgres_raw_query(const db1_con_t* _h, const str* _s, db1_res_t** _r);
 int db_postgres_insert(const db1_con_t* _h, const db_key_t* _k, const db_val_t* _v,
 		const int _n);
 
+/*
+ * Insert and update ON CONFLICT
+ */
+int db_postgres_insert_update(const db1_con_t* _h, const db_key_t* _k, const db_val_t* _v,
+		const int _n);
 
 /*
  * Delete a row from table

--- a/src/modules/db_postgres/km_pg_con.c
+++ b/src/modules/db_postgres/km_pg_con.c
@@ -116,6 +116,10 @@ struct pg_con* db_postgres_new_connection(struct db_id* id)
 		goto err;
 	}
 
+	if (PQserverVersion(ptr->con) <  90500) {
+		LM_WARN("server version < 9.5 does not support insert_update\n");
+	}
+
 	ptr->connected = 1;
 	ptr->timestamp = time(0);
 	ptr->id = id;

--- a/src/modules/db_postgres/km_res.c
+++ b/src/modules/db_postgres/km_res.c
@@ -149,6 +149,7 @@ int db_postgres_get_columns(const db1_con_t* _h, db1_res_t* _r)
 			case BOOLOID:
 			case CHAROID:
 			case VARCHAROID:
+			case NAMEOID:
 			case BPCHAROID:
 				LM_DBG("use DB1_STRING result type\n");
 				RES_TYPES(_r)[col] = DB1_STRING;

--- a/src/modules/db_postgres/pg_mod.c
+++ b/src/modules/db_postgres/pg_mod.c
@@ -534,6 +534,10 @@ int pg_test(void)
 
 int mod_register(char *path, int *dlflags, void *p1, void *p2)
 {
+	if(!pg_alloc_buffer()) {
+		LM_ERR("failed too allocate buffer");
+		return -1;
+	}
 	if(db_api_init()<0)
 		return -1;
 	return 0;

--- a/src/modules/usrloc/doc/usrloc_admin.xml
+++ b/src/modules/usrloc/doc/usrloc_admin.xml
@@ -687,6 +687,48 @@ modparam("usrloc", "db_mode", 2)
 		</example>
 	</section>
 
+	<section id="usrloc.p.db_load">
+		<title><varname>db_load</varname> (integer)</title>
+		<para>
+		Determine if the usrloc module should load contacts from the database storage during module initialization
+		A value of 0 disable the loading from the database
+		</para>
+		<para>
+		<emphasis>
+			Default value is 1.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>db_load</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("usrloc", "db_load", "0")
+...
+		</programlisting>
+		</example>
+	</section>
+
+	<section id="usrloc.p.db_insert_update">
+		<title><varname>db_insert_update</varname> (integer)</title>
+		<para>
+		Determine if the usrloc module should do an update when a duplicate key is found while inserting
+		A value of 1 will activate update on duplicate key
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>db_insert_update</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("usrloc", "db_insert_update", "1")
+...
+		</programlisting>
+		</example>
+	</section>
+
 	<section id="usrloc.p.matching_mode">
 		<title><varname>matching_mode</varname> (integer)</title>
 		<para>

--- a/src/modules/usrloc/ucontact.c
+++ b/src/modules/usrloc/ucontact.c
@@ -679,10 +679,18 @@ int db_insert_ucontact(ucontact_t* _c)
 		return -1;
 	}
 
-	if (ul_dbf.insert(ul_dbh, keys, vals, nr_cols) < 0) {
-		LM_ERR("inserting contact in db failed %.*s (%.*s)\n",
-				_c->aor->len, ZSW(_c->aor->s), _c->ruid.len, ZSW(_c->ruid.s));
-		return -1;
+	if (db_insert_update && ul_dbf.insert_update) {
+		if (ul_dbf.insert_update(ul_dbh, keys, vals, nr_cols) < 0) {
+			LM_ERR("inserting with update contact in db failed %.*s (%.*s)\n",
+					_c->aor->len, ZSW(_c->aor->s), _c->ruid.len, ZSW(_c->ruid.s));
+			return -1;
+		}
+	} else {
+		if (ul_dbf.insert(ul_dbh, keys, vals, nr_cols) < 0) {
+			LM_ERR("inserting contact in db failed %.*s (%.*s)\n",
+					_c->aor->len, ZSW(_c->aor->s), _c->ruid.len, ZSW(_c->ruid.s));
+			return -1;
+		}
 	}
 
 	if (ul_xavp_contact_name.s) {

--- a/src/modules/usrloc/usrloc_mod.c
+++ b/src/modules/usrloc/usrloc_mod.c
@@ -104,6 +104,7 @@ static int ul_preload_param(modparam_t type, void* val);
 
 extern int bind_usrloc(usrloc_api_t* api);
 int ul_db_update_as_insert = 0;
+
 int ul_timer_procs = 0;
 int ul_db_check_update = 0;
 int ul_keepalive_timeout = 0;
@@ -155,6 +156,8 @@ str ulattrs_last_mod_col = str_init(ULATTRS_LAST_MOD_COL);	/*!< Name of column c
 str db_url          = str_init(DEFAULT_DB_URL);	/*!< Database URL */
 int timer_interval  = 60;				/*!< Timer interval in seconds */
 int db_mode         = 0;				/*!< Database sync scheme: 0-no db, 1-write through, 2-write back, 3-only db */
+int db_load         = 1;				/*!< Database load after restart: 1- true, 0- false (only the db_mode allows it) */
+int db_insert_update = 0;				/*!< Database : update on duplicate key instead of error */
 int use_domain      = 0;				/*!< Whether usrloc should use domain part of aor */
 int desc_time_order = 0;				/*!< By default do not enable timestamp ordering */
 int handle_lost_tcp = 0;				/*!< By default do not remove contacts before expiration time */
@@ -202,6 +205,8 @@ static param_export_t params[] = {
 	{"db_url",              PARAM_STR, &db_url        },
 	{"timer_interval",      INT_PARAM, &timer_interval  },
 	{"db_mode",             INT_PARAM, &db_mode         },
+	{"db_load",             INT_PARAM, &db_load         },
+	{"db_insert_update",    INT_PARAM, &db_insert_update },
 	{"use_domain",          INT_PARAM, &use_domain      },
 	{"desc_time_order",     INT_PARAM, &desc_time_order },
 	{"user_agent_column",   PARAM_STR, &user_agent_col},
@@ -416,7 +421,7 @@ static int child_init(int _rank)
 		return -1;
 	}
 	/* _rank==PROC_SIPINIT is used even when fork is disabled */
-	if (_rank==PROC_SIPINIT && db_mode!=DB_ONLY) {
+	if (_rank==PROC_SIPINIT && db_mode!=DB_ONLY && db_load) {
 		/* if cache is used, populate domains from DB */
 		for( ptr=root ; ptr ; ptr=ptr->next) {
 			if (preload_udomain(ul_dbh, ptr->d) < 0) {

--- a/src/modules/usrloc/usrloc_mod.h
+++ b/src/modules/usrloc/usrloc_mod.h
@@ -76,6 +76,7 @@ extern str ulattrs_last_mod_col;
 extern str db_url;
 extern int timer_interval;
 extern int db_mode;
+extern int db_insert_update;
 extern int use_domain;
 extern int desc_time_order;
 extern int cseq_delay;


### PR DESCRIPTION
This pull request is including two commits

1:  adding `db_postgres` insert_update support 
2:  adding new parameters to `usrloc` that are not changing the default behaviour.

I added both to the same PR to highlight that the usage of insert_update will be immediately available for `usrloc` with `db_postgres` and `db_mysql` (maybe others, the ones not supporting it will simply revert to normal insert)