### PR TITLE
Enable the same modules for RHEL 7 as for Centos 7.

### DIFF
--- a/pkg/kamailio/obs/kamailio.spec
+++ b/pkg/kamailio/obs/kamailio.spec
@@ -132,18 +132,18 @@
 %if 0%{?rhel} == 7 && 0%{?centos_ver} != 7
 %define dist_name rhel
 %define dist_version %{?rhel}
-%bcond_with cnxcc
+%bcond_without cnxcc
 %bcond_with dnssec
-%bcond_with geoip
-%bcond_with http_async_client
-%bcond_with jansson
-%bcond_with json
-%bcond_with kazoo
-%bcond_with memcached
+%bcond_without geoip
+%bcond_without http_async_client
+%bcond_without jansson
+%bcond_without json
+%bcond_without kazoo
+%bcond_without memcached
 %bcond_without perl
 %bcond_without redis
-%bcond_with sctp
-%bcond_with websocket
+%bcond_without sctp
+%bcond_without websocket
 %bcond_without xmlrpc
 %endif
 


### PR DESCRIPTION
Currently OBS build more Centos 7 modules than for RHEL 7. The modules builds just fine on RHEL7, so enable them there as well.