### PR TITLE
Add stop_recording function, and make start/stop_recording functions accept flags 

### DIFF
--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -2472,7 +2472,7 @@ rtpengine_manage();
 
 	<section id="rtpengine.f.start_recording">
 		<title>
-		<function moreinfo="none">start_recording()</function>
+		<function moreinfo="none">start_recording([flags])</function>
 		</title>
 		<para>
 		This function will send a signal to the &rtp; relay to record
@@ -2480,6 +2480,12 @@ rtpengine_manage();
 		<quote>record-call=on</quote> for rtpengine_manage()/rtpengine_offer(),
 		which offers an alternative for call recording, saving also call
 		metadata from SDP.
+		</para>
+		<para>
+		It can take the same parameters as <function>rtpengine_manage().</function>
+		The flags parameter to start_recording can be a configuration variable
+		containing the flags as a string.
+		The call-id flag can be used to start recording for a different call.
 		</para>
 		<para>
 		This function can be used from REQUEST_ROUTE and ONREPLY_ROUTE.
@@ -2496,14 +2502,19 @@ start_recording();
 
 	<section id="rtpengine.f.stop_recording">
 		<title>
-		<function moreinfo="none">stop_recording()</function>
+		<function moreinfo="none">stop_recording([flags])</function>
 		</title>
 		<para>
-		This function will send a signal to the &rtp; relay to record
+		This function will send a signal to the &rtp; relay to stop recording
 		the &rtp; stream flowing through it. See also the option
 		<quote>record-call=off</quote> for rtpengine_manage()/rtpengine_offer(),
-		which offers an alternative for call recording, saving also call
-		metadata from SDP.
+		which offers an alternative for call recording.
+		</para>
+		<para>
+		It can take the same parameters as <function>rtpengine_manage().</function>
+		The flags parameter to start_recording can be a configuration variable
+		containing the flags as a string.
+		The call-id flag can be used to stop recording for a different call.
 		</para>
 		<para>
 		This function can be used from REQUEST_ROUTE and ONREPLY_ROUTE.

--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -2494,6 +2494,30 @@ start_recording();
 		</example>
 	</section>
 
+	<section id="rtpengine.f.stop_recording">
+		<title>
+		<function moreinfo="none">stop_recording()</function>
+		</title>
+		<para>
+		This function will send a signal to the &rtp; relay to record
+		the &rtp; stream flowing through it. See also the option
+		<quote>record-call=off</quote> for rtpengine_manage()/rtpengine_offer(),
+		which offers an alternative for call recording, saving also call
+		metadata from SDP.
+		</para>
+		<para>
+		This function can be used from REQUEST_ROUTE and ONREPLY_ROUTE.
+		</para>
+		<example>
+		<title><function>stop_recording</function> usage</title>
+		<programlisting format="linespecific">
+...
+stop_recording();
+...
+		</programlisting>
+		</example>
+	</section>
+
 
 	</section>
 

