### PR TITLE
topos: fix contact for BYE before 200 OK

### DIFF
--- a/src/modules/topos/tps_storage.c
+++ b/src/modules/topos/tps_storage.c
@@ -1102,7 +1102,7 @@ int tps_db_update_dialog(sip_msg_t *msg, tps_data_t *md, tps_data_t *sd,
 
 	if((mode & TPS_DBU_RPLATTRS) && msg->first_line.type==SIP_REPLY) {
 		if(sd->b_tag.len<=0
-				&& msg->first_line.u.reply.statuscode>=183
+				&& msg->first_line.u.reply.statuscode>=180
 				&& msg->first_line.u.reply.statuscode<300) {
 
 			if((sd->iflags&TPS_IFLAG_DLGON) == 0) {
@@ -1152,7 +1152,7 @@ int tps_storage_update_dialog(sip_msg_t *msg, tps_data_t *md, tps_data_t *sd,
 	if(md->s_method_id != METHOD_INVITE) {
 		return 0;
 	}
-	if(msg->first_line.u.reply.statuscode<183
+	if(msg->first_line.u.reply.statuscode<180
 			|| msg->first_line.u.reply.statuscode>=300) {
 		return 0;
 	}

--- a/src/modules/topos/tps_storage.c
+++ b/src/modules/topos/tps_storage.c
@@ -1102,7 +1102,7 @@ int tps_db_update_dialog(sip_msg_t *msg, tps_data_t *md, tps_data_t *sd,
 
 	if((mode & TPS_DBU_RPLATTRS) && msg->first_line.type==SIP_REPLY) {
 		if(sd->b_tag.len<=0
-				&& msg->first_line.u.reply.statuscode>=200
+				&& msg->first_line.u.reply.statuscode>=183
 				&& msg->first_line.u.reply.statuscode<300) {
 
 			if((sd->iflags&TPS_IFLAG_DLGON) == 0) {
@@ -1152,7 +1152,7 @@ int tps_storage_update_dialog(sip_msg_t *msg, tps_data_t *md, tps_data_t *sd,
 	if(md->s_method_id != METHOD_INVITE) {
 		return 0;
 	}
-	if(msg->first_line.u.reply.statuscode<200
+	if(msg->first_line.u.reply.statuscode<183
 			|| msg->first_line.u.reply.statuscode>=300) {
 		return 0;
 	}


### PR DESCRIPTION
Currently PRACK and BYE does not handling properly, before 200 OK, because topos_d.b_contact field are filling only after receiving 200 OK.
PRACK must be send to Contact from 183 Progress response.
BYE must be send to Contact from 180 Ringing or 183 Progress if 200 OK was not received before.
So I think that we must filled topos_d.b_contact field after receiving 180 Ringing and 183 Progress.

To test this you can try to terminate call after 180 Ringing or 183 Progres before 200 OK.