### PR TITLE
nat_traversal: handle local generated transactions

### DIFF
--- a/src/modules/nat_traversal/nat_traversal.c
+++ b/src/modules/nat_traversal/nat_traversal.c
@@ -1381,9 +1381,10 @@ __tm_reply_in(struct cell *trans, int type, struct tmcb_params *param)
                 	if(parse_msg(tmp, param->send_buf.len, &msg) != 0) {
                 		LM_ERR("ERROR PARSING REPLY\n");
                 	} else {
-                    	expire = get_expires(&msg);
+				expire = get_expires(&msg);
                 	}
                 	free_sip_msg(&msg);
+			pkg_free(tmp);
             	}
             } else {
             	expire = get_expires(param->rpl);

--- a/src/modules/nat_traversal/nat_traversal.c
+++ b/src/modules/nat_traversal/nat_traversal.c
@@ -1363,6 +1363,9 @@ __tm_reply_in(struct cell *trans, int type, struct tmcb_params *param)
     if (param->req==NULL || param->rpl==NULL)
         return;
 
+    if(type == TMCB_RESPONSE_SENT && param->rpl!=FAKED_REPLY)
+	return;
+
     if (param->code >= 200 && param->code < 300) {
         switch (param->req->REQ_METHOD) {
         case METHOD_SUBSCRIBE:


### PR DESCRIPTION
when using the below script blocks for handling SUBSCRIBE messages, the nat_keepalive does not work as expected.
```
#!ifdef NAT_TRAVERSAL_ROLE
route[PRESENCE_NAT]
{   
    force_rport();
    if (client_nat_test("3")) {
        if(is_first_hop())
           set_contact_alias();
        nat_keepalive();
    }
}
#!endif

route[HANDLE_SUBSCRIBE]
{
    if (!is_method("SUBSCRIBE")) {
        return;
    }

    #!ifdef NAT_TRAVERSAL_ROLE
      route(PRESENCE_NAT);
    #!endif

    if (!t_newtran()) {
        sl_reply_error();
        exit;
    }
    
    if(has_totag()) {
        route(HANDLE_RESUBSCRIBE);
    } else {
        route(HANDLE_NEW_SUBSCRIBE);
    }
    t_release();    
    exit;
}
```

i believe this should be backported to stable branches
Thanks