### PR TITLE
kamctl: fix dangerous 'rm -rf' code in case if variables are not defined

### DIFF
--- a/utils/kamctl/kamctl
+++ b/utils/kamctl/kamctl
@@ -2614,7 +2614,7 @@ tls_ca() {
 			merr "Failed to create root directory $CA_PATH"
 			exit 1
 		fi
-		rm -fr $CA_PATH/*
+		rm -fr "${CA_PATH:?}"/*
 		mkdir $CA_PATH/private
 		mkdir $CA_PATH/certs
 		touch $CA_PATH/index.txt
@@ -2685,7 +2685,7 @@ tls_ca() {
 			merr "Failed to create user directory $USER_DIR "
 			exit 1
 		fi
-		rm -fr $USER_DIR/*
+		rm -fr "${USER_DIR:?}"/*
 
 		mecho "Creating user certificate request"
 		openssl req  -config $USER_CFG -out $USER_DIR/$USER-cert_req.pem \


### PR DESCRIPTION
Hi,

kamctl has a historical bomb which can be new https://github.com/MrMEEE/bumblebee-Old-and-abbandoned/issues/123 in case if variables are undefined for some reason.

Have fun! CC @linuxmaniac 

