### PR TITLE
presence: update contact in update_subs_db

### DIFF
--- a/src/modules/presence/subscribe.c
+++ b/src/modules/presence/subscribe.c
@@ -420,6 +420,13 @@ int update_subs_db(subs_t* subs, int type)
 		update_vals[n_update_cols].nul = 0;
 		update_vals[n_update_cols].val.int_val = subs->updated_winfo;
 		n_update_cols++;
+
+		update_keys[n_update_cols] = &str_contact_col;
+		update_vals[n_update_cols].type = DB1_STR;
+		update_vals[n_update_cols].nul = 0;
+		update_vals[n_update_cols].val.str_val = subs->contact;
+		n_update_cols++;
+
 	}
 	if(type & LOCAL_TYPE)
 	{


### PR DESCRIPTION
when using presence with dbmode = 3, the contact is never updated. if using dbmode != 3 the contact is updated in the hash table.

we've seen some UAs re-subscribing with a different contact port of the initial subscribe. it works with dbmode != 3 but not with dbmode == 3

this should be backported to 5.0/5.1 branch
Thanks