### PR TITLE
pua_reginfo: use outbound proxy for PUBLISHes

### DIFF
--- a/src/modules/enum/enum.c
+++ b/src/modules/enum/enum.c
@@ -82,7 +82,7 @@ static int cclen(const char *number)
 	d1 = number[0];
 	d2 = number[1];
 
-	if(!isdigit((int)d2))
+	if(!isdigit((int)d1) || !isdigit((int)d2))
 		return (0);
 
 	switch(d1) {
@@ -90,13 +90,13 @@ static int cclen(const char *number)
 		case '7':
 			return (1);
 		case '2':
-			if((d2 == '0') || (d1 == '7'))
+			if((d2 == '0') || (d2 == '7'))
 				return (2);
 			break;
 		case '3':
-			if((d2 >= '0') && (d1 <= '4'))
+			if((d2 >= '0') && (d2 <= '4'))
 				return (2);
-			if((d2 == '6') || (d1 == '9'))
+			if((d2 == '6') || (d2 == '9'))
 				return (2);
 			break;
 		case '4':
@@ -104,19 +104,19 @@ static int cclen(const char *number)
 				return (2);
 			break;
 		case '5':
-			if((d2 >= '1') && (d1 <= '8'))
+			if((d2 >= '1') && (d2 <= '8'))
 				return (2);
 			break;
 		case '6':
-			if(d1 <= '6')
+			if(d2 <= '6')
 				return (2);
 			break;
 		case '8':
-			if((d2 == '1') || (d1 == '2') || (d1 == '4') || (d1 == '6'))
+			if((d2 == '1') || (d2 == '2') || (d2 == '4') || (d2 == '6'))
 				return (2);
 			break;
 		case '9':
-			if(d1 <= '5')
+			if(d2 <= '5')
 				return (2);
 			if(d2 == '8')
 				return (2);

--- a/src/modules/pua_reginfo/usrloc_cb.c
+++ b/src/modules/pua_reginfo/usrloc_cb.c
@@ -323,6 +323,9 @@ void reginfo_usrloc_cb(ucontact_t* c, int type, void* param) {
 	publ.event |= REGINFO_EVENT;
 	publ.extra_headers= NULL;
 
+	if(outbound_proxy.s && outbound_proxy.len)
+		publ.outbound_proxy= &outbound_proxy;
+
 	if(pua.send_publish(&publ) < 0) {
 		LM_ERR("Error while sending publish\n");
 	}	


### PR DESCRIPTION
Hi, guys!

Pua module provides a callback "send_publish". One of the parameters is "outbound_proxy", but pua_reginfo does not use it while PUBLISH constructing, even if the parameter is specified.

Documentation says: "The outbound_proxy uri to be used when sending Subscribe requests."
Any reason to use it only for SUBSCRIBE, and not for PUBLISH?

If PR is acceptable, do I need to correct documentation for pua_reginfo module?

I have studied the contributing gide, but if something is not OK - please point out,.