### PR TITLE
drouting: use keepalive to monitor GW/destinations (sort_order 0 only)

### DIFF
--- a/src/modules/drouting/README
+++ b/src/modules/drouting/README
@@ -51,6 +51,7 @@ Anca-Maria Vamanu
               3.12. drg_grpid_col (str)
               3.13. fetch_rows (int)
               3.14. force_dns (int)
+              3.15. enable_keepalive (int)
 
         4. Functions
 
@@ -92,11 +93,12 @@ Anca-Maria Vamanu
    1.12. Set drg_grpid_col parameter
    1.13. Set fetch_rows parameter
    1.14. Set force_dns parameter
-   1.15. do_routing usage
-   1.16. use_next_gw usage
-   1.17. goes_to_gw usage
-   1.18. is_from_gw usage
+   1.15. Set enable_keepalive parameter
+   1.16. do_routing usage
+   1.17. use_next_gw usage
+   1.18. goes_to_gw usage
    1.19. is_from_gw usage
+   1.20. is_from_gw usage
 
 Chapter 1. Admin Guide
 
@@ -136,6 +138,7 @@ Chapter 1. Admin Guide
         3.12. drg_grpid_col (str)
         3.13. fetch_rows (int)
         3.14. force_dns (int)
+        3.15. enable_keepalive (int)
 
    4. Functions
 
@@ -500,6 +503,7 @@ Chapter 1. Admin Guide
    3.12. drg_grpid_col (str)
    3.13. fetch_rows (int)
    3.14. force_dns (int)
+   3.15. enable_keepalive (int)
 
 3.1. db_url(str)
 
@@ -690,6 +694,22 @@ modparam("drouting", "fetch_rows", 1500)
 modparam("drouting", "force_dns", 0)
 ...
 
+3.15. enable_keepalive (int)
+
+   Enable monitoring of GW/destinations using keepalive module.
+   Destinations found unavailable will not be used on do_routing() call.
+
+   NOTE: this option is only compatible with <em>sort_order</em> 0
+   currently. With sort_order value of 1 or 2, destinations status will
+   simply be ignored.
+
+   Default value is “0 (disabled)”.
+
+   Example 1.15. Set enable_keepalive parameter
+...
+modparam("drouting", "enable_keepalive", 1)
+...
+
 4. Functions
 
    4.1. do_routing("[groupID]")
@@ -710,7 +730,7 @@ modparam("drouting", "force_dns", 0)
    specification. If none specified, the function will automatically try
    to query the dr_group table to get this information.
 
-   Example 1.15. do_routing usage
+   Example 1.16. do_routing usage
 ...
 do_routing();
 ...
@@ -733,7 +753,7 @@ do_routing("$avp(i:10)");
    is no other alternative destinations are found or in case of internal
    processing error.
 
-   Example 1.16. use_next_gw usage
+   Example 1.17. use_next_gw usage
 ...
 if (use_next_gw()) {
         t_relay();
@@ -754,7 +774,7 @@ if (use_next_gw()) {
    The function can take one optional parameter:
      * type (optional) - GW/destination type to be checked
 
-   Example 1.17. goes_to_gw usage
+   Example 1.18. goes_to_gw usage
 ...
 if (goes_to_gw("1")) {
         sl_send_reply("403","Forbidden");
@@ -775,7 +795,7 @@ if (goes_to_gw("1")) {
      * flags - if message is a request and the GW has a STRIP defined,
        then apply it if GW is source.
 
-   Example 1.18. is_from_gw usage
+   Example 1.19. is_from_gw usage
 ...
 if (is_from_gw("1") {
 }
@@ -793,7 +813,7 @@ if (is_from_gw("1") {
      * flags (optional) - if message is a request and the GW has a STRIP
        defined, then apply it if GW is source.
 
-   Example 1.19. is_from_gw usage
+   Example 1.20. is_from_gw usage
 ...
 if (is_from_gw("3","1") {
 }

--- a/src/modules/drouting/doc/drouting_admin.xml
+++ b/src/modules/drouting/doc/drouting_admin.xml
@@ -1142,6 +1142,30 @@ modparam("drouting", "force_dns", 0)
 		</example>
 	</section>
 
+	<section>
+		<title><varname>enable_keepalive</varname> (int)</title>
+		<para>
+		Enable monitoring of GW/destinations using keepalive module.
+		Destinations found unavailable will not be used on do_routing() call.
+		</para>
+		<para>
+		NOTE: this option is only compatible with <em>sort_order</em> 0 currently.
+		With sort_order value of 1 or 2, destinations status will simply be ignored.
+		</para>
+		<para>
+		<emphasis>Default value is <quote>0 (disabled)</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>enable_keepalive</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("drouting", "enable_keepalive", 1)
+...
+	</programlisting>
+		</example>
+	</section>
+
 </section>
 
 <section>

--- a/src/modules/drouting/dr_load.c
+++ b/src/modules/drouting/dr_load.c
@@ -38,6 +38,8 @@
 //#include "../../core/db/db.h"
 #include "../../core/mem/shm_mem.h"
 
+#include "../keepalive/api.h"
+
 #include "dr_load.h"
 #include "routing.h"
 #include "prefix_tree.h"
@@ -129,6 +131,7 @@ static struct dr_gwl_tmp* dr_gw_lists = NULL;
 	} while(0)
 
 extern int dr_fetch_rows;
+extern keepalive_api_t keepalive_api;
 
 
 static int add_tmp_gw_list(unsigned int id, char *list)

--- a/src/modules/drouting/prefix_tree.h
+++ b/src/modules/drouting/prefix_tree.h
@@ -32,6 +32,7 @@
 
 #include "../../core/str.h"
 #include "../../core/ip_addr.h"
+#include "../keepalive/api.h"
 #include "dr_time.h"
 
 #define PTREE_CHILDREN 13  //decimal digits, '*', '#',  '+'
@@ -67,6 +68,9 @@ typedef struct pgw_ {
 	str ip;
 	int type;
 	str attrs;
+	// gateway state (see keepalive module)
+	ka_state state;
+
 	struct pgw_ *next;
 }pgw_t;
 

--- a/src/modules/drouting/routing.c
+++ b/src/modules/drouting/routing.c
@@ -324,6 +324,8 @@ add_dst(
 	pgw->id = id;
 	pgw->strip = strip;
 	pgw->type = type;
+	// by default, the destination is considered up
+	pgw->state = KA_STATE_UP;
 
 	/* add address in the list */
 	if(pgw->ip.len<5 || (strncasecmp("sip:", ip, 4)


### PR DESCRIPTION
If keepalive is enabled and sort_order is 0, unavailable destinations are
excluded from do_routing() resultset.