### PR TITLE
ims_usrloc_scscf: assignment of length missing for query_buffer in db_link_contact_to_impu() - 5.1

### DIFF
--- a/src/modules/ims_usrloc_scscf/usrloc_db.c
+++ b/src/modules/ims_usrloc_scscf/usrloc_db.c
@@ -1079,7 +1079,7 @@ int db_link_contact_to_impu(impurecord_t* _r, ucontact_t* _c) {
 
     }
 
-    query_buffer_len = snprintf(query_buffer.s, query_buffer_len, impu_contact_insert_query, _r->public_identity.len, _r->public_identity.s, _c->c.len, _c->c.s);
+    query_buffer.len = snprintf(query_buffer.s, query_buffer_len, impu_contact_insert_query, _r->public_identity.len, _r->public_identity.s, _c->c.len, _c->c.s);
 
     LM_DBG("QUERY IS [%.*s] and len is %d\n", query_buffer.len, query_buffer.s, query_buffer.len);
     if (ul_dbf.raw_query(ul_dbh, &query_buffer, &rs) != 0) {


### PR DESCRIPTION
When writing to query_buffer with the help of the snprintf() function,
the result of the functio is written to variable query_buffer_len
instead of to the query_buffer.len itself. This leads to core dump
in some cases. Replaced "_" by "." in "query_buffer_len ="

(cherry picked from commit 11c179ab232222f1c78f19557032afd49bef7324)

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Created by cherry-pick from master
