### PR TITLE
Cfg reset

### DIFF
--- a/src/core/cfg/cfg_ctx.h
+++ b/src/core/cfg/cfg_ctx.h
@@ -119,6 +119,9 @@ int cfg_rollback(cfg_ctx_t *ctx);
 int cfg_get_by_name(cfg_ctx_t *ctx, str *group_name, unsigned int *group_id, str *var_name,
 			void **val, unsigned int *val_type);
 
+int cfg_get_default_value_by_name(cfg_ctx_t *ctx, str *group_name, unsigned int *group_id, str *var_name,
+			void **val, unsigned int *val_type);
+
 /*! \brief returns the description of a variable */
 int cfg_help(cfg_ctx_t *ctx, str *group_name, str *var_name,
 			char **ch, unsigned int *input_type);

--- a/src/modules/cfg_rpc/README
+++ b/src/modules/cfg_rpc/README
@@ -11,33 +11,33 @@ Miklos Tirpak
 
    1. Admin Guide
 
-        1.1. Overview
-        1.2. Dependencies
+        1. Overview
+        2. Dependencies
 
-              1.2.1. SIP Router Modules
-              1.2.2. External Libraries or Applications
+              2.1. SIP Router Modules
+              2.2. External Libraries or Applications
 
-        1.3. RPC Commands
+        3. RPC Commands
 
-              1.3.1. cfg.list
-              1.3.2. cfg.get
-              1.3.3. cfg.seti
-              1.3.4. cfg.set_now_int
-              1.3.5. cfg.sets
-              1.3.6. cfg.reset
-              1.3.7. cfg.set_now_string
-              1.3.8. cfg.set
-              1.3.9. cfg.del
-              1.3.10. cfg.set_delayed_int
-              1.3.11. cfg.set_delayed_string
-              1.3.12. cfg.set_delayed
-              1.3.13. cfg.del_delayed
-              1.3.14. cfg.commit
-              1.3.15. cfg.rollback
-              1.3.16. cfg.help
-              1.3.17. cfg.diff
-              1.3.18. cfg.add_group_inst
-              1.3.19. cfg.del_group_inst
+              3.1. cfg.list
+              3.2. cfg.get
+              3.3. cfg.seti
+              3.4. cfg.set_now_int
+              3.5. cfg.sets
+              3.6. cfg.reset
+              3.7. cfg.set_now_string
+              3.8. cfg.set
+              3.9. cfg.del
+              3.10. cfg.set_delayed_int
+              3.11. cfg.set_delayed_string
+              3.12. cfg.set_delayed
+              3.13. cfg.del_delayed
+              3.14. cfg.commit
+              3.15. cfg.rollback
+              3.16. cfg.help
+              3.17. cfg.diff
+              3.18. cfg.add_group_inst
+              3.19. cfg.del_group_inst
 
    List of Examples
 
@@ -49,7 +49,37 @@ Miklos Tirpak
 
 Chapter 1. Admin Guide
 
-1.1. Overview
+   Table of Contents
+
+   1. Overview
+   2. Dependencies
+
+        2.1. SIP Router Modules
+        2.2. External Libraries or Applications
+
+   3. RPC Commands
+
+        3.1. cfg.list
+        3.2. cfg.get
+        3.3. cfg.seti
+        3.4. cfg.set_now_int
+        3.5. cfg.sets
+        3.6. cfg.reset
+        3.7. cfg.set_now_string
+        3.8. cfg.set
+        3.9. cfg.del
+        3.10. cfg.set_delayed_int
+        3.11. cfg.set_delayed_string
+        3.12. cfg.set_delayed
+        3.13. cfg.del_delayed
+        3.14. cfg.commit
+        3.15. cfg.rollback
+        3.16. cfg.help
+        3.17. cfg.diff
+        3.18. cfg.add_group_inst
+        3.19. cfg.del_group_inst
+
+1. Overview
 
    The module implements RPC commands to set and get configuration
    variables on-the-fly, that are declared by Kamailio core and by the
@@ -64,24 +94,47 @@ Chapter 1. Admin Guide
    'kamcmd' can be used to execute the RPC commands implemented in this
    module.
 
