### PR TITLE
presence: update record_route in database

### DIFF
--- a/src/modules/presence/subscribe.c
+++ b/src/modules/presence/subscribe.c
@@ -427,6 +427,12 @@ int update_subs_db(subs_t* subs, int type)
 		update_vals[n_update_cols].val.str_val = subs->contact;
 		n_update_cols++;
 
+		update_keys[n_update_cols] = &str_record_route_col;
+		update_vals[n_update_cols].type = DB1_STR;
+		update_vals[n_update_cols].nul = 0;
+		update_vals[n_update_cols].val.str_val = subs->record_route;
+		n_update_cols++;
+
 	}
 	if(type & LOCAL_TYPE)
 	{


### PR DESCRIPTION
missed update from 49272f23b22445415721766709bf5841865e8609
should be backported with 816d2cd44d96245b5a5b53505d6fbc350bda378c
