### PR TITLE
pkg: fixed location of ChangeLog

### DIFF
--- a/pkg/kamailio/deb/debian/rules
+++ b/pkg/kamailio/deb/debian/rules
@@ -187,7 +187,7 @@ binary-common:
 	dh_installman
 	dh_installinfo
 	dh_lintian
-	dh_installchangelogs ChangeLog
+	dh_installchangelogs ../ChangeLog
 	dh_link
 	dh_strip --dbg-package=kamailio-dbg
 	dh_compress

--- a/pkg/kamailio/deb/jessie/rules
+++ b/pkg/kamailio/deb/jessie/rules
@@ -187,7 +187,7 @@ binary-common:
 	dh_installman
 	dh_installinfo
 	dh_lintian
-	dh_installchangelogs ChangeLog
+	dh_installchangelogs ../ChangeLog
 	dh_link
 	dh_strip --dbg-package=kamailio-dbg
 	dh_compress

--- a/pkg/kamailio/deb/precise/rules
+++ b/pkg/kamailio/deb/precise/rules
@@ -184,7 +184,7 @@ binary-common:
 	dh_installman
 	dh_installinfo
 	dh_lintian
-	dh_installchangelogs ChangeLog
+	dh_installchangelogs ../ChangeLog
 	dh_link
 	dh_strip --dbg-package=kamailio-dbg
 	dh_compress

--- a/pkg/kamailio/deb/sid/rules
+++ b/pkg/kamailio/deb/sid/rules
@@ -187,7 +187,7 @@ binary-common:
 	dh_installman
 	dh_installinfo
 	dh_lintian
-	dh_installchangelogs ChangeLog
+	dh_installchangelogs ../ChangeLog
 	dh_link
 	dh_strip --dbg-package=kamailio-dbg
 	dh_compress

--- a/pkg/kamailio/deb/stretch/rules
+++ b/pkg/kamailio/deb/stretch/rules
@@ -187,7 +187,7 @@ binary-common:
 	dh_installman
 	dh_installinfo
 	dh_lintian
-	dh_installchangelogs ChangeLog
+	dh_installchangelogs ../ChangeLog
 	dh_link
 	dh_strip --dbg-package=kamailio-dbg
 	dh_compress

--- a/pkg/kamailio/deb/trusty/rules
+++ b/pkg/kamailio/deb/trusty/rules
@@ -185,7 +185,7 @@ binary-common:
 	dh_installman
 	dh_installinfo
 	dh_lintian
-	dh_installchangelogs ChangeLog
+	dh_installchangelogs ../ChangeLog
 	dh_link
 	dh_strip --dbg-package=kamailio-dbg
 	dh_compress

--- a/pkg/kamailio/deb/wheezy/rules
+++ b/pkg/kamailio/deb/wheezy/rules
@@ -184,7 +184,7 @@ binary-common:
 	dh_installman
 	dh_installinfo
 	dh_lintian
-	dh_installchangelogs ChangeLog
+	dh_installchangelogs ../ChangeLog
 	dh_link
 	dh_strip --dbg-package=kamailio-dbg
 	dh_compress

--- a/pkg/kamailio/deb/xenial/rules
+++ b/pkg/kamailio/deb/xenial/rules
@@ -187,7 +187,7 @@ binary-common:
 	dh_installman
 	dh_installinfo
 	dh_lintian
-	dh_installchangelogs ChangeLog
+	dh_installchangelogs ../ChangeLog
 	dh_link
 	dh_strip --dbg-package=kamailio-dbg
 	dh_compress


### PR DESCRIPTION
the packaging system couldn't find ChangeLog, since the sources has been moved to a src directory.