-1.2. Dependencies
+2. Dependencies
 
-1.2.1. SIP Router Modules
+   2.1. SIP Router Modules
+   2.2. External Libraries or Applications
+
+2.1. SIP Router Modules
 
    The following modules must be loaded before this module:
      * No dependencies on other SIP Router modules.
 
-1.2.2. External Libraries or Applications
+2.2. External Libraries or Applications
 
    The following libraries or applications must be installed before
    running SIP Router with this module loaded:
      * None.
 
-1.3. RPC Commands
+3. RPC Commands
+
+   3.1. cfg.list
+   3.2. cfg.get
+   3.3. cfg.seti
+   3.4. cfg.set_now_int
+   3.5. cfg.sets
+   3.6. cfg.reset
+   3.7. cfg.set_now_string
+   3.8. cfg.set
+   3.9. cfg.del
+   3.10. cfg.set_delayed_int
+   3.11. cfg.set_delayed_string
+   3.12. cfg.set_delayed
+   3.13. cfg.del_delayed
+   3.14. cfg.commit
+   3.15. cfg.rollback
+   3.16. cfg.help
+   3.17. cfg.diff
+   3.18. cfg.add_group_inst
+   3.19. cfg.del_group_inst
 
    The module implements the RPC commands documented in the next sections.
 
-1.3.1. cfg.list
+3.1. cfg.list
 
    cfg.list - List the configuration variables. The function has one
    optional parameter: group name.
@@ -91,7 +144,7 @@ Chapter 1. Admin Guide
 # kamcmd cfg.list
 ...
 
-1.3.2. cfg.get
+3.2. cfg.get
 
    cfg.get - Get the value of a configuration variable. The function
    accepts two parameters: group name, variable name. The group name can
@@ -102,7 +155,7 @@ Chapter 1. Admin Guide
 # kamcmd cfg.get core debug
 ...
 
-1.3.3. cfg.seti
+3.3. cfg.seti
 
    cfg.seti - Set the value of a configuration variable and commit the
    change immediately. The function accepts three parameters: group name,
@@ -114,11 +167,11 @@ Chapter 1. Admin Guide
 # kamcmd cfg.seti core debug 1
 ...
 
-1.3.4. cfg.set_now_int
+3.4. cfg.set_now_int
 
    cfg.set_now_int - This is an alias to the command cfg.seti.
 
-1.3.5. cfg.sets
+3.5. cfg.sets
 
    cfg.sets - Set the value of a configuration variable and commit the
    change immediately. The function accepts three parameters: group name,
@@ -130,7 +183,7 @@ Chapter 1. Admin Guide
 # kamcmd cfg.sets voicemail srv_ip "1.2.3.4"
 ...
 
-1.3.6. cfg.reset
+3.6. cfg.reset
 
    cfg.reset - Reset the variable values of a configuration group. The
    function accepts only one parameter: group name.
@@ -140,11 +193,11 @@ Chapter 1. Admin Guide
 # kamcmd cfg.reset core
 ...
 
-1.3.7. cfg.set_now_string
+3.7. cfg.set_now_string
 
    cfg.set_now_string - This is an alias to the command cfg.sets.
 
-1.3.8. cfg.set
+3.8. cfg.set
 
    cfg.set - Set the value of a configuration variable and commit the
    change immediately. This is a wrapper command for cfg.set_now_int and
@@ -153,7 +206,7 @@ Chapter 1. Admin Guide
    int/string value. The group name can optionally contain the group
    instance id, for example foo[5].
 
-1.3.9. cfg.del
+3.9. cfg.del
 
    cfg.del - Delete the value of a configuration variable from a group
    instance and commit the change immediately. The value is reset to the
@@ -161,21 +214,21 @@ Chapter 1. Admin Guide
    two parameters: group name, variable name. The group name must contain
    the group instance id, for example foo[5].
 
-1.3.10. cfg.set_delayed_int
+3.10. cfg.set_delayed_int
 
    cfg.set_delayed_int - Prepare the change of a configuration variable,
    but does not commit the new value yet. The function accepts three
    parameters: group name, variable name, integer value. The group name
    can optionally contain the group instance id, for example foo[5].
 
