### PR TITLE
db_sqlite: new param to set database journal mode

### DIFF
--- a/src/modules/db_sqlite/db_sqlite.c
+++ b/src/modules/db_sqlite/db_sqlite.c
@@ -28,6 +28,7 @@
 #include "../../core/sr_module.h"
 #include "../../lib/srdb1/db_query.h"
 #include "../../lib/srdb1/db.h"
+#include "../../core/parser/parse_param.h"
 #include "dbase.h"
 #include "db_sqlite.h"
 
@@ -58,10 +59,10 @@ static db_param_list_t *db_param_list = NULL;
 static void db_param_list_add(db_param_list_t *e) {
 	if (!db_param_list) {
 		db_param_list = e;
-		LM_DBG("adding readonly database [%s]\n", e->database.s);
+		LM_DBG("adding database params [%s]\n", e->database.s);
 		clist_init(db_param_list, next, prev);
 	} else {
-		LM_DBG("adding append constraint [%s]\n", e->database.s);
+		LM_DBG("append database params [%s]\n", e->database.s);
 		clist_append(db_param_list, e, next, prev);
 	}
 }
@@ -71,6 +72,8 @@ static void db_param_list_destroy(db_param_list_t *e) {
 		return;
 	if (e->database.s)
 		pkg_free(e->database.s);
+	if (e->journal_mode.s)
+		pkg_free(e->journal_mode.s);
 	pkg_free(e);
 	e = NULL;
 }
@@ -93,39 +96,106 @@ error:
 	return NULL;
 }
 
