### PR TITLE
core : honor parse_param separator

### DIFF
--- a/src/core/parser/parse_param.c
+++ b/src/core/parser/parse_param.c
@@ -348,11 +348,9 @@ static inline int parse_token_param(str *_s, str *_r, char separator)
 		 * mark end of the token
 		 */
 		switch(_s->s[i]) {
-			case ' ':
 			case '\t':
 			case '\r':
 			case '\n':
-			case ',':
 				/* So if you find
 				 * any of them
 				 * stop iterating


### PR DESCRIPTION
fixes the use case when spaces should not be excluded 'BS ParkingTestCase 1'
```
     xlog("L_INFO", "$ci|log exploding test\n");
     $var(test) = "Notify=false;Presence-ID=1001@kamailio.io;Account-Name=BS ParkingTestCase 1";
     xavp_params_explode($var(test), "mytest");
     xlog("L_INFO", "$ci|log exploded test\n");
```

@miconda i believe this should be included in 5.1 and backported to 5.0