-1.3.11. cfg.set_delayed_string
+3.11. cfg.set_delayed_string
 
    cfg.set_delayed_string - Prepare the change of a configuration
    variable, but does not commit the new value yet. The function accepts
    three parameters: group name, variable name, string value. The group
    name can optionally contain the group instance id, for example foo[5].
 
-1.3.12. cfg.set_delayed
+3.12. cfg.set_delayed
 
    cfg.set_delayed - Prepare the change of a configuration variable, but
    does not commit the new value yet. This is a wrapper command for
@@ -184,7 +237,7 @@ Chapter 1. Admin Guide
    variable name, int/string value. The group name can optionally contain
    the group instance id, for example foo[5].
 
-1.3.13. cfg.del_delayed
+3.13. cfg.del_delayed
 
    cfg.del_delayed - Prepare the deletion of the value of a configuration
    variable from a group instance, but does not commit the change yet. The
@@ -192,33 +245,33 @@ Chapter 1. Admin Guide
    The function accepts two parameters: group name, variable name. The
    group name must contain the group instance id, for example foo[5].
 
-1.3.14. cfg.commit
+3.14. cfg.commit
 
    cfg.commit - Commit the previously prepared configuration changes. The
    function does not have any parameters.
 
-1.3.15. cfg.rollback
+3.15. cfg.rollback
 
    cfg.rollback - Drop the prepared configuration changes. The function
    does not have any parameters.
 
-1.3.16. cfg.help
+3.16. cfg.help
 
    cfg.help - Print the description of a configuration variable. The
    function accepts two parameters: group name, variable name.
 
-1.3.17. cfg.diff
+3.17. cfg.diff
 
    cfg.diff - List the pending configuration changes that have not been
    committed yet. The function does not have any parameters.
 
-1.3.18. cfg.add_group_inst
+3.18. cfg.add_group_inst
 
    cfg.add_group_inst - Add a new instance to an existing configuration
    group. The function accepts one parameter: group name[instance id], for
    example foo[5].
 
-1.3.19. cfg.del_group_inst
+3.19. cfg.del_group_inst
 
    cfg.del_group_inst - Delete an instance of an existing configuration
    group. The function accepts one parameter: group name[instance id], for

--- a/src/modules/cfg_rpc/README
+++ b/src/modules/cfg_rpc/README
@@ -11,32 +11,33 @@ Miklos Tirpak
 
    1. Admin Guide
 
-        1. Overview
-        2. Dependencies
+        1.1. Overview
+        1.2. Dependencies
 
-              2.1. SIP Router Modules
-              2.2. External Libraries or Applications
+              1.2.1. SIP Router Modules
+              1.2.2. External Libraries or Applications
 
-        3. RPC Commands
+        1.3. RPC Commands
 
-              3.1. cfg.list
-              3.2. cfg.get
-              3.3. cfg.seti
-              3.4. cfg.set_now_int
-              3.5. cfg.sets
-              3.6. cfg.set_now_string
-              3.7. cfg.set
-              3.8. cfg.del
-              3.9. cfg.set_delayed_int
-              3.10. cfg.set_delayed_string
-              3.11. cfg.set_delayed
-              3.12. cfg.del_delayed
-              3.13. cfg.commit
-              3.14. cfg.rollback
-              3.15. cfg.help
-              3.16. cfg.diff
-              3.17. cfg.add_group_inst
-              3.18. cfg.del_group_inst
+              1.3.1. cfg.list
+              1.3.2. cfg.get
+              1.3.3. cfg.seti
+              1.3.4. cfg.set_now_int
+              1.3.5. cfg.sets
+              1.3.6. cfg.reset
+              1.3.7. cfg.set_now_string
+              1.3.8. cfg.set
+              1.3.9. cfg.del
+              1.3.10. cfg.set_delayed_int
+              1.3.11. cfg.set_delayed_string
+              1.3.12. cfg.set_delayed
+              1.3.13. cfg.del_delayed
+              1.3.14. cfg.commit
+              1.3.15. cfg.rollback
+              1.3.16. cfg.help
+              1.3.17. cfg.diff
+              1.3.18. cfg.add_group_inst
+              1.3.19. cfg.del_group_inst
 
    List of Examples
 
