### PR TITLE
Usrloc fix

### DIFF
--- a/src/modules/usrloc/ul_rpc.c
+++ b/src/modules/usrloc/ul_rpc.c
@@ -217,6 +217,8 @@ static void ul_rpc_dump(rpc_t* rpc, void* ctx)
 	int summary = 0;
 	ucontact_t* c;
 	void* th;
+	void* dah;
+	void* dh;
 	void* ah;
 	void* bh;
 	void* ih;
@@ -228,14 +230,27 @@ static void ul_rpc_dump(rpc_t* rpc, void* ctx)
 	if(brief.len==5 && (strncmp(brief.s, "brief", 5)==0))
 		summary = 1;
 
+	if (rpc->add(ctx, "{", &th) < 0)
+	{
+		rpc->fault(ctx, 500, "Internal error creating top rpc");
+		return;
+	}
+	if (rpc->struct_add(th, "[", "Domains", &dah) < 0)
+	{
+		rpc->fault(ctx, 500, "Internal error creating inner struct");
+		return;
+	}
+	
 	for( dl=root ; dl ; dl=dl->next ) {
 		dom = dl->d;
-		if (rpc->add(ctx, "{", &th) < 0)
+
+		if (rpc->struct_add(dah, "{", "Domain", &dh) < 0)
 		{
-			rpc->fault(ctx, 500, "Internal error creating top rpc");
+			rpc->fault(ctx, 500, "Internal error creating inner struct");
 			return;
 		}
-		if(rpc->struct_add(th, "Sd[",
+
+		if(rpc->struct_add(dh, "Sd[",
 					"Domain",  &dl->name,
 					"Size",    (int)dom->size,
 					"AoRs",    &ah)<0)
@@ -289,7 +304,7 @@ static void ul_rpc_dump(rpc_t* rpc, void* ctx)
 		}
 
 		/* extra attributes node */
-		if(rpc->struct_add(th, "{", "Stats",    &sh)<0)
+		if(rpc->struct_add(dh, "{", "Stats",    &sh)<0)
 		{
 			rpc->fault(ctx, 500, "Internal error creating stats struct");
 			return;

--- a/src/modules/usrloc/ul_rpc.c
+++ b/src/modules/usrloc/ul_rpc.c
@@ -254,6 +254,7 @@ static void ul_rpc_dump(rpc_t* rpc, void* ctx)
 					if(rpc->struct_add(ah, "S",
 								"AoR", &r->aor)<0)
 					{
+						unlock_ulslot( dom, i);
 						rpc->fault(ctx, 500, "Internal error creating aor struct");
 						return;
 					}


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
The first commit unlocks a usrloc slot when "ul.dump brief" fails. Otherwise, it stays locked forever.
The second one changes "ul.dump" output format and adds "Domains" array that includes all location domains.  Without this fix "kamctl ul show" shows only the first domain. 