### PR TITLE
nathelper: allow port to be specified in force_socket, fixes #1298

### DIFF
--- a/src/modules/nathelper/doc/nathelper_admin.xml
+++ b/src/modules/nathelper/doc/nathelper_admin.xml
@@ -139,7 +139,7 @@
 		<title>Set <varname>force_socket</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("nathelper", "force_socket", "localhost:33333")
+modparam("nathelper", "force_socket", "127.0.0.1:5060")
 ...
 </programlisting>
 		</example>

--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -428,6 +428,8 @@ mod_init(void)
 	struct in_addr addr;
 	pv_spec_t avp_spec;
 	str s;
+	int port, proto;
+	str host;
 
 	if(nathelper_rpc_init()<0)
 	{
@@ -453,8 +455,13 @@ mod_init(void)
 		rcv_avp_type = 0;
 	}
 
-	if (force_socket_str.s && force_socket_str.len>0) {
-		force_socket=grep_sock_info(&force_socket_str,0,0);
+	if(force_socket_str.s && force_socket_str.len > 0) {
+		if(parse_phostport(force_socket_str.s, &host.s, &host.len, &port, &proto) == 0) {
+			force_socket = grep_sock_info(&host, port, proto);
+			if(force_socket == 0) {
+				LM_ERR("non-local force_socket <%s>\n", force_socket_str.s);
+			}
+		}
 	}
 
 	/* create raw socket? */


### PR DESCRIPTION
cherry-picked to be part of next 5.0.x release