### PR TITLE
dispatcher: latency statistics

### DIFF
--- a/src/modules/dispatcher/dispatch.h
+++ b/src/modules/dispatcher/dispatch.h
@@ -156,12 +156,25 @@ typedef struct _ds_attrs {
 	int rweight;
 } ds_attrs_t;
 
+typedef struct _ds_latency_stats {
+	struct timeval start;
+	int min;
+	int max;
+	float average;  // weigthed average, estimate of the last few weeks
+	float stdev;    // last standard deviation
+	float estimate; // short term estimate, EWMA exponential weighted moving average
+	float last_q;   // q for N-1
+	int32_t count;
+	uint32_t timeout;
+} ds_latency_stats_t;
+
 typedef struct _ds_dest {
 	str uri;
 	int flags;
 	int priority;
 	int dload;
 	ds_attrs_t attrs;
+	ds_latency_stats_t latency_stats;
 	struct socket_info * sock;
 	struct ip_addr ip_address; 	/*!< IP-Address of the entry */
 	unsigned short int port; 	/*!< Port of the URI */

--- a/src/modules/dispatcher/doc/dispatcher.xml
+++ b/src/modules/dispatcher/doc/dispatcher.xml
@@ -54,6 +54,11 @@
                 <email>martingil.luis@gmail.com</email>
                 </address>
             </editor>
+            <editor>
+                <firstname>Julien</firstname>
+                <surname>Chavanton</surname>
+                <email>jchavanton@gmail.com</email>
+            </editor>
 	</authorgroup>
 	<copyright>
 	    <year>2004</year>
@@ -74,6 +79,10 @@
 	<copyright>
             <year>2015</year>
             <holder>Alessandro Arrichiello, Hewlett Packard</holder>
+        </copyright>
+	<copyright>
+            <year>2017</year>
+            <holder>Julien chavanton, Flowroute</holder>
         </copyright>
    </bookinfo>
     <toc></toc>

--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding='ISO-8859-1'?>
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
 "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
-
+ 
 <!-- Include general documentation entities -->
 <!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
 %docentities;
@@ -706,6 +706,79 @@ modparam("dispatcher", "force_dst", 1)
  		</example>
 	</section>
 
+ 	<section id="dispatcher.p.ds_ping_latency_stats">
+ 		<title><varname>ds_ping_latency_stats</varname> (int)</title>
+ 		<para>
+		Enable latency measurement when pinging nodes
+		</para>
+
+		<itemizedlist>
+		<listitem>
+			<para>If set to 0, disable latency measurement.</para>
+		</listitem>
+		<listitem>
+			<para>If set to 1, enable latency measurement.
+			</para>
+		</listitem>
+		</itemizedlist>
+ 		<para>
+ 		<emphasis>
+ 			Default value is <quote>0</quote>.
+ 		</emphasis>
+ 		</para>
+ 		<example>
+ 		<title>accessing the metrics</title>
+ <programlisting format="linespecific">
+# using the command :
+kamcmd dispatcher.list
+ ...
+DEST: {
+	URI: sip:1.2.3.4
+	FLAGS: AX
+	PRIORITY: 9
+	LATENCY: {
+		AVG: 24.250000 # weigthed moving average for the last few weeks
+		STD: 1.035000  # standard deviation of AVG
+		EST: 25.000000 # short term estimate, see parameter: ds_latency_estimator_alpha
+		MAX: 26        # maximun value seen
+		TIMEOUT: 0     # count of ping timeouts
+	}
+}
+ ...
+ </programlisting>
+ 		</example>
+ 		<example>
+ 		<title>Set the <quote>ds_ping_latency_stats</quote> parameter</title>
+ <programlisting format="linespecific">
+ ...
+ modparam("dispatcher", "ds_ping_latency_stats", 1)
+ ...
+ </programlisting>
+ 		</example>
+	</section>
+ 	<section id="dispatcher.p.ds_latency_estimator_alpha">
+ 		<title><varname>ds_latency_estimator_alpha</varname> (int)</title>
+		<para>
+		The value to be used to control the memory of the estimator EWMA "exponential weighted moving average" or
+		"the speed at which the older samples are dampened"
+		a goog explanation can be found here : http://www.itl.nist.gov/div898/handbook/pmc/section3/pmc324.htm
+		Because Kamailio doesn't support float parameter types, the value in the parameter is divided by 1000 and stored as float.
+		For example, if you want to set the alpha to be 0.75, use value 750 here.
+ 		</para>
+ 		<para>
+ 		<emphasis>
+			Default value is <quote>900 => 0.9</quote>.
+ 		</emphasis>
+ 		</para>
+ 		<example>
+ 		<title>Set the <quote>ds_hash_size</quote> parameter</title>
+ <programlisting format="linespecific">
+ ...
+ modparam("dispatcher", "ds_latency_estimator_alpha", 900)
+ ...
+ </programlisting>
+ 		</example>
+	</section>
  	<section id="dispatcher.p.ds_hash_size">
  		<title><varname>ds_hash_size</varname> (int)</title>
  		<para>


### PR DESCRIPTION
#### Pre-Submission Checklist
- [ X] Commit message has the format required by CONTRIBUTING guide
- [ X] Commits are split per component (core, individual modules, libs, utils, ...)
- [ X] Each component has a single commit (if not, squash them into one commit)
- [ X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [ X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
With the proposed modification the dispatcher can now compute the latency of all the nodes it is pinging and also report timeouts counts.

Default module behavior is unchanged, the stats needs to be explicitly activated.

In this first stage, the objective is to start to monitor latency and intermittent timeouts and share the result to be used by an external monitoring system.

The metrics are only expose using `kamcmd dispatcher.list` maybe they should be made available elsewhere, for example from the routing script ? but this can be done later ...
```
DEST: {
	URI: sip:1.2.3.4
	FLAGS: AX
	PRIORITY: 9
	LATENCY: {
		AVG: 24.250000 # weigthed moving average for the last few weeks
		STD: 1.035000  # standard deviation of AVG
		EST: 25.000000 # short term estimate, see parameter: ds_latency_estimator_alpha
		MAX: 26        # maximun value seen
		TIMEOUT: 0     # count of ping timeouts
	}
}
```

Another stage would probably be to adjust the load distribution/weight considering the latency estimator, the dispatcher would be able to detect intermittent remote server lags and minimize the impact.

tested :

Some tests done on the calculation generating billions of fake samples to verify calculations.

ds_reload : 
- safe because it is using a blue/green update keeping the active version while creating the new one
- this will currently reset the stats

