### PR TITLE
ims_usrloc_scscf: missing assignment of record_route

### DIFF
--- a/src/modules/ims_usrloc_scscf/subscribe.c
+++ b/src/modules/ims_usrloc_scscf/subscribe.c
@@ -346,6 +346,7 @@ int update_subscriber(impurecord_t* urec, reg_subscriber** _reg_subscriber, int 
     subs.callid = rs->call_id;
     subs.expires = rs->expires - act_time;
     subs.contact = rs->watcher_contact;
+    subs.record_route = rs->record_route;
     
     hash_code = core_hash(&subs.callid, &subs.to_tag, sub_dialog_hash_size);
     


### PR DESCRIPTION
In update_subscriber() function, when the rs is assigned to the subs,
it is missing the record_route component, which leads to core dump in
some scenarios.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Without this bugfix, a core dump can happen during SIP REGISTER in S-CSCF.
Reason: the record_route component was forgotten to be assigned when assigning rs to Subs in the update_subscriber() function.
This assignment was added.