@@ -44,39 +45,11 @@ Miklos Tirpak
    1.2. Use cfg.get RPC command
    1.3. Use cfg.seti RPC command
    1.4. Use cfg.sets RPC command
+   1.5. Use cfg.reset RPC command
 
 Chapter 1. Admin Guide
 
-   Table of Contents
-
-   1. Overview
-   2. Dependencies
-
-        2.1. SIP Router Modules
-        2.2. External Libraries or Applications
-
-   3. RPC Commands
-
-        3.1. cfg.list
-        3.2. cfg.get
-        3.3. cfg.seti
-        3.4. cfg.set_now_int
-        3.5. cfg.sets
-        3.6. cfg.set_now_string
-        3.7. cfg.set
-        3.8. cfg.del
-        3.9. cfg.set_delayed_int
-        3.10. cfg.set_delayed_string
-        3.11. cfg.set_delayed
-        3.12. cfg.del_delayed
-        3.13. cfg.commit
-        3.14. cfg.rollback
-        3.15. cfg.help
-        3.16. cfg.diff
-        3.17. cfg.add_group_inst
-        3.18. cfg.del_group_inst
-
-1. Overview
+1.1. Overview
 
    The module implements RPC commands to set and get configuration
    variables on-the-fly, that are declared by Kamailio core and by the
@@ -91,46 +64,24 @@ Chapter 1. Admin Guide
    'kamcmd' can be used to execute the RPC commands implemented in this
    module.
 
-2. Dependencies
+1.2. Dependencies
 
-   2.1. SIP Router Modules
-   2.2. External Libraries or Applications
-
-2.1. SIP Router Modules
+1.2.1. SIP Router Modules
 
    The following modules must be loaded before this module:
      * No dependencies on other SIP Router modules.
 
-2.2. External Libraries or Applications
+1.2.2. External Libraries or Applications
 
    The following libraries or applications must be installed before
    running SIP Router with this module loaded:
      * None.
 
-3. RPC Commands
-
-   3.1. cfg.list
-   3.2. cfg.get
-   3.3. cfg.seti
-   3.4. cfg.set_now_int
-   3.5. cfg.sets
-   3.6. cfg.set_now_string
-   3.7. cfg.set
-   3.8. cfg.del
-   3.9. cfg.set_delayed_int
-   3.10. cfg.set_delayed_string
-   3.11. cfg.set_delayed
-   3.12. cfg.del_delayed
-   3.13. cfg.commit
-   3.14. cfg.rollback
-   3.15. cfg.help
-   3.16. cfg.diff
-   3.17. cfg.add_group_inst
-   3.18. cfg.del_group_inst
+1.3. RPC Commands
 
    The module implements the RPC commands documented in the next sections.
 
-3.1. cfg.list
+1.3.1. cfg.list
 
    cfg.list - List the configuration variables. The function has one
    optional parameter: group name.
@@ -140,7 +91,7 @@ Chapter 1. Admin Guide
 # kamcmd cfg.list
 ...
 
-3.2. cfg.get
+1.3.2. cfg.get
 
    cfg.get - Get the value of a configuration variable. The function
    accepts two parameters: group name, variable name. The group name can
@@ -151,7 +102,7 @@ Chapter 1. Admin Guide
 # kamcmd cfg.get core debug
 ...
 
-3.3. cfg.seti
+1.3.3. cfg.seti
 
    cfg.seti - Set the value of a configuration variable and commit the
    change immediately. The function accepts three parameters: group name,
@@ -163,11 +114,11 @@ Chapter 1. Admin Guide
 # kamcmd cfg.seti core debug 1
 ...
 
-3.4. cfg.set_now_int
+1.3.4. cfg.set_now_int
 
    cfg.set_now_int - This is an alias to the command cfg.seti.
 
