### PR TITLE
Sipcapture backport

### DIFF
--- a/src/modules/sipcapture/doc/sipcapture_admin.xml
+++ b/src/modules/sipcapture/doc/sipcapture_admin.xml
@@ -185,7 +185,7 @@ modparam("sipcapture", "db_insert_mode", 1)
 	<section id="sipcapture.p.capture_on">
 		<title><varname>capture_on</varname> (integer)</title>
 		<para>
-		Parameter to enable/disable capture globaly (on(1)/off(0))
+		Parameter to enable/disable capture globally (on(1)/off(0))
 		</para>
 		<para>
 		<emphasis>

--- a/src/modules/sipcapture/doc/sipcapture_admin.xml
+++ b/src/modules/sipcapture/doc/sipcapture_admin.xml
@@ -493,6 +493,26 @@ modparam("sipcapture", "topoh_unmask", 1)
 			</programlisting>
 		</example>
 	</section>
+
+	<section id="sipcapture.p.nonsip_hook">
+		<title><varname>nonsip_hook</varname> (int)</title>
+		<para>
+		If set to 1, event route <emphasis>sipcapture:siprequest</emphasis> is
+		run when HEP message is received.
+		</para>
+		<para>
+			Default value is <emphasis>0</emphasis>.
+		</para>
+		<example>
+			<title>Set <varname>nonsip_hook</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipcapture", "nonsip_hook", 1)
+...
+			</programlisting>
+		</example>
+	</section>
+
 </section>	
 <section>
 	<title>Functions</title>

--- a/src/modules/sipcapture/examples/kamailio.cfg
+++ b/src/modules/sipcapture/examples/kamailio.cfg
@@ -861,10 +861,6 @@ route[STORE] {
 	sip_capture("$var(a)");
 }
 
