### PR TITLE
acc: new json format with outputs to mqueue or syslog

### DIFF
--- a/src/modules/acc/Makefile
+++ b/src/modules/acc/Makefile
@@ -8,9 +8,20 @@ auto_gen=
 NAME=acc.so
 LIBS=
 
+ifeq ($(CROSS_COMPILE),)
+JSON_SUPPORTED=$(shell \
+	if pkg-config --exists jansson; then \
+		echo 'libjansson found'; \
+	fi)
+endif
+ifneq ($(JSON_SUPPORTED),)
+	DEFS+= $(shell pkg-config --cflags jansson)
+	DEFS+= -DWITH_JSON
+	LIBS+= $(shell pkg-config --libs jansson)
+endif
+
 DEFS+=-DKAMAILIO_MOD_INTERFACE
 
 SERLIBPATH=../../lib
 SER_LIBS+=$(SERLIBPATH)/srdb1/srdb1
-
 include ../../Makefile.modules

--- a/src/modules/acc/acc.h
+++ b/src/modules/acc/acc.h
@@ -74,6 +74,7 @@
 
 void acc_log_init(void);
 int  acc_log_request( struct sip_msg *req);
+int  acc_json_request(struct sip_msg *req);
 
 int core2strar(struct sip_msg *req, str *c_vals, int *i_vals, char *t_vals);
 

--- a/src/modules/acc/acc_mod.h
+++ b/src/modules/acc/acc_mod.h
@@ -48,6 +48,9 @@ extern int log_level;
 extern int log_flag;
 extern int log_missed_flag;
 
+extern int json_flag;
+extern int json_missed_flag;
+
 extern int cdr_enable;
 extern int cdr_extra_nullable;
 extern int cdr_start_on_confirmed;

--- a/src/modules/acc/doc/acc.xml
+++ b/src/modules/acc/doc/acc.xml
@@ -43,6 +43,12 @@
 		<affiliation><orgname>1&amp;1 Internet AG</orgname></affiliation>
 		<email>sven.knoblich@1und1.de</email>
 		</editor>
+		<editor>
+		<firstname>Julien</firstname>
+		<surname>Chavanton</surname>
+		<affiliation><orgname>Flowroute</orgname></affiliation>
+		<email>jchavanton@gmail.com</email>
+		</editor>
 	</authorgroup>
 	<copyright>
 		<year>2002</year>
@@ -57,6 +63,10 @@
 	<copyright>
 		<year>2011</year>
 		<holder>1&amp;1 Internet AG</holder>
+	</copyright>
+	<copyright>
+		<year>2018</year>
+		<holder>Flowroute</holder>
 	</copyright>
 	</bookinfo>
 	<toc></toc>

