### PR TITLE
ndb_redis: add disable server on failure feature

### DIFF
--- a/src/modules/ndb_redis/doc/ndb_redis_admin.xml
+++ b/src/modules/ndb_redis/doc/ndb_redis_admin.xml
@@ -181,6 +181,64 @@ modparam("ndb_redis", "cluster", 1)
 			</programlisting>
 		</example>
 	</section>
+	<section id="ndb_redis.p.allowed_timeouts">
+		<title><varname>allowed_timeouts</varname> (integer)</title>
+		<para>
+			If this is set to a non-negative value, it sets the number
+			of consecutive REDIS commands that can fail before temporarily
+			disabling the REDIS server. This is similar to rtpengine_disable_tout
+			parameter from the rtpengine module.
+		</para>
+		<para>
+			When communicating with a REDIS server, if redis_cmd or redis_execute
+			will fail for more than <quote>allowed_timeouts</quote> consecutive
+			times, the server will be temporary disabled for a number of seconds 
+			configured by the <quote>disable_time</quote> parameter.
+		</para>
+		<para>
+			Disabling a server means that further redis_cmd and redis_execute commands
+			will not do anything and return a negative value <quote>-2</quote>. 
+			Messages are also logged when disabling and re-enabling a server.
+		</para>
+		<para>
+			The number of consecutive fails are counted by each Kamailio process, 
+			so when disabling a server this is done just for that process, not globally.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>-1</quote> (disabled).
+		</emphasis>
+		</para>
+		<example>
+			<title>Set <varname>allowed_timeots</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("ndb_redis", "allowed_timeouts", 3)
+...
+			</programlisting>
+		</example>
+	</section>
+	<section id="ndb_redis.p.disable_time">
+		<title><varname>disable_time</varname> (integer)</title>
+		<para>
+			If allowed_timeouts is set to a non negative value this determines the 
+			number of seconds the REDIS server will be disabled
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote>.
+		</emphasis>
+		</para>
+		<example>
+			<title>Set <varname>disable_time</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("ndb_redis", "allowed_timeouts", 0)
+modparam("ndb_redis", "disable_time", 30)
+...
+			</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>

--- a/src/modules/ndb_redis/ndb_redis_mod.c
+++ b/src/modules/ndb_redis/ndb_redis_mod.c
@@ -48,6 +48,8 @@ int init_without_redis = 0;
 int redis_connect_timeout_param = 1000;
 int redis_cmd_timeout_param = 1000;
 int redis_cluster_param = 0;
+int disable_time=0;
+int allowed_timeouts=-1;
 
 static int w_redis_cmd3(struct sip_msg* msg, char* ssrv, char* scmd,
 		char* sres);
@@ -120,6 +122,8 @@ static param_export_t params[]={
 	{"connect_timeout", INT_PARAM, &redis_connect_timeout_param},
 	{"cmd_timeout", INT_PARAM, &redis_cmd_timeout_param},
 	{"cluster", INT_PARAM, &redis_cluster_param},
+	{"disable_time", INT_PARAM, &disable_time},
+	{"allowed_timeouts", INT_PARAM, &allowed_timeouts},
 	{0, 0, 0}
 };
 

--- a/src/modules/ndb_redis/ndb_redis_mod.c
+++ b/src/modules/ndb_redis/ndb_redis_mod.c
@@ -48,8 +48,8 @@ int init_without_redis = 0;
 int redis_connect_timeout_param = 1000;
 int redis_cmd_timeout_param = 1000;
 int redis_cluster_param = 0;
-int disable_time=0;
-int allowed_timeouts=-1;
+int redis_disable_time_param=0;
+int redis_allowed_timeouts_param=-1;
 
 static int w_redis_cmd3(struct sip_msg* msg, char* ssrv, char* scmd,
 		char* sres);
