### PR TITLE
Let the partition column be configurable.

### DIFF
--- a/src/modules/usrloc/doc/usrloc_admin.xml
+++ b/src/modules/usrloc/doc/usrloc_admin.xml
@@ -516,6 +516,26 @@ modparam("usrloc", "keepalive_column", "kalive")
 		</example>
 	</section>
 
+	<section id="usrloc.p.partition_column">
+		<title><varname>partition_column</varname> (string)</title>
+		<para>
+		Name of database table column containing the value for partition id.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>partition</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>partitioncolumn</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("usrloc", "partition_column", "part")
+...
+</programlisting>
+		</example>
+	</section>
+
 	<section id="usrloc.p.use_domain">
 		<title><varname>use_domain</varname> (integer)</title>
 		<para>

--- a/src/modules/usrloc/usrloc_mod.c
+++ b/src/modules/usrloc/usrloc_mod.c
@@ -218,6 +218,7 @@ static param_export_t params[] = {
 	{"server_id_column",    PARAM_STR, &srv_id_col    },
 	{"connection_id_column",PARAM_STR, &con_id_col    },
 	{"keepalive_column",    PARAM_STR, &keepalive_col },
+	{"partition_column",    PARAM_STR, &partition_col },
 	{"matching_mode",       INT_PARAM, &matching_mode   },
 	{"cseq_delay",          INT_PARAM, &cseq_delay      },
 	{"fetch_rows",          INT_PARAM, &ul_fetch_rows   },


### PR DESCRIPTION
#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

When using xDB Replication Server with PostgreSQL, "partition" is a reserved
name and breaks replication. Therefore let the column name be configurable.

An even better fix would be to also change the default name, as "partition" is a
SQL key word which is reserved by SQL:2011. See
https://www.postgresql.org/docs/current/static/sql-keywords-appendix.html