### PR TITLE
core: build reply of core.sockets_list as an array

### DIFF
--- a/src/core/core_cmd.c
+++ b/src/core/core_cmd.c
@@ -920,7 +920,7 @@ static void core_sockets_list(rpc_t* rpc, void* c)
 	unsigned short proto;
 
 	proto=PROTO_UDP;
-	rpc->add(c, "{", &hr);
+	rpc->add(c, "[", &hr);
 	do{
 		list=get_sock_info_list(proto);
 		for(si=list?*list:0; si; si=si->next){
@@ -991,7 +991,7 @@ static rpc_export_t core_rpc_methods[] = {
 	{"core.udp4_raw_info",     core_udp4rawinfo,       core_udp4rawinfo_doc,
 		0},
 	{"core.aliases_list",      core_aliases_list,      core_aliases_list_doc,   0},
-	{"core.sockets_list",      core_sockets_list,      core_sockets_list_doc,   RET_ARRAY},
+	{"core.sockets_list",      core_sockets_list,      core_sockets_list_doc,   0},
 #ifdef USE_DNS_CACHE
 	{"dns.mem_info",          dns_cache_mem_info,     dns_cache_mem_info_doc,
 		0	},


### PR DESCRIPTION
I realized with more tests that my previous commit for core.sockets_list 38f514064a326f759e0e88adeffd03b32b35d6c0 is not working. The result is returned yes as an array but inside there is still the sockets list as an object (so with multiple "socket" keys). Digging more in kamailio json lib I understood that to be considered an array the rpc result must be enclosed in "[]". 
I was misled by a wrong test result, sorry for the noise. 