### PR TITLE
Dispatcher set_state "all"

### DIFF
--- a/src/modules/dispatcher/dispatch.c
+++ b/src/modules/dispatcher/dispatch.c
@@ -2608,6 +2608,39 @@ int ds_reinit_state(int group, str *address, int state)
 /**
  *
  */
+int ds_reinit_state_all(int group, int state)
+{
+	int i = 0;
+	ds_set_t *idx = NULL;
+
+	if(_ds_list == NULL || _ds_list_nr <= 0) {
+		LM_ERR("the list is null\n");
+		return -1;
+	}
+
+	/* get the index of the set */
+	if(ds_get_index(group, *crt_idx, &idx) != 0) {
+		LM_ERR("destination set [%d] not found\n", group);
+		return -1;
+	}
+
+	for(i = 0; i < idx->nr; i++) {
+		int old_state = idx->dlist[i].flags;
+		/* reset the bits used for states */
+		idx->dlist[i].flags &= ~(DS_STATES_ALL);
+		/* set the new states */
+		idx->dlist[i].flags |= state;
+		if(idx->dlist[i].attrs.rweight > 0) {
+			ds_reinit_rweight_on_state_change(
+					old_state, idx->dlist[i].flags, idx);
+		}
+	}
+	return 0;
+}
+
+/**
+ *
+ */
 void ds_fprint_set(FILE *fout, ds_set_t *node)
 {
 	int i, j;

--- a/src/modules/dispatcher/dispatch.h
+++ b/src/modules/dispatcher/dispatch.h
@@ -115,6 +115,7 @@ int ds_select_dst(struct sip_msg *msg, int set, int alg, int mode);
 int ds_next_dst(struct sip_msg *msg, int mode);
 int ds_update_state(sip_msg_t *msg, int group, str *address, int state);
 int ds_reinit_state(int group, str *address, int state);
+int ds_reinit_state_all(int group, int state);
 int ds_mark_dst(struct sip_msg *msg, int mode);
 int ds_print_list(FILE *fout);
 int ds_log_sets(void);

--- a/src/modules/dispatcher/dispatcher.c
+++ b/src/modules/dispatcher/dispatcher.c
@@ -1360,9 +1360,13 @@ static void dispatcher_rpc_set_state(rpc_t *rpc, void *ctx)
 		return;
 	}
 
-	if(ds_reinit_state(group, &dest, stval) < 0) {
-		rpc->fault(ctx, 500, "State Update Failed");
-		return;
+	if(strcmp(dest.s, "all") == 0) {
+		ds_reinit_state_all(group, stval);
+	} else {
+		if(ds_reinit_state(group, &dest, stval) < 0) {
+			rpc->fault(ctx, 500, "State Update Failed");
+			return;
+		}
 	}
 
 	return;

--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -1511,7 +1511,8 @@ onreply_route {
 
 			<listitem><para>_group_: destination group id</para></listitem>
 
-			<listitem><para>_address_: address of the destination in the _group_</para></listitem>
+			<listitem><para>_address_: address of the destination in the _group_
+					or 'all' to update all destinations in the group</para></listitem>
 		</itemizedlist>
 		<para>
 		Example:
@@ -1520,6 +1521,7 @@ onreply_route {
 ...
 # prototype: &sercmd; dispatcher.set_state _state_ _group_ _address_
 &sercmd; dispatcher.set_state ip 2 sip:127.0.0.1:5080
+&sercmd; dispatcher.set_state ip 3 all
 ...
 </programlisting>
     </section>


### PR DESCRIPTION
#### Type Of Change
- [x] New feature (non-breaking change which adds new functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] Tested changes locally

#### Description
<!-- Describe your changes in detail -->
Adds a new option to RPC command `dispatcher.set_state` to bulk update all destinations as part of a dispatcher set. The way we use dispatcher sets this comes in handy in a few cases.