### PR TITLE
acc: use acc.time_mode to save cdrs in gmtime

### DIFF
--- a/src/modules/acc/acc_cdr.c
+++ b/src/modules/acc/acc_cdr.c
@@ -64,6 +64,7 @@
 
 #define TIME_STR_BUFFER_SIZE 20
 #define TIME_BUFFER_LENGTH 256
+#define TIME_STRING_FORMAT "%Y-%m-%d %H:%M:%S"
 
 struct dlg_binds dlgb;
 struct acc_extra* cdr_extra = NULL;
@@ -141,6 +142,8 @@ static int db_write_cdr( struct dlg_cell* dialog,
 	long long_val;
 	double double_val;
 	char * end;
+	struct tm *t;
+	char cdr_time_format_buf[MAX_CDR_CORE][TIME_STR_BUFFER_SIZE];
 
 	if(acc_cdrs_table.len<=0)
 		return 0;
@@ -182,13 +185,24 @@ static int db_write_cdr( struct dlg_cell* dialog,
 				VAL_STR(db_cdr_vals+i) = cdr_value_array[i];
 				break;
 			case TYPE_DATE:
-				VAL_TYPE(db_cdr_vals+i)=DB1_DATETIME;
 				VAL_NULL(db_cdr_vals+i)=0;
 				if(string2time(&cdr_value_array[i], &timeval_val) < 0) {
 					LM_ERR("failed to convert string to timeval.\n");
 					goto error;
 				}
-				VAL_TIME(db_cdr_vals+i) = timeval_val.tv_sec;
+				if (acc_time_mode==4) {
+					VAL_TYPE(db_cdr_vals+i)=DB1_STRING;
+					t = gmtime(&timeval_val.tv_sec);
+					/* Convert time_t structure to format accepted by the database */
+					if (strftime(cdr_time_format_buf[i], TIME_STR_BUFFER_SIZE, TIME_STRING_FORMAT, t) <= 0) {
+						cdr_time_format_buf[i][0] = '\0';
+					}
+
+					VAL_STRING(db_cdr_vals+i) = cdr_time_format_buf[i];
+				} else {
+					VAL_TYPE(db_cdr_vals+i)=DB1_DATETIME;
+					VAL_TIME(db_cdr_vals+i) = timeval_val.tv_sec;
+				}
 				break;
 			case TYPE_DOUBLE:
 				VAL_TYPE(db_cdr_vals+i)=DB1_DOUBLE;

--- a/src/modules/acc/doc/acc_admin.xml
+++ b/src/modules/acc/doc/acc_admin.xml
@@ -1306,12 +1306,12 @@ modparam("acc", "cdrs_table", "acc_cdrs")
 		</listitem>
 		<listitem>
 			<para><emphasis>3</emphasis> - save formatted time according
-				to time_format parameter, using the output of localtime().
+				to time_format parameter, using the output of localtime(). Used for cdr entries too.
 			</para>
 		</listitem>
 		<listitem>
 			<para><emphasis>4</emphasis> - save formatted time according
-				to time_format parameter, using the output of gmtime().
+				to time_format parameter, using the output of gmtime(). Used for cdr entries too.
 			</para>
 		</listitem>
 		</itemizedlist>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #1358 

#### Description
<!-- Describe your changes in detail -->
acc.time_mode modparam allows storing acc transactions time field using the output of gmtime() when it is set to 4.

This commit aims to reuse this modparam for cdr entries (start_time, end_time). This way, if time_mode is 4, both acc and cdr entries will be stored in gmtime.