### PR TITLE
db_sqlite: new param to open some database in read-only

### DIFF
--- a/src/modules/db_sqlite/db_sqlite.h
+++ b/src/modules/db_sqlite/db_sqlite.h
@@ -1,0 +1,37 @@
+/*
+ * $Id$
+ *
+ * SQlite module interface
+ *
+ * Copyright (C) 2017 Julien Chavanton, Flowroute
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef DBSQLITE_H
+#define DBSQLITE_H
+
+typedef struct db_param_list {
+	struct db_param_list* next;
+	struct db_param_list* prev;
+	str database;
+	int readonly;
+} db_param_list_t;
+
+db_param_list_t *db_param_list_search(char *db_filename);
+
+#endif

--- a/src/modules/db_sqlite/doc/db_sqlite.xml
+++ b/src/modules/db_sqlite/doc/db_sqlite.xml
@@ -32,6 +32,22 @@
 	    <year>2011</year>
 	    <holder>Timo Teräs</holder>
 	</copyright>
+	<authorgroup>
+	    <editor>
+		<firstname>Julien</firstname>
+		<surname>Chavanton</surname>
+		<affiliation><orgname>flowroute.com</orgname></affiliation>
+		<email>jchavanton@gmail.com</email>
+		<address>
+		<otheraddr>
+		<ulink></ulink>
+		</otheraddr>
+		</address>
+	    </editor>
+	</authorgroup>
+	<copyright>
+	    <year>2017</year>
+	</copyright>
     </bookinfo>
     <toc></toc>
 

--- a/src/modules/db_sqlite/doc/db_sqlite_admin.xml
+++ b/src/modules/db_sqlite/doc/db_sqlite_admin.xml
@@ -62,9 +62,31 @@
 	</section>
 
 	<section>
-	<title>Parameters</title>
+		<title>Parameters</title>
 		<para>
-		NONE
+		<section id="db_sqlite.p.db_set_readonly">
+		<title><varname>db_set_readonly</varname> (string)</title>
+
+		This will set the db connection to "SQLITE_OPEN_READONLY", useful if another program is writing to the DB.
+		The value is the full path to the sqlite file used for example in any db_url or sqlops/sqlcon
+
+		This parameter may be set multiple times to set many DB connections to readonly in the same configuration file.
+		</para>
+		<para>
+		<emphasis>
+			By default all the db connection are using "SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE"
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>db_set_readonly</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("db_sqlite","db_set_readonly","/var/mydb.sqlite")
+modparam("sqlops","sqlcon","lrn=>sqlite:////var/mydb.sqlite") # Example if using the sqlops module
+...
+		</programlisting>
+		</example>
+		</section>
 		</para>
 	</section>
 


### PR DESCRIPTION
Using a `db_param_list` `clist` we can preset `SQLITE_OPEN_READONLY` on specific database file, this can be reused for more sqlite specific settings since we probably do not want extand `km_dbase` for db engine specific settings.

This is required when another process is writing to the db

Example: 
``modparam("db_sqlite","db_set_readonly","/var/mydb.sqlite")``