### PR TITLE
nathelper: allow port to be specified in force_socket, fixes #1298

### DIFF
--- a/src/modules/nathelper/doc/nathelper_admin.xml
+++ b/src/modules/nathelper/doc/nathelper_admin.xml
@@ -128,8 +128,7 @@
 		<title><varname>force_socket</varname> (string)</title>
 		<para>
 		Socket to be used when sending NAT pings for UDP communication.
-		It uses the first socket it finds based on the IP address. If
-		no one specified, the OS will choose a socket.
+		If no one specified, the OS will choose a socket.
 		</para>
 		<para>
 		<emphasis>
@@ -140,7 +139,7 @@
 		<title>Set <varname>force_socket</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("nathelper", "force_socket", "127.0.0.1")
+modparam("nathelper", "force_socket", "127.0.0.1:5060")
 ...
 </programlisting>
 		</example>

--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -417,6 +417,8 @@ static int mod_init(void)
 	struct in_addr addr;
 	pv_spec_t avp_spec;
 	str s;
+	int port, proto;
+	str host;
 
 	if(nathelper_rpc_init() < 0) {
 		LM_ERR("failed to register RPC commands\n");
@@ -442,7 +444,12 @@ static int mod_init(void)
 	}
 
 	if(force_socket_str.s && force_socket_str.len > 0) {
-		force_socket = grep_sock_info(&force_socket_str, 0, 0);
+		if(parse_phostport(force_socket_str.s, &host.s, &host.len, &port, &proto) == 0) {
+			force_socket = grep_sock_info(&host, port, proto);
+			if(force_socket == 0) {
+				LM_ERR("non-local force_socket <%s>\n", force_socket_str.s);
+			}
+		}
 	}
 
 	/* create raw socket? */


### PR DESCRIPTION
With regards to your comment on ticket #1298 that the nathelper force_socket should be parsed correctly. Plus I found the time to work on it :-)