### PR TITLE
ndb_redis: enhance debug info related to redis replies

### DIFF
--- a/src/modules/ndb_redis/redis_client.h
+++ b/src/modules/ndb_redis/redis_client.h
@@ -36,6 +36,7 @@
 
 #define MAXIMUM_PIPELINED_COMMANDS 1000
 #define MAXIMUM_NESTED_KEYS 10
+#define LM_DBG_redis_reply(rpl) print_redis_reply(L_DBG,(rpl),0)
 
 int redisc_init(void);
 int redisc_destroy(void);
@@ -97,4 +98,5 @@ int redisc_free_reply(str *name);
 int redisc_check_auth(redisc_server_t *rsrv, char *pass);
 int redis_check_server(redisc_server_t *rsrv);
 int redis_count_err_and_disable(redisc_server_t *rsrv);
+void print_redis_reply(int log_level, redisReply *rpl,int offset);
 #endif


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Added a way to print the redis responses when they are arrays, since the previous log message would just print (null) instead. In case a MULTI/EXEC transaction will be used to issue redis commands, the response would be an array, making the original debug message useless. With this new debug, arrays, strings, integers, and other replies such as status or error replies are logged properly. 
Also added an error message when a reply is expected but not received. 