### PR TITLE
ims_registar_pcscf: security_t parameters should be allocated on shared memory

### DIFF
--- a/src/modules/ims_registrar_pcscf/save.c
+++ b/src/modules/ims_registrar_pcscf/save.c
@@ -334,12 +334,9 @@ int save_pending(struct sip_msg* _m, udomain_t* _d) {
 		ci.received_port = 5060;
 
     // Parse security parameters
-    security_t sec_params;
-    memset(&sec_params, 0, sizeof(security_t));
-
-    int ret;
-    if((ret = cscf_get_security(_m, &sec_params)) != 0) {
-        LM_ERR("Error parsing sec-agree parameters: %d\n", ret);
+    security_t* sec_params = NULL;
+    if((sec_params = cscf_get_security(_m)) == NULL) {
+        LM_ERR("Will save pending contact without security parameters\n");
     }
 
 	ul.lock_udomain(_d, &ci.via_host, ci.via_port, ci.via_prot);
@@ -357,14 +354,13 @@ int save_pending(struct sip_msg* _m, udomain_t* _d) {
 	}
 
     // Update security parameters
-    if(ul.update_temp_security(_d, sec_params.type, &sec_params, pcontact) != 0)
+    if(ul.update_temp_security(_d, sec_params->type, sec_params, pcontact) != 0)
     {
         LM_ERR("Error updating temp security\n");
     }
 
 	ul.unlock_udomain(_d, &ci.via_host, ci.via_port, ci.via_prot);
 
-    free_security_t(&sec_params);
 
 	return 1;
 

--- a/src/modules/ims_registrar_pcscf/sec_agree.c
+++ b/src/modules/ims_registrar_pcscf/sec_agree.c
@@ -25,7 +25,6 @@
 #include "../../core/parser/msg_parser.h"
 #include "../../core/mem/mem.h"
 
-
 static uint32_t parse_digits(str value)
 {
     uint32_t ret = 0;
@@ -47,19 +46,30 @@ static uint32_t parse_digits(str value)
     return ret;
 }
 
-static void process_sec_agree_param(str name, str value, ipsec_t *ret)
+
+#define SEC_COPY_STR_PARAM(DST, SRC)\
+        DST.s = shm_malloc(SRC.len);\
+        if(DST.s == NULL) {\
+            return -1;\
+        }\
+        memcpy(DST.s, SRC.s, SRC.len);\
+        DST.len = SRC.len;
+
+
+static int process_sec_agree_param(str name, str value, ipsec_t *ret)
 {
+
     if(strncasecmp(name.s, "alg", name.len) == 0) {
-        ret->r_alg = value;
+        SEC_COPY_STR_PARAM(ret->r_alg, value);
     }
     else if(strncasecmp(name.s, "prot", name.len) == 0) {
-        ret->prot = value;
+        SEC_COPY_STR_PARAM(ret->prot, value);
     }
     else if(strncasecmp(name.s, "mod", name.len) == 0) {
-        ret->mod = value;
+        SEC_COPY_STR_PARAM(ret->mod, value);
     }
     else if(strncasecmp(name.s, "ealg", name.len) == 0) {
-        ret->r_alg = value;
+        SEC_COPY_STR_PARAM(ret->r_alg, value);
     }
     else if(strncasecmp(name.s, "spi-c", name.len) == 0) {
         ret->spi_uc = parse_digits(value);
@@ -76,19 +86,19 @@ static void process_sec_agree_param(str name, str value, ipsec_t *ret)
     else {
         //unknown parameter
     }
+
+    return 0;
 }
 
-static int parse_sec_agree(str body, security_t *params)
+static security_t* parse_sec_agree(struct hdr_field* h)
 {
     int i = 0;
 
     str name = {0,0};
     str value = {0,0};
     str mechanism_name = {0,0};
-
-    if(!params) {
-        return 10;
-    }
+    security_t* params = NULL;
+    str body = h->body;
 
     // skip leading whitespace
     while(body.len && (body.s[0]==' ' || body.s[0]=='\t' || body.s[0]=='<')){
@@ -101,27 +111,43 @@ static int parse_sec_agree(str body, security_t *params)
         body.len--;
     }
 
-    // skip mechanism name - noone seems to need it
+    // skip  header name - noone seems to need it
     for(i = 0; body.s[i] != ';' && i < body.len; i++);
 
     mechanism_name.s = body.s;
     mechanism_name.len = i;
 
     if(strncasecmp(mechanism_name.s, "ipsec-3gpp", 10) != 0) {
-        //unsupported mechanism
+        // unsupported mechanism
         LM_ERR("Unsupported mechanism: %.*s\n", STR_FMT(&mechanism_name));
-        return 11;
+        goto cleanup;
     }
 
-    params->type = SECURITY_IPSEC;
+    // allocate shm memory for security_t (it will be saved in contact)
+    if ((params = shm_malloc(sizeof(security_t))) == NULL) {
+        LM_ERR("Error allocating shm memory for security_t parameters during sec-agree parsing\n");
+        return NULL;
+    }
+    memset(params, 0, sizeof(security_t));
 
-    params->data.ipsec = pkg_malloc(sizeof(ipsec_t));
+    if((params->sec_header.s = shm_malloc(h->name.len)) == NULL) {
+        LM_ERR("Error allocating shm memory for security_t sec_header parameter during sec-agree parsing\n");
+        goto cleanup;
+    }
+    memcpy(params->sec_header.s, h->name.s, h->name.len);
+    params->sec_header.len = h->name.len;
+
+    // allocate memory for ipsec_t in security_t
+    params->data.ipsec = shm_malloc(sizeof(ipsec_t));
     if(!params->data.ipsec) {
         LM_ERR("Error allocating memory for ipsec parameters during sec-agree parsing\n");
-        return 12;
+        goto cleanup;
     }
-
     memset(params->data.ipsec, 0, sizeof(ipsec_t));
+
+
+    // set security type to IPSEC
+    params->type = SECURITY_IPSEC;
 
     body.s=body.s+i+1;
     body.len=body.len-i-1;
@@ -145,7 +171,9 @@ static int parse_sec_agree(str body, security_t *params)
             i=0;
 
             if(name.len && value.len) {
-                process_sec_agree_param(name, value, params->data.ipsec);
+                if(process_sec_agree_param(name, value, params->data.ipsec)) {
+                    goto cleanup;
+                }
             }
             //else - something's wrong. Ignore!
 
@@ -170,8 +198,26 @@ static int parse_sec_agree(str body, security_t *params)
         }
     }
 
-    return 0;
+    return params;
+
+cleanup:
+    if(params) {
+        shm_free(params->sec_header.s);
+
+        if(params->data.ipsec) {
+            shm_free(params->data.ipsec->r_alg.s);
+            shm_free(params->data.ipsec->prot.s);
+            shm_free(params->data.ipsec->mod.s);
+            shm_free(params->data.ipsec->ealg.s);
+
+            shm_free(params->data.ipsec);
+        }
+
+        shm_free(params);
+    }
+    return NULL;
 }
+
 
 static str s_security_client={"Security-Client",15};
 static str s_security_server={"Security-Server",15};
@@ -183,15 +229,14 @@ static str s_security_verify={"Security-Verify",15};
  * @param params - ptr to struct sec_agree_params, where parsed values will be saved
  * @returns 0 on success, error code on failure
  */
-int cscf_get_security(struct sip_msg *msg, security_t *params)
+security_t* cscf_get_security(struct sip_msg *msg)
 {
     struct hdr_field *h = NULL;
 
-    if (!msg) return 1;
-    if (!params) return 2;
+    if (!msg) return NULL;
 
     if (parse_headers(msg, HDR_EOH_F, 0)<0) {
-        return 3;
+        return NULL;
     }
 
     h = msg->headers;
@@ -201,28 +246,13 @@ int cscf_get_security(struct sip_msg *msg, security_t *params)
             (h->name.len == s_security_server.len && strncasecmp(h->name.s, s_security_server.s, s_security_server.len)==0) ||
             (h->name.len == s_security_verify.len && strncasecmp(h->name.s, s_security_verify.s, s_security_verify.len)==0) )
         {
-            params->sec_header = h->name;
-            return parse_sec_agree(h->body, params);
+            return parse_sec_agree(h);
         }
 
         h = h->next;
     }
 
