### PR TITLE
db_text: change field separator from ":" to "|"

### DIFF
--- a/src/modules/db_text/db_text.c
+++ b/src/modules/db_text/db_text.c
@@ -47,6 +47,8 @@ int db_mode = 0;  /* Database usage mode: 0 = cache, 1 = no cache */
 int empty_string = 0;  /* Treat empty string as "" = 0, 1 = NULL */
 int _db_text_read_buffer_size = DEFAULT_DB_TEXT_READ_BUFFER_SIZE;
 int _db_text_max_result_rows = DEFAULT_MAX_RESULT_ROWS;
+int _dbt_delim = ':'; /* ':' is the default delim */
+str _dbt_delim_str = str_init(":"); /* ':' is the default delim */
 str dbt_default_connection = str_init("");
 
 int dbt_bind_api(db_func_t *dbb);
@@ -69,6 +71,7 @@ static param_export_t params[] = {
 	{"file_buffer_size", INT_PARAM, &_db_text_read_buffer_size},
 	{"max_result_rows", INT_PARAM, &_db_text_max_result_rows},
 	{"default_connection", PARAM_STR, &dbt_default_connection},
+	{"db_delim", PARAM_STR, &_dbt_delim_str},
 	{0, 0, 0}
 };
 
@@ -103,6 +106,14 @@ int mod_register(char *path, int *dlflags, void *p1, void *p2)
 
 static int mod_init(void)
 {
+	if (_dbt_delim_str.len != 1) {
+		LM_ERR("db_delim must be a character, defaulting to \":\"\n");
+		pkg_free(_dbt_delim_str.s);
+		_dbt_delim_str.s = ":";
+		_dbt_delim_str.len = 1;
+	}
+	_dbt_delim = _dbt_delim_str.s[0];
+
 	if(dbt_init_cache())
 		return -1;
 	/* return make_demo(); */

--- a/src/modules/db_text/dbt_file.c
+++ b/src/modules/db_text/dbt_file.c
@@ -317,7 +317,7 @@ dbt_table_p dbt_load_file(const str *tbn, const str *dbn)
 						dtval.val.int_val = 0;
 						dtval.type = dtp->colv[ccol]->type;
 
-						if(c==DBT_DELIM ||
+						if(c==_dbt_delim ||
 								(ccol==dtp->nrcols-1
 									&& (c==DBT_DELIM_R || c==EOF)))
 							dtval.nul = 1;
@@ -341,7 +341,7 @@ dbt_table_p dbt_load_file(const str *tbn, const str *dbn)
 							//LM_DBG("data[%d,%d]=%d\n", crow,
 							//	ccol, dtval.val.int_val);
 						}
-						if(c!=DBT_DELIM && c!=DBT_DELIM_R && c!=EOF)
+						if(c!=_dbt_delim && c!=DBT_DELIM_R && c!=EOF)
 							goto clean;
 						if(dbt_row_set_val(rowp,&dtval,dtp->colv[ccol]->type,
 									ccol))
@@ -356,7 +356,7 @@ dbt_table_p dbt_load_file(const str *tbn, const str *dbn)
 						dtval.val.double_val = 0.0;
 						dtval.type = DB1_DOUBLE;
 
-						if(c==DBT_DELIM ||
+						if(c==_dbt_delim ||
 								(ccol==dtp->nrcols-1
 									&& (c==DBT_DELIM_R || c==EOF)))
 							dtval.nul = 1;
@@ -392,7 +392,7 @@ dbt_table_p dbt_load_file(const str *tbn, const str *dbn)
 							//LM_DBG("data[%d,%d]=%10.2f\n",
 							//	crow, ccol, dtval.val.double_val);
 						}
-						if(c!=DBT_DELIM && c!=DBT_DELIM_R && c!=EOF)
+						if(c!=_dbt_delim && c!=DBT_DELIM_R && c!=EOF)
 							goto clean;
 						if(dbt_row_set_val(rowp,&dtval,DB1_DOUBLE,ccol))
 							goto clean;
@@ -408,7 +408,7 @@ dbt_table_p dbt_load_file(const str *tbn, const str *dbn)
 						dtval.type = dtp->colv[ccol]->type;
 
 						bp = 0;
-						if(c==DBT_DELIM ||
+						if(c==_dbt_delim ||
 							(ccol == dtp->nrcols-1
 								&& (c == DBT_DELIM_R || c==EOF))) {
 							/* If empty_string is enabled, we'll just return
@@ -421,7 +421,7 @@ dbt_table_p dbt_load_file(const str *tbn, const str *dbn)
 						} else
 						{
 							dtval.nul = 0;
-							while(c!=DBT_DELIM && c!=DBT_DELIM_R && c!=EOF)
+							while(c!=_dbt_delim && c!=DBT_DELIM_R && c!=EOF)
 							{
 								if(c=='\\')
 								{
@@ -440,13 +440,12 @@ dbt_table_p dbt_load_file(const str *tbn, const str *dbn)
 										case '\\':
 											c = '\\';
 										break;
-										case DBT_DELIM:
-											c = DBT_DELIM;
-										break;
 										case '0':
 											c = 0;
 										break;
 										default:
+											if (c==_dbt_delim)
+												break;
 											goto clean;
 									}
 								}
@@ -458,7 +457,7 @@ dbt_table_p dbt_load_file(const str *tbn, const str *dbn)
 							//LM_DBG("data[%d,%d]=%.*s\n",
 							///	crow, ccol, bp, buf);
 						}
-						if(c!=DBT_DELIM && c!=DBT_DELIM_R && c!=EOF)
+						if(c!=_dbt_delim && c!=DBT_DELIM_R && c!=EOF)
 							goto clean;
 						if(dbt_row_set_val(rowp,&dtval,dtp->colv[ccol]->type,
 									ccol))
@@ -467,7 +466,7 @@ dbt_table_p dbt_load_file(const str *tbn, const str *dbn)
 					default:
 						goto clean;
 				}
-				if(c==DBT_DELIM)
+				if(c==_dbt_delim)
 					c = fgetc(fin);
 				ccol++;
 			break; // state DBT_DATA_ST
@@ -588,13 +587,14 @@ int dbt_print_table_row_ex(dbt_table_p _dtp, dbt_row_p rowp, FILE *fout, int new
                                         case '\\':
                                                 fprintf(fout, "\\\\");
                                                 break;
-                                        case DBT_DELIM:
-                                                fprintf(fout, "\\%c", DBT_DELIM);
-                                                break;
                                         case '\0':
                                                 fprintf(fout, "\\0");
                                                 break;
                                         default:
+                                                if (*p==_dbt_delim) {
+                                                        fprintf(fout, "\\%c", _dbt_delim);
+                                                        break;
+                                                }
                                                 fprintf(fout, "%c", *p);
                                         }
                                         p++;
@@ -607,7 +607,7 @@ int dbt_print_table_row_ex(dbt_table_p _dtp, dbt_row_p rowp, FILE *fout, int new
                         return -1;
                 }
                 if(ccol<_dtp->nrcols-1)
-                        fprintf(fout, "%c",DBT_DELIM);
+                        fprintf(fout, "%c",_dbt_delim);
         }
         if(newline)
                 fprintf(fout, "%c", DBT_DELIM_R);

--- a/src/modules/db_text/dbt_lib.h
+++ b/src/modules/db_text/dbt_lib.h
@@ -41,7 +41,6 @@
 #define DBT_FL_SET		0
 #define DBT_FL_UNSET	1
 
-#define DBT_DELIM	':'
 #define DBT_DELIM_C	' '
 #define DBT_DELIM_R	'\n'
 
@@ -51,6 +50,8 @@
 extern int db_mode; /* Database usage mode: 0 = no cache, 1 = cache */
 extern int empty_string; /* If TRUE, an empty string is an empty string, otherwise NULL */
 extern int _db_text_read_buffer_size; /* size of the buffer to allocate when reading file */
+extern int _dbt_delim;
+extern str _dbt_delim_str; /* the delimiter inside db_text files */
 extern int _db_text_max_result_rows; /* max result rows */
 
 typedef db_val_t dbt_val_t, *dbt_val_p;

--- a/src/modules/db_text/doc/db_text_admin.xml
+++ b/src/modules/db_text/doc/db_text_admin.xml
@@ -270,6 +270,26 @@ modparam("db_text", "db_mode", 1)
 </programlisting>
 			</example>
 		</section>
+		<section>
+			<title><varname>db_delim</varname> (string)</title>
+			<para>
+			Set the delimiter inside the db_text file.
+			</para>
+
+			<para>
+			<emphasis>
+				Default value is <quote>:</quote>.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>db_mode</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("db_text", "db_delim", "|")
+...
+</programlisting>
+			</example>
+		</section>
         <section>
             <title><varname>default_connection</varname> (string)</title>
             <para>


### PR DESCRIPTION
- changed separator because if IPv6 addresses were to be saved in a db_text file, their format would upset the parser

I think that 4.4 would also benefit by back-porting this. Agree?