### PR TITLE
core: removing the condition for second record_route ipv6 header

### DIFF
--- a/src/core/msg_translator.c
+++ b/src/core/msg_translator.c
@@ -724,8 +724,7 @@ static inline int lumps_len(struct sip_msg* msg, struct lump* lumps,
 			case SUBST_SND_ALL: \
 				if (send_sock){ \
 					new_len+=send_address_str->len; \
-					if ((send_sock->address.af!=AF_INET) && \
-							(send_address_str==&(send_sock->address_str))) \
+					if ((send_sock->address.af!=AF_INET)) \
 						new_len+=2; \
 					if ((send_sock->port_no!=SIP_PORT) || \
 							(send_port_str!=&(send_sock->port_no_str))){ \
@@ -1085,15 +1084,13 @@ void process_lumps( struct sip_msg* msg,
 		case SUBST_SND_ALL: \
 			if (send_sock){  \
 				/* address */ \
-				if ((send_sock->address.af!=AF_INET) && \
-						(send_address_str==&(send_sock->address_str))){\
+				if ((send_sock->address.af!=AF_INET)){\
 					new_buf[offset]='['; offset++; \
 				}\
 				memcpy(new_buf+offset, send_address_str->s, \
 						send_address_str->len); \
 				offset+=send_address_str->len; \
-				if ((send_sock->address.af!=AF_INET) && \
-						(send_address_str==&(send_sock->address_str))){\
+				if ((send_sock->address.af!=AF_INET)){\
 					new_buf[offset]=']'; offset++; \
 				}\
 				/* :port */ \


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
when we are sending the call from ipv6 tls registered endpoint to kamailio and kamailio use the dispatcher module to forward that call to tcp sip server then second record route header have ipv6 address without [].so another sip server is saying 400 bad record route header.
before (with error):
Record-Route: <sip:2600:1F1C:74E:E100:E89F:BEB1:10AF:1CB1:5060;transport=tcp;r2=on;lr=on;ftag=msDr8yzIe5obR7fSfD-jPiJPFcJoVwwr;did=ae1.8861>

after (correct):
Record-Route: <sip:[2600:1F1C:74E:E100:E89F:BEB1:10AF:1CB1]:5060;transport=tcp;r2=on;lr=on;ftag=msDr8yzIe5obR7fSfD-jPiJPFcJoVwwr;did=ae1.8861>