### PR TITLE
presence: extra columns updated for dbmode 2

### DIFF
--- a/src/modules/presence/subscribe.c
+++ b/src/modules/presence/subscribe.c
@@ -1175,6 +1175,7 @@ int handle_subscribe(struct sip_msg* msg, str watcher_user, str watcher_domain)
 			LM_INFO("getting stored info\n");
 			goto error;
 		}
+		found = 1;
 		reason= subs.reason;
 	}
 
@@ -2218,17 +2219,17 @@ void update_db_subs_timer_dbnone(int no_lock)
 void update_db_subs_timer(db1_con_t *db,db_func_t dbf, shtable_t hash_table,
 		int htable_size, int no_lock, handle_expired_func_t handle_expired_func)
 {
-	db_key_t query_cols[24], update_cols[6];
-	db_val_t query_vals[24], update_vals[6];
+	db_key_t query_cols[25], update_cols[8];
+	db_val_t query_vals[25], update_vals[8];
 	db_op_t update_ops[1];
 	subs_t* del_s;
 	int pres_uri_col, to_user_col, to_domain_col, from_user_col, from_domain_col,
 		callid_col, totag_col, fromtag_col, event_col,status_col, event_id_col,
 		local_cseq_col, remote_cseq_col, expires_col, record_route_col,
 		contact_col, local_contact_col, version_col,socket_info_col,reason_col,
-		watcher_user_col, watcher_domain_col, updated_col, updated_winfo_col;
+		watcher_user_col, watcher_domain_col, updated_col, updated_winfo_col, user_agent_col;
 	int u_expires_col, u_local_cseq_col, u_remote_cseq_col, u_version_col,
-		u_reason_col, u_status_col;
+		u_reason_col, u_status_col, u_contact_col, u_record_route_col;
 	int i;
 	subs_t* s= NULL, *prev_s= NULL;
 	int n_query_cols= 0, n_update_cols= 0;
@@ -2359,6 +2360,11 @@ void update_db_subs_timer(db1_con_t *db,db_func_t dbf, shtable_t hash_table,
 	query_vals[updated_winfo_col].nul = 0;
 	n_query_cols++;
 
+	query_cols[user_agent_col= n_query_cols]=&str_user_agent_col;
+	query_vals[user_agent_col].type = DB1_STR;
+	query_vals[user_agent_col].nul = 0;
+	n_query_cols++;
+
 	/* cols and values used for update */
 	update_cols[u_expires_col= n_update_cols]= &str_expires_col;
 	update_vals[u_expires_col].type = DB1_INT;
@@ -2390,6 +2396,16 @@ void update_db_subs_timer(db1_con_t *db,db_func_t dbf, shtable_t hash_table,
 	update_vals[u_version_col].nul = 0;
 	n_update_cols++;
 
+	update_cols[u_contact_col= n_update_cols]= &str_contact_col;
+	update_vals[u_contact_col].type = DB1_STR;
+	update_vals[u_contact_col].nul = 0;
+	n_update_cols++;
+
+	update_cols[u_record_route_col= n_update_cols]= &str_record_route_col;
+	update_vals[u_record_route_col].type = DB1_STR;
+	update_vals[u_record_route_col].nul = 0;
+	n_update_cols++;
+
 	for(i=0; i<htable_size; i++)
 	{
 		if(!no_lock)
@@ -2416,6 +2432,8 @@ void update_db_subs_timer(db1_con_t *db,db_func_t dbf, shtable_t hash_table,
 				/* need for a struct free/destroy? */
 				if (del_s->contact.s)
 					shm_free(del_s->contact.s);
+				if (del_s->record_route.s)
+					shm_free(del_s->record_route.s);
 				shm_free(del_s);
 				continue;
 			}
@@ -2441,6 +2459,8 @@ void update_db_subs_timer(db1_con_t *db,db_func_t dbf, shtable_t hash_table,
 					update_vals[u_version_col].val.int_val= s->version;
 					update_vals[u_status_col].val.int_val= s->status;
 					update_vals[u_reason_col].val.str_val= s->reason;
+					update_vals[u_contact_col].val.str_val = s->contact;
+					update_vals[u_record_route_col].val.str_val = s->record_route;
 
 					if(dbf.update(db, query_cols, 0, query_vals, update_cols,
 								update_vals, n_query_update, n_update_cols)< 0)
@@ -2478,6 +2498,8 @@ void update_db_subs_timer(db1_con_t *db,db_func_t dbf, shtable_t hash_table,
 					query_vals[socket_info_col].val.str_val= s->sockinfo_str;
 					query_vals[updated_col].val.int_val = -1;
 					query_vals[updated_winfo_col].val.int_val = -1;
+					query_vals[user_agent_col].val.str_val = s->user_agent;
+
 
 					if(dbf.insert(db,query_cols,query_vals,n_query_cols )<0)
 					{


### PR DESCRIPTION
we noticed some phones and upstream clusters sending
diferent route / contact after initial subscription.

this commit adds contact and record_route to updated columns for dbmode = 2
also adds user_agent to initial save
and a simple fix for getting the correct message in debug

should be backported to stable/maintained to fix issue in existing deployments