### PR TITLE
modules/{acc,cdp}: allows big endian build

### DIFF
--- a/src/modules/acc/diam_message.h
+++ b/src/modules/acc/diam_message.h
@@ -74,7 +74,6 @@
 	#define ST_MSG_CODE      0x13010000
 	#define MASK_MSG_CODE    0xffffff00
 #else
-	#error BIG endian detected!!
 	#define AS_MSG_CODE      0x00000112
 	#define AC_MSG_CODE      0x0000010f
 	#define CE_MSG_CODE      0x00000101

--- a/src/modules/cdp/diameter.h
+++ b/src/modules/cdp/diameter.h
@@ -115,7 +115,6 @@
 	#define ST_MSG_CODE      0x13010000
 	#define MASK_MSG_CODE    0xffffff00
 #else
-	#error BIG endian detected!!
 	#define AS_MSG_CODE      0x00000112
 	#define AC_MSG_CODE      0x0000010f
 	#define CE_MSG_CODE      0x00000101


### PR DESCRIPTION
In modules/cdp/diameter.h and modules/acc/diam_message.h, this directive still exists : 


```#error BIG endian detected!!```

Meanwhile in modules/auth_diameter/diameter_msg.h, for example, this directive was removed in 5.0 release. Is there any reason to leave this directive present in these 2 headers?

The build system is Alpine Linux s390x which is big endian.
