### PR TITLE
tsilo: fix internal data structures

### DIFF
--- a/src/modules/tsilo/ts_hash.c
+++ b/src/modules/tsilo/ts_hash.c
@@ -280,10 +280,10 @@ void remove_ts_urecord(ts_urecord_t* _r)
 	if (_r->next)
 		_r->next->prev = _r->prev;
 
-	/* it was the last urecord */
-	if (entry->n == 1) {
-                entry->first = entry->last = NULL;
-	}
+	if (entry->first == _r)
+		entry->first = _r->next;
+	if (entry->last == _r)
+		entry->last = _r->prev;
 
 	update_stat(stored_ruris, -1);
 


### PR DESCRIPTION
- avoid crash by fixing "first" and "last" pointers of of the ts_entry_t after ts_urecord_t deletion

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

tsilo module didn't reset "**first**" and "**last**" pointers of a doubly linked list of **ts_urecord_t** objects. It worked correctly only when there were no hash collisions and each ts_entry slot had only one **ts_urecord_t** object. To faster reproduce the problem one can set **modparam("tsilo", "hash_size", 2)** and run a light load test (5...10 simultaneous call setups).