### PR TITLE
xmlrpc: add <value> tag to array elements

### DIFF
--- a/src/modules/xmlrpc/xmlrpc.c
+++ b/src/modules/xmlrpc/xmlrpc.c
@@ -1805,6 +1805,7 @@ static int rpc_array_add(struct rpc_struct* s, char* fmt, ...)
 
 	va_start(ap, fmt);
 	while(*fmt) {
+		if (add_xmlrpc_reply(reply, &value_prefix) < 0) goto err;
 		if (*fmt == '{' || *fmt == '[') {
 			void_ptr = va_arg(ap, void**);
 			p = new_rpcstruct(0, 0, s->reply, (*fmt=='[')?RET_ARRAY:0);
@@ -1822,6 +1823,7 @@ static int rpc_array_add(struct rpc_struct* s, char* fmt, ...)
 		} else {
 			if (print_value(reply, reply, *fmt, &ap) < 0) goto err;
 		}
+		if (add_xmlrpc_reply(reply, &value_suffix) < 0) goto err;
 		fmt++;
 	}
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

As XML-RPC specification says

> An `<array>` contains a single `<data>` element, which can contain any number of `<value>`s.

Before this PR the function `rpc_array_add` adds elements to the `<data>` tag without wrapping them in `<value>` tag.

See http://xmlrpc.scripting.com/spec.html