### PR TITLE
dmq: remove worker lock

### DIFF
--- a/src/modules/dmq/worker.c
+++ b/src/modules/dmq/worker.c
@@ -79,12 +79,8 @@ void worker_loop(int id)
 
 	worker = &workers[id];
 	for(;;) {
-		LM_DBG("dmq_worker [%d %d] getting lock\n", id, my_pid());
-		lock_get(&worker->lock);
-		LM_DBG("dmq_worker [%d %d] lock acquired\n", id, my_pid());
-		/* multiple lock_release calls might be performed, so remove
-		 * from queue until empty */
-		do {
+		sleep_us(100);
+		while(job_queue_size(worker->queue) > 0) {
 			/* fill the response with 0's */
 			memset(&peer_response, 0, sizeof(peer_response));
 			current_job = job_queue_pop(worker->queue);
@@ -136,7 +132,7 @@ void worker_loop(int id)
 				shm_free(current_job);
 				worker->jobs_processed++;
 			}
-		} while(job_queue_size(worker->queue) > 0);
+		}
 	}
 }
 
@@ -198,7 +194,6 @@ int add_dmq_job(struct sip_msg* msg, dmq_peer_t* peer)
 	if (job_queue_push(worker->queue, &new_job)<0) {
 		goto error;
 	}
-	lock_release(&worker->lock);
 	return 0;
 error:
 	if (cloned_msg!=NULL) {
@@ -213,9 +208,6 @@ error:
 void init_worker(dmq_worker_t* worker)
 {
 	memset(worker, 0, sizeof(*worker));
-	lock_init(&worker->lock);
-	// acquire the lock for the first time - so that dmq_worker_loop blocks
-	lock_get(&worker->lock);
 	worker->queue = alloc_job_queue();
 }
 


### PR DESCRIPTION
- fixes a high cpu condition waiting for lock yield on FreeBSD
  reported by GH #822