-3.5. cfg.sets
+1.3.5. cfg.sets
 
    cfg.sets - Set the value of a configuration variable and commit the
    change immediately. The function accepts three parameters: group name,
@@ -179,11 +130,21 @@ Chapter 1. Admin Guide
 # kamcmd cfg.sets voicemail srv_ip "1.2.3.4"
 ...
 
-3.6. cfg.set_now_string
+1.3.6. cfg.reset
+
+   cfg.reset - Reset the variable values of a configuration group. The
+   function accepts only one parameter: group name.
+
+   Example 1.5. Use cfg.reset RPC command
+...
+# kamcmd cfg.reset core
+...
+
+1.3.7. cfg.set_now_string
 
    cfg.set_now_string - This is an alias to the command cfg.sets.
 
-3.7. cfg.set
+1.3.8. cfg.set
 
    cfg.set - Set the value of a configuration variable and commit the
    change immediately. This is a wrapper command for cfg.set_now_int and
@@ -192,7 +153,7 @@ Chapter 1. Admin Guide
    int/string value. The group name can optionally contain the group
    instance id, for example foo[5].
 
-3.8. cfg.del
+1.3.9. cfg.del
 
    cfg.del - Delete the value of a configuration variable from a group
    instance and commit the change immediately. The value is reset to the
@@ -200,21 +161,21 @@ Chapter 1. Admin Guide
    two parameters: group name, variable name. The group name must contain
    the group instance id, for example foo[5].
 
-3.9. cfg.set_delayed_int
+1.3.10. cfg.set_delayed_int
 
    cfg.set_delayed_int - Prepare the change of a configuration variable,
    but does not commit the new value yet. The function accepts three
    parameters: group name, variable name, integer value. The group name
    can optionally contain the group instance id, for example foo[5].
 
-3.10. cfg.set_delayed_string
+1.3.11. cfg.set_delayed_string
 
    cfg.set_delayed_string - Prepare the change of a configuration
    variable, but does not commit the new value yet. The function accepts
    three parameters: group name, variable name, string value. The group
    name can optionally contain the group instance id, for example foo[5].
 
-3.11. cfg.set_delayed
+1.3.12. cfg.set_delayed
 
    cfg.set_delayed - Prepare the change of a configuration variable, but
    does not commit the new value yet. This is a wrapper command for
@@ -223,7 +184,7 @@ Chapter 1. Admin Guide
    variable name, int/string value. The group name can optionally contain
    the group instance id, for example foo[5].
 
-3.12. cfg.del_delayed
+1.3.13. cfg.del_delayed
 
    cfg.del_delayed - Prepare the deletion of the value of a configuration
    variable from a group instance, but does not commit the change yet. The
@@ -231,33 +192,33 @@ Chapter 1. Admin Guide
    The function accepts two parameters: group name, variable name. The
    group name must contain the group instance id, for example foo[5].
 
-3.13. cfg.commit
+1.3.14. cfg.commit
 
    cfg.commit - Commit the previously prepared configuration changes. The
    function does not have any parameters.
 
-3.14. cfg.rollback
+1.3.15. cfg.rollback
 
    cfg.rollback - Drop the prepared configuration changes. The function
    does not have any parameters.
 
-3.15. cfg.help
+1.3.16. cfg.help
 
    cfg.help - Print the description of a configuration variable. The
    function accepts two parameters: group name, variable name.
 
-3.16. cfg.diff
+1.3.17. cfg.diff
 
    cfg.diff - List the pending configuration changes that have not been
    committed yet. The function does not have any parameters.
 
-3.17. cfg.add_group_inst
+1.3.18. cfg.add_group_inst
 
    cfg.add_group_inst - Add a new instance to an existing configuration
    group. The function accepts one parameter: group name[instance id], for
    example foo[5].
 
-3.18. cfg.del_group_inst
+1.3.19. cfg.del_group_inst
 
    cfg.del_group_inst - Delete an instance of an existing configuration
    group. The function accepts one parameter: group name[instance id], for

--- a/src/modules/cfg_rpc/cfg_rpc.c
+++ b/src/modules/cfg_rpc/cfg_rpc.c
@@ -368,9 +368,10 @@ static void rpc_reset(rpc_t* rpc, void* c)
 	void	*val;
 	int	i, ret;
 	str	group;
