### PR TITLE
textops: Fix 'offset exceeds message size' crash.

### DIFF
--- a/src/modules/textops/textops.c
+++ b/src/modules/textops/textops.c
@@ -682,12 +682,19 @@ static int subst_helper_f(sip_msg_t* msg, struct subst_expr* se)
 	int off;
 	int ret;
 	int nmatches;
+	char c;
 
 	begin=get_header(msg);  /* start after first line to avoid replacing
 							* the uri */
 	off=begin-msg->buf;
 	ret=-1;
-	if ((lst=subst_run(se, begin, msg, &nmatches))==0)
+
+	c = msg->buf[msg->len];
+	msg->buf[msg->len] = '\0';
+	lst=subst_run(se, begin, msg, &nmatches);
+	msg->buf[msg->len] = c;
+
+	if (lst==0)
 		goto error; /* not found */
 	for (rpl=lst; rpl; rpl=rpl->next){
 		LM_DBG("%s: replacing at offset %d [%.*s] with [%.*s]\n",
@@ -826,6 +833,7 @@ static int subst_body_helper_f(struct sip_msg* msg, struct subst_expr* se)
 	int ret;
 	int nmatches;
 	str body;
+	char c;
 
 	body.s = get_body(msg);
 	if (body.s==0) {
@@ -842,7 +850,13 @@ static int subst_body_helper_f(struct sip_msg* msg, struct subst_expr* se)
 
 	off=begin-msg->buf;
 	ret=-1;
-	if ((lst=subst_run(se, begin, msg, &nmatches))==0)
+
+	c = body.s[body.len];
+	body.s[body.len] = '\0';
+	lst=subst_run(se, begin, msg, &nmatches);
+	body.s[body.len] = c;
+
+	if (lst==0)
 		goto error; /* not found */
 	for (rpl=lst; rpl; rpl=rpl->next){
 		LM_DBG("%s replacing at offset %d [%.*s] with [%.*s]\n",


### PR DESCRIPTION
Ensure that buffer is null terminated when subst_run() function is used.