### PR TITLE
Keepalive module - prototype

### DIFF
--- a/src/modules/keepalive/Makefile
+++ b/src/modules/keepalive/Makefile
@@ -1,0 +1,18 @@
+#
+# example module makefile
+#
+# 
+# WARNING: do not run this directly, it should be run by the master Makefile
+
+include ../../Makefile.defs
+
+auto_gen=
+NAME=keepalive.so
+
+LIBS=
+
+DEFS+=-DKAMAILIO_MOD_INTERFACE
+
+SERLIBPATH=../../lib
+SER_LIBS+=$(SERLIBPATH)/srdb1/srdb1
+include ../../Makefile.modules

--- a/src/modules/keepalive/api.h
+++ b/src/modules/keepalive/api.h
@@ -1,0 +1,74 @@
+/**
+ * keepalive module - remote destinations probing
+ *
+ * Copyright (C) 2017 Guillaume Bour <guillaume@bour.cc>
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/*! \file
+ * \ingroup keepalive
+ * \brief Keepalive :: Send keepalives
+ */
+
+#ifndef __KEEPALIVE_API_H_
+#define __KEEPALIVE_API_H_
+
+#include "../../core/sr_module.h"
+
+typedef int ka_state;
+
+#define KA_STATE_UNKNOWN    0
+#define KA_STATE_UP         1
+#define KA_STATE_DOWN       2
+
+typedef void (*ka_statechanged_f)(str uri, int state, void *user_attr);
+typedef int  (*ka_add_dest_f)(str uri, str owner, int flags, ka_statechanged_f callback,
+                              void *user_attr);
+typedef ka_state (*ka_dest_state_f)(str uri);
+
+typedef struct keepalive_api {
+	ka_add_dest_f	  add_destination;
+	ka_dest_state_f   destination_state;
+} keepalive_api_t;
+
+typedef int (*bind_keepalive_f)(keepalive_api_t* api);
+int bind_keepalive(keepalive_api_t* api);
+
+/**
+ * @brief Load the dispatcher API
+ */
+static inline int keepalive_load_api(keepalive_api_t *api)
+{
+	bind_keepalive_f bindkeepalive;
+
+	bindkeepalive = (bind_keepalive_f)find_export("bind_keepalive", 0, 0);
+	if(bindkeepalive == 0) {
+		LM_ERR("cannot find bind_keepalive\n");
+		return -1;
+	}
+
+	if(bindkeepalive(api) < 0)
+	{
+		LM_ERR("cannot bind keepalive api\n");
+		return -1;
+	}
+	return 0;
+}
+
+#endif /* __KEEPALIVE_API_H__ */
+

--- a/src/modules/keepalive/doc/Makefile
+++ b/src/modules/keepalive/doc/Makefile
@@ -1,0 +1,4 @@
+docs = keepalive.xml
+
+docbook_dir = ../../../../doc/docbook
+include $(docbook_dir)/Makefile.module

--- a/src/modules/keepalive/doc/keepalive.xml
+++ b/src/modules/keepalive/doc/keepalive.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<book xmlns:xi="http://www.w3.org/2001/XInclude">
+    <bookinfo>
+	<title>KeepAlive Module</title>
+	<productname class="trade">kamailio.org</productname>
+	<authorgroup>
+	    <author>
+		<firstname>Guillaume</firstname>
+		<surname>Bour</surname>
+		<email>guillaume@bour.cc</email>
+	    </author>
+
+		<editor>
+		<firstname>Guillaume</firstname>
+		<surname>Bour</surname>
+		<email>guillaume@bour.cc</email>
+	    </editor>
+	</authorgroup>
+	<copyright>
+	    <year>2017</year>
+	    <holder>Guillaume Bour</holder>
+	</copyright>
+    </bookinfo>
+    <toc></toc>
+    
+    <xi:include href="keepalive_admin.xml"/>
+    
+    
+</book>

