### PR TITLE
rtpengine: fixed segfault when using read_sdp_pv

### DIFF
--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -3328,6 +3328,7 @@ rtpengine_offer_answer(struct sip_msg *msg, const char *flags, int op, int more)
 	str body, newbody;
 	struct lump *anchor;
 	pv_value_t pv_val;
+	str cur_body = {0, 0};
 
 	dict = rtpp_function_call_ok(&bencbuf, msg, op, flags, &body);
 	if (!dict)
@@ -3357,7 +3358,12 @@ rtpengine_offer_answer(struct sip_msg *msg, const char *flags, int op, int more)
 			pkg_free(newbody.s);
 
 		} else {
-			anchor = del_lump(msg, body.s - msg->buf, body.len, 0);
+			/* get the body from the message as body ptr may have changed */
+			cur_body.len = 0;
+			cur_body.s = get_body(msg);
+			cur_body.len = msg->buf + msg->len - cur_body.s;
+
+			anchor = del_lump(msg, cur_body.s - msg->buf, cur_body.len, 0);
 			if (!anchor) {
 				LM_ERR("del_lump failed\n");
 				goto error_free;


### PR DESCRIPTION
#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This was an odd one. I can't see how `read_sdp_pv` ever worked. When the old SDP is deleted with `del_lump` from the SIP `msg`, the lump pointer is calculated assuming that `body` is a pointer relative to `msg`. When `read_sdp_pv` is set, `body` pointer is set to something entirely different and doing pointer maths relative to `msg` causes integer overflows and results in a segfault on `del_lump`.

This change explicitly gets the body pointer (`cur_body`) relative to `msg` before trying to `del_lump`. If it's preferable, I can have it only do this if `read_sdp_pv` is set but I figured it's not a heavy operation and it's safer to always do it.