### PR TITLE
ndb_redis: add flush_db_on_reconnect parameter

### DIFF
--- a/src/modules/ndb_redis/doc/ndb_redis_admin.xml
+++ b/src/modules/ndb_redis/doc/ndb_redis_admin.xml
@@ -239,6 +239,38 @@ modparam("ndb_redis", "disable_time", 30)
 			</programlisting>
 		</example>
 	</section>
+	<section id="ndb_redis.p.flush_db_on_reconnect">
+		<title><varname>flush_db_on_reconnect</varname> (integer)</title>
+		<para>
+			If this is set to a non zero value, a "FLUSHALL" command is
+			issued after reconnecting to a REDIS server, to clear the 
+			entire database. 
+		</para>
+		<para>
+			When a command to a REDIS server fails, a reconnection
+			to that server is made, so with this parameter each failed
+			command will result in a flush of the database. 
+		</para>
+		<para>
+			This is useful in scenarios when a REDIS server does not respond
+			to commands, but the commands might have been issued, and the 
+			responses lost. If this leaves the data in the db in an uncertain
+			state, a flush might fix any issues that may occur.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote> (disabled).
+		</emphasis>
+		</para>
+		<example>
+			<title>Set <varname>flush_db_on_reconnect</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("ndb_redis", "flush_db_on_reconnect", 1)
+...
+			</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>

--- a/src/modules/ndb_redis/ndb_redis_mod.c
+++ b/src/modules/ndb_redis/ndb_redis_mod.c
@@ -50,6 +50,7 @@ int redis_cmd_timeout_param = 1000;
 int redis_cluster_param = 0;
 int redis_disable_time_param=0;
 int redis_allowed_timeouts_param=-1;
+int redis_flush_db_on_reconnect_param=0;
 
 static int w_redis_cmd3(struct sip_msg* msg, char* ssrv, char* scmd,
 		char* sres);
@@ -124,6 +125,7 @@ static param_export_t params[]={
 	{"cluster", INT_PARAM, &redis_cluster_param},
 	{"disable_time", INT_PARAM, &redis_disable_time_param},
 	{"allowed_timeouts", INT_PARAM, &redis_allowed_timeouts_param},
+	{"flush_db_on_reconnect", INT_PARAM, &redis_flush_db_on_reconnect_param},
 	{0, 0, 0}
 };
 

--- a/src/modules/ndb_redis/redis_client.c
+++ b/src/modules/ndb_redis/redis_client.c
@@ -51,6 +51,7 @@ extern int redis_cmd_timeout_param;
 extern int redis_cluster_param;
 extern int redis_disable_time_param;
 extern int redis_allowed_timeouts_param;
+extern int redis_flush_db_on_reconnect_param;
 
 /* backwards compatibility with hiredis < 0.12 */
 #if (HIREDIS_MAJOR == 0) && (HIREDIS_MINOR < 12)
@@ -374,7 +375,9 @@ int redisc_reconnect_server(redisc_server_t *rsrv)
 		goto err2;
 	if ((redis_cluster_param == 0) && redisCommandNR(rsrv->ctxRedis, "SELECT %i", db))
 		goto err2;
-
+	if (redis_flush_db_on_reconnect_param)
+		if (redisCommandNR(rsrv->ctxRedis, "FLUSHALL"))
+			goto err2;
 	return 0;
 
 err2:


### PR DESCRIPTION
Hello,
We added a new parameter to ndb_redis module. If set to 1 a "FLUSHALL" command is issued to the REDIS server when reconnecting to a server after a failed command. This way for each failed command the database is flushed. 

This is useful when a connection to the REDIS server may become unstable and some commands are issued but the replies are not received (it may happen that the command has reached the REDIS server but the reply was lost). If for example we increment and decrement counters this may leave the db in an invalid state.

This can especially happen if the allowed_timeouts/disable_time parameters are configured, since the first commands may be issued and the next ones are never tried.