-    return 4;
-}
+    LM_INFO("No security parameters found\n");
 
-void free_security_t(security_t *params)
-{
-    switch (params->type)
-    {
-        case SECURITY_IPSEC:
-            pkg_free(params->data.ipsec);
-        break;
-
-        case SECURITY_TLS:
-            pkg_free(params->data.ipsec);
-        break;
-
-        //default: Nothing to deallocate
-    }
+    return NULL;
 }

--- a/src/modules/ims_registrar_pcscf/sec_agree.h
+++ b/src/modules/ims_registrar_pcscf/sec_agree.h
@@ -30,7 +30,7 @@
  * @param params - ptr to struct sec_agree_params, where parsed values will be saved
  * @returns 0 on success, error code on failure
  */
-int cscf_get_security(struct sip_msg *msg, security_t *params);
+security_t* cscf_get_security(struct sip_msg *msg);
 
 void free_security_t(security_t *params);
 

--- a/src/modules/ims_usrloc_pcscf/pcontact.c
+++ b/src/modules/ims_usrloc_pcscf/pcontact.c
@@ -112,6 +112,38 @@ void free_ppublic(ppublic_t* _p)
 	shm_free(_p);
 }
 
+void free_security(security_t* _p)
+{
+    if (!_p)
+        return;
+
+    shm_free(_p->sec_header.s);
+
+    switch (_p->type)
+    {
+        case SECURITY_IPSEC:
+            shm_free(_p->data.ipsec->ealg.s);
+            shm_free(_p->data.ipsec->r_ealg.s);
+            shm_free(_p->data.ipsec->ck.s);
+            shm_free(_p->data.ipsec->alg.s);
+            shm_free(_p->data.ipsec->r_alg.s);
+            shm_free(_p->data.ipsec->ik.s);
+            shm_free(_p->data.ipsec->prot.s);
+            shm_free(_p->data.ipsec->mod.s);
+
+            shm_free(_p->data.ipsec);
+        break;
+
+        case SECURITY_TLS:
+            shm_free(_p->data.tls);
+        break;
+
+        //default: Nothing to deallocate
+    }
+
+    shm_free(_p);
+}
+
 int new_pcontact(struct udomain* _d, str* _contact, struct pcontact_info* _ci, struct pcontact** _c)
 {
 	int i, has_rinstance=0;
@@ -274,6 +306,10 @@ void free_pcontact(pcontact_t* _c) {
 		_c->service_routes = 0;
 		_c->num_service_routes = 0;
 	}
+
+    // free_security() checks for NULL ptr
+    free_security(_c->security_temp);
+    free_security(_c->security);
 
 	if (_c->rx_session_id.len > 0 && _c->rx_session_id.s)
 		shm_free(_c->rx_session_id.s);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X ] Commit message has the format required by CONTRIBUTING guide
- [ X] Commits are split per component (core, individual modules, libs, utils, ...)
- [ X] Each component has a single commit (if not, squash them into one commit)
- [ X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
ims_registar_pcscf has functionality which parses sec-agree parameters from REGISTER and saves them in usrloc contact. However the memory allocated for the security_t data structure was allocated in the private memory, instead on the shared memory.