+	char	*ch;
 	unsigned int	*group_id;
 	unsigned int	val_type;
-
+	unsigned int	input_type;
 
 	if (rpc->scan(c, "S", &group) < 1)
 		return;

--- a/src/modules/cfg_rpc/cfg_rpc.c
+++ b/src/modules/cfg_rpc/cfg_rpc.c
@@ -355,6 +355,60 @@ static void rpc_get(rpc_t* rpc, void* c)
 	}
 
 }
+static const char* rpc_reset_doc[2] = {
+       "Reset all the values of a configuration group and commit the change immediately",
+       0
+};
+
+static void rpc_reset(rpc_t* rpc, void* c)
+{
+	void	*h;
+	str	gname, var;
+	cfg_def_t	*def;
+	void	*val;
+	int	i, ret;
+	str	group;
+	unsigned int	*group_id;
+	unsigned int	val_type;
+
+
+	if (rpc->scan(c, "S", &group) < 1)
+		return;
+
+	if (get_group_id(&group, &group_id)) {
+		rpc->fault(c, 400, "Wrong group syntax. Use either \"group\", or \"group[id]\"");
+	return;
+	}
+
+	cfg_get_group_init(&h);
+	while(cfg_get_group_next(&h, &gname, &def))
+		if (((gname.len == group.len) && (memcmp(gname.s, group.s, group.len) == 0)))
+		{
+			for (i=0; def[i].name; i++){
+
+				var.s = def[i].name;
+				var.len = (int)strlen(def[i].name);
+				ret = cfg_get_default_value_by_name(ctx, &gname, group_id, &var,
+						&val, &val_type);
+
+				if (ret != 0)
+					continue;
+
+				if (cfg_help(ctx, &group, &var,
+							&ch, &input_type)
+					) {
+					rpc->fault(c, 400, "Failed to get the variable description");
+					return;
+				}
+
+				if (input_type == CFG_INPUT_INT)
+					cfg_set_now_int(ctx, &gname, group_id, &var, val);
+				else if (input_type == CFG_INPUT_STRING)
+					cfg_set_now_string(ctx, &gname, group_id, &var, val);
+			}
+		}
+}
+
 
 static const char* rpc_help_doc[2] = {
         "Print the description of a configuration variable",
@@ -546,6 +600,7 @@ static rpc_export_t rpc_calls[] = {
 	{"cfg.commit",		rpc_commit,		rpc_commit_doc,		0},
 	{"cfg.rollback",	rpc_rollback,		rpc_rollback_doc,	0},
 	{"cfg.get",		rpc_get,		rpc_get_doc,		0},
+	{"cfg.reset",           rpc_reset,              rpc_reset_doc,          0},
 	{"cfg.help",		rpc_help,		rpc_help_doc,		0},
 	{"cfg.list",		rpc_list,		rpc_list_doc,		0},
 	{"cfg.diff",		rpc_diff,		rpc_diff_doc,		0},

--- a/src/modules/cfg_rpc/doc/rpc.xml
+++ b/src/modules/cfg_rpc/doc/rpc.xml
@@ -88,6 +88,22 @@
 # &kamcmd; cfg.sets voicemail srv_ip "1.2.3.4"
 ...
 </programlisting>
+                </example>
+        </section>
+        <section id="cfg_rpc.rpc.reset">
+    <title>cfg.reset</title>
+            <para>
+                <emphasis>cfg.reset</emphasis> - Reset the variable values of
+                a configuration group. The function accepts only one parameter:
+                group name.
+            </para>
+                <example>
+                <title>Use <varname>cfg.reset</varname> RPC command</title>
+                <programlisting format="linespecific">
+...
+# &sercmd; cfg.reset core
+...
+</programlisting>
 		</example>
 	</section>
 	<section id="cfg_rpc.rpc.set_now_string">


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
kamcmd cfg.reset "group_name", cfg.reset has been created in order to reset all the variables of the referred group to be set to their initial values (default).