### PR TITLE
ims_auth: fixed rare core dump, due to null ptr check

### DIFF
--- a/src/modules/ims_auth/utils.c
+++ b/src/modules/ims_auth/utils.c
@@ -204,7 +204,9 @@ str ims_get_body(struct sip_msg * msg)
 		LM_DBG("Error parsing until header Content-Length: \n");
 		return x;
 	}
-	x.len = (int)(long)msg->content_length->parsed;
+	if (msg->content_length)
+	    // Content-Length header might be missing
+	    x.len = (int)(long)msg->content_length->parsed;
         
         if (x.len>0) 
             x.s = get_body(msg);	


### PR DESCRIPTION
The ims_auth module reads the value from the Content-Length header
of a REGISTER request, before decoding the message body.
Due to a missing null pointer check, reading this value leads
to core dump in case the Content-Length header is missing.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ x] Commit message has the format required by CONTRIBUTING guide
- [ x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ x] Each component has a single commit (if not, squash them into one commit)
- [ x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ x] PR should be backported to stable branches
- [ x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Added a null pointer check in function ims_get_body() - file utils.c of
module ims_auth - to check whether Content-Length Header was present
in REGISTER message.
If Content-Length Header is not present, a Default value of 0 will be assumed.

