### PR TITLE
Rich redirects

### DIFF
--- a/src/core/config.h
+++ b/src/core/config.h
@@ -166,7 +166,7 @@
 
 #define MAX_PRINT_TEXT 		256	/*!< max length of the text of fifo 'print' command */
 
-#define MAX_REDIRECTION_LEN	512	/*!< maximum length of Contact header field in redirection replies */
+#define MAX_REDIRECTION_LEN	4096	/*!< maximum length of Contact header field in redirection replies */
 
 /*! \brief used by FIFO statistics in module to terminate line;
    extra whitespaces are used to overwrite remainders of

--- a/src/core/dset.c
+++ b/src/core/dset.c
@@ -472,7 +472,7 @@ int append_branch(struct sip_msg* msg, str* uri, str* dst_uri, str* path,
  * end = end of target buffer
  * Returns 0 on success or -1 on error (buffer is too short)
  */
-static int print_contact_str(char **dest, str *uri, qvalue_t q, char *end)
+static int print_contact_str(char **dest, str *uri, qvalue_t q, char *end, int options)
 {
 	char *p = *dest;
 	str buf;
@@ -507,7 +507,7 @@ static int print_contact_str(char **dest, str *uri, qvalue_t q, char *end)
  * Create a Contact header field from the dset
  * array
  */
-char* print_dset(struct sip_msg* msg, int* len)
+char* print_dset(struct sip_msg* msg, int* len, int options)
 {
 	int cnt = 0;
 	qvalue_t q;
@@ -529,7 +529,7 @@ char* print_dset(struct sip_msg* msg, int* len)
 
 	/* current uri */
 	if (msg->new_uri.s) {
-		if (print_contact_str(&p, &msg->new_uri, ruri_q, end) < 0) {
+		if (print_contact_str(&p, &msg->new_uri, ruri_q, end, options) < 0) {
 			goto memfail;
 		}
 		cnt++;
@@ -546,7 +546,7 @@ char* print_dset(struct sip_msg* msg, int* len)
 			p += CONTACT_DELIM_LEN;
 		}
 
-		if (print_contact_str(&p, &uri, q, end) < 0) {
+		if (print_contact_str(&p, &uri, q, end, options) < 0) {
 			goto memfail;
 		}
 

--- a/src/core/dset.h
+++ b/src/core/dset.h
@@ -158,7 +158,7 @@ void clear_branches(void);
  * Create a Contact header field from the
  * list of current branches
  */
-char* print_dset(struct sip_msg* msg, int* len);
+char* print_dset(struct sip_msg* msg, int* len, int options);
 
 
 /*! \brief

--- a/src/core/dset.h
+++ b/src/core/dset.h
@@ -37,6 +37,7 @@
 extern unsigned int nr_branches;
 extern int ruri_is_new;
 
+#define DS_FLAGS    1
 #define DS_PATH     2
 
 /*! \brief

--- a/src/core/dset.h
+++ b/src/core/dset.h
@@ -37,6 +37,8 @@
 extern unsigned int nr_branches;
 extern int ruri_is_new;
 
+#define DS_PATH     2
+
 /*! \brief
  * Structure for storing branch attributes
  */

--- a/src/core/parser/contact/contact.c
+++ b/src/core/parser/contact/contact.c
@@ -244,6 +244,7 @@ int parse_contacts(str* _s, contact_t** _c)
 			c->methods = hooks.contact.methods;
 			c->instance = hooks.contact.instance;
 			c->reg_id = hooks.contact.reg_id;
+			c->flags = hooks.contact.flags;
 
 			if (_s->len == 0) goto ok;
 		}
@@ -314,6 +315,7 @@ void print_contacts(FILE* _o, contact_t* _c)
 		fprintf(_o, "methods : %p\n", ptr->methods);
 		fprintf(_o, "instance: %p\n", ptr->instance);
 		fprintf(_o, "reg-id  : %p\n", ptr->reg_id);
+		fprintf(_o, "flags   : %p\n", ptr->flags);
 		fprintf(_o, "len     : %d\n", ptr->len);
 		if (ptr->params) {
 			print_params(_o, ptr->params);

--- a/src/core/parser/contact/contact.h
+++ b/src/core/parser/contact/contact.h
@@ -50,6 +50,7 @@ typedef struct contact {
 	param_t* received;      /* received parameter hook */
 	param_t* instance;      /* sip.instance parameter hook */
 	param_t* reg_id;        /* reg-id parameter hook */
+	param_t* flags;         /* flags parameter hook */
 	param_t* params;        /* List of all parameters */
 	int len;                /* Total length of the element */
         struct contact* next; /* Next contact in the list */

--- a/src/core/parser/parse_param.c
+++ b/src/core/parser/parse_param.c
@@ -173,6 +173,14 @@ static inline void parse_contact_class(param_hooks_t *_h, param_t *_p)
 				_h->contact.ob = _p;
 			}
 			break;
+		case 'f':
+		case 'F':
+			if ((_p->name.len == 5) &&
+				(!strncasecmp(_p->name.s + 1, "lags", 4))) {
+				_p->type = P_FLAGS;
+				_h->contact.flags = _p;
+			}
+			break;
 	}
 }
 
@@ -672,6 +680,9 @@ static inline void print_param(FILE *_o, param_t *_p)
 			break;
 		case P_METHODS:
 			type = "P_METHODS";
+			break;
+		case P_FLAGS:
+			type = "P_FLAGS";
 			break;
 		case P_TRANSPORT:
 			type = "P_TRANSPORT";

--- a/src/core/parser/parse_param.h
+++ b/src/core/parser/parse_param.h
@@ -44,6 +44,7 @@ typedef enum ptype {
 	P_EXPIRES,   /*!< Contact: expires parameter */
 	P_METHODS,   /*!< Contact: methods parameter */
 	P_RECEIVED,  /*!< Contact: received parameter */
+	P_FLAGS,     /*!< Contact: flags parameter */
 	P_TRANSPORT, /*!< URI: transport parameter */
 	P_LR,        /*!< URI: lr parameter */
 	P_R2,        /*!< URI: r2 parameter (ser specific) */
@@ -98,6 +99,7 @@ struct contact_hooks {
 	struct param* instance; /*!< sip.instance parameter */
 	struct param* reg_id;   /*!< reg-id parameter */
 	struct param* ob;       /*!< ob parameter */
+	struct param* flags;    /*!< flags parameter */
 };
 
 

--- a/src/modules/pv/pv_core.c
+++ b/src/modules/pv/pv_core.c
@@ -1335,7 +1335,7 @@ int pv_get_dset(struct sip_msg *msg, pv_param_t *param,
 	if(msg==NULL)
 		return -1;
 
-	s.s = print_dset(msg, &s.len);
+	s.s = print_dset(msg, &s.len, 0);
 	if (s.s == NULL)
 		return pv_get_null(msg, param, res);
 	s.len -= CRLF_LEN;

--- a/src/modules/sl/doc/sl_params.xml
+++ b/src/modules/sl/doc/sl_params.xml
@@ -61,4 +61,34 @@ modparam("sl", "bind_tm", 0)  # feature disabled
 		</example>
 	</section>
 
+	<section id="rich_redirect">
+		<title><varname>rich_redirect</varname> (int)</title>
+		<para>
+		When sending a 3xx class reply, include additional branch info
+		to the contacts such as path vector and branch flags.
+		</para>
+		<itemizedlist>
+			<listitem><para>
+			<emphasis>0</emphasis> - no extra info is added (default)
+			</para></listitem>
+			<listitem><para>
+			<emphasis>1</emphasis> - include branch flags as contact header parameter
+			</para></listitem>
+			<listitem><para>
+			<emphasis>2</emphasis> - include path as contact uri Route header
+			</para></listitem>
+		</itemizedlist>
+		<para>
+		Values may be combined (added).
+		</para>
+		<example>
+			<title>rich_redirect example</title>
+			<programlisting format="linespecific">
+...
+modparam("sl", "rich_redirect", 3)
+...
+			</programlisting>
+		</example>
+	</section>
+
 </section>

--- a/src/modules/sl/sl.c
+++ b/src/modules/sl/sl.c
@@ -116,6 +116,7 @@ static param_export_t params[] = {
 	{"default_code",   PARAM_INT, &default_code},
 	{"default_reason", PARAM_STR, &default_reason},
 	{"bind_tm",        PARAM_INT, &sl_bind_tm},
+	{"rich_redirect",  PARAM_INT, &sl_rich_redirect},
 
 	{0, 0, 0}
 };

--- a/src/modules/sl/sl_funcs.c
+++ b/src/modules/sl/sl_funcs.c
@@ -150,7 +150,7 @@ int sl_reply_helper(struct sip_msg *msg, int code, char *reason, str *tag)
 
 	/* if that is a redirection message, dump current message set to it */
 	if (code>=300 && code<400) {
-		dset.s=print_dset(msg, &dset.len);
+		dset.s=print_dset(msg, &dset.len, 0);
 		if (dset.s) {
 			add_lump_rpl(msg, dset.s, dset.len, LUMP_RPL_HDR);
 		}

--- a/src/modules/sl/sl_funcs.c
+++ b/src/modules/sl/sl_funcs.c
@@ -55,6 +55,9 @@ static int _sl_filtered_ack_route = -1; /* default disabled */
 
 static int _sl_evrt_local_response = -1; /* default disabled */
 
+/* send path and flags in 3xx class reply */
+int sl_rich_redirect = 0;
+
 /*!
  * lookup sl event routes
  */
@@ -150,7 +153,7 @@ int sl_reply_helper(struct sip_msg *msg, int code, char *reason, str *tag)
 
 	/* if that is a redirection message, dump current message set to it */
 	if (code>=300 && code<400) {
-		dset.s=print_dset(msg, &dset.len, 0);
+		dset.s=print_dset(msg, &dset.len, sl_rich_redirect);
 		if (dset.s) {
 			add_lump_rpl(msg, dset.s, dset.len, LUMP_RPL_HDR);
 		}

--- a/src/modules/sl/sl_funcs.h
+++ b/src/modules/sl/sl_funcs.h
@@ -30,6 +30,8 @@
 
 #define SL_TOTAG_SEPARATOR '.'
 
+extern int sl_rich_redirect;
+
 int sl_startup();
 int sl_shutdown();
 

--- a/src/modules/tm/doc/params.xml
+++ b/src/modules/tm/doc/params.xml
@@ -1485,4 +1485,34 @@ modparam("tm", "relay_100", 1)
 		</example>
 	</section>
 
+	<section id="tm.p.rich_redirect">
+		<title><varname>rich_redirect</varname> (int)</title>
+		<para>
+			When sending a 3xx class reply, include additional branch info
+			to the contacts such as path vector and branch flags.
+		</para>
+		<itemizedlist>
+			<listitem><para>
+			<emphasis>0</emphasis> - no extra info is added (default)
+			</para></listitem>
+			<listitem><para>
+			<emphasis>1</emphasis> - include branch flags as contact header parameter
+			</para></listitem>
+			<listitem><para>
+			<emphasis>2</emphasis> - include path as contact uri Route header
+			</para></listitem>
+		</itemizedlist>
+		<para>
+		Values may be combined (added).
+		</para>
+		<example>
+			<title>rich_redirect example</title>
+			<programlisting>
+...
+modparam("tm", "rich_redirect", 3)
+....
+			</programlisting>
+		</example>
+	</section>
+
 </section>

--- a/src/modules/tm/t_reply.c
+++ b/src/modules/tm/t_reply.c
@@ -640,7 +640,7 @@ static int _reply( struct cell *trans, struct sip_msg* p_msg,
 
 	/* if that is a redirection message, dump current message set to it */
 	if (code>=300 && code<400) {
-		dset=print_dset(p_msg, &dset_len);
+		dset=print_dset(p_msg, &dset_len, 0);
 		if (dset) {
 			add_lump_rpl(p_msg, dset, dset_len, LUMP_RPL_HDR);
 		}

--- a/src/modules/tm/t_reply.c
+++ b/src/modules/tm/t_reply.c
@@ -102,6 +102,8 @@ int goto_on_sl_reply=0;
 
 /* remap 503 response code to 500 */
 extern int tm_remap_503_500;
+/* send path and flags in 3xx class reply */
+int tm_rich_redirect = 0;
 
 /* how to deal with winning branch reply selection in failure_route
  * can be overwritten per transaction with t_drop_replies(...)
@@ -640,7 +642,7 @@ static int _reply( struct cell *trans, struct sip_msg* p_msg,
 
 	/* if that is a redirection message, dump current message set to it */
 	if (code>=300 && code<400) {
-		dset=print_dset(p_msg, &dset_len, 0);
+		dset=print_dset(p_msg, &dset_len, tm_rich_redirect);
 		if (dset) {
 			add_lump_rpl(p_msg, dset, dset_len, LUMP_RPL_HDR);
 		}

--- a/src/modules/tm/tm.c
+++ b/src/modules/tm/tm.c
@@ -475,6 +475,7 @@ static param_export_t params[]={
 	{"xavp_contact",        PARAM_STR, &ulattrs_xavp_name                    },
 	{"event_callback",      PARAM_STR, &tm_event_callback                    },
 	{"relay_100",           PARAM_INT, &default_tm_cfg.relay_100             },
+	{"rich_redirect" ,      PARAM_INT, &tm_rich_redirect                     },
 	{0,0,0}
 };
 

--- a/src/modules/uac_redirect/doc/uac_redirect_admin.xml
+++ b/src/modules/uac_redirect/doc/uac_redirect_admin.xml
@@ -302,8 +302,46 @@ branch_route[1] {
 				</programlisting>
 			</example>
 		</section>
+		<section>
+			<title><varname>flags_hdr_mode</varname> (int)</title>
+			<para>
+			Specifies if and how a Contact&apos;s flags header parameter
+			must be used. If set, and a flags header parameter is set,
+			its value will be set as branch flags for that contact.
+			</para>
+			<para>
+			Its values may be:
+			</para>
+			<itemizedlist>
+				<listitem>
+				<para><emphasis>0</emphasis> - ignore flags header parameter,
+				just use bflags module parameter</para>
+				</listitem>
+				<listitem>
+				<para><emphasis>1</emphasis> - use flags header parameter if
+				present, ignore bflags module parameter</para>
+				</listitem>
+				<listitem>
+				<para><emphasis>2</emphasis> - use flags header parameter if
+				present and merge (binary or) it with the bflags module
+				parameter</para>
+				</listitem>
+			</itemizedlist>
+			<para>
+				<emphasis>
+					The default value is <quote>0</quote>.
+				</emphasis>
+			</para>
+			<example>
+				<title>Set <varname>flags_hdr_mode</varname> parameter</title>
+				<programlisting format="linespecific">
+...
+modparam("uac_redirect","flags_hdr_mode",2)
+...
+				</programlisting>
+			</example>
+		</section>
 	</section>
-
 	<section>
 		<title>Functions</title>
 		<section id="uac_redirect.f.set_deny_filter">

--- a/src/modules/uac_redirect/rd_funcs.c
+++ b/src/modules/uac_redirect/rd_funcs.c
@@ -199,6 +199,7 @@ static int shmcontact2dset(struct sip_msg *req, struct sip_msg *sh_rpl,
 	int added;
 	int dup;
 	int ret;
+	unsigned int flags;
 
 	/* dup can be:
 	 *    0 - sh reply but nothing duplicated 
@@ -294,8 +295,14 @@ static int shmcontact2dset(struct sip_msg *req, struct sip_msg *sh_rpl,
 		LM_DBG("adding contact <%.*s>\n", scontacts[i]->uri.len,
 				scontacts[i]->uri.s);
 		if(sruid_next(&_redirect_sruid)==0) {
+			if (flags_hdr_mode && scontacts[i]->flags && str2int(&(scontacts[i]->flags->body), &flags) == 0) {
+				if (flags_hdr_mode == 2)
+					flags |= bflags;
+			} else {
+				flags = bflags;
+			}
 			if(append_branch( 0, &scontacts[i]->uri, 0, 0, sqvalues[i],
-						bflags, 0, &_redirect_sruid.uid, 0,
+						flags, 0, &_redirect_sruid.uid, 0,
 						&_redirect_sruid.uid, &_redirect_sruid.uid)<0) {
 				LM_ERR("failed to add contact to dset\n");
 			} else {

--- a/src/modules/uac_redirect/rd_funcs.h
+++ b/src/modules/uac_redirect/rd_funcs.h
@@ -36,6 +36,8 @@ extern cmd_function   rd_acc_fct;
 
 extern char *acc_db_table;
 
+extern int flags_hdr_mode;
+
 int get_redirect( struct sip_msg *msg , int maxt, int maxb,
 		struct acc_param *reason, unsigned int bflags);
 

--- a/src/modules/uac_redirect/uac_redirect.c
+++ b/src/modules/uac_redirect/uac_redirect.c
@@ -48,6 +48,7 @@ char *accept_filter_s = 0;
 char *def_filter_s = 0;
 
 unsigned int bflags = 0;
+int flags_hdr_mode = 0;
 
 #define ACCEPT_RULE_STR "accept"
 #define DENY_RULE_STR   "deny"
@@ -86,6 +87,7 @@ static param_export_t params[] = {
 	{"acc_function",    PARAM_STRING,  &acc_fct_s        },
 	{"acc_db_table",    PARAM_STRING,  &acc_db_table     },
 	{"bflags",    		INT_PARAM,  &bflags			  },
+	{"flags_hdr_mode",	INT_PARAM,  &flags_hdr_mode	  },
 	{0, 0, 0}
 };
 

--- a/src/modules/xprint/xp_lib.c
+++ b/src/modules/xprint/xp_lib.c
@@ -559,7 +559,7 @@ static int xl_get_dset(struct sip_msg *msg, str *res, str *hp, int hi, int hf)
     if(msg==NULL || res==NULL)
 	return -1;
 
-    res->s = print_dset(msg, &res->len);
+    res->s = print_dset(msg, &res->len, 0);
 
     if ((res->s) == NULL) return xl_get_null(msg, res, hp, hi, hf);
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
If Kamailio sends a 301/302, the current dset is added as Contact header automatically. The feature in this PR will optionally extend this Contact header with more information. 

- The path vector for each contact can be added as a Contact-uri Route header (rfc 3327 conformant).
- The branch flags can be added as a Contact-header parameter (non-standard).

In addition, the get_redirects function is extended to optionally parse the new flags parameter. The Route header can be extracted from the r-uri in the script.

The new functionality must be enabled with module parameters, by default the behavior is unchanged.

This feature is based on a patchset by me as <alex@speakup.nl> published at https://lists.kamailio.org/pipermail/sr-dev/2011-August/012064.html