### PR TITLE
cfg_rpc: extending the functionality of cfg.get command

### DIFF
--- a/src/modules/cfg_rpc/doc/rpc.xml
+++ b/src/modules/cfg_rpc/doc/rpc.xml
@@ -35,7 +35,8 @@
 	    <para>
 		<emphasis>cfg.get</emphasis> - Get the value of
 		a configuration variable. The function accepts two parameters:
-		group name, variable name. The group name can optionally contain the
+		group name, variable name, but if all the elements belonging to a certain group is wanted to be retrieved
+		then only the group name would suffice as the function parameter. The group name can optionally contain the
 		group instance id, for example foo[5].
 	    </para>
 		<example>
@@ -43,6 +44,7 @@
 		<programlisting format="linespecific">
 ...
 # &sercmd; cfg.get core debug
+# &sercmd; cfg.get tm
 ...
 </programlisting>
 		</example>


### PR DESCRIPTION
- rpc_get function can be also called with only entering the group name information.
Before it used to work only with group name and variable name and returning the value for a variable.
With the enhancement, it is also possible to retrieve all variable values belonging to a specific group.
e.g.: kamcmd cfg.get core.
Above given example will print the values of all variables of the configuration group "core".

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
rpc_get function can be also called with only entering the group name information.
Before it used to work only with group name and variable name and returning the value for a variable.
With the enhancement, it is also possible to retrieve all variable values belonging to a specific group.
e.g.: kamcmd cfg.get core.
Above given example will print the values of all variables of the configuration group "core".
