### PR TITLE
dispatcher: latency fix stdev calculation

### DIFF
--- a/src/modules/dispatcher/Makefile
+++ b/src/modules/dispatcher/Makefile
@@ -9,7 +9,7 @@ include ../../Makefile.defs
 auto_gen=
 NAME=dispatcher.so
 
-LIBS=
+LIBS=-lm
 
 DEFS+=-DKAMAILIO_MOD_INTERFACE
 

--- a/src/modules/dispatcher/dispatch.h
+++ b/src/modules/dispatcher/dispatch.h
@@ -163,7 +163,7 @@ typedef struct _ds_latency_stats {
 	float average;  // weigthed average, estimate of the last few weeks
 	float stdev;    // last standard deviation
 	float estimate; // short term estimate, EWMA exponential weighted moving average
-	float last_q;   // q for N-1
+	double m2;      // sum of squares, used for recursive variance calculation
 	int32_t count;
 	uint32_t timeout;
 } ds_latency_stats_t;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This PR to fix a calculation error on the latency standard deviation

test with random values from 1-30
```
total[1726000000]value[3] count[2097152] std[8.654594] avg[15.541001] est[14.098082]
total[1727000000]value[2] count[2097152] std[8.654230] avg[15.542887] est[16.070623]
total[1728000000]value[2] count[2097152] std[8.655254] avg[15.546928] est[13.154167]
```
test with random values 1-500
```
total[1056000000]value[373] count[2097152] std[144.397552] avg[249.993790] est[297.913574]
total[1057000000]value[118] count[2097152] std[144.369400] avg[250.121262] est[222.419662]
total[1058000000]value[431] count[2097152] std[144.314056] avg[250.138077] est[295.765625]
```
