### PR TITLE
carrierroute: warning for the same carrier/domain having routes with only 0 probability

### DIFF
--- a/src/modules/carrierroute/cr_db.c
+++ b/src/modules/carrierroute/cr_db.c
@@ -265,6 +265,7 @@ int load_user_carrier(str * user, str * domain) {
  */
 int load_route_data_db(struct route_data_t * rd) {
 	db1_res_t * res = NULL;
+	db1_res_t * prob_res = NULL;
 	db_row_t * row = NULL;
 	int i, ret;
 	struct carrier_data_t * tmp_carrier_data;
@@ -352,6 +353,7 @@ int load_route_data_db(struct route_data_t * rd) {
 		}
 	}
 	int n = 0;
+	boolean query_done = false;
 	do {
 		LM_DBG("loading, cycle %d", n++);
 		for (i = 0; i < RES_ROW_N(res); ++i) {
@@ -396,6 +398,35 @@ int load_route_data_db(struct route_data_t * rd) {
 					p_tmp_comment) == -1) {
 				goto errout;
 			}
+			if (row->values[COL_PROB].val.double_val == 0 && !query_done) {
+				int ret_tmp;
+				char query_tmp[QUERY_LEN];
+				str query_tmp_str;
+
+				memset(query_tmp, 0, QUERY_LEN);
+				ret_tmp = snprintf(query_tmp, QUERY_LEN, "SELECT * FROM %.*s WHERE %.*s=%d and %.*s=%d and %.*s>%d",
+						carrierroute_table.len, carrierroute_table.s, columns[COL_CARRIER]->len, columns[COL_CARRIER]->s, row->values[COL_CARRIER].val.int_val,
+						columns[COL_DOMAIN]->len, columns[COL_DOMAIN]->s, row->values[COL_DOMAIN].val.int_val, columns[COL_PROB]->len, columns[COL_PROB]->s, 0);
+
+				if (ret_tmp < 0) {
+					LM_ERR("error in snprintf while querying prob column");
+					goto errout;
+				}
+				query_tmp_str.s = query_tmp;
+				query_tmp_str.len = ret_tmp;
+
+				if (carrierroute_dbf.raw_query(carrierroute_dbh, &query_tmp_str, &prob_res) < 0) {
+					LM_ERR("Failed to query carrierroute db table based on prob column.\n");
+					goto errout;
+				}
+				if(RES_ROW_N(prob_res) == 0) {
+					LM_ERR("Carrierroute db table contains route(s) with only 0 probability.\n");
+					query_done = true;
+				}
+				carrierroute_dbf.free_result(carrierroute_dbh, prob_res);
+				prob_res = NULL;
+			}
+
 		}
 		if (DB_CAPABILITY(carrierroute_dbf, DB_CAP_FETCH)) {
 			if(carrierroute_dbf.fetch_result(carrierroute_dbh, &res,  cfg_get(carrierroute, carrierroute_cfg, fetch_rows)) < 0) {
@@ -461,6 +492,9 @@ int load_route_data_db(struct route_data_t * rd) {
 errout:
 	if (res) {
 		carrierroute_dbf.free_result(carrierroute_dbh, res);
+	}
+	if (prob_res) {
+		carrierroute_dbf.free_result(carrierroute_dbh, prob_res);
 	}
 	return -1;
 }

--- a/src/modules/carrierroute/cr_db.h
+++ b/src/modules/carrierroute/cr_db.h
@@ -88,4 +88,9 @@ int load_route_data_db (struct route_data_t * rd);
 
 int load_user_carrier(str * user, str * domain);
 
+typedef enum {
+	false = 0,
+	true = 1
+} boolean;
+
 #endif

--- a/src/modules/carrierroute/cr_func.c
+++ b/src/modules/carrierroute/cr_func.c
@@ -471,7 +471,7 @@ static int rewrite_on_rule(struct route_flags *rf_head, flag_t flags, str * dest
 			avp_value_t cr_new_uri;
 
 			if(rf->dice_max == 0) {
-				LM_ERR("invalid dice_max value\n");
+				LM_ERR("invalid dice_max value (route has probability 0)\n");
 				return -1;
 			}
 			if ((prob = hash_func(msg, hash_source, rf->dice_max)) < 0) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
  While starting kamailio or reloading the routes, if the same carrier/domain pairs do not have
  any route with a probability other than 0 (zero) then an error log will be printed on the screen.
  Besides, the log "invalid dice_max value" in the cr_func.c has been made more clear.