### PR TITLE
core: Don't terminate on harmless SIGCHLD.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -675,6 +675,7 @@ void handle_sigs(void)
 {
 	pid_t	chld;
 	int	chld_status;
+	int	any_chld_stopped;
 	int memlog;
 
 	switch(sig_flag){
@@ -730,7 +731,9 @@ void handle_sigs(void)
 			break;
 
 		case SIGCHLD:
+			any_chld_stopped=0;
 			while ((chld=waitpid( -1, &chld_status, WNOHANG ))>0) {
+				any_chld_stopped=1;
 				if (WIFEXITED(chld_status))
 					LM_ALERT("child process %ld exited normally,"
 							" status=%d\n", (long)chld,
@@ -747,6 +750,16 @@ void handle_sigs(void)
 								" signal %d\n", (long)chld,
 								 WSTOPSIG(chld_status));
 			}
+
+			/* If it appears that no child process has stopped, then do not terminate on SIGCHLD.
+			   Certain modules like app_python can run external scripts which cause child processes to be started and
+			   stopped. That can result in SIGCHLD being received here even though there is no real problem. Therefore,
+			   we do not terminate Kamailio unless we can find the child process which has stopped. */
+			if (!any_chld_stopped) {
+				LM_INFO("SIGCHLD received, but no child has stopped, ignoring it\n");
+				break;
+			}
+
 #ifndef STOP_JIRIS_CHANGES
 			if (dont_fork) {
 				LM_INFO("dont_fork turned on, living on\n");


### PR DESCRIPTION
If it appears that no child process has stopped, then do not terminate
on SIGCHLD. Certain modules like app_python can run external scripts
which cause child processes to be started and stopped. That can result
in SIGCHLD being received even though there is no real problem.
Therefore, we do not terminate Kamailio unless we can find the child
process which has stopped.