### PR TITLE
dispatcher: Increase line buffer size

### DIFF
--- a/src/modules/dispatcher/dispatch.c
+++ b/src/modules/dispatcher/dispatch.c
@@ -623,7 +623,7 @@ err1:
 /*! \brief load groups of destinations from file */
 int ds_load_list(char *lfile)
 {
-	char line[256], *p;
+	char line[1024], *p;
 	FILE *f = NULL;
 	int id, setn, flags, priority;
 	str uri;
@@ -650,7 +650,7 @@ int ds_load_list(char *lfile)
 	*next_idx = (*crt_idx + 1) % 2;
 	ds_avl_destroy(&ds_lists[*next_idx]);
 
-	p = fgets(line, 256, f);
+	p = fgets(line, 1024, f);
 	while(p) {
 		/* eat all white spaces */
 		while(*p && (*p == ' ' || *p == '\t' || *p == '\r' || *p == '\n'))
@@ -728,7 +728,7 @@ int ds_load_list(char *lfile)
 			LM_WARN("unable to add destination %.*s to set %d -- skipping\n",
 					uri.len, uri.s, id);
 	next_line:
-		p = fgets(line, 256, f);
+		p = fgets(line, 1024, f);
 	}
 
 	if(reindex_dests(ds_lists[*next_idx]) != 0) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Depending on how many custom attributes one has set in the dispatcher file, some of them might be ignored due to the 256 read line buffer size. Increase the line buffer size. Probably adding a modparam for that would be a better approach ?! but I want to avoid any dynamic alloc/free(for now).