--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -284,9 +284,15 @@ static cmd_export_t cmds[] = {
 	{"start_recording",	(cmd_function)start_recording_f,	0,
 		0, 0,
 		ANY_ROUTE },
+	{"start_recording",	(cmd_function)start_recording_f,	1,
+		fixup_spve_null, 0,
+		ANY_ROUTE},
 	{"stop_recording",	(cmd_function)stop_recording_f, 	0,
 		0, 0,
 		ANY_ROUTE },
+	{"stop_recording",	(cmd_function)stop_recording_f, 	1,
+		fixup_spve_null, 0,
+		ANY_ROUTE},
 	{"rtpengine_offer",	(cmd_function)rtpengine_offer1_f,	0,
 		0, 0,
 		ANY_ROUTE},
@@ -3375,23 +3381,41 @@ error:
 
 
 static int rtpengine_start_recording_wrap(struct sip_msg *msg, void *d, int more) {
-	return rtpp_function_call_simple(msg, OP_START_RECORDING, NULL);
+	return rtpp_function_call_simple(msg, OP_START_RECORDING, d);
 }
 
 static int rtpengine_stop_recording_wrap(struct sip_msg *msg, void *d, int more) {
-	return rtpp_function_call_simple(msg, OP_STOP_RECORDING, NULL);
+	return rtpp_function_call_simple(msg, OP_STOP_RECORDING, d);
 }
 
 static int
-start_recording_f(struct sip_msg* msg, char *foo, char *bar)
+start_recording_f(struct sip_msg* msg, char *str1, char *str2)
 {
-	return rtpengine_rtpp_set_wrap(msg, rtpengine_start_recording_wrap, NULL, 1);
+	str flags;
+	flags.s = NULL;
+	if (str1) {
+		if (get_str_fparam(&flags, msg, (fparam_t *) str1)) {
+			LM_ERR("Error getting string parameter\n");
+			return -1;
+		}
+	}
+
+	return rtpengine_rtpp_set_wrap(msg, rtpengine_start_recording_wrap, flags.s, 1);
 }
 
 static int
-stop_recording_f(struct sip_msg* msg, char *foo, char *bar)
+stop_recording_f(struct sip_msg* msg, char *str1, char *str2)
 {
-	return rtpengine_rtpp_set_wrap(msg, rtpengine_stop_recording_wrap, NULL, 1);
+	str flags;
+	flags.s = NULL;
+	if (str1) {
+		if (get_str_fparam(&flags, msg, (fparam_t *) str1)) {
+			LM_ERR("Error getting string parameter\n");
+			return -1;
+		}
+	}
+
+	return rtpengine_rtpp_set_wrap(msg, rtpengine_stop_recording_wrap, flags.s, 1);
 }
 
 static int rtpengine_rtpstat_wrap(struct sip_msg *msg, void *d, int more) {

--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -126,6 +126,7 @@ static const char *command_strings[] = {
 	[OP_START_RECORDING]	= "start recording",
 	[OP_QUERY]		= "query",
 	[OP_PING]		= "ping",
+	[OP_STOP_RECORDING]	= "stop recording",
 };
 
 struct minmax_mos_stats {
@@ -166,6 +167,7 @@ struct minmax_stats_vals {
 static char *gencookie();
 static int rtpp_test(struct rtpp_node*, int, int);
 static int start_recording_f(struct sip_msg *, char *, char *);
+static int stop_recording_f(struct sip_msg *, char *, char *);
 static int rtpengine_answer1_f(struct sip_msg *, char *, char *);
 static int rtpengine_offer1_f(struct sip_msg *, char *, char *);
 static int rtpengine_delete1_f(struct sip_msg *, char *, char *);
@@ -280,6 +282,9 @@ static cmd_export_t cmds[] = {
 		fixup_set_id, 0,
 		ANY_ROUTE},
 	{"start_recording",	(cmd_function)start_recording_f,	0,
+		0, 0,
+		ANY_ROUTE },
+	{"stop_recording",	(cmd_function)stop_recording_f, 	0,
 		0, 0,
 		ANY_ROUTE },
 	{"rtpengine_offer",	(cmd_function)rtpengine_offer1_f,	0,
@@ -3373,10 +3378,20 @@ static int rtpengine_start_recording_wrap(struct sip_msg *msg, void *d, int more
 	return rtpp_function_call_simple(msg, OP_START_RECORDING, NULL);
 }
 
+static int rtpengine_stop_recording_wrap(struct sip_msg *msg, void *d, int more) {
+	return rtpp_function_call_simple(msg, OP_STOP_RECORDING, NULL);
+}
+
 static int
 start_recording_f(struct sip_msg* msg, char *foo, char *bar)
 {
 	return rtpengine_rtpp_set_wrap(msg, rtpengine_start_recording_wrap, NULL, 1);
+}
+
+static int
+stop_recording_f(struct sip_msg* msg, char *foo, char *bar)
+{
+	return rtpengine_rtpp_set_wrap(msg, rtpengine_stop_recording_wrap, NULL, 1);
 }
 
 static int rtpengine_rtpstat_wrap(struct sip_msg *msg, void *d, int more) {
@@ -3503,6 +3518,11 @@ static int ki_start_recording(sip_msg_t *msg)
 	return rtpengine_rtpp_set_wrap(msg, rtpengine_start_recording_wrap, NULL, 1);
 }
 
+static int ki_stop_recording(sip_msg_t *msg)
+{
+	return rtpengine_rtpp_set_wrap(msg, rtpengine_stop_recording_wrap, NULL, 1);
+}
+
 static int ki_set_rtpengine_set(sip_msg_t *msg, int r1)
 {
 	rtpp_set_link_t rtpl1;
@@ -3609,6 +3629,11 @@ static sr_kemi_t sr_kemi_rtpengine_exports[] = {
     },
     { str_init("rtpengine"), str_init("start_recording"),
         SR_KEMIP_INT, ki_start_recording,
+        { SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE,
+            SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+    },
+    { str_init("rtpengine"), str_init("stop_recording"),
+        SR_KEMIP_INT, ki_stop_recording,
         { SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE,
             SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
     },

--- a/src/modules/rtpengine/rtpengine.h
+++ b/src/modules/rtpengine/rtpengine.h
@@ -35,6 +35,7 @@ enum rtpe_operation {
         OP_ANSWER,
         OP_DELETE,
         OP_START_RECORDING,
+        OP_STOP_RECORDING,
         OP_QUERY,
         OP_PING,
 };


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

ce5362d adds stop_recording function that is similar to start_recording. This is useful when wanting to stop recording in the middle of the call since it has it's own message and is not attached to the offer/answer/delete message (like the "record-call off" flag in rtpengine_manage function).

45b4d35  enables the use of flags with both start_recording and stop_recording functions. This allows overwriting fields like call-id to start/stop recording for different ongoing calls (for example from a rtimer route).