### PR TITLE
pv: add received ip/port pvars for advertised ip/port

### DIFF
--- a/src/modules/pv/pv.c
+++ b/src/modules/pv/pv.c
@@ -375,6 +375,12 @@ static pv_export_t mod_pvs[] = {
 	{{"Rp", (sizeof("Rp")-1)}, /* */
 		PVT_OTHER, pv_get_rcvport, 0,
 		0, 0, 0, 0},
+	{{"RAi", (sizeof("RAi")-1)}, /* */
+		PVT_OTHER, pv_get_rcv_advertised_ip, 0,
+		0, 0, 0, 0},
+	{{"RAp", (sizeof("RAp")-1)}, /* */
+		PVT_OTHER, pv_get_rcv_advertised_port, 0,
+		0, 0, 0, 0},
 	{{"sf", (sizeof("sf")-1)}, /* */
 		PVT_OTHER, pv_get_sflags, pv_set_sflags,
 		0, 0, 0, 0},

--- a/src/modules/pv/pv_core.c
+++ b/src/modules/pv/pv_core.c
@@ -739,6 +739,34 @@ int pv_get_rcvport(struct sip_msg *msg, pv_param_t *param,
 			&msg->rcv.bind_address->port_no_str);
 }
 
+int pv_get_rcv_advertised_ip(struct sip_msg *msg, pv_param_t *param,
+		pv_value_t *res)
+{
+	if(msg==NULL)
+		return -1;
+
+	if(msg->rcv.bind_address!=NULL
+			&& msg->rcv.bind_address->useinfo.address_str.len > 0) {
+		return pv_get_strval(msg, param, res, &msg->rcv.bind_address->useinfo.address_str);
+	}
+
+	return pv_get_rcvip(msg, param, res);
+}
+
+int pv_get_rcv_advertised_port(struct sip_msg *msg, pv_param_t *param,
+		pv_value_t *res)
+{
+	if(msg==NULL)
+		return -1;
+
+	if(msg->rcv.bind_address!=NULL
+			&& msg->rcv.bind_address->useinfo.port_no_str.len > 0) {
+		return pv_get_strval(msg, param, res, &msg->rcv.bind_address->useinfo.port_no_str);
+	}
+
+	return pv_get_rcvport(msg, param, res);
+}
+
 /**
  *
  */

--- a/src/modules/pv/pv_core.h
+++ b/src/modules/pv/pv_core.h
@@ -142,6 +142,12 @@ int pv_get_rcvip(struct sip_msg *msg, pv_param_t *param,
 int pv_get_rcvport(struct sip_msg *msg, pv_param_t *param,
 		pv_value_t *res);
 
+int pv_get_rcv_advertised_ip(struct sip_msg *msg, pv_param_t *param,
+		pv_value_t *res);
+
+int pv_get_rcv_advertised_port(struct sip_msg *msg, pv_param_t *param,
+		pv_value_t *res);
+
 int pv_get_force_sock(struct sip_msg *msg, pv_param_t *param,
 		pv_value_t *res);
 


### PR DESCRIPTION
adds $RAi , $RAp
if advertise is not set, defaults to reveived ip/port