### PR TITLE
pua: removed null pointer access from subscribe_cbparam()

### DIFF
--- a/src/modules/pua/send_subscribe.c
+++ b/src/modules/pua/send_subscribe.c
@@ -821,7 +821,7 @@ ua_pres_t* subscribe_cbparam(subs_info_t* subs, int ua_flag)
 	{
 		CONT_COPY(hentity, hentity->id, subs->id);
 	}
-	if(subs->extra_headers && hentity->extra_headers->s)
+	if(subs->extra_headers)
 	{
 		hentity->extra_headers= (str*)((char*)hentity+ size);
 		size+= sizeof(str);


### PR DESCRIPTION
A newly introduced condition in an if () statement leads to core
dump in some scenarios. It is removed.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Without this Change a core dump happens in the P-CSCF during handling the SIP REGISTER.
Obviously a condition was added to an if() Statement, which itself created a null pointer Access.
This additional Statement was removed.