--- a/src/modules/keepalive/doc/keepalive_admin.xml
+++ b/src/modules/keepalive/doc/keepalive_admin.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+<!-- Module User's Guide -->
+
+<chapter>
+	
+	<title>&adminguide;</title>
+	
+	<section>
+		<title>Overview</title>
+		<para>
+		This module performs destinations monitoring either for itself, or on the behalf of other modules
+		</para>
+	</section>
+
+	<section>
+		<title>Dependencies</title>
+		<section>
+			<title>&kamailio; Modules</title>
+			<para>
+				The following modules must be loaded before this module:
+				<itemizedlist>
+				<listitem>
+				<para>
+					<emphasis>tm</emphasis> - Transaction module
+				</para>
+				</listitem>
+				</itemizedlist>
+			</para>
+		</section>
+		<section>
+			<title>External Libraries or Applications</title>
+			<para>
+				The following libraries or applications must be installed before running
+				&kamailio; with this module loaded:
+				<itemizedlist>
+				<listitem>
+	            <para>
+					<emphasis>none</emphasis>
+				</para>
+				</listitem>
+				</itemizedlist>
+			</para>
+		</section>
+		<section>
+			<title>Parameters</title>
+			<section>
+				<title><varname>ping_interval</varname> (integer)</title>
+				<para>
+					Interval requests are sent to destinations (in seconds)
+				</para>
+				<para>
+				<emphasis>
+					Default value is 30 seconds.
+				</emphasis>
+				</para>
+				<example>
+					<title>Set <varname>ping_interval</varname> parameter</title>
+					<programlisting format="linespecific">
+...
+modparam("keepalive", "ping_interval", 10)
+...
+					</programlisting>
+				</example>
+			</section>
+			<section>
+				<title><varname>destination</varname> (string)</title>
+				<para>
+					Allows to specify statically destinations you want to monitor
+				</para>
+				<example>
+					<title>Set <varname>destination</varname> parameter</title>
+					<programlisting format="linespecific">
+...
+modparam("keepalive", "destination", "192.168.10.20")
+modparam("keepalive", "destination", "sip.provider.com")
+...
+					</programlisting>
+				</example>
+			</section>
+		</section>
+
+		<section>
+			<title>Functions</title>
+			<section id="keepalive.is_alive">
+			    <title>
+					<function moreinfo="none">is_alive(destination)</function>
+			    </title>
+				<para>
+					Get destination status
+				</para>
+		        <para>
+					Parameter <quote>destination</quote> is destination you want to check status
+		        </para>
+        		<para>
+		            Return value: 1 if destination is up, 2 if destination is down, -1 on error.
+        		</para>
+		        <para>
+				    This function can be used from ANY_ROUTE.
+		        </para>
+				<example>
+					<title><function>is_alive()</function> usage</title>
+					<programlisting format="linespecific">
+...
+is_alive("192.168.10.20");
+...
+			        </programlisting>
+			    </example>
+			</section>
+		</section>
+	</section>
+</chapter>
+

