### PR TITLE
resolve an issue found by cppcheck

### DIFF
--- a/utils/db_berkeley/kambdb_recover.c
+++ b/utils/db_berkeley/kambdb_recover.c
@@ -336,14 +336,14 @@ int recover(char* jfn)
 		return 2;
 	}
 	
-	tp  = tbc->dtp;
-	
-	if(!tbc || !tp)
+	if(!tbc || !tbc->dtp)
 	{
 		fprintf(stderr, "[recover]: FAILED to get find metadata for : %s.\n", tn);
 		fclose(fp);
 		return 3;
 	}
+
+	tp  = tbc->dtp;
 	
 	while ( fgets(line , MAX_ROW_SIZE, fp) != NULL )
 	{


### PR DESCRIPTION
[utils/db_berkeley/kambdb_recover.c:339] -> [utils/db_berkeley/kambdb_recover.c:341]: (warning) Either the condition '!tbc' is redundant or there is possible null pointer dereference: tbc.