### PR TITLE
app_lua: add "NOTICE" loglevel to sr.log

### DIFF
--- a/src/modules/app_lua/app_lua_sr.c
+++ b/src/modules/app_lua/app_lua_sr.c
@@ -96,6 +96,8 @@ static int lua_sr_log (lua_State *L)
 				LM_DBG("%s", txt);
 			} else if(strcasecmp(level, "info")==0) {
 				LM_INFO("%s", txt);
+			} else if(strcasecmp(level, "notice")==0) {
+				LM_NOTICE("%s", txt);
 			} else if(strcasecmp(level, "warn")==0) {
 				LM_WARN("%s", txt);
 			} else if(strcasecmp(level, "crit")==0) {


### PR DESCRIPTION
The "notice" loglevel is missing in app_lua's sr.log function. This patch adds it.