### PR TITLE
Minor improvements to RPM packaging

### DIFF
--- a/pkg/kamailio/obs/kamailio.init
+++ b/pkg/kamailio/obs/kamailio.init
@@ -36,7 +36,7 @@ RUN_KAMAILIO=no
 check_fork ()
 {
     if grep -q "^[[:space:]]*fork[[:space:]]*=[[:space:]]*no.*" $KAMCFG; then
-        echo "Not starting $DESC: fork=no specified in config file; run /etc/init.d/kamailio debug instead"
+        echo "Not starting $PROG: fork=no specified in config file; run /etc/init.d/kamailio debug instead"
         exit 1
     fi
 }
@@ -44,10 +44,10 @@ check_fork ()
 check_kamailio_config ()
 {
         # Check if kamailio configuration is valid before starting the server
-        out=$($KAM -c 2>&1 > /dev/null)
+        out=$($KAM -c $OPTIONS 2>&1 > /dev/null)
         retcode=$?
         if [ "$retcode" != '0' ]; then
-            echo "Not starting $DESC: invalid configuration file!"
+            echo "Not starting $PROG: invalid configuration file!"
             echo -e "\n$out\n"
             exit 1
         fi
@@ -69,7 +69,7 @@ start() {
 
 stop() {
 	echo -n $"Stopping $PROG: "
-	killproc $KAM
+	killproc -p $PID_FILE
 	RETVAL=$?
 	echo
 	[ $RETVAL = 0 ] && rm -f $LOCK_FILE $PID_FILE
@@ -81,7 +81,7 @@ if [ -f $DEFAULTS ]; then
 fi
 
 if [ "$RUN_KAMAILIO" != "yes" ]; then
-    echo "Kamailio not yet configured. Edit /etc/default/kamailio first."
+    echo "Kamailio not yet configured. Edit $DEFAULTS first."
     exit 0
 fi
 
@@ -108,7 +108,7 @@ if [ ! -d $HOMEDIR ]; then
 	chown ${USER}:${GROUP} $HOMEDIR
 fi
 
-OPTIONS="-P $PID_FILE -m $SHM_MEMORY -M $PKG_MEMORY -u $USER -g $GROUP $EXTRA_OPTIONS"
+OPTIONS="-f $KAMCFG -P $PID_FILE -m $SHM_MEMORY -M $PKG_MEMORY -u $USER -g $GROUP $EXTRA_OPTIONS"
 
 
 # See how we were called.

--- a/pkg/kamailio/obs/kamailio.spec
+++ b/pkg/kamailio/obs/kamailio.spec
@@ -1188,7 +1188,6 @@ fi
 %doc %{_docdir}/kamailio/modules/README.group
 %doc %{_docdir}/kamailio/modules/README.htable
 %doc %{_docdir}/kamailio/modules/README.imc
-%doc %{_docdir}/kamailio/modules/README.ims_ocs
 %doc %{_docdir}/kamailio/modules/README.ipops
 %doc %{_docdir}/kamailio/modules/README.kex
 %doc %{_docdir}/kamailio/modules/README.malloc_test
@@ -1336,7 +1335,6 @@ fi
 %{_libdir}/kamailio/modules/group.so
 %{_libdir}/kamailio/modules/htable.so
 %{_libdir}/kamailio/modules/imc.so
-%{_libdir}/kamailio/modules/ims_ocs.so
 %{_libdir}/kamailio/modules/ipops.so
 %{_libdir}/kamailio/modules/kex.so
 %{_libdir}/kamailio/modules/malloc_test.so
@@ -1553,6 +1551,7 @@ fi
 %doc %{_docdir}/kamailio/modules/README.ims_diameter_server
 %doc %{_docdir}/kamailio/modules/README.ims_icscf
 %doc %{_docdir}/kamailio/modules/README.ims_isc
+%doc %{_docdir}/kamailio/modules/README.ims_ocs
 %doc %{_docdir}/kamailio/modules/README.ims_qos
 %doc %{_docdir}/kamailio/modules/README.ims_registrar_pcscf
 %doc %{_docdir}/kamailio/modules/README.ims_registrar_scscf
@@ -1570,6 +1569,7 @@ fi
 %{_libdir}/kamailio/modules/ims_diameter_server.so
 %{_libdir}/kamailio/modules/ims_icscf.so
 %{_libdir}/kamailio/modules/ims_isc.so
+%{_libdir}/kamailio/modules/ims_ocs.so
 %{_libdir}/kamailio/modules/ims_qos.so
 %{_libdir}/kamailio/modules/ims_registrar_pcscf.so
 %{_libdir}/kamailio/modules/ims_registrar_scscf.so


### PR DESCRIPTION
### Description
kamailio.spec: Move the ims_ocs module into the ims RPM. It has a dependancy on libkamailio_ims.so

kamailio.init: Pass the .cfg file as a parameter when starting or syntax checking. Use the pidfile to kill only the relevant instance.
This makes it easier to reuse the same script when running multiple kamailio instances on the same server. Only the environment vars at the top need to be changed.