### PR TITLE
Adapt some core rpc command to json

### DIFF
--- a/src/core/core_cmd.c
+++ b/src/core/core_cmd.c
@@ -989,7 +989,7 @@ static rpc_export_t core_rpc_methods[] = {
 	{"core.udp4_raw_info",     core_udp4rawinfo,       core_udp4rawinfo_doc,
 		0},
 	{"core.aliases_list",      core_aliases_list,      core_aliases_list_doc,   0},
-	{"core.sockets_list",      core_sockets_list,      core_sockets_list_doc,   0},
+	{"core.sockets_list",      core_sockets_list,      core_sockets_list_doc,   RET_ARRAY},
 #ifdef USE_DNS_CACHE
 	{"dns.mem_info",          dns_cache_mem_info,     dns_cache_mem_info_doc,
 		0	},

--- a/src/core/core_cmd.c
+++ b/src/core/core_cmd.c
@@ -876,14 +876,16 @@ static const char* core_aliases_list_doc[] = {
 static void core_aliases_list(rpc_t* rpc, void* c)
 {
 	void *hr;
+	void *hs;
 	void *ha;
 	struct host_alias* a;
 
 	rpc->add(c, "{", &hr);
 	rpc->struct_add(hr, "s",
 			"myself_callbacks", is_check_self_func_list_set()?"yes":"no");
+	rpc->struct_add(hr, "[", "aliases", &hs);
 	for(a=aliases; a; a=a->next) {
-		rpc->struct_add(hr, "{", "alias", &ha);
+		rpc->struct_add(hs, "{", "alias", &ha);
 		rpc->struct_add(ha, "sS",
 				"proto",  proto2a(a->proto),
 				"address", &a->alias


### PR DESCRIPTION
Recently playing with jsonrpcs I found an issue with core.sockets_list and core.aliases_list commands called via jsonrpc_dispatch. 
The problem for the first is that the socket's list is that the JSON produced is like
{
        "jsonrpc":      "2.0",
        "result":       {
                "socket":       {
                        "proto":        "udp",
                        "address":      "XX.XX.XX.XX",
                        "ipaddress":    "XX.XX.XX.XX",
                        "port": "5060",
                        "mcast":        "no",
                        "mhomed":       "no"
                },
                "socket":       {
                        "proto":        "udp",
                        "address":      "XX.XX.XX.XX",
                        "ipaddress":    "XX.XX.XX.XX",
                        "port": "5060",
                        "mcast":        "no",
                        "mhomed":       "no"
                },
                ....
        },
        "id":   1
 }

While this is a valid JSON document, the fact that the "socket" key is defined several time in the same object makes many parsers not to properly parse it and only keep the last value.
Solution for this is to set the RET_ARRAY flag for the rpc command core.sockets_list reply so that the jsonrpcs module will create an array for the sockets instead on an object.
Similar issue for the aliases list returned by the core.aliases_list command: in this case the proposed solution is to add an "aliases" array to the rpc reply.