### PR TITLE
Update textops.c

### DIFF
--- a/src/modules/textops/textops.c
+++ b/src/modules/textops/textops.c
@@ -3940,7 +3940,7 @@ static sr_kemi_t sr_kemi_textops_exports[] = {
 		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
-	{ str_init("textops"), str_init("is_list"),
+	{ str_init("textops"), str_init("in_list"),
 		SR_KEMIP_INT, ki_in_list,
 		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }


### PR DESCRIPTION
textops: fixed naming convention

- The original function is named in_ rather than is_, updating to the same standard