### PR TITLE
ndb_redis: enhance access to REDIS replies

### DIFF
--- a/src/modules/ndb_redis/doc/ndb_redis_admin.xml
+++ b/src/modules/ndb_redis/doc/ndb_redis_admin.xml
@@ -319,6 +319,12 @@ modparam("ndb_redis", "flush_on_reconnect", 1)
 			</listitem>
 			</itemizedlist>
 		</para>
+		<para>
+			In case one of the members of the array is also an array (for example calling SMEMBERS
+			in a MULTI/EXEC transaction), the members of the array can be accessed by adding any of
+			the above keys, after a value[n] key. The first value[n] references the element in the
+			first array, while the next key references an element of the referenced array.
+		</para>
 		<example>
 		<title><function>redis_cmd</function> usage</title>
 		<programlisting format="linespecific">
@@ -350,6 +356,16 @@ redis_cmd("srvN", "HMGET %s %s %s", "key1", "field1", "field2", "r");
 if(redis_cmd("srvN", "HMGET foo_key field1 field3", "r")) {
     xlog("array size: $redis(r=>size)\n");
     xlog("first values: $redis(r=>value[0]) , $redis(r=>value[1])\n");
+}
+
+
+# array as element of an array example
+redis_cmd("srvN", "MULTI", "r1");
+redis_cmd("srvN", "SMEMBERS foo", "r2");
+if (redis_cmd("srvN", "EXEC", "r")) {
+    xlog("array size: $redis(r=>value[0]=>size)\n");
+    xlog("first member of the set:$redis(r=>value[0]=>value[0])\n");
+    xlog("type of the second member of the set:$redis(r=>value[0]=>type[1])\n");
 }
 ...
 </programlisting>

--- a/src/modules/ndb_redis/redis_client.h
+++ b/src/modules/ndb_redis/redis_client.h
@@ -35,6 +35,7 @@
 #include "../../core/mod_fix.h"
 
 #define MAXIMUM_PIPELINED_COMMANDS 1000
+#define MAXIMUM_NESTED_KEYS 10
 
 int redisc_init(void);
 int redisc_destroy(void);
@@ -74,7 +75,8 @@ typedef struct redisc_pv {
 	redisc_reply_t *reply;
 	str rkey;
 	int rkeyid;
-	gparam_t pos;  /* Array element position. */
+	gparam_t pos[MAXIMUM_NESTED_KEYS];  /* Array element position. */
+	int rkeynum;
 } redisc_pv_t;
 
 /* Server related functions */


### PR DESCRIPTION
Hello, 

I have enhanced the way REDIS replied are accessed in the Kamailio config, to be able to access arrays that are members of other arrays. In the original code, we could access members of an array like this: $redis(reply=>value[0]). 
But if that member was itself an array it was impossible to access it, as accessing an array directly returns (null). This case can happen if we use redis transactions with, and all commands are given between MULTI and EXEC commands. Then the EXEC command returns an array with the responses of the individual commands, so if any command returns an array, then we have an array within that array.

I have modified the syntax of the redis replies in the config, to be able to add other keys after value[n] keys. This way we can access members of the array within the first array.
For example after the following sequence:
```
redis_cmd("srvN", "MULTI", "r1");
redis_cmd("srvN", "SMEMBERS foo", "r2");
redis_cmd("srvN", "EXEC", "reply")

```
The PV to access the response will look like this

- to access the first elemenent of SMEMBERS:

   `$redis(reply=>value[0]=>value[0])` 

- to access the second element of SMEMBERS:

    `$redis(reply=>value[0]=>value[1])`

- to see how many elements SMEMBERS returned:

   `$redis(reply=>value[0]=>size)`

- to see the type the first element returned by SMEMBERS:

    `$redis(reply=>value[0]=>type[0])`