--- a/src/modules/keepalive/keepalive.h
+++ b/src/modules/keepalive/keepalive.h
@@ -1,7 +1,6 @@
 /**
  * keepalive module - remote destinations probing
  * 
- * Copyright (C) 2004-2006 FhG Fokus
  * Copyright (C) 2017 Guillaume Bour <guillaume@bour.cc>
  *
  * This file is part of Kamailio, a free SIP server.

--- a/src/modules/keepalive/keepalive.h
+++ b/src/modules/keepalive/keepalive.h
@@ -1,0 +1,86 @@
+/**
+ * keepalive module - remote destinations probing
+ * 
+ * Copyright (C) 2004-2006 FhG Fokus
+ * Copyright (C) 2017 Guillaume Bour <guillaume@bour.cc>
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License 
+ * along with this program; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/*! \file
+ * \ingroup keepalive
+ * \brief Keepalive :: Keepalive
+ */
+
+#ifndef _KEEPALIVE_H_
+#define _KEEPALIVE_H_
+
+#include <time.h>
+#include "../../core/sr_module.h"
+
+
+#define KA_INACTIVE_DST		1  /*!< inactive destination */
+#define KA_TRYING_DST		2  /*!< temporary trying destination */
+#define KA_DISABLED_DST		4  /*!< admin disabled destination */
+#define KA_PROBING_DST		8  /*!< checking destination */
+#define KA_STATES_ALL		15  /*!< all bits for the states of destination */
+
+#define ds_skip_dst(flags)	((flags) & (KA_INACTIVE_DST|KA_DISABLED_DST))
+
+#define KA_PROBE_NONE			0
+#define KA_PROBE_ALL			1
+#define KA_PROBE_INACTIVE		2
+#define KA_PROBE_ONLYFLAGGED	3
+
+typedef void (*ka_statechanged_f)(str uri, int state, void *user_attr);
+
+typedef struct _ka_dest
+{
+	str uri;
+	str owner;                  // name of destination "owner"
+                                // (module asking to monitor this destination
+	int flags;
+	int state;
+	time_t last_checked,
+		   last_up,
+		   last_down;
+	//ds_attrs_t attrs;
+
+	void *user_attr;
+	ka_statechanged_f statechanged_clb;
+
+	struct socket_info * sock;
+	struct ip_addr ip_address; 	/*!< IP-Address of the entry */
+	unsigned short int port; 	/*!< Port of the URI */
+	unsigned short int proto; 	/*!< Protocol of the URI */
+	//int message_count;
+	struct _ka_dest *next;
+} ka_dest_t;
+
+typedef struct _ka_destinations_list
+{
+	ka_dest_t *first;
+} ka_destinations_list_t;
+
+extern ka_destinations_list_t *ka_destinations_list;
+
+int ka_add_dest(str uri, str owner, int flags, ka_statechanged_f callback, void *user_attr);
+int ka_destination_state(str uri);
+int ka_str_copy(str src, str *dest, char *prefix);
+
+#endif
+