-event_route[sipcapture:request] {
-	xlog("received sipcapture request from $si:$sp\r\n");
-}
-
 #!ifdef WITH_HOMER_CUSTOM_STATS
 event_route[xhttp:request] {
         set_reply_close();
@@ -908,12 +904,14 @@ event_route[xhttp:request] {
 
 event_route[sipcapture:request] {
 
-        xlog("HEP Request!\n");
-        xlog("received sipcapture request from $si:$sp\r\n");
-        xlog("HEP VERSION $hep(version) request from $si:$sp\r\n");
-        xlog("HEP CHUNK Source IP $hep(0x002) request from $si:$sp\r\n");
+	xlog("HEP Request!\n");
+	xlog("received sipcapture request from $si:$sp\n");
+	xlog("HEP VERSION $hep(version) request from $si:$sp\n");
+	xlog("HEP CHUNK Source IP $hep(0x002) request from $si:$sp\n");
+
 	#Is it SIP ?
-	if($hep(0x00b) == 1){
+	if($hep(0x00b) == 1)
+	{
 
 		#Do parsing internal
 		return 1;
@@ -921,8 +919,8 @@ event_route[sipcapture:request] {
 	else 
 	{
 		#If report lets proceed here with payload
-	        xlog("HEP CHUNK PAYLOAD $hep(0x00f) request from $si:$sp\r\n");
-        	return 0;   
+		xlog("HEP CHUNK PAYLOAD $hep(0x00f) request from $si:$sp\n");
+		return 0;
 	}
 }
 

--- a/src/modules/sipcapture/hep.c
+++ b/src/modules/sipcapture/hep.c
@@ -372,16 +372,14 @@ int parsing_hepv3_message(char *buf, unsigned int len) {
                                         break;
                                 case 9:
                                         hg->time_sec  = (hep_chunk_uint32_t *) (tmp);
-                                        hg->time_sec->data = ntohl(hg->time_sec->data);
-                                        heptime->tv_sec = hg->time_sec->data;
+                                        heptime->tv_sec = ntohl(hg->time_sec->data);
                                         i+=chunk_length;
                                         totelem++;
-                                        break;                                                     
-                                                     
+                                        break;
+
                                 case 10:
                                         hg->time_usec  = (hep_chunk_uint32_t *) (tmp);
-                                        hg->time_usec->data = ntohl(hg->time_usec->data);
-                                        heptime->tv_usec = hg->time_usec->data;
+                                        heptime->tv_usec = ntohl(hg->time_usec->data);
                                         i+=chunk_length;
                                         totelem++;
                                         break;      
@@ -394,8 +392,8 @@ int parsing_hepv3_message(char *buf, unsigned int len) {
 
                                 case 12:
                                         hg->capt_id  = (hep_chunk_uint32_t *) (tmp);
-                                        i+=chunk_length;
                                         heptime->captid = ntohl(hg->capt_id->data);
+                                        i+=chunk_length;
                                         totelem++;
                                         break;
 
@@ -482,13 +480,6 @@ int parsing_hepv3_message(char *buf, unsigned int len) {
         si->name.len = si->address_str.len;
         si->name.s = si->address_str.s;
         ri.bind_address=si;
-
-
-	/*TIME*/ 
-        heptime->tv_sec = hg->time_sec->data;
-        heptime->tv_usec = hg->time_usec->data;
-        heptime->captid = ntohl(hg->capt_id->data);
-          
 
         if(payload != NULL ) {
                 /* and now recieve message */
@@ -646,19 +637,17 @@ int hepv3_message_parse(char *buf, unsigned int len, sip_msg_t* msg) {
                                         break;
                                 case 9:
                                         hg->time_sec  = (hep_chunk_uint32_t *) (tmp);
-                                        hg->time_sec->data = ntohl(hg->time_sec->data);
-                                        heptime->tv_sec = hg->time_sec->data;
+                                        heptime->tv_sec = ntohl(hg->time_sec->data);
                                         i+=chunk_length;
                                         totelem++;
-                                        break;                                                     
-                                                     
+                                        break;
+
                                 case 10:
                                         hg->time_usec  = (hep_chunk_uint32_t *) (tmp);
-                                        hg->time_usec->data = ntohl(hg->time_usec->data);
-                                        heptime->tv_usec = hg->time_usec->data;
+                                        heptime->tv_usec = ntohl(hg->time_usec->data);
                                         i+=chunk_length;
                                         totelem++;
-                                        break;      
+                                        break;
 
                                 case 11:
                                         hg->proto_t  = (hep_chunk_uint8_t *) (tmp);
@@ -728,10 +717,10 @@ int hepv3_message_parse(char *buf, unsigned int len, sip_msg_t* msg) {
 
         if(payload != NULL) ret = len - payload_len;
 
-	/*TIME*/ 
-        heptime->tv_sec = hg->time_sec->data;
-        heptime->tv_usec = hg->time_usec->data;
-        heptime->captid = ntohl(hg->capt_id->data);
+
+
+
+
 
 done:
           
@@ -987,11 +976,10 @@ int hepv3_get_chunk(struct sip_msg *msg, char *buf, unsigned int len, int req_ch
                                         hg->time_sec->data = ntohl(hg->time_sec->data);
                                         ret = pv_get_uintval(msg, param, res, hg->time_sec->data);
                                         goto done;
-                                                     
+
                                 case 10:
                                         hg->time_usec  = (hep_chunk_uint32_t *) (tmp);
-                                        hg->time_usec->data = ntohl(hg->time_usec->data);
-                                        ret = pv_get_uintval(msg, param, res, hg->time_usec->data);
+                                        ret = pv_get_uintval(msg, param, res, ntohl(hg->time_usec->data));
                                         goto done;
 
                                 case 11:

--- a/src/modules/sipcapture/hep.c
+++ b/src/modules/sipcapture/hep.c
@@ -973,8 +973,7 @@ int hepv3_get_chunk(struct sip_msg *msg, char *buf, unsigned int len, int req_ch
                                         goto done;
                                 case 9:
                                         hg->time_sec  = (hep_chunk_uint32_t *) (tmp);
-                                        hg->time_sec->data = ntohl(hg->time_sec->data);
-                                        ret = pv_get_uintval(msg, param, res, hg->time_sec->data);
+                                        ret = pv_get_uintval(msg, param, res, ntohl(hg->time_sec->data));
                                         goto done;
 
                                 case 10:

--- a/src/modules/sipcapture/hep.c
+++ b/src/modules/sipcapture/hep.c
@@ -989,13 +989,14 @@ int hepv3_get_chunk(struct sip_msg *msg, char *buf, unsigned int len, int req_ch
 
                                 case 12:
                                         hg->capt_id  = (hep_chunk_uint32_t *) (tmp);
-                                        ret = pv_get_uintval(msg, param, res, ntohs(hg->capt_id->data));
+                                        ret = pv_get_uintval(msg, param, res, ntohl(hg->capt_id->data));
                                         goto done;
 
                                 case 13:
                                         hg->keep_tm  = (hep_chunk_uint16_t *) (tmp);
-                                        ret = pv_get_uintval(msg, param, res, hg->keep_tm->data);                                                                                
+                                        ret = pv_get_uintval(msg, param, res, ntohs(hg->keep_tm->data));
                                         goto done;
+
                                 case 14:
                                         tmpstr.s = (char *) tmp + sizeof(hep_chunk_t);
                                         tmpstr.len = chunk_length - sizeof(hep_chunk_t); 

--- a/src/modules/sipcapture/sipcapture.c
+++ b/src/modules/sipcapture/sipcapture.c
@@ -271,7 +271,7 @@ enum hash_source source = hs_error;
 
 //unsigned int rr_idx = 0;
 
-struct hep_timehdr* heptime;
+struct hep_timeinfo* heptime;
 
 /*! \brief
  * Exported functions
@@ -1150,7 +1150,7 @@ static int child_init(int rank)
 	}
 
 
-	heptime = (struct hep_timehdr*)pkg_malloc(sizeof(struct hep_timehdr));
+	heptime = (struct hep_timeinfo*)pkg_malloc(sizeof(struct hep_timeinfo));
 	if(heptime==NULL) {
 		LM_ERR("no more pkg memory left\n");
 		return -1;

--- a/src/modules/sipcapture/sipcapture.c
+++ b/src/modules/sipcapture/sipcapture.c
@@ -1887,7 +1887,7 @@ static int sip_capture(struct sip_msg *msg, str *_table, _capture_mode_data_t * 
 	else { EMPTY_STR(sco.custom1); }
 	
 	/* Custom - field2 */
-	if(custom_field3_header.len > 0 && (tmphdr[5] = get_hdr_by_name(msg,custom_field2_header.s, custom_field2_header.len)) != NULL) {
+	if(custom_field2_header.len > 0 && (tmphdr[5] = get_hdr_by_name(msg,custom_field2_header.s, custom_field2_header.len)) != NULL) {
 		sco.custom2 =  tmphdr[5]->body;
 	}
 	else { EMPTY_STR(sco.custom2); }

--- a/src/modules/sipcapture/sipcapture.c
+++ b/src/modules/sipcapture/sipcapture.c
@@ -446,6 +446,7 @@ int parse_table_names (str table_name, str ** table_names){
 	names = (str*)pkg_malloc(sizeof(str) * no_tables);
 	if(names == NULL) {
 		LM_ERR("no more pkg memory left\n");
+		pkg_free(table_name_cpy);
 		return -1;
 	}
 	p = strtok (table_name_cpy,"| \t");

--- a/src/modules/sipcapture/sipcapture.c
+++ b/src/modules/sipcapture/sipcapture.c
@@ -1039,6 +1039,9 @@ static int w_float2int(struct sip_msg* _m, char* _val, char* _coof, char* s2)
 		return -1;
 	}
 
+	if(value.s==NULL || coof.s==NULL)
+		return -1;
+	
 	ret = (int) (atof (value.s) * atoi(coof.s));
 
 	return  ret ? ret : -1;


### PR DESCRIPTION
Backport fixes for sipcapture to 5.0.

Important for $hep() to work properly. Mostly from GH #1191 