@@ -122,8 +122,8 @@ static param_export_t params[]={
 	{"connect_timeout", INT_PARAM, &redis_connect_timeout_param},
 	{"cmd_timeout", INT_PARAM, &redis_cmd_timeout_param},
 	{"cluster", INT_PARAM, &redis_cluster_param},
-	{"disable_time", INT_PARAM, &disable_time},
-	{"allowed_timeouts", INT_PARAM, &allowed_timeouts},
+	{"disable_time", INT_PARAM, &redis_disable_time_param},
+	{"allowed_timeouts", INT_PARAM, &redis_allowed_timeouts_param},
 	{0, 0, 0}
 };
 

--- a/src/modules/ndb_redis/redis_client.c
+++ b/src/modules/ndb_redis/redis_client.c
@@ -49,8 +49,8 @@ extern int init_without_redis;
 extern int redis_connect_timeout_param;
 extern int redis_cmd_timeout_param;
 extern int redis_cluster_param;
-extern int disable_time;
-extern int allowed_timeouts;
+extern int redis_disable_time_param;
+extern int redis_allowed_timeouts_param;
 
 /* backwards compatibility with hiredis < 0.12 */
 #if (HIREDIS_MAJOR == 0) && (HIREDIS_MINOR < 12)
@@ -1043,17 +1043,17 @@ int redis_check_server(redisc_server_t *rsrv)
 
 int redis_count_err_and_disable(redisc_server_t *rsrv)
 {
-	if (allowed_timeouts < 0)
+	if (redis_allowed_timeouts_param < 0)
 	{
 		return 0;
 	}
 
 	rsrv->disable.consecutive_errors++;
-	if (rsrv->disable.consecutive_errors > allowed_timeouts)
+	if (rsrv->disable.consecutive_errors > redis_allowed_timeouts_param)
 	{
 		rsrv->disable.disabled=1;
-		rsrv->disable.restore_tick=get_ticks() + disable_time;
-		LM_WARN("REDIS server %.*s disabled for %d seconds",rsrv->sname->len,rsrv->sname->s,disable_time);
+		rsrv->disable.restore_tick=get_ticks() + redis_disable_time_param;
+		LM_WARN("REDIS server %.*s disabled for %d seconds",rsrv->sname->len,rsrv->sname->s,redis_disable_time_param);
 		return 1;
 	}
 	return 0;

--- a/src/modules/ndb_redis/redis_client.h
+++ b/src/modules/ndb_redis/redis_client.h
@@ -53,6 +53,12 @@ typedef struct redisc_piped_cmds {
 	int pending_commands;
 } redisc_piped_cmds_t;
 
+typedef struct redisc_srv_disable {
+	int disabled;
+	int consecutive_errors;
+	time_t restore_tick;
+} redisc_srv_disable_t;
+
 typedef struct redisc_server {
 	str *sname;
 	unsigned int hname;
@@ -60,6 +66,7 @@ typedef struct redisc_server {
 	redisContext *ctxRedis;
 	struct redisc_server *next;
 	redisc_piped_cmds_t piped;
+	redisc_srv_disable_t disable;
 } redisc_server_t;
 
 typedef struct redisc_pv {
@@ -86,4 +93,6 @@ redisReply* redisc_exec_argv(redisc_server_t *rsrv, int argc, const char **argv,
 redisc_reply_t *redisc_get_reply(str *name);
 int redisc_free_reply(str *name);
 int redisc_check_auth(redisc_server_t *rsrv, char *pass);
+int redis_check_server(redisc_server_t *rsrv);
+int redis_count_err_and_disable(redisc_server_t *rsrv);
 #endif


### PR DESCRIPTION
Hello, 

We added a new feature to the ndb_redis module, similar to how the rtpengine_disable_tout parameter of the rtpengine module works. 

If a number of consecutive commands to a redis server fail, that server is temporarily disabled. This is configurable by parameters: "allowed_timeouts" and "disable_time". 
Disabling a server means that for "disable_time" seconds any command to that sever will not send the command to the server, but an error is returned instead. 

For example if allowed_timeouts is configured to 0 and disable_time to 30, the first time redis_cmd or redis_execute functions fail the server will be disabled for 30 seconds. 

The server information is retained by each Kamailio process individually, so this means that disabling a server is done by that process only and not globally. 

