### PR TITLE
ndb_redis: dynamic discovery of nodes

### DIFF
--- a/src/modules/ndb_redis/doc/ndb_redis_admin.xml
+++ b/src/modules/ndb_redis/doc/ndb_redis_admin.xml
@@ -271,6 +271,36 @@ modparam("ndb_redis", "flush_on_reconnect", 1)
 			</programlisting>
 		</example>
 	</section>
+	<section id="ndb_redis.p.allow_dynamic_nodes">
+		<title><varname>allow_dynamic_nodes</varname> (integer)</title>
+		<para>
+			If set to 1, the module will connect to servers indicated in the "MOVED" reply,
+			even if they are not specified at startup.
+		</para>
+		<para>
+			When <quote>cluster</quote> is enabled the module supports redirections ("MOVED") replies.
+			Set <quote>allow_dynamic_nodes</quote> to 1 to avoid listing all the nodes at startup.
+			You can only list one node, e.g. by using a DNS name for the cluster instead of an IP address.
+			The module will add dynamically the new nodes as the MOVED replies are received.
+			Only works if <quote>cluster</quote> is set to 1.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote> (disabled).
+		</emphasis>
+		</para>
+		<example>
+			<title>Set <varname>allow_dynamic_nodes</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("ndb_redis", "server", "name=redis_cluster;addr=127.0.0.1;port=26008")
+...
+modparam("ndb_redis", "cluster", 1)
+modparam("ndb_redis", "allow_dynamic_nodes", 1)
+...
+			</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>

--- a/src/modules/ndb_redis/ndb_redis_mod.c
+++ b/src/modules/ndb_redis/ndb_redis_mod.c
@@ -52,6 +52,7 @@ int redis_cluster_param = 0;
 int redis_disable_time_param=0;
 int redis_allowed_timeouts_param=-1;
 int redis_flush_on_reconnect_param=0;
+int redis_allow_dynamic_nodes_param = 0;
 
 static int w_redis_cmd3(struct sip_msg* msg, char* ssrv, char* scmd,
 		char* sres);
@@ -127,6 +128,7 @@ static param_export_t params[]={
 	{"disable_time", INT_PARAM, &redis_disable_time_param},
 	{"allowed_timeouts", INT_PARAM, &redis_allowed_timeouts_param},
 	{"flush_on_reconnect", INT_PARAM, &redis_flush_on_reconnect_param},
+	{"allow_dynamic_nodes", INT_PARAM, &redis_allow_dynamic_nodes_param},
 	{0, 0, 0}
 };
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This change provides support in `ndb_redis` for a scenario where the Redis server is part of a cluster _and_ the IP addresses of the nodes are either not known in advance or are subject to change (for example in case the cluster sees new nodes being added).
Before this change `ndb_redis` supports the `cluster` option, so that after a `MOVED` response from a node `ndb_redis` will perform again the same query but towards the redirection target. The caveat is that `ndb_redis` must know in advance which IP addresses will be used by the nodes.
A`MOVED` response is in the form `-MOVED 1234 1.2.3.4:6379.`, indicating the hash for the request and the redirection target IP address and port.
Every node in the cluster must have a modparam entry with `name=IP_ADDRESS:PORT;addr=IP_ADDRESS;port=PORT`.
With the changes in this PR, ndb_redis doesn't need to have in advance the list of nodes but it can "discover" them at runtime.
There is a caveat to this solution: while defining the nodes in advance allows to define also `pass`, `sock` and `db`, this is currently not supported (and default values are used). If this change will be accepted though, we could add a module parameter to define `pass`, `sock` and `db` for the dynamic nodes.