-db_param_list_t *db_param_list_search(char *db_filename) {
+db_param_list_t *db_param_list_search(str db_filename) {
 	db_param_list_t *e;
 	if (!db_param_list) {
 		return NULL;
 	}
-	if (strcmp(db_filename, db_param_list->database.s) == 0) {
+	if (strncmp(db_filename.s, db_param_list->database.s, db_filename.len) == 0) {
 		return db_param_list;
 	}
 	clist_foreach(db_param_list, e, next){
-		if (strcmp(db_filename, e->database.s) == 0) {
+		if (strncmp(db_filename.s, e->database.s, db_filename.len) == 0) {
 			return e;
 		}
 	}
 	return NULL;
 }
 
+static int db_set_journal_mode_entry(str db_filename, str journal_mode) {
+	if(!db_filename.s || !journal_mode.s)
+		return -1;
+	db_param_list_t *e = db_param_list_search(db_filename);
+	if (!e)
+		e = db_param_list_new(db_filename.s);
+	if (!e) {
+		LM_ERR("can't create a new db_param for [%s]\n", db_filename.s);
+		return -1;
+	}
+	e->journal_mode.s = pkg_malloc(journal_mode.len+1);
+	if (!e->journal_mode.s) goto error;
+	strncpy(e->journal_mode.s, journal_mode.s, journal_mode.len);
+	e->journal_mode.len = journal_mode.len;
+	e->journal_mode.s[e->journal_mode.len] = '\0';
+	return 1;
+	error:
+		db_param_list_destroy(e);
+		return -1;
+}
+
+int db_set_journal_mode(modparam_t type, void *val) {
+	param_t* params_list = NULL;
+	param_hooks_t phooks;
+	param_t *pit=NULL;
+	str s;
+
+	if (val==NULL)
+		return -1;
+
+	s.s = (char*)val;
+	s.len = strlen(s.s);
+	if (s.len<=0)
+		return -1;
+	if (s.s[s.len-1]==';')
+		s.len--;
+
+	if (parse_params(&s, CLASS_ANY, &phooks, &params_list)<0)
+		goto error;
+	// PRAGMA schema.journal_mode = DELETE | TRUNCATE | PERSIST | MEMORY | WAL | OFF
+	for (pit = params_list; pit; pit=pit->next) {
+		LM_DBG("[param][%.*s]\n", pit->name.len, pit->name.s);
+		if ( pit->body.len==3 && strncasecmp(pit->body.s,"WAL", 3) ) {
+			db_set_journal_mode_entry(pit->name, pit->body);
+		} else if ( pit->body.len==6 && strncasecmp(pit->body.s,"DELETE", 6) ) {
+			db_set_journal_mode_entry(pit->name, pit->body);
+		} else if ( pit->body.len==8 && strncasecmp(pit->body.s,"TRUNCATE", 8) ) {
+			db_set_journal_mode_entry(pit->name, pit->body);
+		} else if ( pit->body.len==7 && strncasecmp(pit->body.s,"PERSIST", 7) ) {
+			db_set_journal_mode_entry(pit->name, pit->body);
+		} else if ( pit->body.len==6 && strncasecmp(pit->body.s,"MEMORY", 6) ) {
+			db_set_journal_mode_entry(pit->name, pit->body);
+		} else if ( pit->body.len==3 && strncasecmp(pit->body.s,"OFF", 3) ) {
+			db_set_journal_mode_entry(pit->name, pit->body);
+		}
+	}
+
+	if(params_list!=NULL)
+		free_params(params_list);
+	return 1;
+error:
+	if(params_list!=NULL)
+		free_params(params_list);
+	return -1;
+}
+
 int db_set_readonly(modparam_t type, void *val) {
 	if(val==NULL)
 		return -1;
-	db_param_list_t *e = db_param_list_search((char*)val);
+	str db_name = str_init((char*) val);
+	db_param_list_t *e = db_param_list_search(db_name);
 	if (!e)
-		e = db_param_list_new((char *)val);
+		e = db_param_list_new(db_name.s);
 	if (!e) {
 		LM_ERR("can't create a new db_param for [%s]\n", (char*) val);
 		return -1;
 	}
 	e->readonly = 1;
-	db_param_list_search((char *)val);
 	return 1;
 }
 
 static param_export_t params[] = {
 	{"db_set_readonly",  PARAM_STRING|USE_FUNC_PARAM, (void*)db_set_readonly},
+	{"db_set_journal_mode",  PARAM_STRING|USE_FUNC_PARAM, (void*)db_set_journal_mode},
 	{0,0,0}
 };
 

--- a/src/modules/db_sqlite/db_sqlite.h
+++ b/src/modules/db_sqlite/db_sqlite.h
@@ -30,8 +30,9 @@ typedef struct db_param_list {
 	struct db_param_list* prev;
 	str database;
 	int readonly;
+	str journal_mode;
 } db_param_list_t;
 
-db_param_list_t *db_param_list_search(char *db_filename);
+db_param_list_t *db_param_list_search(str db_filename);
 
 #endif

--- a/src/modules/db_sqlite/doc/db_sqlite_admin.xml
+++ b/src/modules/db_sqlite/doc/db_sqlite_admin.xml
@@ -73,7 +73,7 @@
 		</para>
 		<para>
 		<emphasis>
-			By default all the db connection are using "SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE"
+			By default all the db connections are using "SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE"
 		</emphasis>
 		</para>
 		<example>
@@ -82,6 +82,35 @@
 ...
 modparam("db_sqlite","db_set_readonly","/var/mydb.sqlite")
 modparam("sqlops","sqlcon","lrn=>sqlite:////var/mydb.sqlite") # Example if using the sqlops module
+...
+		</programlisting>
+		</example>
+	</section>
+	<section id="db_sqlite.p.db_set_journal_mode">
+		<title><varname>db_set_journal_mode</varname> (string)</title>
+		<para>
+		This will set the db connection journal mode, for the given connection.
+		The value is the full path to the sqlite file used for example in any db_url or sqlops/sqlcon
+
+		Other journal mode are : DELETE | TRUNCATE | PERSIST | MEMORY | WAL | OFF
+
+		This parameter may be set multiple times to set many DB connections to readonly in the same configuration file.
+		</para>
+		<para>
+		<emphasis>
+			By default all the db connections are using sqlite default journaling mode.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>db_set_journal_mode</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+# In this example we are using Write-Ahead Logging in order to update the database from another process(external to Kamailio) without facing any locking.
+
+#!subst "!DB_FILE!/var/mydb.sqlite!"
+modparam("db_sqlite","db_set_readonly","DB_FILE")   # We are also opening the database in readonly
+modparam("db_sqlite","db_set_journal_mode","DB_FILE=WAL;")
+modparam("sqlops","sqlcon","lrn=>sqlite:///DB_FILE")
 ...
 		</programlisting>
 		</example>


### PR DESCRIPTION

Exposing journal mode as a module parameter, one great feature is to be able to use WAL mode and share a database in read / write mode with facing any locking.

https://sqlite.org/wal.html