--- a/src/modules/keepalive/keepalive_api.c
+++ b/src/modules/keepalive/keepalive_api.c
@@ -1,10 +1,7 @@
 /**
  * keepalive module - remote destinations probing
  *
- * Copyright (C) 2004-2005 FhG Fokus
- * Copyright (C) 2006 Voice Sistem SRL
- * Copyright (C) 2015 Daniel-Constantin Mierla (asipto.com)
- * Copyright (C) 2016 Guillaume Bour <guillaume@bour.cc>
+ * Copyright (C) 2017 Guillaume Bour <guillaume@bour.cc>
  *
  * This file is part of Kamailio, a free SIP server.
  *

--- a/src/modules/keepalive/keepalive_api.c
+++ b/src/modules/keepalive/keepalive_api.c
@@ -1,0 +1,138 @@
+/**
+ * keepalive module - remote destinations probing
+ *
+ * Copyright (C) 2004-2005 FhG Fokus
+ * Copyright (C) 2006 Voice Sistem SRL
+ * Copyright (C) 2015 Daniel-Constantin Mierla (asipto.com)
+ * Copyright (C) 2016 Guillaume Bour <guillaume@bour.cc>
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/*! \file
+ * \ingroup keepalive
+ * \brief Keepalive :: Send keepalives
+ */
+
+/*! \defgroup keepalive Keepalive :: Probing remote gateways by sending keepalives
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../tm/tm_load.h"
+
+#include "keepalive.h"
+#include "api.h"
+
+
+/*
+ * Regroup all exported functions in keepalive_api_t structure
+ *
+ */
+int bind_keepalive(keepalive_api_t* api)
+{
+	if (!api) {
+		ERR("Invalid parameter value\n");
+		return -1;
+	}
+
+	api->add_destination = ka_add_dest;
+	api->destination_state = ka_destination_state;
+	return 0;
+}
+
+/*
+ * Add a new destination in keepalive pool
+ */
+int ka_add_dest(str uri, str owner, int flags, ka_statechanged_f callback, void *user_attr) {
+	LM_INFO("adding destination: %.*s\n", uri.len, uri.s);
+
+	ka_dest_t *dest = (ka_dest_t *) shm_malloc(sizeof(ka_dest_t));
+	if(dest == NULL) {
+		LM_ERR("no more memory.\n");
+		goto err;
+	}
+	memset(dest, 0, sizeof(ka_dest_t));
+
+	if (uri.len >= 4 && (!strncasecmp("sip:", uri.s, 4) || !strncasecmp("sips:", uri.s, 5))) {
+		// protocol found
+		if (ka_str_copy(uri  , &(dest->uri), NULL) < 0)
+			goto err;
+	} else {
+		if (ka_str_copy(uri  , &(dest->uri), "sip:") < 0)
+			goto err;
+	}
+
+	// checking uri is valid
+	struct sip_uri _uri;
+	if (parse_uri(dest->uri.s, dest->uri.len, &_uri) != 0) {
+		LM_ERR("invalid uri <%.*s>\n", dest->uri.len, dest->uri.s);
+		goto err;
+	}
+
+	if (ka_str_copy(owner, &(dest->owner), NULL) < 0)
+		goto err;
+
+	dest->flags                 = flags;
+	dest->statechanged_clb      = callback;
+	dest->user_attr             = user_attr;
+
+	dest->next                  = ka_destinations_list->first;
+	ka_destinations_list->first = dest;
+
+	return 0;
+
+err:
+	if (dest) {
+		if (dest->uri.s)
+			shm_free(dest->uri.s);
+
+		shm_free(dest);
+	}
+	return -1;
+}
+
+/*
+ * TODO
+ */
+int ka_rm_dest() {
+	return -1;
+}
+
+/*
+ *
+ */
+ka_state ka_destination_state(str destination) {
+	ka_dest_t *ka_dest = NULL;
+
+	for(ka_dest = ka_destinations_list->first; ka_dest != NULL; ka_dest = ka_dest->next) {
+		if (strncmp(ka_dest->uri.s+4, destination.s, ka_dest->uri.len-4) == 0) {
+			break;
+		}
+	}
+
+	if (ka_dest == NULL) {
+		return(-1);
+	}
+
+	return ka_dest->state;
+}
+

