### PR TITLE
 usrloc: extend handle_lost_tcp use for get_urecord

### DIFF
--- a/src/modules/usrloc/urecord.c
+++ b/src/modules/usrloc/urecord.c
@@ -216,7 +216,7 @@ void mem_delete_ucontact(urecord_t* _r, ucontact_t* _c)
 	free_ucontact(_c);
 }
 
-static inline int is_valid_tcpconn(ucontact_t *c)
+inline int is_valid_tcpconn(ucontact_t *c)
 {
 	if (c->tcpconn_id == -1)
 		return 0; /* tcpconn_id is not present */
@@ -224,7 +224,7 @@ static inline int is_valid_tcpconn(ucontact_t *c)
 		return 1; /* valid tcpconn_id */
 }
 
-static inline int is_tcp_alive(ucontact_t *c)
+inline int is_tcp_alive(ucontact_t *c)
 {
 	struct tcp_connection *con = NULL;
 	int rc = 0;

--- a/src/modules/usrloc/urecord.c
+++ b/src/modules/usrloc/urecord.c
@@ -216,7 +216,7 @@ void mem_delete_ucontact(urecord_t* _r, ucontact_t* _c)
 	free_ucontact(_c);
 }
 
-inline int is_valid_tcpconn(ucontact_t *c)
+int is_valid_tcpconn(ucontact_t *c)
 {
 	if (c->tcpconn_id == -1)
 		return 0; /* tcpconn_id is not present */
@@ -224,7 +224,7 @@ inline int is_valid_tcpconn(ucontact_t *c)
 		return 1; /* valid tcpconn_id */
 }
 
-inline int is_tcp_alive(ucontact_t *c)
+int is_tcp_alive(ucontact_t *c)
 {
 	struct tcp_connection *con = NULL;
 	int rc = 0;

--- a/src/modules/usrloc/urecord.h
+++ b/src/modules/usrloc/urecord.h
@@ -189,4 +189,8 @@ int get_ucontact(urecord_t* _r, str* _c, str* _callid, str* _path,
 int get_ucontact_by_instance(urecord_t* _r, str* _c, ucontact_info_t* _ci,
 		ucontact_t** _co);
 
+inline int is_valid_tcpconn(ucontact_t *c);
+
+inline int is_tcp_alive(ucontact_t *c);
+
 #endif

--- a/src/modules/usrloc/urecord.h
+++ b/src/modules/usrloc/urecord.h
@@ -189,8 +189,8 @@ int get_ucontact(urecord_t* _r, str* _c, str* _callid, str* _path,
 int get_ucontact_by_instance(urecord_t* _r, str* _c, ucontact_info_t* _ci,
 		ucontact_t** _co);
 
-inline int is_valid_tcpconn(ucontact_t *c);
+int is_valid_tcpconn(ucontact_t *c);
 
-inline int is_tcp_alive(ucontact_t *c);
+int is_tcp_alive(ucontact_t *c);
 
 #endif


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Hi there!
So my case, and why I did not use the existing code:
- incoming INVITE to a user with 2 records in usrloc (1st - UDP, 2nd - TLS)
- some time before lookup, TLS connect of 2nd device is closed, but usrloc record still exists (it going to be removed in the next iteration of timer)
- after lookup(location) - 2 branches are created
- send to 1st - UDP succeed
- send to 2nd - TLS failed. And here is my headache.
-- I want to send push notification to this device
-- I set t_on_branch_failure
-- if I try failure_exec_mode=1 - I get control, and I am able to send push, but I need to wait until fr_timer fire (I wanted not to wait, and send immediately)

The idea of changes:
- usrloc -> get_urecord: if t_contact has tcpcon_id & connection is not alive => mark record as expired
- as a result, in the registrar, while lookup, this contact will fail VALID_CONTACT - and will not be returned to the scriptwriter.

All of this is wrapped by handle_lost_tcp parameter (that is 0 by default), so changes are extending of handle_lost_tcp parameter of usrloc. Checked doc for usrloc, and seems to me that current description of this parameter should be untouched.

Marked as expired contact will be removed by timer as usual.

Open for discussion, and thanks in advance.
