### PR TITLE
nathelper: correct Contact received param

### DIFF
--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -2122,15 +2122,13 @@ add_rcv_param_f(struct sip_msg* msg, char* str1, char* str2)
 	}
 
 	while(c) {
-		param = (char*)pkg_malloc(RECEIVED_LEN + 2 + uri.len);
+		param = (char*)pkg_malloc(RECEIVED_LEN + uri.len);
 		if (!param) {
 			LM_ERR("no pkg memory left\n");
 			return -1;
 		}
 		memcpy(param, RECEIVED, RECEIVED_LEN);
-		param[RECEIVED_LEN] = '\"';
-		memcpy(param + RECEIVED_LEN + 1, uri.s, uri.len);
-		param[RECEIVED_LEN + 1 + uri.len] = '\"';
+		memcpy(param + RECEIVED_LEN, uri.s, uri.len);
 
 		if (hdr_param) {
 			/* add the param as header param */


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
- Received param was enclosed in quotes, making some UACs stumble
  upon it. This fix removes the quotes, adding the received param
  the same way as it is done for example in the path module.
- Reported by Arslan Aseed.