--- a/src/modules/keepalive/keepalive_core.c
+++ b/src/modules/keepalive/keepalive_core.c
@@ -1,10 +1,7 @@
 /**
  * keepalive module - remote destinations probing
  *
- * Copyright (C) 2004-2005 FhG Fokus
- * Copyright (C) 2006 Voice Sistem SRL
- * Copyright (C) 2015 Daniel-Constantin Mierla (asipto.com)
- * Copyright (C) 2016 Guillaume Bour <guillaume@bour.cc>
+ * Copyright (C) 2017 Guillaume Bour <guillaume@bour.cc>
  *
  * This file is part of Kamailio, a free SIP server.
  *

--- a/src/modules/keepalive/keepalive_core.c
+++ b/src/modules/keepalive/keepalive_core.c
@@ -1,0 +1,203 @@
+/**
+ * keepalive module - remote destinations probing
+ *
+ * Copyright (C) 2004-2005 FhG Fokus
+ * Copyright (C) 2006 Voice Sistem SRL
+ * Copyright (C) 2015 Daniel-Constantin Mierla (asipto.com)
+ * Copyright (C) 2016 Guillaume Bour <guillaume@bour.cc>
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/*! \file
+ * \ingroup keepalive
+ * \brief Keepalive :: Send keepalives
+ */
+
+/*! \defgroup keepalive Keepalive :: Probing remote gateways by sending keepalives
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../../core/fmsg.h"
+#include "../tm/tm_load.h"
+
+#include "keepalive.h"
+#include "api.h"
+
+struct tm_binds tmb;
+
+static void ka_run_route(sip_msg_t *msg, str *uri, char *route);
+static void ka_options_callback( struct cell *t, int type, struct tmcb_params *ps );
+
+
+/*! \brief
+ * Timer for checking probing destinations
+ *
+ * This timer is regularly fired.
+ */
+void ka_check_timer(unsigned int ticks, void* param)
+{
+	ka_dest_t *ka_dest;
+	str ka_ping_method = str_init("OPTIONS");
+	str ka_ping_from   = str_init("sip:dispatcher@localhost");
+	str ka_outbound_proxy = {0, 0};
+	uac_req_t uac_r;
+
+	LM_DBG("ka check timer\n");
+
+	for(ka_dest = ka_destinations_list->first; ka_dest != NULL; ka_dest = ka_dest->next) {
+		LM_DBG("ka_check_timer dest:%.*s\n", ka_dest->uri.len, ka_dest->uri.s);
+
+		/* Send ping using TM-Module.
+		 * int request(str* m, str* ruri, str* to, str* from, str* h,
+		 *		str* b, str *oburi,
+		 *		transaction_cb cb, void* cbp); */
+		set_uac_req(&uac_r, &ka_ping_method, 0, 0, 0,
+				TMCB_LOCAL_COMPLETED, ka_options_callback,
+				(void *) ka_dest);
+
+		if (tmb.t_request(&uac_r,
+					&ka_dest->uri,
+					&ka_dest->uri,
+					&ka_ping_from,
+					&ka_outbound_proxy) < 0) {
+			LM_ERR("unable to ping [%.*s]\n", ka_dest->uri.len, ka_dest->uri.s);
+		}
+
+		ka_dest->last_checked = time(NULL);
+	}
+
+	return;
+}
+
+/*! \brief
+ * Callback-Function for the OPTIONS-Request
+ * This Function is called, as soon as the Transaction is finished
+ * (e. g. a Response came in, the timeout was hit, ...)
+ */
+static void ka_options_callback( struct cell *t, int type,
+		struct tmcb_params *ps )
+{
+	str uri = {0, 0};
+	sip_msg_t *msg = NULL;
+	ka_state state;
+
+	char *state_routes[] = {"", "keepalive:dst-up", "keepalive:dst-down"};
+
+	//NOTE: how to be sure destination is still allocated ?
+	ka_dest_t *ka_dest = (ka_dest_t *) (*ps->param);
+
+	uri.s   = t->to.s + 5;
+	uri.len = t->to.len - 8;
+	LM_DBG("OPTIONS-Request was finished with code %d (to %.*s)\n",
+			ps->code, ka_dest->uri.len, ka_dest->uri.s); //uri.len, uri.s);
+
+
+	// accepting 2XX return codes
+	if (ps->code >= 200 && ps->code <= 299) {
+		state              = KA_STATE_UP;
+		ka_dest->last_down = time(NULL);
+	} else {
+		state              = KA_STATE_DOWN;
+		ka_dest->last_up   = time(NULL);
+	}
+
+	LM_DBG("new state is: %d\n", state);
+	if (state != ka_dest->state) {
+		ka_run_route(msg, &uri, state_routes[state]);
+
+		if(ka_dest->statechanged_clb != NULL) {
+			ka_dest->statechanged_clb(ka_dest->uri, state, ka_dest->user_attr);
+		}
+
+		ka_dest->state = state;
+	}
+}
+
+/*
+ * Execute kamailio script event routes
+ *
+ */
+static void ka_run_route(sip_msg_t *msg, str *uri, char *route)
+{
+	int rt, backup_rt;
+	struct run_act_ctx ctx;
+	sip_msg_t *fmsg;
+
+	if (route == NULL)
+	{
+		LM_ERR("bad route\n");
+		return;
+	}
+
+	LM_DBG("ka_run_route event_route[%s]\n", route);
+
+	rt = route_get(&event_rt, route);
+	if (rt < 0 || event_rt.rlist[rt] == NULL)
+	{
+		LM_DBG("route *%s* does not exist", route);
+		return;
+	}
+
+	fmsg = msg;
+	if (fmsg == NULL)
+	{
+		if (faked_msg_init() < 0)
+		{
+			LM_ERR("faked_msg_init() failed\n");
+			return;
+		}
+		fmsg = faked_msg_next();
+		fmsg->parsed_orig_ruri_ok = 0;
+		fmsg->new_uri = *uri;
+	}
+
+	backup_rt = get_route_type();
+	set_route_type(REQUEST_ROUTE);
+	init_run_actions_ctx(&ctx);
+	run_top_route(event_rt.rlist[rt], fmsg, 0);
+	set_route_type(backup_rt);
+}
+
+
+/*
+ * copy str into dynamically allocated shm memory
+ */
+int ka_str_copy(str src, str *dest, char *prefix) {
+	int lp = prefix?strlen(prefix):0;
+
+	dest->s = (char *) shm_malloc((src.len + 1 + lp) * sizeof(char));
+	if(dest->s == NULL)
+	{
+		LM_ERR("no more memory!\n");
+		return -1;
+	}
+
+	if(prefix)
+		strncpy(dest->s, prefix, lp);
+	strncpy(dest->s+lp, src.s, src.len);
+	dest->s[src.len+lp] = '\0';
+	dest->len           = src.len+lp;
+
+	return 0;
+}
+

