### PR TITLE
rtpengine: Delete flags & delete handling improvement

### DIFF
--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -1784,6 +1784,8 @@ static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg, enu
 			case 6:
 				if (str_eq(&key, "to-tag")) {
 					ng_flags->to = 1;
+					if (val.s && val.len > 0)
+						bencode_dictionary_str_add_str(ng_flags->dict,&key,&val);
 					goto next;
 				}
 				break;
@@ -1893,6 +1895,7 @@ static bencode_item_t *rtpp_function_call(bencode_buffer_t *bencbuf, struct sip_
 	struct ng_flags_parse ng_flags;
 	bencode_item_t *item, *resp;
 	str callid = STR_NULL, from_tag = STR_NULL, to_tag = STR_NULL, viabranch = STR_NULL;
+        str temp = STR_NULL, temp_fromtag = STR_NULL, temp_totag = STR_NULL;
 	str body = STR_NULL, error = STR_NULL;
 	int ret, queried_nodes = 0;
 	struct rtpp_node *node;
@@ -1967,8 +1970,13 @@ static bencode_item_t *rtpp_function_call(bencode_buffer_t *bencbuf, struct sip_
 	if (ng_flags.rtcp_mux && ng_flags.rtcp_mux->child)
 		bencode_dictionary_add(ng_flags.dict, "rtcp-mux", ng_flags.rtcp_mux);
 
-	bencode_dictionary_add_str(ng_flags.dict, "call-id", &callid);
-
+        temp.s = NULL;
+        if (!bencode_dictionary_get_str(ng_flags.dict, "call-id", &temp))
+                bencode_dictionary_add_str(ng_flags.dict, "call-id", &callid);
+	else if (temp.s) {
+		LM_NOTICE("using call-id from command flags: %.*s\n",temp.len,temp.s);
+	}
+	
 	if (ng_flags.via) {
 		if (ng_flags.via == 1 || ng_flags.via == 2)
 			ret = get_via_branch(msg, ng_flags.via, &viabranch);
@@ -1992,11 +2000,15 @@ static bencode_item_t *rtpp_function_call(bencode_buffer_t *bencbuf, struct sip_
 	bencode_list_add_string(item, ip_addr2a(&msg->rcv.src_ip));
 
 	if ((msg->first_line.type == SIP_REQUEST && op != OP_ANSWER)
+                || (msg->first_line.type == SIP_REPLY && op == OP_DELETE)
 		|| (msg->first_line.type == SIP_REPLY && op == OP_ANSWER))
 	{
-		bencode_dictionary_add_str(ng_flags.dict, "from-tag", &from_tag);
-		if (ng_flags.to && to_tag.s && to_tag.len)
-			bencode_dictionary_add_str(ng_flags.dict, "to-tag", &to_tag);
+		if (!bencode_dictionary_get_str(ng_flags.dict, "from-tag", &temp_fromtag))
+			bencode_dictionary_add_str(ng_flags.dict, "from-tag", &from_tag);
+		if (ng_flags.to )
+			if (!bencode_dictionary_get_str(ng_flags.dict,"to-tag",&temp_totag) && to_tag.s && to_tag.len)
+				bencode_dictionary_add_str(ng_flags.dict, "to-tag", &to_tag);
+
 	}
 	else {
 		if (!to_tag.s || !to_tag.len) {
@@ -2026,7 +2038,11 @@ select_node:
 			goto error;
 		}
 
-		node = select_rtpp_node(callid, viabranch, 1, queried_nodes_ptr, queried_nodes, op);
+		if (temp.s)
+			node = select_rtpp_node(temp, viabranch, 1, queried_nodes_ptr, queried_nodes, op);
+		else
+			node = select_rtpp_node(callid, viabranch, 1, queried_nodes_ptr, queried_nodes, op);
+
 		if (!node) {
 			LM_ERR("no available proxies\n");
 			goto error;


### PR DESCRIPTION
-Extending rtpengine_delete() in order to enable specifying Call-ID, To-Tag and From-Tag for timed out dialogs.
-Matching the calls to rtpengine machine correctly.