### PR TITLE
presence: subsription double delete fix

### DIFF
--- a/src/modules/presence/notify.c
+++ b/src/modules/presence/notify.c
@@ -1847,7 +1847,7 @@ void p_tm_callback( struct cell *t, int type, struct tmcb_params *ps)
 
         if(ps->code == 404
 	   || ps->code == 481
-	   || (ps->code == 408 && timeout_rm_subs)
+	   || (ps->code == 408 && timeout_rm_subs && subs->status != TERMINATED_STATUS)
 	   || pres_get_delete_sub()) {
 		delete_subs(&subs->pres_uri, &subs->event->name,
 				&subs->to_tag, &subs->from_tag, &subs->callid);


### PR DESCRIPTION
i have timeout_rm_subs=1 (as default) and It was a lot of messages in kamailio.log like this

```
Jun 23 12:08:56 kamailio[8366] ERROR: presence [subscribe.c:487]: delete_subs(): Failed to delete subscription from memory [slot: 255 ev: sip:2579*109@host pu: presence ci: 08f29987584a4e47b12110ff09e48d92 ft: 8fece9a08beb407cb0fec4c703e6f99e tt: 302fa4d0674d106ffe861f2ef3364869.711a]
```

The reason is timout NOTIFY with "Subscription-State: terminated;reason=timeout"

