### PR TITLE
carrierroute: update to readme to precise that decsavp need to be an avp

### DIFF
--- a/src/modules/carrierroute/doc/carrierroute_admin.xml
+++ b/src/modules/carrierroute/doc/carrierroute_admin.xml
@@ -514,7 +514,7 @@ cr_tree_rewrite_uri(tree, domain)
   		    </para>
         </listitem>
         <listitem>
-		      <para><emphasis>decsavp</emphasis> - Name of the AVP where to store the description.
+		      <para><emphasis>decsavp</emphasis> - AVP where to store the description.
 			This parameter is optional.
   		    </para>
         </listitem>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [x] Related to issue #1210 (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Make documentation of parameters description more clear that it has to be an avp not just the name.
