### PR TITLE
http_async_client: cleanup avps/xavps after exec route on Http worker

### DIFF
--- a/src/modules/http_async_client/async_http.c
+++ b/src/modules/http_async_client/async_http.c
@@ -45,6 +45,7 @@
 #include "../../core/dprint.h"
 #include "../../core/ut.h"
 #include "../../core/cfg/cfg_struct.h"
+#include "../../core/receive.h"
 #include "../../core/fmsg.h"
 #include "../../core/kemi.h"
 #include "../../modules/tm/tm_load.h"
@@ -263,6 +264,7 @@ void async_http_cb(struct http_m_reply *reply, void *param)
 				LM_ERR("error running event route kemi callback\n");
 			}
 		}
+		ksr_msg_env_reset();
 	}
 
 done:


### PR DESCRIPTION
when suspend_transaction is false

As suggested at #1391 to avoid shared memory leak