### PR TITLE
cplc: use route names to set proxy_route modparam

### DIFF
--- a/src/modules/cplc/cplc.c
+++ b/src/modules/cplc/cplc.c
@@ -62,6 +62,7 @@ static str db_table        = str_init("cpl");  /* database table */
 static char *dtd_file      = 0;  /* name of the DTD file for CPL parser */
 static char *lookup_domain = 0;
 static str  timer_avp      = STR_NULL;  /* name of variable timer AVP */
+static str  proxy_route    = STR_NULL;
 
 
 struct cpl_enviroment    cpl_env = {
@@ -132,7 +133,7 @@ static param_export_t params[] = {
 	{"db_table",       PARAM_STR, &db_table                        },
 	{"cpl_dtd_file",   PARAM_STRING, &dtd_file                          },
 	{"proxy_recurse",  INT_PARAM, &cpl_env.proxy_recurse             },
-	{"proxy_route",    INT_PARAM, &cpl_env.proxy_route               },
+	{"proxy_route",    PARAM_STR, &proxy_route                     },
 	{"log_dir",        PARAM_STRING, &cpl_env.log_dir                   },
 	{"case_sensitive", INT_PARAM, &cpl_env.case_sensitive            },
 	{"realm_prefix",   PARAM_STR, &cpl_env.realm_prefix            },
@@ -230,6 +231,14 @@ static int cpl_init(void)
 			"the maximum safety value (%d)\n",
 			cpl_env.proxy_recurse,MAX_PROXY_RECURSE);
 		goto error;
+	}
+
+	if (proxy_route.len>0) {
+		cpl_env.proxy_route=route_lookup(&main_rt, proxy_route.s);
+		if (cpl_env.proxy_route==-1) {
+			LM_CRIT("route <%s> defined in proxy_route does not exist\n",proxy_route.s);
+			goto error;
+		}
 	}
 
 	/* fix the timer_avp name */

--- a/src/modules/cplc/doc/cplc_admin.xml
+++ b/src/modules/cplc/doc/cplc_admin.xml
@@ -280,7 +280,7 @@ modparam("cpl-c","proxy_recurse",2)
 			</example>
 		</section>
 		<section>
-			<title><varname>proxy_route</varname> (int)</title>
+			<title><varname>proxy_route</varname> (string)</title>
 			<para>
 				Before doing proxy (forward), a script route can be executed.
 				All modifications made by that route will be reflected only for
@@ -288,14 +288,14 @@ modparam("cpl-c","proxy_recurse",2)
 			</para>
 			<para>
 				<emphasis>
-					Default value of this parameter is 0 (none).
+					Default value of this parameter is NULL (none).
 				</emphasis>
 			</para>
 			<example>
 				<title>Set <varname>proxy_route</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","proxy_route",1)
+modparam("cpl-c","proxy_route","1")
 ...
 </programlisting>
 			</example>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
After allowing routes identification using names, the integer value defined in the parameter is not triggering the route referred by the name, but to the mapped id for one of the routes defined in the script. 
The proxy_route modparam type has been changed from integer to string in order to define the route to be executed by its name.
