### PR TITLE
Redis remove redis_execute() command with no arguments

### DIFF
--- a/src/modules/ndb_redis/doc/ndb_redis_admin.xml
+++ b/src/modules/ndb_redis/doc/ndb_redis_admin.xml
@@ -292,7 +292,7 @@ if(redis_cmd("srvN", "HMGET foo_key field1 field3", "r")) {
 	</section>
 	<section id="ndb_redis.f.redis_execute">
 	<title>
-		<function moreinfo="none">redis_execute([srvname])</function>
+		<function moreinfo="none">redis_execute(srvname)</function>
 	</title>
 	<para>
 		Sends commands to REDIS server identified by srvname. Commands are added 
@@ -300,10 +300,6 @@ if(redis_cmd("srvN", "HMGET foo_key field1 field3", "r")) {
 		When this function is called all the commands will be sent in a single message
 		to the REDIS server.
 
-	</para>
-	<para>
-		If this function is called without any parameters, it will iterate through all 
-		existing servers and send the existing pipelined commands for them.
 	</para>
 	<para>
 		When using redis_cmd together with redis_pipe_cmd it is recommended that a call to 
@@ -324,12 +320,12 @@ After several redis command calls:
 
 	redis_pipe_cmd("srvB", "SET ruri $ru", "r2");
 
-	redis_pipe_cmd("srvC", "GET foo", "r3");
+	redis_pipe_cmd("srvB", "GET foo", "r3");
 
 Send the data and retrieve the results:
 	redis_execute("srvA"); //send command to srvA and wait for reply. Store the reply in r1
 
-	redis_execute(); //send remaining commands (the set to srvB and get to srvC), wait for replies, and store the replies in r2 and r3
+	redis_execute("srvB"); //send command to srvA and wait for reply. Store the replies in r2 (for SET ruri $ru) and r3 (for GET foo)
 
 Using both redis_cmd and redis_pipe_cmd:
 	redis_pipe_cmd("srvA", "SET foo bar", "r1");

--- a/src/modules/ndb_redis/ndb_redis_mod.c
+++ b/src/modules/ndb_redis/ndb_redis_mod.c
@@ -66,7 +66,6 @@ static int w_redis_pipe_cmd5(struct sip_msg* msg, char* ssrv, char* scmd,
 static int w_redis_pipe_cmd6(struct sip_msg* msg, char* ssrv, char* scmd,
 		char *sargv1, char *sargv2, char *sargv3, char* sres);
 static int fixup_redis_cmd6(void** param, int param_no);
-static int w_redis_execute_noargs(struct sip_msg* msg);
 static int w_redis_execute(struct sip_msg* msg, char* ssrv);
 
 static int w_redis_free_reply(struct sip_msg* msg, char* res);
@@ -105,8 +104,6 @@ static cmd_export_t cmds[]={
 	{"redis_pipe_cmd", (cmd_function)w_redis_pipe_cmd6, 6, fixup_redis_cmd6,
 		0, ANY_ROUTE},
 	{"redis_execute", (cmd_function)w_redis_execute, 1, fixup_redis_cmd6,
-		0, ANY_ROUTE},
-	{"redis_execute", (cmd_function)w_redis_execute_noargs, 0, 0,
 		0, ANY_ROUTE},
 	{"redis_free", (cmd_function)w_redis_free_reply, 1, fixup_spve_null,
 		0, ANY_ROUTE},
@@ -540,20 +537,6 @@ static int w_redis_pipe_cmd6(struct sip_msg* msg, char* ssrv, char* scmd,
 	arg1.s[arg1.len] = c1;
 	arg2.s[arg2.len] = c2;
 	arg3.s[arg3.len] = c3;
-	return 1;
-}
-
-/**
- *
- */
-static int w_redis_execute_noargs(struct sip_msg* msg)
-{
-	if (redis_cluster_param) 
-	{
-		LM_ERR("Pipelining is not supported if cluster parameter is enabled\n");
-		return -1;
-	}
-	redisc_exec_pipelined_cmd_all();
 	return 1;
 }
 

--- a/src/modules/ndb_redis/ndb_redis_mod.c
+++ b/src/modules/ndb_redis/ndb_redis_mod.c
@@ -546,6 +546,7 @@ static int w_redis_pipe_cmd6(struct sip_msg* msg, char* ssrv, char* scmd,
 static int w_redis_execute(struct sip_msg* msg, char* ssrv)
 {
 	str s;
+	int rv;
 
 	if (redis_cluster_param) 
 	{
@@ -557,7 +558,9 @@ static int w_redis_execute(struct sip_msg* msg, char* ssrv)
 		LM_ERR("no redis server name\n");
 		return -1;
 	}
-	redisc_exec_pipelined_cmd(&s);
+	rv=redisc_exec_pipelined_cmd(&s);
+	if (rv)
+		return rv;
 	return 1;
 }
 

--- a/src/modules/ndb_redis/redis_client.c
+++ b/src/modules/ndb_redis/redis_client.c
@@ -488,26 +488,6 @@ int redisc_exec_pipelined_cmd(str *srv)
 /**
  *
  */
-int redisc_exec_pipelined_cmd_all()
-{
-	redisc_server_t *rsrv=NULL;
-
-	rsrv=_redisc_srv_list;
-	while(rsrv!=NULL)
-	{
-		if ((rsrv->ctxRedis != NULL) && (rsrv->pendingReplies != 0))
-		{
-			redisc_exec_pipelined(rsrv);
-		}
-		rsrv=rsrv->next;
-	}
-
-	return 0;
-}
-
-/**
- *
- */
 int redisc_exec_pipelined(redisc_server_t *rsrv)
 {
 	redisc_reply_t *rpl;

--- a/src/modules/ndb_redis/redis_client.h
+++ b/src/modules/ndb_redis/redis_client.h
@@ -73,7 +73,6 @@ int redisc_reconnect_server(redisc_server_t *rsrv);
 int redisc_exec(str *srv, str *res, str *cmd, ...);
 int redisc_append_cmd(str *srv, str *res, str *cmd, ...);
 int redisc_exec_pipelined_cmd(str *srv);
-int redisc_exec_pipelined_cmd_all();
 int redisc_exec_pipelined(redisc_server_t *rsrv);
 redisReply* redisc_exec_argv(redisc_server_t *rsrv, int argc, const char **argv,
 		const size_t *argvlen);


### PR DESCRIPTION
Hello, 

We realized that redis_execute should return a negative value in case of failure (just like redis_cmd), instead of always returning 1. This introduced a problem with the behavior when calling redis_execute without giving a server name. Since this function will loop through all the servers and execute the pipelined commands for each one, in case of failure the user cannot determine for what server the error occurred, by only returning a negative value. This is why we decided to remove the possibility to call redis_execute with no arguments, and have it loop through all defined servers. The user should only call redis_execute(srv_name) and check the return value for this. 