### PR TITLE
schema: allow null in active_watchers reason

### DIFF
--- a/src/lib/srdb1/schema/pr_active_watchers.xml
+++ b/src/lib/srdb1/schema/pr_active_watchers.xml
@@ -153,6 +153,7 @@
         <name>reason</name>
         <type>string</type>
         <size>&user_len;</size>
+        <null/>
         <description>Reason</description>
     </column>
 


### PR DESCRIPTION
some code paths in presence module set the `reason` field to null causing problems updating the database.