### PR TITLE
Fix memory leak in ldap module.

### DIFF
--- a/src/modules/ldap/ldap_api_fn.c
+++ b/src/modules/ldap/ldap_api_fn.c
@@ -39,6 +39,7 @@
 #include "ld_session.h"
 
 static LDAP* last_ldap_handle = NULL;
+static LDAPMessage* last_ldap_result_holder = NULL;
 static LDAPMessage* last_ldap_result = NULL;
 
 int get_connected_ldap_session(
@@ -111,9 +112,10 @@ int get_connected_ldap_session(char* _lds_name, struct ld_session** _lds)
 		}
 		else
 		{
-			if (last_ldap_result != NULL)
+			if (last_ldap_result_holder != NULL)
 			{
-				ldap_msgfree(last_ldap_result);
+				ldap_msgfree(last_ldap_result_holder);
+				last_ldap_result_holder = NULL;
 				last_ldap_result = NULL;
 			}
 			ldap_disconnect(_lds_name);
@@ -412,9 +414,10 @@ int lds_search(
 	/*
 	 * free last_ldap_result
 	 */
-        if (last_ldap_result != NULL) {
-                ldap_msgfree(last_ldap_result);
-                last_ldap_result = NULL;
+        if (last_ldap_result_holder != NULL) {
+                ldap_msgfree(last_ldap_result_holder);
+                last_ldap_result_holder = NULL;
+		last_ldap_result = NULL;
         }
 
 	
@@ -445,7 +448,7 @@ int lds_search(
 		NULL,
 		&lds->client_search_timeout,
 		0,
-		&last_ldap_result);
+		&last_ldap_result_holder);
 
 #ifdef LDAP_PERF
 	gettimeofday(&after_search, NULL);
@@ -458,10 +461,10 @@ int lds_search(
 
 	if (*_ld_error != LDAP_SUCCESS)
 	{
-		if (last_ldap_result != NULL)
+		if (last_ldap_result_holder != NULL)
 		{
-			ldap_msgfree(last_ldap_result);
-			last_ldap_result = NULL;
+			ldap_msgfree(last_ldap_result_holder);
+			last_ldap_result_holder = NULL;
 		}
 
 		if (LDAP_API_ERROR(*_ld_error))
@@ -476,12 +479,14 @@ int lds_search(
 	}
 
 	last_ldap_handle = lds->handle;
-	*_ld_result_count = ldap_count_entries(lds->handle, last_ldap_result);
+	*_ld_result_count = ldap_count_entries(lds->handle, last_ldap_result_holder);
 	if (*_ld_result_count < 0)
 	{
 		LM_DBG("[%s]: ldap_count_entries failed\n", _lds_name);
 		return -1;
 	}
+
+	last_ldap_result = last_ldap_result_holder;
 
 	return 0;
 }


### PR DESCRIPTION
There was a memory leak in the ldap module that occurred only after calling ldap_result_next().
Has run my synthetic tests and tested that it works fine.