### PR TITLE
pkg/kamailio/alpine_docker: Added support ssh git repo url

### DIFF
--- a/pkg/kamailio/alpine_docker/build.sh
+++ b/pkg/kamailio/alpine_docker/build.sh
@@ -23,7 +23,7 @@ apk add --no-cache abuild git gcc build-base bison db-dev flex expat-dev perl-de
 
 build_and_install(){
     cd /usr/src/kamailio
-    REPO_OWNER=$(git remote get-url origin 2> /dev/null | sed -e 's:^.*github.com/::' -e 's:/.*\.git::')
+    REPO_OWNER=$(git remote get-url origin 2> /dev/null | sed -e 's|^.*github.com/||' -e 's|^git@github.com:||' -e 's|/.*\.git||')
     if [ ! -z "$REPO_OWNER" ]; then
         sed -i -e "s:github.com/kamailio:github.com/$REPO_OWNER:" /usr/src/kamailio/pkg/kamailio/alpine/APKBUILD
     fi


### PR DESCRIPTION
Fixed alpine docker build when git repo url use ssh 