### PR TITLE
http_client: add missed useragent parameter

### DIFF
--- a/src/modules/http_client/functions.c
+++ b/src/modules/http_client/functions.c
@@ -552,6 +552,7 @@ int curl_con_query_url_f(struct sip_msg* _m, const str *connection,
 	query_params.cacert = default_tls_cacert;
 	query_params.ciphersuites = conn->ciphersuites;
 	query_params.tlsversion = conn->tlsversion;
+	query_params.useragent = conn->useragent;
 	query_params.verify_peer = conn->verify_peer;
 	query_params.verify_host = conn->verify_host;
 	query_params.timeout = conn->timeout;


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

While preparing query_params, "useragent" was missed - add it. 
As before User-Agent was never present in HTTP requests.
not sure if it has to be backported
