### PR TITLE
tm: make t_run_local_req reentrant

### DIFF
--- a/src/modules/tm/uac.c
+++ b/src/modules/tm/uac.c
@@ -221,7 +221,7 @@ static inline int t_run_local_req(
 		uac_req_t *uac_r,
 		struct cell *new_cell, struct retr_buf *request)
 {
-	static struct sip_msg lreq;
+	struct sip_msg lreq = {0};
 	struct onsend_info onsnd_info;
 	tm_xlinks_t backup_xd;
 	int sflag_bk;


### PR DESCRIPTION
- avoid crash when local-request event route is triggered inside another one

Nested calls to tm:local-routes generate a crash.
I've been recently experiencing this with the following scenario:

- event_route[tm:local-request] defined
- dialog module's send_bye param set to 1 
- htable module's enable_dmq param set to 1

When a dialog reaches the timeout, the BYE generated by dialog module triggers the tm:local-request event route. One of the operations done in my scenario is an htable decrement on a table for which dmq replication is enabled. This trigger again the tm event route (because dmq is using tm uac). When the execution of the 2nd route ends the first one is continued, but the sip_msg structure is at this point corrupted because is declared static in  t_run_local_req.