--- a/src/modules/keepalive/keepalive_mod.c
+++ b/src/modules/keepalive/keepalive_mod.c
@@ -1,10 +1,7 @@
 /**
  * keepalive module - remote destinations probing
  *
- * Copyright (C) 2004-2005 FhG Fokus
- * Copyright (C) 2006 Voice Sistem SRL
- * Copyright (C) 2015 Daniel-Constantin Mierla (asipto.com)
- * Copyright (C) 2016 Guillaume Bour <guillaume@bour.cc>
+ * Copyright (C) 2017 Guillaume Bour <guillaume@bour.cc>
  *
  * This file is part of Kamailio, a free SIP server.
  *

--- a/src/modules/keepalive/keepalive_mod.c
+++ b/src/modules/keepalive/keepalive_mod.c
@@ -1,0 +1,193 @@
+/**
+ * keepalive module - remote destinations probing
+ *
+ * Copyright (C) 2004-2005 FhG Fokus
+ * Copyright (C) 2006 Voice Sistem SRL
+ * Copyright (C) 2015 Daniel-Constantin Mierla (asipto.com)
+ * Copyright (C) 2016 Guillaume Bour <guillaume@bour.cc>
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/*! \file
+ * \ingroup keepalive
+ * \brief Keepalive :: Send keepalives
+ */
+
+/*! \defgroup keepalive Keepalive :: Probing remote gateways by sending keepalives
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../tm/tm_load.h"
+#include "../dispatcher/api.h"
+
+#include "keepalive.h"
+#include "api.h"
+
+MODULE_VERSION
+
+
+static int  mod_init(void);
+static void mod_destroy(void);
+static int  ka_mod_add_destination(modparam_t type, void *val);
+int  ka_init_rpc(void);
+int         ka_alloc_destinations_list();
+extern void ka_check_timer(unsigned int ticks, void* param);
+
+static int cmd_is_alive(struct sip_msg* msg, char *str1, char *str2);
+
+extern struct tm_binds tmb;
+
+int ka_ping_interval = 30;
+ka_destinations_list_t *ka_destinations_list = NULL;
+
+
+static cmd_export_t cmds[]={
+	{"is_alive",       (cmd_function)cmd_is_alive, 1, 0, 0,
+		REQUEST_ROUTE|FAILURE_ROUTE|ONREPLY_ROUTE},
+	// internal API
+	{"bind_keepalive", (cmd_function)bind_keepalive, 0, 0, 0, 0},
+	{0,0,0,0,0,0}
+};
+
+
+static param_export_t params[]={
+	{"ping_interval", PARAM_INT                  , &ka_ping_interval},
+	{"destination"  , PARAM_STRING|USE_FUNC_PARAM, (void *)ka_mod_add_destination},
+	{0,0,0}
+};
+
+
+/** module exports */
+struct module_exports exports= {
+	"keepalive",
+	DEFAULT_DLFLAGS, /* dlopen flags */
+	cmds,
+	params,
+	0,          /* exported statistics */
+	0,          /* exported MI functions - no available anymore since 5.0 */
+	0,          /* exported pseudo-variables */
+	0,          /* extra processes */
+	mod_init,   /* module initialization function */
+	0,
+	(destroy_function) mod_destroy,
+	0           /* per-child init function */
+};
+
+
+/**
+ * Module initialization
+ */
+static int mod_init(void)
+{
+	LM_INFO("Initializing keepalive module\n");
+
+	if (load_tm_api( &tmb ) == -1)
+	{
+		LM_ERR("could not load the TM-functions - please load tm module\n");
+		return -1;
+	}
+
+	if(ka_init_rpc() < 0) {
+		LM_ERR("failed to register RPC commands\n");
+		return -1;
+	}
+
+	if (ka_alloc_destinations_list() < 0)
+		return -1;
+
+	if(register_timer(ka_check_timer, NULL, ka_ping_interval) < 0) {
+		LM_ERR("failed registering timer\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+/*! \brief
+ * destroy function
+ */
+static void mod_destroy(void)
+{
+}
+
+
+/*! \brief
+ * parses string to dispatcher dst flags set
+ * returns <0 on failure or int with flag on success.
+ */
+int ka_parse_flags( char* flag_str, int flag_len )
+{
+	return 0;
+}
+
+
+/*
+ * Function callback executer per module param "destination".
+ * Is just a wrapper to ka_add_dest() api function
+ */
+static int ka_mod_add_destination(modparam_t type, void *val) 
+{
+	if (ka_alloc_destinations_list() < 0)
+		return -1;
+
+	str dest = {val, strlen(val)};
+	str owner = str_init("_params");
+	LM_DBG("adding destination %.*s\n", dest.len, dest.s);
+
+	return ka_add_dest(dest, owner, 0, 0, 0);
+}
+
+/*
+ * Allocate global variable *ka_destination_list* if not already done
+ * WHY:  when specifying static destinations as module param, ka_mod_add_destination() is 
+ *       executed BEFORE mod_init()
+ */
+int ka_alloc_destinations_list()
+{
+	if (ka_destinations_list != NULL) {
+		LM_DBG("ka_destinations_list already allocated\n");
+		return 1;
+	}
+
+	ka_destinations_list = (ka_destinations_list_t *) shm_malloc(sizeof(ka_destinations_list_t));
+	if(ka_destinations_list == NULL) {
+		LM_ERR("no more memory.\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+
+static int cmd_is_alive(struct sip_msg* msg, char *str1, char *str2)
+{
+	str dest = {str1, strlen(str1)};
+
+	ka_state state = ka_destination_state(dest);
+	// must not return 0, as it stops dialplan execution
+	if (state == KA_STATE_UNKNOWN) {
+		return KA_STATE_UP;
+	}
+
+	return state;
+}

--- a/src/modules/keepalive/keepalive_rpc.c
+++ b/src/modules/keepalive/keepalive_rpc.c
@@ -1,0 +1,101 @@
+/**
+ * keepalive module - remote destinations probing
+ *
+ * Copyright (C) 2016 Guillaume Bour <guillaume@bour.cc>
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/*! \file
+ * \ingroup keepalive
+ * \brief Keepalive :: Send keepalives
+ */
+
+/*! \defgroup keepalive Keepalive :: Probing remote gateways by sending keepalives
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "../../core/rpc.h"
+#include "../../core/rpc_lookup.h"
+
+#include "keepalive.h"
+#include "api.h"
+
+static const char *keepalive_rpc_list_doc[2];
+static void keepalive_rpc_list(rpc_t *rpc, void *ctx);
+
+rpc_export_t keepalive_rpc_cmds[] = {
+	{"keepalive.list", keepalive_rpc_list, keepalive_rpc_list_doc, 0},
+	{0, 0, 0, 0}
+};
+
+int ka_init_rpc(void) {
+	if (rpc_register_array(keepalive_rpc_cmds) != 0) {
+		LM_ERR("failed to register RPC commands\n");
+	}
+
+	return 0;
+}
+
+static const char *keepalive_rpc_list_doc[2] = {
+		"Return the content of dispatcher sets", 0};
+
+static void keepalive_rpc_list(rpc_t *rpc, void *ctx) {
+	str text = str_init("foobar");
+	if (rpc->add(ctx, "Sd", &text, 42) < 0) 
+		LM_ERR("%s: error creating RPC struct\n", __FUNCTION__);
+	if (rpc->add(ctx, "Sd", &text, 42) < 0) 
+		LM_ERR("%s: error creating RPC struct\n", __FUNCTION__);
+
+	void *foo;
+	rpc->add(ctx, "{", &foo);
+	rpc->struct_add(foo, "Sd", "text", &text, "number", 42);
+
+	void *bar, *baz;
+	rpc->add(ctx, "{", &bar);
+	rpc->struct_add(bar, "[", "list", &baz);
+	rpc->struct_add(baz, "d", "nn", 17);
+	rpc->struct_add(baz, "d", "nn", 22);
+	
+
+	for(ka_dest_t *dest = ka_destinations_list->first; dest != NULL; dest = dest->next) {
+		void *sub;
+		rpc->add(ctx, "{", &sub);
+
+		rpc->struct_add(sub, "SS", 
+			"uri"  , &dest->uri,
+			"owner", &dest->owner);
+
+		char *_ctime = ctime(&dest->last_checked);
+		_ctime[strlen(_ctime) - 1] = '\0';
+		rpc->struct_add(sub, "s", "last checked", _ctime);
+		char *_utime = ctime(&dest->last_up);
+		_utime[strlen(_utime) - 1] = '\0';
+		rpc->struct_add(sub, "s", "last up", _utime);
+		char *_dtime = ctime(&dest->last_down);
+		_dtime[strlen(_dtime) - 1] = '\0';
+		rpc->struct_add(sub, "s", "last down", _dtime);
+	}
+
+	return;
+}

--- a/src/modules/keepalive/keepalive_rpc.c
+++ b/src/modules/keepalive/keepalive_rpc.c
@@ -1,7 +1,7 @@
 /**
  * keepalive module - remote destinations probing
  *
- * Copyright (C) 2016 Guillaume Bour <guillaume@bour.cc>
+ * Copyright (C) 2017 Guillaume Bour <guillaume@bour.cc>
  *
  * This file is part of Kamailio, a free SIP server.
  *


### PR DESCRIPTION
Hi all,   

Here is a prototype of Keepalive module I discussed on the mailing-list.
It can work standalone:
- destinations are set statically as module parameters
- *is_alive()* function allows to check destination state

It can also be used alongside with drouting module (currently only with sort_order 0)
- all destinations defined in drouting module are automatically monitored when drouting *enable_keepalive* option is set to 1
- unavailable destinations are ignored when calling do_routing() function

All comments are welcome

Thanks,
Guillaume