### PR TITLE
configuration reset function (cfg.reset)

### DIFF
--- a/src/core/cfg/cfg_ctx.h
+++ b/src/core/cfg/cfg_ctx.h
@@ -119,6 +119,9 @@ int cfg_rollback(cfg_ctx_t *ctx);
 int cfg_get_by_name(cfg_ctx_t *ctx, str *group_name, unsigned int *group_id, str *var_name,
 			void **val, unsigned int *val_type);
 
+int cfg_get_default_value_by_name(cfg_ctx_t *ctx, str *group_name, unsigned int *group_id, str *var_name,
+			void **val, unsigned int *val_type);
+
 /*! \brief returns the description of a variable */
 int cfg_help(cfg_ctx_t *ctx, str *group_name, str *var_name,
 			char **ch, unsigned int *input_type);

--- a/src/modules/cfg_rpc/cfg_rpc.c
+++ b/src/modules/cfg_rpc/cfg_rpc.c
@@ -355,6 +355,61 @@ static void rpc_get(rpc_t* rpc, void* c)
 	}
 
 }
+static const char* rpc_reset_doc[2] = {
+       "Reset all the values of a configuration group and commit the change immediately",
+       0
+};
+
+static void rpc_reset(rpc_t* rpc, void* c)
+{
+	void	*h;
+	str	gname, var;
+	cfg_def_t	*def;
+	void	*val;
+	int	i, ret;
+	str	group;
+	char	*ch;
+	unsigned int	*group_id;
+	unsigned int	val_type;
+	unsigned int	input_type;
+
+	if (rpc->scan(c, "S", &group) < 1)
+		return;
+
+	if (get_group_id(&group, &group_id)) {
+		rpc->fault(c, 400, "Wrong group syntax. Use either \"group\", or \"group[id]\"");
+	return;
+	}
+
+	cfg_get_group_init(&h);
+	while(cfg_get_group_next(&h, &gname, &def))
+		if (((gname.len == group.len) && (memcmp(gname.s, group.s, group.len) == 0)))
+		{
+			for (i=0; def[i].name; i++){
+
+				var.s = def[i].name;
+				var.len = (int)strlen(def[i].name);
+				ret = cfg_get_default_value_by_name(ctx, &gname, group_id, &var,
+						&val, &val_type);
+
+				if (ret != 0)
+					continue;
+
+				if (cfg_help(ctx, &group, &var,
+							&ch, &input_type)
+					) {
+					rpc->fault(c, 400, "Failed to get the variable description");
+					return;
+				}
+
+				if (input_type == CFG_INPUT_INT)
+					cfg_set_now_int(ctx, &gname, group_id, &var, val);
+				else if (input_type == CFG_INPUT_STRING)
+					cfg_set_now_string(ctx, &gname, group_id, &var, val);
+			}
+		}
+}
+
 
 static const char* rpc_help_doc[2] = {
         "Print the description of a configuration variable",
@@ -546,6 +601,7 @@ static rpc_export_t rpc_calls[] = {
 	{"cfg.commit",		rpc_commit,		rpc_commit_doc,		0},
 	{"cfg.rollback",	rpc_rollback,		rpc_rollback_doc,	0},
 	{"cfg.get",		rpc_get,		rpc_get_doc,		0},
+	{"cfg.reset",           rpc_reset,              rpc_reset_doc,          0},
 	{"cfg.help",		rpc_help,		rpc_help_doc,		0},
 	{"cfg.list",		rpc_list,		rpc_list_doc,		0},
 	{"cfg.diff",		rpc_diff,		rpc_diff_doc,		0},

--- a/src/modules/cfg_rpc/doc/rpc.xml
+++ b/src/modules/cfg_rpc/doc/rpc.xml
@@ -88,6 +88,22 @@
 # &kamcmd; cfg.sets voicemail srv_ip "1.2.3.4"
 ...
 </programlisting>
+                </example>
+        </section>
+        <section id="cfg_rpc.rpc.reset">
+    <title>cfg.reset</title>
+            <para>
+                <emphasis>cfg.reset</emphasis> - Reset the variable values of
+                a configuration group. The function accepts only one parameter:
+                group name.
+            </para>
+                <example>
+                <title>Use <varname>cfg.reset</varname> RPC command</title>
+                <programlisting format="linespecific">
+...
+# &sercmd; cfg.reset core
+...
+</programlisting>
 		</example>
 	</section>
 	<section id="cfg_rpc.rpc.set_now_string">


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
kamcmd cfg.reset "group_name", cfg.reset has been created in order to reset all the variables of the referred group to be set to their initial values (default).
