### PR TITLE
pkg/debian: Fix installation issue by enabling mpath line in example config

### DIFF
--- a/etc/kamailio.cfg
+++ b/etc/kamailio.cfg
@@ -215,7 +215,7 @@ voicemail.srv_port = "5060" desc "VoiceMail Port"
 ####### Modules Section ########
 
 /* set paths to location of modules */
-# mpath="/usr/local/lib/kamailio/modules/"
+mpath="/usr/local/lib/kamailio/modules/"
 
 #!ifdef WITH_MYSQL
 loadmodule "db_mysql.so"


### PR DESCRIPTION
When installing a new Kamailio from debian packages, dpkg will fail because
Kamailio can't load any modules, resulting in a broken apt state. This is because
the "mpath" line in the example config is commented out. Enabling this line fixes
the install problem.
Tested on Debian Jessie.