--- a/src/modules/acc/doc/acc_admin.xml
+++ b/src/modules/acc/doc/acc_admin.xml
@@ -300,6 +300,18 @@ if (uri=~"sip:+40") /* calls to Romania */ {
 				RADIUS AVPs used in call-leg AVP set definition.
 				</para></note>
 				</listitem>
+				<listitem>
+				<para><emphasis>Json</emphasis> -- Json format for accounting,
+                                the resulting json dictionnary can be either logged to syslog
+                                or mqueue using the parameters json_syslog and json_mqueue
+				</para>
+				<note><para>log_extra is use to control the extra fields,
+                                json_mqueue to set the mqueue name.
+                                You can use both json_mqueue and json_syslog at the same time.
+                                The same set of fields found in previous syslog/database are present
+                                in json acc records, including time_mode.
+				</para></note>
+				</listitem>
 			</itemizedlist>
 		</section>
 	</section>
@@ -456,6 +468,11 @@ $dlg_var(callee) = $avp(callee); #callee='C'
 				<listitem>
 				<para><emphasis>dialog</emphasis> -- Dialog, if
 				<quote>cdr_enable</quote> module parameter is enabled.
+				</para>
+				</listitem>
+				<listitem>
+				<para><emphasis>mqueue</emphasis> -- Mqueue, if
+				<quote>json_mqueue</quote> module parameter is enabled.
 				</para>
 				</listitem>
 			</itemizedlist>
@@ -662,6 +679,110 @@ modparam("acc", "multi_leg_info",
 # for DIAMETER-based accounting, use the DIAMETER AVP ID (as integer)
 modparam("acc", "multi_leg_info",
     "2345=$avp(src);2346=$avp(dst)")
+...
+</programlisting>
+		</example>
+	</section>
+	<!-- JSON specific ACC parameters -->
+	<section id="acc.p.json_flag">
+		<title><varname>json_flag</varname> (integer)</title>
+		<para>
+		Request flag which needs to be set to account a transaction in json.
+                See json_mqueue and json_syslog
+		</para>
+		<para>
+		Default value is not-set (no flag).
+		</para>
+		<example>
+		<title>json_flag example</title>
+		<programlisting format="linespecific">
+...
+modparam("acc", "json_flag", 2)
+...
+</programlisting>
+		</example>
+	</section>
+	<section id="acc.p.json_missed_flag">
+		<title><varname>json_missed_flag</varname> (integer)</title>
+		<para>
+		Request flag which needs to be set to account missed calls in json.
+                See json_mqueue and json_syslog
+		</para>
+		<para>
+		Default value is not-set (no flag).
+		</para>
+		<example>
+		<title>json_missed_flag example</title>
+		<programlisting format="linespecific">
+...
+modparam("acc", "json_missed_flag", 3)
+...
+</programlisting>
+		</example>
+	</section>
+	<section id="acc.p.json_mqueue">
+		<title><varname>json_mqueue</varname> (integer)</title>
+		<para>
+                Requires the mqueue module.
+                The acc module will queue json acc events in the specified mqueue.
+                Using a rtimer module exec you can access the queue and process them.
+		</para>
+		<para>
+		Default value is not-set mqueue will not be required
+		</para>
+		<example>
+		<title>json_mqueue usage example</title>
+		<programlisting format="linespecific">
+...
+# example using json_mqueue/http_client to publish to NSQD
+max_while_loops=100000
+modparam("mqueue", "mqueue", "name=acc_events;size=100000")
+modparam("acc", "json_mqueue", "acc_events")
+modparam("acc", "json_flag", 2)
+modparam("acc", "log_extra", "caller_ip_port=$avp(caller_ip_port);")
+modparam("rtimer", "timer", "name=nsqt;interval=1;mode=1;")
+modparam("rtimer", "exec", "timer=nsqt;route=RUN_CDR_PUBLISH")
+modparam("http_client", "keep_connections", 1)
+modparam("http_client", "httpcon", "nsqd=>http://localhost:4151/pub?topic=acc")
+
+route[RUN_CDR_PUBLISH] {
+   $var(count) = 0;
+   while (mq_fetch("acc_events")) {
+      $var(q_size) = mq_size("acc_events");
+      $var(count) = $var(count) + 1;
+      xinfo("[RUN_CDR_PUBLISH][$var(q_size)][$var(count)][$mqk(acc_events)][$mqv(acc_events)]\n");
+      $var(res) = http_connect("nsqd", "", "application/json", $mqv(acc_events), "$var(nsq_res)");
+      if ($var(res) != "200") {
+         mq_add("acc_events", "acc_key", "$mqv(acc_events)");
+         return;
+      }
+   }
+   if ($var(count) > 0 ) {
+      xinfo("[RUN_CDR_PUBLISH]done count[$var(count)]\n");
+   }
+}
+...
+</programlisting>
+		</example>
+	</section>
+	<section id="acc.p.json_syslog">
+		<title><varname>json_syslog</varname> (integer)</title>
+		<para>
+		Control if the output of acc json should be sent to syslog.
+                This is not dependent on Kamailio global logging settigns,
+                we can use syslog even if Kamailio is not daemonized and/or
+                logging is done to sdtout stderr.
+		</para>
+		<para>
+		Default value is not-set (no flag).
+		</para>
+		<example>
+		<title>json_flag example</title>
+		<programlisting format="linespecific">
+...
+modparam("acc", "json_syslog", 1)
+modparam("acc", "log_level", 2)
+modparam("acc", "log_facility", "LOG_DAEMON")
 ...
 </programlisting>
 		</example>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

This commit is introducing JSON format for ACC events.
2 way to output the ACC events are proposed/implemented (syslog and mqueue) 

The option to use db_flastore was considered and found less attractive, mainly because the DB abstraction layer is not making much sense, example reformatting the data many times ...
and other outputs could benefit from JSON format.

1- syslog (directly from the module, because it may be valuable to run Kamailio using runit or in docker and not "daemionizing" it anymore while still using syslog for acc events)

2- mqueue this way you may be able to control the acc event from  Kamailio routing script, and example is provided using the http_client module to publish to NSQD

This seemed to be the best approach to remain as compatible as possible with the ACC module and benefit from it, while introducing the JSON format.

Many parameters are reused like time_mode, log_extra, log_facility, it seemed like reusing was making sense, this may be questionable.

If jansson or mqueue is not available or loaded the module will still build and run disabling the extra features

----------------------------------------------------------
#### Usage example 
where we use mqueue and process acc events in other worker processes.
example also inluded in the doc

```
# example using json_mqueue/http_client to publish to NSQD
max_while_loops=100000
modparam("mqueue", "mqueue", "name=acc_events;size=100000")
modparam("acc", "json_mqueue", "acc_events")
modparam("acc", "json_flag", 2)
modparam("acc", "log_extra", "caller_ip_port=$avp(caller_ip_port);")
modparam("rtimer", "timer", "name=nsqt;interval=1;mode=1;")
modparam("rtimer", "exec", "timer=nsqt;route=RUN_CDR_PUBLISH")
modparam("http_client", "keep_connections", 1)
modparam("http_client", "httpcon", "nsqd=>http://localhost:4151/pub?topic=acc")

route[RUN_CDR_PUBLISH] {
   $var(count) = 0;
   while (mq_fetch("acc_events")) {
      $var(q_size) = mq_size("acc_events");
      $var(count) = $var(count) + 1;
      xinfo("[RUN_CDR_PUBLISH][$var(q_size)][$var(count)][$mqk(acc_events)][$mqv(acc_events)]\n");
      $var(res) = http_connect("nsqd", "", "application/json", $mqv(acc_events), "$var(nsq_res)");
      if ($var(res) != "200") {
         mq_add("acc_events", "acc_key", "$mqv(acc_events)");
         return;
      }
   }
   if ($var(count) > 0 ) {
      xinfo("[RUN_CDR_PUBLISH]done count[$var(count)]\n");
   }
}
```

#### Load testing
Load tests where conducted with both json_syslog and json_mqueue/http to NSQD, latency was very stable it was high because the test server used was on West coast 
California >> New-Jersey >> California

![image](https://user-images.githubusercontent.com/3736014/36117214-a6ebcebc-0fed-11e8-928c-9ff9321bef86.png)
average message/response latency graph in ms/sec

----------------------------------------------------------
Using voip_perf to send SIP compliant traffic (INVITE < 100 < 180 < 200 > ACK || BYE < 200) 
7M SIP messages calls sent > 800/sec
https://github.com/jchavanton/voip_perf
```
Total 1000000 INVITE calls sent in 1037082 ms at rate of 819/sec 
Total 1000000 responses received in 1037881 ms at rate of 818/sec:
                                                                  
Detailed responses received:                                    
 - 200 responses:   1000000     (OK)                             
                    ------                                      
 TOTAL responses:   1000000 (rate=818/sec)                       
```

All the ACC events where queued in NSQD and written to SYSLOG without introducing delay.
```
curl -v http://127.0.0.1:4151/stats
 
nsqd v1.0.0-compat (built w/go1.8)
start_time 2018-02-12T17:10:58Z
uptime 33m4.181861175s
 
Health: OK
 
   [acc            ] depth: 3000004 be-depth: 2990004 msgs: 3000004  e2e%:
```
```
wc -l /var/log/json_acc.log
 
3000004 /var/log/json_acc.log
```