### PR TITLE
app_python3: first release

### DIFF
--- a/src/modules/app_python3/Makefile
+++ b/src/modules/app_python3/Makefile
@@ -1,0 +1,29 @@
+# 
+# WARNING: do not run this directly, it should be run by the master Makefile
+
+include ../../Makefile.defs
+auto_gen=
+NAME=app_python3.so
+
+# If you have multiple Python versions installed make sure to modify the
+# the following to point to the correct instance. Module has been tested
+# to work with 2.6 and 2.5. Python 2.4 has been only confirmed to compile,
+# but no testing has been done with that.
+PYTHON3?=python3
+
+PYTHON3_VERSION=${shell ${PYTHON3} -c "import distutils.sysconfig;print(distutils.sysconfig.get_config_var('VERSION'))"}
+PYTHON3_LIBDIR=${shell ${PYTHON3} -c "import distutils.sysconfig;print(distutils.sysconfig.get_config_var('LIBDIR'))"}
+PYTHON3_LDFLAGS=${shell ${PYTHON3} -c "import distutils.sysconfig;print(distutils.sysconfig.get_config_var('LINKFORSHARED'))"}
+PYTHON3_INCDIR=${shell ${PYTHON3} -c "import distutils.sysconfig;print(distutils.sysconfig.get_python_inc())"}
+
+LIBS=${shell ${PYTHON3}-config --libs}
+
+ifeq ($(OS), freebsd)
+LIBS+=-pthread
+endif
+
+DEFS+=-I${PYTHON3_INCDIR}
+DEFS+=-DKAMAILIO_MOD_INTERFACE
+
+include ../../Makefile.modules
+

--- a/src/modules/app_python3/README
+++ b/src/modules/app_python3/README
@@ -1,0 +1,196 @@
+app_python Module
+
+Maxim Sobolev
+
+Edited by
+
+Maxim Sobolev
+
+   Copyright © 2010 Maxim Sobolev
+     __________________________________________________________________
+
+   Table of Contents
+
+   1. Admin Guide
+
+        1. Overview
+        2. Dependencies
+
+              2.1. Kamailio Modules
+              2.2. External Libraries or Applications
+
+        3. Parameters
+
+              3.1. load (string)
+              3.2. script_name (string)
+              3.3. mod_init_function (string)
+              3.4. child_init_method (string)
+
+        4. Functions
+
+              4.1. python_exec(method [, args])
+
+        5. RPC Commands
+
+              5.1. app_python.reload
+              5.2. app_python.api_list
+
+   List of Examples
+
+   1.1. Set load parameter
+   1.2. Set mod_init_function parameter
+   1.3. Set child_init_method parameter
+   1.4. python_exec usage
+
+Chapter 1. Admin Guide
+
+   Table of Contents
+
+   1. Overview
+   2. Dependencies
+
+        2.1. Kamailio Modules
+        2.2. External Libraries or Applications
+
+   3. Parameters
+
+        3.1. load (string)
+        3.2. script_name (string)
+        3.3. mod_init_function (string)
+        3.4. child_init_method (string)
+
+   4. Functions
+
+        4.1. python_exec(method [, args])
+
+   5. RPC Commands
+
+        5.1. app_python.reload
+        5.2. app_python.api_list
+
+1. Overview
+
+   This module allows executing Python scripts from config file, exporting
+   functions to access the SIP message from Python.
+
+   For some basic examples of Python scripts that can be used with this
+   module, look at the files inside source tree located at
+   'modules/app_python/python_examples/'.
+
+2. Dependencies
+
+   2.1. Kamailio Modules
+   2.2. External Libraries or Applications
+
+2.1. Kamailio Modules
+
+   The following modules must be loaded before this module:
+     * none.
+
+2.2. External Libraries or Applications
+
+   The following libraries or applications must be installed before
+   running Kamailio with this module loaded:
+     * python-dev - Python devel library.
+
+3. Parameters
+
+   3.1. load (string)
+   3.2. script_name (string)
+   3.3. mod_init_function (string)
+   3.4. child_init_method (string)
+
+3.1. load (string)
+
+   The path to the file with Python code to be executed from configuration
+   file.
+
+   Default value is “/usr/local/etc/kamailio/handler.py”.
+
+   Example 1.1. Set load parameter
+...
+modparam("app_python", "load", "/usr/local/etc/kamailio/myscript.py")
+...
+
+3.2. script_name (string)
+
+   This is same as "load" parameter, kept for backward compatibility with
+   the older versions of the module.
+
+3.3. mod_init_function (string)
+
+   The Python function to be executed by this module when it is initialied
+   by Kamailio.
+
+   Default value is “mod_init”.
+
+   Example 1.2. Set mod_init_function parameter
+...
+modparam("app_python", "mod_init_function", "my_mod_init")
+...
+
+3.4. child_init_method (string)
+
+   The Python function to be executed by this module when a new worker
+   process (child) is initialied by Kamailio.
+
+   Default value is “child_init”.
+
+   Example 1.3. Set child_init_method parameter
+...
+modparam("app_python", "child_init_method", "my_child_init")
+...
+
+4. Functions
+
+   4.1. python_exec(method [, args])
+
+4.1.  python_exec(method [, args])
+
+   Execute the Python function with the name given by the parameter
+   'method'. Optionally can be provided a second string with parameters to
+   be passed to the Python function.
+
+   Both parameters can contain pseudo-variables.
+
+   Example 1.4. python_exec usage
+...
+python_exec("my_python_function");
+python_exec("my_python_function", "my_params");
+python_exec("my_python_function", "$rU");
+...
+
+5. RPC Commands
+
+   5.1. app_python.reload
+   5.2. app_python.api_list
+
+5.1.  app_python.reload
+
+   IMPORTANT: not functional yet (can crash a running instance, use it
+   only for testing).
+
+   Marks the need to reload the js script. The actual reload is done by
+   every working process when the next call to KEMI config is executed.
+
+   Name: app_python.reload
+
+   Parameters: none
+
+   Example:
+...
+kamcmd app_python.reload
+...
+
+5.2.  app_python.api_list
+
+   List the functions available via Kemi framework.
+
+   Name: app_python.api_list
+
+   Parameters: none
+
+   Example:
+...
+kamcmd app_python.api_list
+...

--- a/src/modules/app_python3/README.TestCase-Loggers
+++ b/src/modules/app_python3/README.TestCase-Loggers
@@ -1,0 +1,16 @@
+
+Example of using loggers in Python:
+
+loadmodule "app_python.so"
+modparam("app_python", "script_name", "/path/to/Loggers.py")
+modparam("app_python", "mod_init_function", "mod_init")
+modparam("app_python", "child_init_method", "child_init")
+
+...
+
+route
+{
+    python_exec("TestLoggers", "Test Message\n");
+    ...
+}
+

--- a/src/modules/app_python3/app_python_mod.c
+++ b/src/modules/app_python3/app_python_mod.c
@@ -1,0 +1,532 @@
+/*
+ * Copyright (C) 2009 Sippy Software, Inc., http://www.sippysoft.com
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <Python.h>
+#include <libgen.h>
+
+#include "../../core/str.h"
+#include "../../core/sr_module.h"
+#include "../../core/mod_fix.h"
+#include "../../core/kemi.h"
+
+#include "python_exec.h"
+#include "python_iface.h"
+#include "python_msgobj.h"
+#include "python_support.h"
+#include "app_python_mod.h"
+
+#include "mod_Router.h"
+#include "mod_Core.h"
+#include "mod_Ranks.h"
+#include "mod_Logger.h"
+
+#include "apy_kemi.h"
+
+MODULE_VERSION
+
+
+str _sr_python_load_file = str_init("/usr/local/etc/" NAME "/handler.py");
+static str mod_init_fname = str_init("mod_init");
+static str child_init_mname = str_init("child_init");
+
+static int mod_init(void);
+static int child_init(int rank);
+static void mod_destroy(void);
+
+PyObject *_sr_apy_handler_obj;
+
+char *dname = NULL, *bname = NULL;
+
+int _apy_process_rank = 0;
+
+PyThreadState *myThreadState;
+
+/** module parameters */
+static param_export_t params[]={
+	{"script_name",        PARAM_STR, &_sr_python_load_file },
+	{"load",               PARAM_STR, &_sr_python_load_file },
+	{"mod_init_function",  PARAM_STR, &mod_init_fname },
+	{"child_init_method",  PARAM_STR, &child_init_mname },
+	{0,0,0}
+};
+
+/*
+ * Exported functions
+ */
+static cmd_export_t cmds[] = {
+	{ "python_exec", (cmd_function)python_exec1, 1,  fixup_spve_null,
+		0,	ANY_ROUTE },
+	{ "python_exec", (cmd_function)python_exec2, 2,  fixup_spve_spve,
+		0,	ANY_ROUTE },
+	{ 0, 0, 0, 0, 0, 0 }
+};
+
+/** module exports */
+struct module_exports exports = {
+	"app_python3",                   /* module name */
+	RTLD_NOW | RTLD_GLOBAL,         /* dlopen flags */
+	cmds,                           /* exported functions */
+	params,                         /* exported parameters */
+	0,                              /* exported statistics */
+	0,                              /* exported MI functions */
+	0,                              /* exported pseudo-variables */
+	0,                              /* extra processes */
+	mod_init,                       /* module initialization function */
+	(response_function) NULL,       /* response handling function */
+	(destroy_function) mod_destroy, /* destroy function */
+	child_init                      /* per-child init function */
+};
+
+
+/**
+ *
+ */
+static int mod_init(void)
+{
+	char *dname_src, *bname_src;
+	int i;
+
+	if(apy_sr_init_mod()<0) {
+		LM_ERR("failed to init the sr mod\n");
+		return -1;
+	}
+	if(app_python_init_rpc()<0) {
+		LM_ERR("failed to register RPC commands\n");
+		return -1;
+	}
+
+	dname_src = as_asciiz(&_sr_python_load_file);
+	bname_src = as_asciiz(&_sr_python_load_file);
+
+	if(dname_src==NULL || bname_src==NULL)
+	{
+		LM_ERR("no more pkg memory\n");
+		if(dname_src) pkg_free(dname_src);
+		if(bname_src) pkg_free(bname_src);
+		return -1;
+	}
+
+	dname = strdup(dirname(dname_src));
+	if(dname==NULL) {
+		LM_ERR("no more system memory\n");
+		pkg_free(dname_src);
+		pkg_free(bname_src);
+		return -1;
+	}
+	if (strlen(dname) == 0) {
+		free(dname);
+		dname = malloc(2);
+		if(dname==NULL) {
+			LM_ERR("no more system memory\n");
+			pkg_free(dname_src);
+			pkg_free(bname_src);
+			return -1;
+		}
+		dname[0] = '.';
+		dname[1] = '\0';
+	}
+	bname = strdup(basename(bname_src));
+	i = strlen(bname);
+	if (bname[i - 1] == 'c' || bname[i - 1] == 'o')
+		i -= 1;
+	if (bname[i - 3] == '.' && bname[i - 2] == 'p' && bname[i - 1] == 'y') {
+		bname[i - 3] = '\0';
+	} else {
+		LM_ERR("%s: script_name doesn't look like a python script\n",
+				_sr_python_load_file.s);
+		pkg_free(dname_src);
+		pkg_free(bname_src);
+		return -1;
+	}
+
+	if(apy_load_script()<0) {
+		pkg_free(dname_src);
+		pkg_free(bname_src);
+		LM_ERR("failed to load python script\n");
+		return -1;
+	}
+
+	pkg_free(dname_src);
+	pkg_free(bname_src);
+	return 0;
+}
+
+/**
+ *
+ */
+static int child_init(int rank)
+{
+	_apy_process_rank = rank;
+	return apy_init_script(rank);
+}
+
+/**
+ *
+ */
+static void mod_destroy(void)
+{
+	if (dname)
+		free(dname);	// dname was strdup'ed
+	if (bname)
+		free(bname);	// bname was strdup'ed
+
+	destroy_mod_Core();
+	destroy_mod_Ranks();
+	destroy_mod_Logger();
+	destroy_mod_Router();
+}
+
+int apy_load_script(void)
+{
+	PyObject *sys_path, *pDir, *pModule, *pFunc, *pArgs;
+	PyThreadState *mainThreadState;
+
+	if (ap_init_modules() != 0) {
+		return -1;
+	}
+
+	Py_Initialize();
+	//TODO PyEval_InitThreads();
+	//TODI mainThreadState = PyThreadState_Get();
+
+	format_exc_obj = InitTracebackModule();
+
+	if (format_exc_obj == NULL || !PyCallable_Check(format_exc_obj))
+	{
+		Py_XDECREF(format_exc_obj);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	sys_path = PySys_GetObject("path");
+	/* PySys_GetObject doesn't pass reference! No need to DEREF */
+	if (sys_path == NULL) {
+		if (!PyErr_Occurred())
+			PyErr_Format(PyExc_AttributeError,
+					"'module' object 'sys' has no attribute 'path'");
+		python_handle_exception("mod_init");
+		Py_DECREF(format_exc_obj);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	pDir = PyUnicode_FromString(dname);
+	if (pDir == NULL) {
+		if (!PyErr_Occurred())
+			PyErr_Format(PyExc_AttributeError,
+					"PyUnicode_FromString() has failed");
+		python_handle_exception("mod_init");
+		Py_DECREF(format_exc_obj);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	PyList_Insert(sys_path, 0, pDir);
+	Py_DECREF(pDir);
+
+	if (python_msgobj_init() != 0) {
+		if (!PyErr_Occurred())
+			PyErr_SetString(PyExc_AttributeError,
+					"python_msgobj_init() has failed");
+		python_handle_exception("mod_init");
+		Py_DECREF(format_exc_obj);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	pModule = PyImport_ImportModule(bname);
+	if (pModule == NULL) {
+                PyErr_PrintEx(0);
+		if (!PyErr_Occurred())
+			PyErr_Format(PyExc_ImportError, "No module named '%s'", bname);
+		python_handle_exception("mod_init");
+		Py_DECREF(format_exc_obj);
+		//TODO PyEval_SaveThread();
+
+		return -1;
+	}
+
+	pFunc = PyObject_GetAttrString(pModule, mod_init_fname.s);
+	Py_DECREF(pModule);
+
+	/* pFunc is a new reference */
+
+	if (pFunc == NULL) {
+		if (!PyErr_Occurred())
+			PyErr_Format(PyExc_AttributeError,
+					"'module' object '%s' has no attribute '%s'",
+					bname, mod_init_fname.s);
+		python_handle_exception("mod_init");
+		Py_DECREF(format_exc_obj);
+		Py_XDECREF(pFunc);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	if (!PyCallable_Check(pFunc)) {
+		if (!PyErr_Occurred())
+			PyErr_Format(PyExc_AttributeError,
+					"module object '%s' has is not callable attribute '%s'",
+					bname, mod_init_fname.s);
+		python_handle_exception("mod_init");
+		Py_DECREF(format_exc_obj);
+		Py_XDECREF(pFunc);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+
+	pArgs = PyTuple_New(0);
+	if (pArgs == NULL) {
+		python_handle_exception("mod_init");
+		Py_DECREF(format_exc_obj);
+		Py_DECREF(pFunc);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	_sr_apy_handler_obj = PyObject_CallObject(pFunc, pArgs);
+
+	Py_XDECREF(pFunc);
+	Py_XDECREF(pArgs);
+
+	if (_sr_apy_handler_obj == Py_None) {
+		if (!PyErr_Occurred())
+			PyErr_Format(PyExc_TypeError,
+					"Function '%s' of module '%s' has returned None."
+					" Should be a class instance.", mod_init_fname.s, bname);
+		python_handle_exception("mod_init");
+		Py_DECREF(format_exc_obj);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	if (PyErr_Occurred()) {
+		python_handle_exception("mod_init");
+		Py_XDECREF(_sr_apy_handler_obj);
+		Py_DECREF(format_exc_obj);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	if (_sr_apy_handler_obj == NULL) {
+		LM_ERR("PyObject_CallObject() returned NULL but no exception!\n");
+		if (!PyErr_Occurred())
+			PyErr_Format(PyExc_TypeError,
+					"Function '%s' of module '%s' has returned not returned"
+					" object. Should be a class instance.",
+					mod_init_fname.s, bname);
+		python_handle_exception("mod_init");
+		Py_DECREF(format_exc_obj);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	//TODO myThreadState = PyThreadState_New(mainThreadState->interp);
+	//TODO PyEval_SaveThread();
+
+	return 0;
+}
+
+int apy_init_script(int rank)
+{
+	PyObject *pFunc, *pArgs, *pValue, *pResult;
+	int rval;
+	char *classname;
+
+	//TODO PyEval_AcquireLock();
+	//TODO PyThreadState_Swap(myThreadState);
+
+	// get instance class name
+	classname = get_instance_class_name(_sr_apy_handler_obj);
+	if (classname == NULL)
+	{
+		if (!PyErr_Occurred())
+			PyErr_Format(PyExc_AttributeError,
+					"'module' instance has no class name");
+		python_handle_exception("child_init");
+		Py_DECREF(format_exc_obj);
+		//TODO PyThreadState_Swap(NULL);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	pFunc = PyObject_GetAttrString(_sr_apy_handler_obj, child_init_mname.s);
+
+	if (pFunc == NULL) {
+		python_handle_exception("child_init");
+		Py_XDECREF(pFunc);
+		Py_DECREF(format_exc_obj);
+		//TODO PyThreadState_Swap(NULL);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	if (!PyCallable_Check(pFunc)) {
+		if (!PyErr_Occurred())
+			PyErr_Format(PyExc_AttributeError,
+					"class object '%s' has is not callable attribute '%s'",
+					classname, mod_init_fname.s);
+		python_handle_exception("child_init");
+		Py_DECREF(format_exc_obj);
+		Py_XDECREF(pFunc);
+		//TODO PyThreadState_Swap(NULL);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	pArgs = PyTuple_New(1);
+	if (pArgs == NULL) {
+		python_handle_exception("child_init");
+		Py_DECREF(format_exc_obj);
+		Py_DECREF(pFunc);
+		//TODO PyThreadState_Swap(NULL);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	pValue = PyLong_FromLong((long)rank);
+	if (pValue == NULL) {
+		python_handle_exception("child_init");
+		Py_DECREF(format_exc_obj);
+		Py_DECREF(pArgs);
+		Py_DECREF(pFunc);
+		//TODO PyThreadState_Swap(NULL);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+	PyTuple_SetItem(pArgs, 0, pValue);
+	/* pValue has been stolen */
+
+	pResult = PyObject_CallObject(pFunc, pArgs);
+	Py_DECREF(pFunc);
+	Py_DECREF(pArgs);
+
+	if (PyErr_Occurred()) {
+		python_handle_exception("child_init");
+		Py_DECREF(format_exc_obj);
+		Py_XDECREF(pResult);
+		//TODO PyThreadState_Swap(NULL);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	if (pResult == NULL) {
+		LM_ERR("PyObject_CallObject() returned NULL but no exception!\n");
+		//TODO PyThreadState_Swap(NULL);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	if (!PyLong_Check(pResult))
+	{
+		if (!PyErr_Occurred())
+			PyErr_Format(PyExc_TypeError,
+					"method '%s' of class '%s' should return 'int' type",
+					child_init_mname.s, classname);
+		python_handle_exception("child_init");
+		Py_DECREF(format_exc_obj);
+		Py_XDECREF(pResult);
+		//TODO PyThreadState_Swap(NULL);
+		//TODO PyEval_SaveThread();
+		return -1;
+	}
+
+	rval = PyLong_AsLong(pResult);
+	Py_DECREF(pResult);
+	//TODO PyThreadState_Swap(NULL);
+	//TODO PyEval_SaveThread();
+
+	return rval;
+}
+/**
+ *
+ */
+static int ki_app_python_exec(sip_msg_t *msg, str *method)
+{
+	if(method==NULL || method->s==NULL || method->len<=0) {
+		LM_ERR("invalid method name\n");
+		return -1;
+	}
+	if(method->s[method->len]!='\0') {
+		LM_ERR("invalid terminated method name\n");
+		return -1;
+	}
+	return apy_exec(msg, method->s, NULL, 1);
+}
+
+/**
+ *
+ */
+static int ki_app_python_exec_p1(sip_msg_t *msg, str *method, str *p1)
+{
+	if(method==NULL || method->s==NULL || method->len<=0) {
+		LM_ERR("invalid method name\n");
+		return -1;
+	}
+	if(method->s[method->len]!='\0') {
+		LM_ERR("invalid terminated method name\n");
+		return -1;
+	}
+	if(p1==NULL || p1->s==NULL || p1->len<0) {
+		LM_ERR("invalid p1 value\n");
+		return -1;
+	}
+	if(p1->s[p1->len]!='\0') {
+		LM_ERR("invalid terminated p1 value\n");
+		return -1;
+	}
+
+	return apy_exec(msg, method->s, p1->s, 1);
+}
+
+/**
+ *
+ */
+/* clang-format off */
+static sr_kemi_t sr_kemi_app_python_exports[] = {
+	{ str_init("app_python3"), str_init("exec"),
+		SR_KEMIP_INT, ki_app_python_exec,
+		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("app_python3"), str_init("exec_p1"),
+		SR_KEMIP_INT, ki_app_python_exec_p1,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+
+	{ {0, 0}, {0, 0}, 0, NULL, { 0, 0, 0, 0, 0, 0 } }
+};
+/* clang-format on */
+
+/**
+ *
+ */
+int mod_register(char *path, int *dlflags, void *p1, void *p2)
+{
+	str ename = str_init("python");
+
+	sr_kemi_eng_register(&ename, sr_kemi_config_engine_python);
+	sr_kemi_modules_add(sr_kemi_app_python_exports);
+
+	return 0;
+}

--- a/src/modules/app_python3/app_python_mod.h
+++ b/src/modules/app_python3/app_python_mod.h
@@ -1,0 +1,31 @@
+/* 
+ * Copyright (C) 2009 Sippy Software, Inc., http://www.sippysoft.com
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+*/
+
+#ifndef _PYTHON_MOD_H
+#define  _PYTHON_MOD_H
+
+#include <Python.h>
+
+extern PyObject *_sr_apy_handler_obj;
+extern PyObject *format_exc_obj;
+extern PyThreadState *myThreadState;
+
+#endif

--- a/src/modules/app_python3/apy_kemi.c
+++ b/src/modules/app_python3/apy_kemi.c
@@ -1,0 +1,1292 @@
+/**
+ * Copyright (C) 2016 Daniel-Constantin Mierla (asipto.com)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#include <Python.h>
+
+#include "../../core/dprint.h"
+#include "../../core/route.h"
+#include "../../core/fmsg.h"
+#include "../../core/kemi.h"
+#include "../../core/pvar.h"
+#include "../../core/mem/pkg.h"
+#include "../../core/mem/shm.h"
+#include "../../core/rpc.h"
+#include "../../core/rpc_lookup.h"
+
+#include "msgobj_struct.h"
+#include "python_exec.h"
+#include "apy_kemi_export.h"
+#include "apy_kemi.h"
+
+static int *_sr_python_reload_version = NULL;
+static int _sr_python_local_version = 0;
+extern str _sr_python_load_file;
+extern int _apy_process_rank;
+
+/**
+ *
+ */
+
+int apy_reload_script(void)
+{
+	if(_sr_python_reload_version == NULL) {
+		return 0;
+	}
+	if(*_sr_python_reload_version == _sr_python_local_version) {
+		return 0;
+	}
+	if(apy_load_script()<0) {
+		LM_ERR("failed to load script file\n");
+		return -1;
+	}
+	if(apy_init_script(_apy_process_rank)<0) {
+		LM_ERR("failed to init script\n");
+		return -1;
+	}
+	_sr_python_local_version = *_sr_python_reload_version;
+	return 0;
+}
+/**
+ *
+ */
+int sr_kemi_config_engine_python(sip_msg_t *msg, int rtype, str *rname,
+		str *rparam)
+{
+	int ret;
+
+	ret = -1;
+	if(rtype==REQUEST_ROUTE) {
+		if(rname!=NULL && rname->s!=NULL) {
+			ret = apy_exec(msg, rname->s,
+					(rparam && rparam->s)?rparam->s:NULL, 0);
+		} else {
+			ret = apy_exec(msg, "ksr_request_route", NULL, 1);
+		}
+	} else if(rtype==CORE_ONREPLY_ROUTE) {
+		ret = apy_exec(msg, "ksr_reply_route", NULL, 0);
+	} else if(rtype==BRANCH_ROUTE) {
+		if(rname!=NULL && rname->s!=NULL) {
+			ret = apy_exec(msg, rname->s, NULL, 0);
+		}
+	} else if(rtype==FAILURE_ROUTE) {
+		if(rname!=NULL && rname->s!=NULL) {
+			ret = apy_exec(msg, rname->s, NULL, 0);
+		}
+	} else if(rtype==BRANCH_FAILURE_ROUTE) {
+		if(rname!=NULL && rname->s!=NULL) {
+			ret = apy_exec(msg, rname->s, NULL, 0);
+		}
+	} else if(rtype==TM_ONREPLY_ROUTE) {
+		if(rname!=NULL && rname->s!=NULL) {
+			ret = apy_exec(msg, rname->s, NULL, 0);
+		}
+	} else if(rtype==ONSEND_ROUTE) {
+		ret = apy_exec(msg, "ksr_onsend_route", NULL, 0);
+	} else if(rtype==EVENT_ROUTE) {
+		if(rname!=NULL && rname->s!=NULL) {
+			ret = apy_exec(msg, rname->s,
+					(rparam && rparam->s)?rparam->s:NULL, 0);
+		}
+	} else {
+		if(rname!=NULL) {
+			LM_ERR("route type %d with name [%.*s] not implemented\n",
+				rtype, rname->len, rname->s);
+		} else {
+			LM_ERR("route type %d with no name not implemented\n",
+				rtype);
+		}
+	}
+
+	if(rname!=NULL) {
+		LM_DBG("execution of route type %d with name [%.*s] returned %d\n",
+				rtype, rname->len, rname->s, ret);
+	} else {
+		LM_DBG("execution of route type %d with no name returned %d\n",
+			rtype, ret);
+	}
+
+	return 1;
+}
+
+/**
+ *
+ */
+PyObject *sr_kemi_apy_return_true(void)
+{
+	Py_INCREF(Py_True);
+	return Py_True;
+}
+
+/**
+ *
+ */
+PyObject *sr_kemi_apy_return_false(void)
+{
+	Py_INCREF(Py_False);
+	return Py_False;
+}
+
+/**
+ *
+ */
+PyObject *sr_apy_kemi_return_none(void)
+{
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+/**
+ *
+ */
+PyObject *sr_kemi_apy_return_int(sr_kemi_t *ket, int rval)
+{
+	if(ket!=NULL && ket->rtype==SR_KEMIP_BOOL) {
+		if(rval==SR_KEMI_TRUE) {
+			return sr_kemi_apy_return_true();
+		} else {
+			return sr_kemi_apy_return_false();
+		}
+	}
+	return PyLong_FromLong((long)rval);
+}
+
+/**
+ *
+ */
+PyObject *sr_apy_kemi_return_str(sr_kemi_t *ket, char *sval, int slen)
+{
+	return PyUnicode_FromStringAndSize(sval, slen);
+}
+/**
+ *
+ */
+PyObject *sr_apy_kemi_exec_func(PyObject *self, PyObject *args, int idx)
+{
+	str fname;
+	int i;
+	int ret;
+	sr_kemi_t *ket = NULL;
+	sr_kemi_val_t vps[SR_KEMI_PARAMS_MAX];
+	sr_apy_env_t *env_P;
+	sip_msg_t *lmsg = NULL;
+
+	env_P = sr_apy_env_get();
+
+	if(env_P==NULL) {
+		LM_ERR("invalid Python environment attributes\n");
+		return sr_kemi_apy_return_false();
+	}
+	if(env_P->msg==NULL) {
+		lmsg = faked_msg_next();
+	} else {
+		lmsg = env_P->msg;
+	}
+
+	ket = sr_apy_kemi_export_get(idx);
+	if(ket==NULL) {
+		return sr_kemi_apy_return_false();
+	}
+	if(ket->mname.len>0) {
+		LM_DBG("execution of method: %.*s\n", ket->fname.len, ket->fname.s);
+	} else {
+		LM_DBG("execution of method: %.*s.%.*s\n",
+				ket->mname.len, ket->mname.s,
+				ket->fname.len, ket->fname.s);
+	}
+	fname = ket->fname;
+
+	if(ket->ptypes[0]==SR_KEMIP_NONE) {
+		ret = ((sr_kemi_fm_f)(ket->func))(lmsg);
+		return sr_kemi_apy_return_int(ket, ret);
+	}
+
+	memset(vps, 0, SR_KEMI_PARAMS_MAX*sizeof(sr_kemi_val_t));
+	if(ket->ptypes[1]==SR_KEMIP_NONE) {
+		i = 1;
+		if(ket->ptypes[0]==SR_KEMIP_INT) {
+			if(!PyArg_ParseTuple(args, "i:kemi-param-n", &vps[0].n)) {
+				LM_ERR("unable to retrieve int param %d\n", 0);
+				return sr_kemi_apy_return_false();
+			}
+			LM_DBG("param[%d] for: %.*s is int: %d\n", i,
+				fname.len, fname.s, vps[0].n);
+		} else {
+			if(!PyArg_ParseTuple(args, "s:kemi-param-s", &vps[0].s.s)) {
+				LM_ERR("unable to retrieve str param %d\n", 0);
+				return sr_kemi_apy_return_false();
+			}
+			vps[0].s.len = strlen(vps[0].s.s);
+			LM_DBG("param[%d] for: %.*s is str: %.*s\n", i,
+				fname.len, fname.s, vps[0].s.len, vps[0].s.s);
+		}
+	} else if(ket->ptypes[2]==SR_KEMIP_NONE) {
+		i = 2;
+		if(ket->ptypes[0]==SR_KEMIP_INT && ket->ptypes[1]==SR_KEMIP_INT) {
+			if(!PyArg_ParseTuple(args, "ii:kemi-param-nn", &vps[0].n, &vps[1].n)) {
+				LM_ERR("unable to retrieve int-int params %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			LM_DBG("params[%d] for: %.*s are int-int: [%d] [%d]\n", i,
+				fname.len, fname.s, vps[0].n, vps[1].n);
+		} else if(ket->ptypes[0]==SR_KEMIP_INT && ket->ptypes[1]==SR_KEMIP_STR) {
+			if(!PyArg_ParseTuple(args, "is:kemi-param-ns", &vps[0].n, &vps[1].s.s)) {
+				LM_ERR("unable to retrieve int-str params %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			vps[1].s.len = strlen(vps[1].s.s);
+			LM_DBG("params[%d] for: %.*s are int-str: [%d] [%.*s]\n", i,
+				fname.len, fname.s, vps[0].n, vps[1].s.len, vps[1].s.s);
+		} else if(ket->ptypes[0]==SR_KEMIP_STR && ket->ptypes[1]==SR_KEMIP_INT) {
+			if(!PyArg_ParseTuple(args, "si:kemi-param-sn", &vps[0].s.s, &vps[1].n)) {
+				LM_ERR("unable to retrieve str-int params %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			vps[0].s.len = strlen(vps[0].s.s);
+			LM_DBG("params[%d] for: %.*s are str-int: [%.*s] [%d]\n", i,
+				fname.len, fname.s, vps[0].s.len, vps[0].s.s, vps[1].n);
+		} else {
+			if(!PyArg_ParseTuple(args, "ss:kemi-param-ss", &vps[0].s.s, &vps[1].s.s)) {
+				LM_ERR("unable to retrieve str-str param %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			vps[0].s.len = strlen(vps[0].s.s);
+			vps[1].s.len = strlen(vps[1].s.s);
+			LM_DBG("params[%d] for: %.*s are str: [%.*s] [%.*s]\n", i,
+				fname.len, fname.s, vps[0].s.len, vps[0].s.s,
+				vps[1].s.len, vps[1].s.s);
+		}
+
+	} else if(ket->ptypes[3]==SR_KEMIP_NONE) {
+		i = 3;
+		if(ket->ptypes[0]==SR_KEMIP_INT && ket->ptypes[1]==SR_KEMIP_INT
+				&& ket->ptypes[2]==SR_KEMIP_INT) {
+			if(!PyArg_ParseTuple(args, "iii:kemi-param-nnn", &vps[0].n,
+						&vps[1].n, &vps[2].n)) {
+				LM_ERR("unable to retrieve int-int-int params %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			LM_DBG("params[%d] for: %.*s are int-int-int: [%d] [%d] [%d]\n",
+					i, fname.len, fname.s, vps[0].n, vps[1].n, vps[2].n);
+		} else if(ket->ptypes[0]==SR_KEMIP_INT && ket->ptypes[1]==SR_KEMIP_STR
+				&& ket->ptypes[2]==SR_KEMIP_INT) {
+			if(!PyArg_ParseTuple(args, "isi:kemi-param-nsn", &vps[0].n,
+						&vps[1].s.s, &vps[2].n)) {
+				LM_ERR("unable to retrieve int-str-int params %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			vps[1].s.len = strlen(vps[1].s.s);
+			LM_DBG("params[%d] for: %.*s are int-str-int: [%d] [%.*s] [%d]\n", i,
+				fname.len, fname.s, vps[0].n, vps[1].s.len, vps[1].s.s, vps[2].n);
+		} else if(ket->ptypes[0]==SR_KEMIP_STR && ket->ptypes[1]==SR_KEMIP_INT
+				&& ket->ptypes[2]==SR_KEMIP_INT) {
+			if(!PyArg_ParseTuple(args, "sii:kemi-param-snn", &vps[0].s.s,
+						&vps[1].n, &vps[2].n)) {
+				LM_ERR("unable to retrieve str-int-int params %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			vps[0].s.len = strlen(vps[0].s.s);
+			LM_DBG("params[%d] for: %.*s are str-int: [%.*s] [%d] [%d]\n", i,
+					fname.len, fname.s, vps[0].s.len, vps[0].s.s, vps[1].n,
+					vps[2].n);
+		} else if(ket->ptypes[0]==SR_KEMIP_STR && ket->ptypes[1]==SR_KEMIP_STR
+				&& ket->ptypes[2]==SR_KEMIP_INT) {
+			if(!PyArg_ParseTuple(args, "ssi:kemi-param-ssn", &vps[0].s.s,
+						&vps[1].s.s, &vps[2].n)) {
+				LM_ERR("unable to retrieve str-str-int param %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			vps[0].s.len = strlen(vps[0].s.s);
+			vps[1].s.len = strlen(vps[1].s.s);
+			LM_DBG("params[%d] for: %.*s are str-str-int: [%.*s] [%.*s]"
+					" [%d]\n", i, fname.len, fname.s,
+					vps[0].s.len, vps[0].s.s,
+					vps[1].s.len, vps[1].s.s, vps[2].n);
+		} else if(ket->ptypes[0]==SR_KEMIP_STR && ket->ptypes[1]==SR_KEMIP_STR
+				&& ket->ptypes[2]==SR_KEMIP_STR) {
+			if(!PyArg_ParseTuple(args, "sss:kemi-param-sss", &vps[0].s.s,
+						&vps[1].s.s, &vps[2].s.s)) {
+				LM_ERR("unable to retrieve str-str-str param %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			vps[0].s.len = strlen(vps[0].s.s);
+			vps[1].s.len = strlen(vps[1].s.s);
+			vps[2].s.len = strlen(vps[2].s.s);
+			LM_DBG("params[%d] for: %.*s are str-str-int: [%.*s] [%.*s]"
+					" [%.*s]\n", i, fname.len, fname.s,
+					vps[0].s.len, vps[0].s.s,
+					vps[1].s.len, vps[1].s.s, vps[2].s.len, vps[2].s.s);
+		} else {
+			LM_ERR("not implemented yet\n");
+			return sr_kemi_apy_return_false();
+		}
+	} else if(ket->ptypes[4]==SR_KEMIP_NONE) {
+		i = 4;
+		if(ket->ptypes[0]==SR_KEMIP_STR
+				|| ket->ptypes[1]==SR_KEMIP_STR
+				|| ket->ptypes[2]==SR_KEMIP_STR
+				|| ket->ptypes[3]==SR_KEMIP_STR) {
+			if(!PyArg_ParseTuple(args, "ssss:kemi-param-ssss",
+						&vps[0].s.s, &vps[1].s.s, &vps[2].s.s, &vps[3].s.s)) {
+				LM_ERR("unable to retrieve str-str-str-str params %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			vps[0].s.len = strlen(vps[0].s.s);
+			vps[1].s.len = strlen(vps[1].s.s);
+			vps[2].s.len = strlen(vps[2].s.s);
+			vps[3].s.len = strlen(vps[3].s.s);
+			LM_DBG("params[%d] for: %.*s are str: [%.*s] [%.*s]"
+					" [%.*s] [%.*s]\n", i,
+				fname.len, fname.s, vps[0].s.len, vps[0].s.s,
+				vps[1].s.len, vps[1].s.s, vps[2].s.len, vps[2].s.s,
+				vps[3].s.len, vps[3].s.s);
+		} else if(ket->ptypes[0]==SR_KEMIP_STR
+				|| ket->ptypes[1]==SR_KEMIP_STR
+				|| ket->ptypes[2]==SR_KEMIP_INT
+				|| ket->ptypes[3]==SR_KEMIP_INT) {
+			if(!PyArg_ParseTuple(args, "ssii:kemi-param-ssnn",
+						&vps[0].s.s, &vps[1].s.s, &vps[2].n, &vps[3].n)) {
+				LM_ERR("unable to retrieve str-str-int-int params %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			vps[0].s.len = strlen(vps[0].s.s);
+			vps[1].s.len = strlen(vps[1].s.s);
+			LM_DBG("params[%d] for: %.*s are str: [%.*s] [%.*s]"
+					" [%d] [%d]\n", i,
+				fname.len, fname.s, vps[0].s.len, vps[0].s.s,
+				vps[1].s.len, vps[1].s.s, vps[2].n, vps[3].n);
+		} else {
+			LM_ERR("not implemented yet\n");
+			return sr_kemi_apy_return_false();
+		}
+	} else if(ket->ptypes[5]==SR_KEMIP_NONE) {
+		i = 5;
+		if(ket->ptypes[0]==SR_KEMIP_STR
+				|| ket->ptypes[1]==SR_KEMIP_STR
+				|| ket->ptypes[2]==SR_KEMIP_STR
+				|| ket->ptypes[3]==SR_KEMIP_STR
+				|| ket->ptypes[4]==SR_KEMIP_STR) {
+			if(!PyArg_ParseTuple(args, "sssss:kemi-param-sssss",
+						&vps[0].s.s, &vps[1].s.s, &vps[2].s.s, &vps[3].s.s,
+						&vps[4].s.s)) {
+				LM_ERR("unable to retrieve str-str-str-str params %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			vps[0].s.len = strlen(vps[0].s.s);
+			vps[1].s.len = strlen(vps[1].s.s);
+			vps[2].s.len = strlen(vps[2].s.s);
+			vps[3].s.len = strlen(vps[3].s.s);
+			vps[4].s.len = strlen(vps[4].s.s);
+			LM_DBG("params[%d] for: %.*s are str: [%.*s] [%.*s]"
+					" [%.*s] [%.*s] [%.*s]\n", i,
+				fname.len, fname.s, vps[0].s.len, vps[0].s.s,
+				vps[1].s.len, vps[1].s.s, vps[2].s.len, vps[2].s.s,
+				vps[3].s.len, vps[3].s.s, vps[4].s.len, vps[4].s.s);
+		} else {
+			LM_ERR("not implemented yet\n");
+			return sr_kemi_apy_return_false();
+		}
+	} else {
+		i = 6;
+		if(ket->ptypes[0]==SR_KEMIP_STR
+				|| ket->ptypes[1]==SR_KEMIP_STR
+				|| ket->ptypes[2]==SR_KEMIP_STR
+				|| ket->ptypes[3]==SR_KEMIP_STR
+				|| ket->ptypes[4]==SR_KEMIP_STR
+				|| ket->ptypes[5]==SR_KEMIP_STR) {
+			if(!PyArg_ParseTuple(args, "ssssss:kemi-param-ssssss",
+						&vps[0].s.s, &vps[1].s.s, &vps[2].s.s, &vps[3].s.s,
+						&vps[4].s.s, &vps[5].s.s)) {
+				LM_ERR("unable to retrieve str-str-str-str params %d\n", i);
+				return sr_kemi_apy_return_false();
+			}
+			vps[0].s.len = strlen(vps[0].s.s);
+			vps[1].s.len = strlen(vps[1].s.s);
+			vps[2].s.len = strlen(vps[2].s.s);
+			vps[3].s.len = strlen(vps[3].s.s);
+			vps[4].s.len = strlen(vps[4].s.s);
+			vps[5].s.len = strlen(vps[5].s.s);
+			LM_DBG("params[%d] for: %.*s are str: [%.*s] [%.*s]"
+					" [%.*s] [%.*s] [%.*s] [%.*s]\n", i,
+				fname.len, fname.s, vps[0].s.len, vps[0].s.s,
+				vps[1].s.len, vps[1].s.s, vps[2].s.len, vps[2].s.s,
+				vps[3].s.len, vps[3].s.s, vps[4].s.len, vps[4].s.s,
+				vps[5].s.len, vps[5].s.s);
+		} else {
+			LM_ERR("not implemented yet\n");
+			return sr_kemi_apy_return_false();
+		}
+	}
+
+	switch(i) {
+		case 1:
+			if(ket->ptypes[0]==SR_KEMIP_INT) {
+				ret = ((sr_kemi_fmn_f)(ket->func))(lmsg, vps[0].n);
+				return sr_kemi_apy_return_int(ket, ret);
+			} else if(ket->ptypes[0]==SR_KEMIP_STR) {
+				ret = ((sr_kemi_fms_f)(ket->func))(lmsg, &vps[0].s);
+				return sr_kemi_apy_return_int(ket, ret);
+			} else {
+				LM_ERR("invalid parameters for: %.*s\n",
+						fname.len, fname.s);
+				return sr_kemi_apy_return_false();
+			}
+		break;
+		case 2:
+			if(ket->ptypes[0]==SR_KEMIP_INT) {
+				if(ket->ptypes[1]==SR_KEMIP_INT) {
+					ret = ((sr_kemi_fmnn_f)(ket->func))(lmsg, vps[0].n, vps[1].n);
+					return sr_kemi_apy_return_int(ket, ret);
+				} else if(ket->ptypes[1]==SR_KEMIP_STR) {
+					ret = ((sr_kemi_fmns_f)(ket->func))(lmsg, vps[0].n, &vps[1].s);
+					return sr_kemi_apy_return_int(ket, ret);
+				} else {
+					LM_ERR("invalid parameters for: %.*s\n",
+							fname.len, fname.s);
+					return sr_kemi_apy_return_false();
+				}
+			} else if(ket->ptypes[0]==SR_KEMIP_STR) {
+				if(ket->ptypes[1]==SR_KEMIP_INT) {
+					ret = ((sr_kemi_fmsn_f)(ket->func))(lmsg, &vps[0].s, vps[1].n);
+					return sr_kemi_apy_return_int(ket, ret);
+				} else if(ket->ptypes[1]==SR_KEMIP_STR) {
+					ret = ((sr_kemi_fmss_f)(ket->func))(lmsg, &vps[0].s, &vps[1].s);
+					return sr_kemi_apy_return_int(ket, ret);
+				} else {
+					LM_ERR("invalid parameters for: %.*s\n",
+							fname.len, fname.s);
+					return sr_kemi_apy_return_false();
+				}
+			} else {
+				LM_ERR("invalid parameters for: %.*s\n",
+						fname.len, fname.s);
+				return sr_kemi_apy_return_false();
+			}
+		break;
+		case 3:
+			if(ket->ptypes[0]==SR_KEMIP_INT) {
+				if(ket->ptypes[1]==SR_KEMIP_INT) {
+					if(ket->ptypes[2]==SR_KEMIP_INT) {
+						/* nnn */
+						ret = ((sr_kemi_fmnnn_f)(ket->func))(lmsg,
+								vps[0].n, vps[1].n, vps[2].n);
+						return sr_kemi_apy_return_int(ket, ret);
+					} else if(ket->ptypes[2]==SR_KEMIP_STR) {
+						/* nns */
+						ret = ((sr_kemi_fmnns_f)(ket->func))(lmsg,
+								vps[0].n, vps[1].n, &vps[2].s);
+						return sr_kemi_apy_return_int(ket, ret);
+					} else {
+						LM_ERR("invalid parameters for: %.*s\n",
+								fname.len, fname.s);
+						return sr_kemi_apy_return_false();
+					}
+				} else if(ket->ptypes[1]==SR_KEMIP_STR) {
+					if(ket->ptypes[2]==SR_KEMIP_INT) {
+						/* nsn */
+						ret = ((sr_kemi_fmnsn_f)(ket->func))(lmsg,
+								vps[0].n, &vps[1].s, vps[2].n);
+						return sr_kemi_apy_return_int(ket, ret);
+					} else if(ket->ptypes[2]==SR_KEMIP_STR) {
+						/* nss */
+						ret = ((sr_kemi_fmnss_f)(ket->func))(lmsg,
+								vps[0].n, &vps[1].s, &vps[2].s);
+						return sr_kemi_apy_return_int(ket, ret);
+					} else {
+						LM_ERR("invalid parameters for: %.*s\n",
+								fname.len, fname.s);
+						return sr_kemi_apy_return_false();
+					}
+				} else {
+					LM_ERR("invalid parameters for: %.*s\n",
+							fname.len, fname.s);
+					return sr_kemi_apy_return_false();
+				}
+			} else if(ket->ptypes[0]==SR_KEMIP_STR) {
+				if(ket->ptypes[1]==SR_KEMIP_INT) {
+					if(ket->ptypes[2]==SR_KEMIP_INT) {
+						/* snn */
+						ret = ((sr_kemi_fmsnn_f)(ket->func))(lmsg,
+								&vps[0].s, vps[1].n, vps[2].n);
+						return sr_kemi_apy_return_int(ket, ret);
+					} else if(ket->ptypes[2]==SR_KEMIP_STR) {
+						/* sns */
+						ret = ((sr_kemi_fmsns_f)(ket->func))(lmsg,
+								&vps[0].s, vps[1].n, &vps[2].s);
+						return sr_kemi_apy_return_int(ket, ret);
+					} else {
+						LM_ERR("invalid parameters for: %.*s\n",
+								fname.len, fname.s);
+						return sr_kemi_apy_return_false();
+					}
+				} else if(ket->ptypes[1]==SR_KEMIP_STR) {
+					if(ket->ptypes[2]==SR_KEMIP_INT) {
+						/* ssn */
+						ret = ((sr_kemi_fmssn_f)(ket->func))(lmsg,
+								&vps[0].s, &vps[1].s, vps[2].n);
+						return sr_kemi_apy_return_int(ket, ret);
+					} else if(ket->ptypes[2]==SR_KEMIP_STR) {
+						/* sss */
+						ret = ((sr_kemi_fmsss_f)(ket->func))(lmsg,
+								&vps[0].s, &vps[1].s, &vps[2].s);
+						return sr_kemi_apy_return_int(ket, ret);
+					} else {
+						LM_ERR("invalid parameters for: %.*s\n",
+								fname.len, fname.s);
+						return sr_kemi_apy_return_false();
+					}
+				} else {
+					LM_ERR("invalid parameters for: %.*s\n",
+							fname.len, fname.s);
+					return sr_kemi_apy_return_false();
+				}
+			} else {
+				LM_ERR("invalid parameters for: %.*s\n",
+						fname.len, fname.s);
+				return sr_kemi_apy_return_false();
+			}
+		break;
+		case 4:
+			if(ket->ptypes[0]==SR_KEMIP_STR
+					|| ket->ptypes[1]==SR_KEMIP_STR
+					|| ket->ptypes[2]==SR_KEMIP_STR
+					|| ket->ptypes[3]==SR_KEMIP_STR) {
+				/* ssss */
+				ret = ((sr_kemi_fmssss_f)(ket->func))(lmsg,
+						&vps[0].s, &vps[1].s, &vps[2].s, &vps[3].s);
+				return sr_kemi_apy_return_int(ket, ret);
+			} else if(ket->ptypes[0]==SR_KEMIP_STR
+					|| ket->ptypes[1]==SR_KEMIP_STR
+					|| ket->ptypes[2]==SR_KEMIP_INT
+					|| ket->ptypes[3]==SR_KEMIP_INT) {
+				/* ssnn */
+				ret = ((sr_kemi_fmssnn_f)(ket->func))(lmsg,
+						&vps[0].s, &vps[1].s, vps[2].n, vps[3].n);
+				return sr_kemi_apy_return_int(ket, ret);
+			} else {
+				LM_ERR("invalid parameters for: %.*s\n",
+						fname.len, fname.s);
+				return sr_kemi_apy_return_false();
+			}
+		break;
+		case 5:
+			if(ket->ptypes[0]==SR_KEMIP_STR
+					|| ket->ptypes[1]==SR_KEMIP_STR
+					|| ket->ptypes[2]==SR_KEMIP_STR
+					|| ket->ptypes[3]==SR_KEMIP_STR
+					|| ket->ptypes[4]==SR_KEMIP_STR) {
+				/* sssss */
+				ret = ((sr_kemi_fmsssss_f)(ket->func))(lmsg,
+						&vps[0].s, &vps[1].s, &vps[2].s, &vps[3].s,
+						&vps[4].s);
+				return sr_kemi_apy_return_int(ket, ret);
+			} else {
+				LM_ERR("invalid parameters for: %.*s\n",
+						fname.len, fname.s);
+				return sr_kemi_apy_return_false();
+			}
+		break;
+		case 6:
+			if(ket->ptypes[0]==SR_KEMIP_STR
+					|| ket->ptypes[1]==SR_KEMIP_STR
+					|| ket->ptypes[2]==SR_KEMIP_STR
+					|| ket->ptypes[3]==SR_KEMIP_STR
+					|| ket->ptypes[4]==SR_KEMIP_STR
+					|| ket->ptypes[5]==SR_KEMIP_STR) {
+				/* ssssss */
+				ret = ((sr_kemi_fmssssss_f)(ket->func))(lmsg,
+						&vps[0].s, &vps[1].s, &vps[2].s, &vps[3].s,
+						&vps[4].s, &vps[5].s);
+				return sr_kemi_apy_return_int(ket, ret);
+			} else {
+				LM_ERR("invalid parameters for: %.*s\n",
+						fname.len, fname.s);
+				return sr_kemi_apy_return_false();
+			}
+		break;
+		default:
+			LM_ERR("invalid parameters for: %.*s\n",
+					fname.len, fname.s);
+			return sr_kemi_apy_return_false();
+	}
+}
+
+/**
+ *
+ */
+PyObject *_sr_apy_ksr_module = NULL;
+PyObject **_sr_apy_ksr_modules_list = NULL;
+
+PyMethodDef *_sr_KSRMethods = NULL;
+#define SR_APY_KSR_MODULES_SIZE	256
+#define SR_APY_KSR_METHODS_SIZE	(SR_APY_KEMI_EXPORT_SIZE + SR_APY_KSR_MODULES_SIZE)
+
+/**
+ *
+ */
+static int sr_apy_kemi_f_ktest(sip_msg_t *msg, str *txt)
+{
+	if(txt!=NULL && txt->s!=NULL)
+		LM_DBG("%.*s", txt->len, txt->s);
+	return 0;
+}
+
+/**
+ *
+ */
+static sr_kemi_t _sr_apy_kemi_test[] = {
+	{ str_init(""), str_init("ktest"),
+		SR_KEMIP_NONE, sr_apy_kemi_f_ktest,
+		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+
+	{ {0, 0}, {0, 0}, 0, NULL, { 0, 0, 0, 0, 0, 0 } }
+};
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_f_pv_get(PyObject *self, PyObject *args)
+{
+	str pvn;
+	pv_spec_t *pvs;
+	pv_value_t val;
+	int pl;
+	sr_apy_env_t *env_P;
+	sip_msg_t *lmsg = NULL;
+
+	env_P = sr_apy_env_get();
+
+	if(env_P==NULL) {
+		LM_ERR("invalid Python environment attributes\n");
+		return sr_apy_kemi_return_none();
+	}
+	if(env_P->msg==NULL) {
+		lmsg = faked_msg_next();
+	} else {
+		lmsg = env_P->msg;
+	}
+
+	if(!PyArg_ParseTuple(args, "s:pv.get", &pvn.s)) {
+		LM_ERR("unable to retrieve str param\n");
+		return sr_apy_kemi_return_none();
+	}
+
+	if(pvn.s==NULL || lmsg==NULL) {
+		LM_ERR("invalid context attributes\n");
+		return sr_apy_kemi_return_none();
+	}
+
+	pvn.len = strlen(pvn.s);
+	LM_DBG("pv get: %s\n", pvn.s);
+	pl = pv_locate_name(&pvn);
+	if(pl != pvn.len) {
+		LM_ERR("invalid pv [%s] (%d/%d)\n", pvn.s, pl, pvn.len);
+		return sr_apy_kemi_return_none();
+	}
+	pvs = pv_cache_get(&pvn);
+	if(pvs==NULL) {
+		LM_ERR("cannot get pv spec for [%s]\n", pvn.s);
+		return sr_apy_kemi_return_none();
+	}
+	memset(&val, 0, sizeof(pv_value_t));
+	if(pv_get_spec_value(lmsg, pvs, &val) != 0)
+	{
+		LM_ERR("unable to get pv value for [%s]\n", pvn.s);
+		return sr_apy_kemi_return_none();
+	}
+	if(val.flags&PV_VAL_NULL) {
+		return sr_apy_kemi_return_none();
+	}
+	if(val.flags&PV_TYPE_INT) {
+		return sr_kemi_apy_return_int(NULL, val.ri);
+	}
+	return sr_apy_kemi_return_str(NULL, val.rs.s, val.rs.len);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_f_pv_seti(PyObject *self, PyObject *args)
+{
+	str pvn;
+	pv_spec_t *pvs;
+	pv_value_t val;
+	int pl;
+	sr_apy_env_t *env_P;
+	sip_msg_t *lmsg = NULL;
+
+	env_P = sr_apy_env_get();
+
+	if(env_P==NULL) {
+		LM_ERR("invalid Python environment attributes\n");
+		return sr_kemi_apy_return_false();
+	}
+	if(env_P->msg==NULL) {
+		lmsg = faked_msg_next();
+	} else {
+		lmsg = env_P->msg;
+	}
+
+	memset(&val, 0, sizeof(pv_value_t));
+	if(!PyArg_ParseTuple(args, "si:pv.seti", &pvn.s, &val.ri)) {
+		LM_ERR("unable to retrieve str-int params\n");
+		return sr_kemi_apy_return_false();
+	}
+
+	if(pvn.s==NULL || lmsg==NULL) {
+		LM_ERR("invalid context attributes\n");
+		return sr_kemi_apy_return_false();
+	}
+	val.flags |= PV_TYPE_INT|PV_VAL_INT;
+	pvn.len = strlen(pvn.s);
+
+	LM_DBG("pv set: %s\n", pvn.s);
+	pl = pv_locate_name(&pvn);
+	if(pl != pvn.len) {
+		LM_ERR("invalid pv [%s] (%d/%d)\n", pvn.s, pl, pvn.len);
+		return sr_kemi_apy_return_false();
+	}
+	pvs = pv_cache_get(&pvn);
+	if(pvs==NULL) {
+		LM_ERR("cannot get pv spec for [%s]\n", pvn.s);
+		return sr_kemi_apy_return_false();
+	}
+	if(pv_set_spec_value(lmsg, pvs, 0, &val)<0)
+	{
+		LM_ERR("unable to set pv [%s]\n", pvn.s);
+		return sr_kemi_apy_return_false();
+	}
+	return sr_kemi_apy_return_true();
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_f_pv_sets(PyObject *self, PyObject *args)
+{
+	str pvn;
+	pv_spec_t *pvs;
+	pv_value_t val;
+	int pl;
+	sr_apy_env_t *env_P;
+	sip_msg_t *lmsg = NULL;
+
+	env_P = sr_apy_env_get();
+
+	if(env_P==NULL) {
+		LM_ERR("invalid Python environment attributes\n");
+		return sr_kemi_apy_return_false();
+	}
+	if(env_P->msg==NULL) {
+		lmsg = faked_msg_next();
+	} else {
+		lmsg = env_P->msg;
+	}
+
+	memset(&val, 0, sizeof(pv_value_t));
+	if(!PyArg_ParseTuple(args, "ss:pv.sets", &pvn.s, &val.rs.s)) {
+		LM_ERR("unable to retrieve str-int params\n");
+		return sr_kemi_apy_return_false();
+	}
+
+	if(pvn.s==NULL || val.rs.s==NULL || lmsg==NULL) {
+		LM_ERR("invalid context attributes\n");
+		return sr_kemi_apy_return_false();
+	}
+
+	val.rs.len = strlen(val.rs.s);
+	val.flags |= PV_VAL_STR;
+
+	pvn.len = strlen(pvn.s);
+	LM_DBG("pv set: %s\n", pvn.s);
+	pl = pv_locate_name(&pvn);
+	if(pl != pvn.len) {
+		LM_ERR("invalid pv [%s] (%d/%d)\n", pvn.s, pl, pvn.len);
+		return sr_kemi_apy_return_false();
+	}
+	pvs = pv_cache_get(&pvn);
+	if(pvs==NULL) {
+		LM_ERR("cannot get pv spec for [%s]\n", pvn.s);
+		return sr_kemi_apy_return_false();
+	}
+	if(pv_set_spec_value(lmsg, pvs, 0, &val)<0) {
+		LM_ERR("unable to set pv [%s]\n", pvn.s);
+		return sr_kemi_apy_return_false();
+	}
+
+	return sr_kemi_apy_return_true();
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_f_pv_unset(PyObject *self, PyObject *args)
+{
+	str pvn;
+	pv_spec_t *pvs;
+	pv_value_t val;
+	int pl;
+	sr_apy_env_t *env_P;
+	sip_msg_t *lmsg = NULL;
+
+	env_P = sr_apy_env_get();
+
+	if(env_P==NULL) {
+		LM_ERR("invalid Python environment attributes\n");
+		return sr_kemi_apy_return_false();
+	}
+	if(env_P->msg==NULL) {
+		lmsg = faked_msg_next();
+	} else {
+		lmsg = env_P->msg;
+	}
+
+	if(!PyArg_ParseTuple(args, "s:pv.unset", &pvn.s)) {
+		LM_ERR("unable to retrieve str param\n");
+		return sr_kemi_apy_return_false();
+	}
+
+	if(pvn.s==NULL || lmsg==NULL) {
+		LM_ERR("invalid context attributes\n");
+		return sr_kemi_apy_return_false();
+	}
+
+	pvn.len = strlen(pvn.s);
+	LM_DBG("pv unset: %s\n", pvn.s);
+	pl = pv_locate_name(&pvn);
+	if(pl != pvn.len) {
+		LM_ERR("invalid pv [%s] (%d/%d)\n", pvn.s, pl, pvn.len);
+		return sr_kemi_apy_return_false();
+	}
+	pvs = pv_cache_get(&pvn);
+	if(pvs==NULL) {
+		LM_ERR("cannot get pv spec for [%s]\n", pvn.s);
+		return sr_kemi_apy_return_false();
+	}
+	memset(&val, 0, sizeof(pv_value_t));
+	val.flags |= PV_VAL_NULL;
+	if(pv_set_spec_value(lmsg, pvs, 0, &val)<0) {
+		LM_ERR("unable to unset pv [%s]\n", pvn.s);
+		return sr_kemi_apy_return_false();
+	}
+
+	return sr_kemi_apy_return_true();
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_f_pv_is_null(PyObject *self, PyObject *args)
+{
+	str pvn;
+	pv_spec_t *pvs;
+	pv_value_t val;
+	int pl;
+	sr_apy_env_t *env_P;
+	sip_msg_t *lmsg = NULL;
+
+	env_P = sr_apy_env_get();
+
+	if(env_P==NULL) {
+		LM_ERR("invalid Python environment attributes\n");
+		return sr_kemi_apy_return_false();
+	}
+	if(env_P->msg==NULL) {
+		lmsg = faked_msg_next();
+	} else {
+		lmsg = env_P->msg;
+	}
+
+	if(!PyArg_ParseTuple(args, "s:pv.unset", &pvn.s)) {
+		LM_ERR("unable to retrieve str param\n");
+		return sr_kemi_apy_return_false();
+	}
+
+	if(pvn.s==NULL || lmsg==NULL) {
+		LM_ERR("invalid context attributes\n");
+		return sr_kemi_apy_return_false();
+	}
+
+	pvn.len = strlen(pvn.s);
+	LM_DBG("pv is null test: %s\n", pvn.s);
+	pl = pv_locate_name(&pvn);
+	if(pl != pvn.len) {
+		LM_ERR("invalid pv [%s] (%d/%d)\n", pvn.s, pl, pvn.len);
+		return sr_kemi_apy_return_false();
+	}
+	pvs = pv_cache_get(&pvn);
+	if(pvs==NULL) {
+		LM_ERR("cannot get pv spec for [%s]\n", pvn.s);
+		return sr_kemi_apy_return_true();
+	}
+	memset(&val, 0, sizeof(pv_value_t));
+	if(pv_get_spec_value(lmsg, pvs, &val) != 0) {
+		LM_NOTICE("unable to get pv value for [%s]\n", pvn.s);
+		return sr_kemi_apy_return_true();
+	}
+	if(val.flags&PV_VAL_NULL) {
+		return sr_kemi_apy_return_true();
+	} else {
+		return sr_kemi_apy_return_false();
+	}
+}
+
+static PyMethodDef _sr_apy_kemi_pv_Methods[] = {
+	{"get",		sr_apy_kemi_f_pv_get,		METH_VARARGS,
+		NAME " - pv get value"},
+	{"seti",	sr_apy_kemi_f_pv_seti,		METH_VARARGS,
+		NAME " - pv set int value"},
+	{"sets",	sr_apy_kemi_f_pv_sets,		METH_VARARGS,
+		NAME " - pv set str value"},
+	{"unset",	sr_apy_kemi_f_pv_unset,		METH_VARARGS,
+		NAME " - pv uset value (assign $null)"},
+	{"is_null",	sr_apy_kemi_f_pv_is_null,	METH_VARARGS,
+		NAME " - pv test if it is $null"},
+
+	{NULL, 		NULL, 			0, 		NULL}
+};
+
+static struct PyModuleDef KSR_moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "KSR",
+        NULL,
+        -1,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+static struct PyModuleDef KSR_pv_moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "KSR.pv",
+        NULL,
+        -1,
+        _sr_apy_kemi_pv_Methods,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+/**
+ *
+ */
+static PyMethodDef _sr_apy_kemi_x_Methods[] = {
+	{"modf", (PyCFunction)msg_call_function, METH_VARARGS,
+		"Invoke function exported by the other module."},
+	{NULL, NULL, 0, NULL} /* sentinel */
+};
+
+static struct PyModuleDef KSR_x_moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "KSR.x",
+        NULL,
+        -1,
+        _sr_apy_kemi_x_Methods,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+/* forward */
+static PyObject* init_KSR(void);
+int sr_apy_init_ksr(void) {
+	PyImport_AppendInittab("KSR", &init_KSR);
+	return 0;
+}
+/**
+ *
+ */
+static
+PyObject* init_KSR(void)
+{
+	PyMethodDef *_sr_crt_KSRMethods = NULL;
+	sr_kemi_module_t *emods = NULL;
+	int emods_size = 0;
+	int i;
+	int k;
+	int m;
+	int n;
+	char mname[128];
+
+	/* init faked sip msg */
+	if(faked_msg_init()<0)
+	{
+		LM_ERR("failed to init local faked sip msg\n");
+		return NULL;
+	}
+
+	_sr_KSRMethods = malloc(SR_APY_KSR_METHODS_SIZE * sizeof(PyMethodDef));
+	if(_sr_KSRMethods==NULL) {
+		LM_ERR("no more pkg memory\n");
+		return NULL;
+	}
+	_sr_apy_ksr_modules_list = malloc(SR_APY_KSR_MODULES_SIZE * sizeof(PyObject*));
+	if(_sr_apy_ksr_modules_list==NULL) {
+		LM_ERR("no more pkg memory\n");
+		return NULL;
+	}
+	memset(_sr_KSRMethods, 0, SR_APY_KSR_METHODS_SIZE * sizeof(PyMethodDef));
+	memset(_sr_apy_ksr_modules_list, 0, SR_APY_KSR_MODULES_SIZE * sizeof(PyObject*));
+
+	emods_size = sr_kemi_modules_size_get();
+	emods = sr_kemi_modules_get();
+
+	n = 0;
+	_sr_crt_KSRMethods = _sr_KSRMethods;
+	if(emods_size==0 || emods[0].kexp==NULL) {
+		LM_DBG("exporting KSR.%s(...)\n", _sr_apy_kemi_test[0].fname.s);
+		_sr_crt_KSRMethods[0].ml_name = _sr_apy_kemi_test[0].fname.s;
+		_sr_crt_KSRMethods[0].ml_meth = sr_apy_kemi_export_associate(&_sr_apy_kemi_test[0]);
+		_sr_crt_KSRMethods[0].ml_flags = METH_VARARGS;
+		_sr_crt_KSRMethods[0].ml_doc = NAME " exported function";
+	} else {
+		for(i=0; emods[0].kexp[i].func!=NULL; i++) {
+			LM_DBG("exporting KSR.%s(...)\n", emods[0].kexp[i].fname.s);
+			_sr_crt_KSRMethods[i].ml_name = emods[0].kexp[i].fname.s;
+			_sr_crt_KSRMethods[i].ml_meth =
+				sr_apy_kemi_export_associate(&emods[0].kexp[i]);
+			if(_sr_crt_KSRMethods[i].ml_meth == NULL) {
+				LM_ERR("failed to associate kemi function with python export\n");
+				free(_sr_KSRMethods);
+				_sr_KSRMethods = NULL;
+				return NULL;
+			}
+			_sr_crt_KSRMethods[i].ml_flags = METH_VARARGS;
+			_sr_crt_KSRMethods[i].ml_doc = NAME " exported function";
+			n++;
+		}
+	}
+
+	KSR_moduledef.m_methods = _sr_crt_KSRMethods;
+	_sr_apy_ksr_module = PyModule_Create(&KSR_moduledef);
+
+	Py_INCREF(_sr_apy_ksr_module);
+
+	m = 0;
+
+	/* special sub-modules - pv.get() can return int or string */
+	_sr_apy_ksr_modules_list[m] = PyModule_Create(&KSR_pv_moduledef);
+	PyModule_AddObject(_sr_apy_ksr_module, "pv", _sr_apy_ksr_modules_list[m]);
+	Py_INCREF(_sr_apy_ksr_modules_list[m]);
+	m++;
+	/* special sub-modules - x.modf() can have variable number of params */
+	_sr_apy_ksr_modules_list[m] = PyModule_Create(&KSR_x_moduledef);
+	PyModule_AddObject(_sr_apy_ksr_module, "x", _sr_apy_ksr_modules_list[m]);
+	Py_INCREF(_sr_apy_ksr_modules_list[m]);
+	m++;
+
+	if(emods_size>1) {
+		for(k=1; k<emods_size; k++) {
+			n++;
+			_sr_crt_KSRMethods = _sr_KSRMethods + n;
+			snprintf(mname, 128, "KSR.%s", emods[k].kexp[0].mname.s);
+			for(i=0; emods[k].kexp[i].func!=NULL; i++) {
+				LM_DBG("exporting %s.%s(...)\n", mname,
+						emods[k].kexp[i].fname.s);
+				_sr_crt_KSRMethods[i].ml_name = emods[k].kexp[i].fname.s;
+				_sr_crt_KSRMethods[i].ml_meth =
+					sr_apy_kemi_export_associate(&emods[k].kexp[i]);
+				if(_sr_crt_KSRMethods[i].ml_meth == NULL) {
+					LM_ERR("failed to associate kemi function with python export\n");
+					free(_sr_KSRMethods);
+					_sr_KSRMethods = NULL;
+					return NULL;
+				}
+				_sr_crt_KSRMethods[i].ml_flags = METH_VARARGS;
+				_sr_crt_KSRMethods[i].ml_doc = NAME " exported function";
+				n++;
+			}
+			LM_DBG("initializing kemi sub-module: %s (%s)\n", mname,
+					emods[k].kexp[0].mname.s);
+
+			PyModuleDef *mmodule  = malloc(sizeof(PyModuleDef));
+			memset(mmodule, 0, sizeof(PyModuleDef));
+			mmodule->m_name = strndup(mname, 127);
+			mmodule->m_methods = _sr_crt_KSRMethods;
+			mmodule->m_size = -1;
+
+			_sr_apy_ksr_modules_list[m] = PyModule_Create(mmodule);
+			PyModule_AddObject(_sr_apy_ksr_module, emods[k].kexp[0].mname.s, _sr_apy_ksr_modules_list[m]);
+			Py_INCREF(_sr_apy_ksr_modules_list[m]);
+			m++;
+		}
+	}
+	LM_DBG("module 'KSR' has been initialized\n");
+	return _sr_apy_ksr_module;
+}
+
+/**
+ *
+ */
+void sr_apy_destroy_ksr(void)
+{
+	if(_sr_apy_ksr_module!=NULL) {
+		Py_XDECREF(_sr_apy_ksr_module);
+		_sr_apy_ksr_module = NULL;
+	}
+	if(_sr_KSRMethods!=NULL) {
+		free(_sr_KSRMethods);
+		_sr_KSRMethods = NULL;
+	}
+
+	LM_DBG("module 'KSR' has been destroyed\n");
+}
+
+/**
+ *
+ */
+int apy_sr_init_mod(void)
+{
+	if(_sr_python_reload_version == NULL) {
+		_sr_python_reload_version = (int*)shm_malloc(sizeof(int));
+		if(_sr_python_reload_version == NULL) {
+			LM_ERR("failed to allocated reload version\n");
+			return -1;
+		}
+		*_sr_python_reload_version = 0;
+	}
+
+	return 0;
+}
+
+static const char* app_python_rpc_reload_doc[2] = {
+	"Reload python file",
+	0
+};
+
+
+static void app_python_rpc_reload(rpc_t* rpc, void* ctx)
+{
+	int v;
+	void *vh;
+
+	if(_sr_python_load_file.s == NULL && _sr_python_load_file.len<=0) {
+		LM_WARN("script file path not provided\n");
+		rpc->fault(ctx, 500, "No script file");
+		return;
+	}
+	if(_sr_python_reload_version == NULL) {
+		LM_WARN("reload not enabled\n");
+		rpc->fault(ctx, 500, "Reload not enabled");
+		return;
+	}
+
+	v = *_sr_python_reload_version;
+	LM_INFO("marking for reload js script file: %.*s (%d => %d)\n",
+				_sr_python_load_file.len, _sr_python_load_file.s,
+				_sr_python_local_version, v);
+	*_sr_python_reload_version += 1;
+
+	if(apy_reload_script()<0) {
+		rpc->fault(ctx, 500, "Reload failed");
+		return;
+	}
+
+	if (rpc->add(ctx, "{", &vh) < 0) {
+		rpc->fault(ctx, 500, "Server error");
+		return;
+	}
+	rpc->struct_add(vh, "dd",
+			"old", v,
+			"new", *_sr_python_reload_version);
+
+	return;
+}
+
+static const char* app_python_rpc_api_list_doc[2] = {
+	"List kemi exports to javascript",
+	0
+};
+
+static void app_python_rpc_api_list(rpc_t* rpc, void* ctx)
+{
+	int i;
+	int n;
+	sr_kemi_t *ket;
+	void* th;
+	void* sh;
+	void* ih;
+
+	if (rpc->add(ctx, "{", &th) < 0) {
+		rpc->fault(ctx, 500, "Internal error root reply");
+		return;
+	}
+	n = 0;
+	for(i=0; i<SR_APY_KSR_METHODS_SIZE ; i++) {
+		ket = sr_apy_kemi_export_get(i);
+		if(ket==NULL) continue;
+		n++;
+	}
+
+	if(rpc->struct_add(th, "d[",
+				"msize", n,
+				"methods",  &ih)<0)
+	{
+		rpc->fault(ctx, 500, "Internal error array structure");
+		return;
+	}
+	for(i=0; i<SR_APY_KSR_METHODS_SIZE; i++) {
+		ket = sr_apy_kemi_export_get(i);
+		if(ket==NULL) continue;
+		if(rpc->struct_add(ih, "{", "func", &sh)<0) {
+			rpc->fault(ctx, 500, "Internal error internal structure");
+			return;
+		}
+		if(rpc->struct_add(sh, "SSSS",
+				"ret", sr_kemi_param_map_get_name(ket->rtype),
+				"module", &ket->mname,
+				"name", &ket->fname,
+				"params", sr_kemi_param_map_get_params(ket->ptypes))<0) {
+			LM_ERR("failed to add the structure with attributes (%d)\n", i);
+			rpc->fault(ctx, 500, "Internal error creating dest struct");
+			return;
+		}
+	}
+}
+
+rpc_export_t app_python_rpc_cmds[] = {
+	{"app_python.reload", app_python_rpc_reload,
+		app_python_rpc_reload_doc, 0},
+	{"app_python.api_list", app_python_rpc_api_list,
+		app_python_rpc_api_list_doc, 0},
+	{0, 0, 0, 0}
+};
+
+/**
+ * register RPC commands
+ */
+int app_python_init_rpc(void)
+{
+	if (rpc_register_array(app_python_rpc_cmds)!=0)
+	{
+		LM_ERR("failed to register RPC commands\n");
+		return -1;
+	}
+	return 0;
+}

--- a/src/modules/app_python3/apy_kemi.h
+++ b/src/modules/app_python3/apy_kemi.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2016 Daniel-Constantin Mierla (asipto.com)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef __APY_KEMI_H__
+#define __APY_KEMI_H__
+
+#include <Python.h>
+#include "../../core/parser/msg_parser.h"
+
+int sr_apy_init_ksr(void);
+void sr_apy_destroy_ksr(void);
+int sr_kemi_config_engine_python(sip_msg_t *msg, int rtype, str *rname,
+		str *rparam);
+
+PyObject *sr_apy_kemi_exec_func(PyObject *self, PyObject *args, int idx);
+
+int apy_sr_init_mod(void);
+int app_python_init_rpc(void);
+int apy_load_script(void);
+int apy_init_script(int rank);
+
+#endif

--- a/src/modules/app_python3/apy_kemi_export.c
+++ b/src/modules/app_python3/apy_kemi_export.c
@@ -1,0 +1,9288 @@
+/**
+ * Copyright (C) 2016 Daniel-Constantin Mierla (asipto.com)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/**
+ * this file is generated - do not edit
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#include <Python.h>
+
+#include "../../core/dprint.h"
+
+#include "apy_kemi.h"
+#include "apy_kemi_export.h"
+
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_0(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 0);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_2(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 2);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_3(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 3);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_4(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 4);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_5(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 5);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_6(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 6);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_7(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 7);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_8(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 8);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_9(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 9);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_10(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 10);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_11(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 11);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_12(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 12);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_13(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 13);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_14(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 14);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_15(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 15);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_16(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 16);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_17(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 17);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_18(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 18);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_19(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 19);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_20(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 20);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_21(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 21);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_22(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 22);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_23(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 23);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_24(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 24);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_25(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 25);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_26(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 26);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_27(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 27);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_28(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 28);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_29(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 29);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_30(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 30);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_31(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 31);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_32(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 32);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_33(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 33);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_34(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 34);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_35(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 35);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_36(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 36);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_37(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 37);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_38(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 38);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_39(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 39);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_40(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 40);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_41(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 41);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_42(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 42);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_43(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 43);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_44(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 44);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_45(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 45);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_46(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 46);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_47(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 47);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_48(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 48);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_49(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 49);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_50(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 50);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_51(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 51);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_52(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 52);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_53(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 53);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_54(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 54);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_55(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 55);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_56(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 56);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_57(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 57);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_58(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 58);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_59(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 59);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_60(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 60);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_61(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 61);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_62(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 62);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_63(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 63);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_64(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 64);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_65(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 65);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_66(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 66);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_67(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 67);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_68(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 68);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_69(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 69);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_70(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 70);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_71(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 71);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_72(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 72);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_73(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 73);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_74(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 74);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_75(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 75);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_76(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 76);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_77(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 77);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_78(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 78);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_79(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 79);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_80(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 80);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_81(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 81);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_82(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 82);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_83(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 83);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_84(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 84);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_85(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 85);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_86(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 86);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_87(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 87);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_88(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 88);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_89(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 89);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_90(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 90);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_91(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 91);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_92(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 92);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_93(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 93);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_94(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 94);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_95(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 95);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_96(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 96);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_97(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 97);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_98(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 98);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_99(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 99);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_100(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 100);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_101(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 101);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_102(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 102);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_103(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 103);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_104(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 104);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_105(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 105);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_106(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 106);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_107(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 107);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_108(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 108);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_109(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 109);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_110(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 110);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_111(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 111);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_112(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 112);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_113(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 113);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_114(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 114);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_115(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 115);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_116(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 116);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_117(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 117);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_118(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 118);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_119(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 119);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_120(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 120);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_121(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 121);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_122(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 122);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_123(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 123);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_124(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 124);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_125(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 125);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_126(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 126);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_127(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 127);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_128(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 128);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_129(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 129);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_130(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 130);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_131(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 131);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_132(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 132);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_133(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 133);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_134(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 134);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_135(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 135);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_136(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 136);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_137(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 137);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_138(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 138);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_139(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 139);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_140(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 140);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_141(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 141);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_142(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 142);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_143(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 143);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_144(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 144);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_145(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 145);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_146(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 146);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_147(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 147);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_148(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 148);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_149(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 149);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_150(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 150);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_151(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 151);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_152(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 152);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_153(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 153);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_154(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 154);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_155(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 155);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_156(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 156);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_157(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 157);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_158(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 158);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_159(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 159);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_160(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 160);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_161(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 161);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_162(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 162);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_163(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 163);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_164(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 164);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_165(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 165);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_166(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 166);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_167(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 167);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_168(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 168);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_169(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 169);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_170(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 170);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_171(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 171);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_172(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 172);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_173(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 173);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_174(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 174);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_175(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 175);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_176(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 176);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_177(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 177);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_178(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 178);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_179(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 179);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_180(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 180);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_181(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 181);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_182(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 182);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_183(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 183);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_184(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 184);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_185(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 185);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_186(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 186);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_187(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 187);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_188(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 188);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_189(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 189);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_190(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 190);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_191(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 191);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_192(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 192);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_193(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 193);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_194(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 194);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_195(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 195);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_196(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 196);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_197(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 197);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_198(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 198);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_199(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 199);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_200(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 200);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_201(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 201);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_202(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 202);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_203(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 203);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_204(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 204);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_205(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 205);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_206(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 206);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_207(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 207);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_208(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 208);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_209(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 209);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_210(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 210);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_211(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 211);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_212(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 212);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_213(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 213);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_214(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 214);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_215(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 215);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_216(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 216);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_217(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 217);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_218(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 218);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_219(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 219);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_220(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 220);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_221(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 221);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_222(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 222);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_223(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 223);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_224(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 224);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_225(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 225);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_226(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 226);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_227(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 227);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_228(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 228);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_229(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 229);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_230(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 230);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_231(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 231);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_232(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 232);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_233(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 233);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_234(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 234);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_235(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 235);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_236(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 236);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_237(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 237);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_238(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 238);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_239(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 239);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_240(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 240);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_241(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 241);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_242(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 242);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_243(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 243);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_244(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 244);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_245(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 245);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_246(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 246);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_247(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 247);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_248(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 248);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_249(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 249);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_250(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 250);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_251(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 251);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_252(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 252);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_253(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 253);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_254(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 254);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_255(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 255);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_256(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 256);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_257(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 257);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_258(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 258);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_259(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 259);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_260(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 260);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_261(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 261);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_262(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 262);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_263(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 263);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_264(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 264);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_265(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 265);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_266(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 266);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_267(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 267);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_268(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 268);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_269(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 269);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_270(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 270);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_271(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 271);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_272(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 272);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_273(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 273);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_274(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 274);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_275(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 275);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_276(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 276);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_277(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 277);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_278(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 278);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_279(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 279);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_280(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 280);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_281(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 281);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_282(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 282);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_283(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 283);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_284(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 284);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_285(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 285);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_286(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 286);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_287(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 287);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_288(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 288);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_289(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 289);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_290(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 290);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_291(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 291);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_292(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 292);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_293(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 293);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_294(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 294);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_295(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 295);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_296(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 296);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_297(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 297);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_298(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 298);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_299(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 299);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_300(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 300);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_301(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 301);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_302(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 302);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_303(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 303);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_304(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 304);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_305(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 305);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_306(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 306);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_307(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 307);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_308(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 308);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_309(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 309);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_310(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 310);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_311(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 311);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_312(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 312);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_313(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 313);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_314(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 314);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_315(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 315);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_316(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 316);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_317(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 317);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_318(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 318);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_319(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 319);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_320(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 320);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_321(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 321);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_322(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 322);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_323(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 323);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_324(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 324);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_325(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 325);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_326(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 326);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_327(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 327);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_328(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 328);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_329(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 329);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_330(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 330);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_331(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 331);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_332(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 332);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_333(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 333);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_334(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 334);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_335(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 335);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_336(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 336);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_337(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 337);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_338(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 338);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_339(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 339);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_340(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 340);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_341(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 341);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_342(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 342);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_343(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 343);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_344(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 344);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_345(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 345);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_346(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 346);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_347(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 347);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_348(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 348);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_349(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 349);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_350(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 350);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_351(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 351);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_352(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 352);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_353(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 353);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_354(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 354);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_355(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 355);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_356(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 356);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_357(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 357);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_358(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 358);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_359(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 359);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_360(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 360);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_361(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 361);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_362(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 362);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_363(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 363);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_364(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 364);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_365(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 365);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_366(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 366);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_367(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 367);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_368(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 368);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_369(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 369);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_370(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 370);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_371(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 371);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_372(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 372);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_373(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 373);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_374(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 374);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_375(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 375);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_376(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 376);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_377(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 377);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_378(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 378);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_379(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 379);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_380(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 380);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_381(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 381);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_382(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 382);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_383(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 383);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_384(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 384);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_385(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 385);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_386(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 386);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_387(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 387);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_388(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 388);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_389(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 389);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_390(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 390);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_391(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 391);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_392(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 392);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_393(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 393);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_394(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 394);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_395(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 395);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_396(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 396);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_397(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 397);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_398(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 398);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_399(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 399);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_400(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 400);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_401(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 401);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_402(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 402);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_403(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 403);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_404(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 404);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_405(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 405);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_406(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 406);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_407(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 407);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_408(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 408);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_409(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 409);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_410(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 410);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_411(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 411);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_412(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 412);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_413(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 413);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_414(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 414);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_415(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 415);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_416(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 416);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_417(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 417);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_418(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 418);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_419(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 419);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_420(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 420);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_421(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 421);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_422(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 422);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_423(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 423);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_424(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 424);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_425(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 425);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_426(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 426);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_427(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 427);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_428(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 428);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_429(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 429);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_430(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 430);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_431(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 431);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_432(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 432);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_433(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 433);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_434(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 434);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_435(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 435);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_436(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 436);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_437(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 437);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_438(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 438);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_439(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 439);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_440(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 440);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_441(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 441);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_442(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 442);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_443(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 443);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_444(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 444);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_445(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 445);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_446(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 446);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_447(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 447);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_448(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 448);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_449(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 449);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_450(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 450);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_451(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 451);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_452(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 452);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_453(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 453);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_454(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 454);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_455(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 455);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_456(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 456);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_457(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 457);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_458(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 458);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_459(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 459);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_460(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 460);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_461(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 461);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_462(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 462);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_463(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 463);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_464(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 464);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_465(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 465);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_466(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 466);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_467(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 467);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_468(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 468);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_469(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 469);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_470(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 470);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_471(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 471);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_472(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 472);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_473(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 473);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_474(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 474);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_475(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 475);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_476(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 476);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_477(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 477);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_478(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 478);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_479(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 479);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_480(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 480);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_481(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 481);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_482(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 482);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_483(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 483);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_484(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 484);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_485(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 485);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_486(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 486);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_487(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 487);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_488(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 488);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_489(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 489);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_490(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 490);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_491(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 491);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_492(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 492);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_493(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 493);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_494(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 494);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_495(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 495);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_496(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 496);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_497(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 497);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_498(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 498);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_499(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 499);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_500(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 500);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_501(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 501);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_502(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 502);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_503(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 503);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_504(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 504);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_505(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 505);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_506(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 506);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_507(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 507);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_508(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 508);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_509(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 509);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_510(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 510);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_511(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 511);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_512(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 512);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_513(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 513);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_514(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 514);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_515(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 515);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_516(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 516);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_517(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 517);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_518(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 518);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_519(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 519);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_520(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 520);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_521(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 521);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_522(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 522);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_523(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 523);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_524(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 524);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_525(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 525);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_526(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 526);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_527(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 527);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_528(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 528);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_529(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 529);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_530(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 530);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_531(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 531);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_532(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 532);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_533(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 533);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_534(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 534);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_535(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 535);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_536(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 536);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_537(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 537);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_538(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 538);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_539(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 539);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_540(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 540);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_541(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 541);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_542(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 542);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_543(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 543);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_544(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 544);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_545(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 545);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_546(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 546);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_547(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 547);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_548(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 548);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_549(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 549);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_550(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 550);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_551(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 551);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_552(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 552);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_553(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 553);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_554(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 554);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_555(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 555);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_556(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 556);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_557(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 557);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_558(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 558);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_559(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 559);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_560(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 560);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_561(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 561);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_562(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 562);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_563(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 563);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_564(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 564);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_565(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 565);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_566(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 566);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_567(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 567);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_568(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 568);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_569(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 569);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_570(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 570);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_571(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 571);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_572(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 572);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_573(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 573);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_574(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 574);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_575(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 575);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_576(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 576);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_577(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 577);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_578(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 578);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_579(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 579);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_580(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 580);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_581(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 581);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_582(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 582);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_583(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 583);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_584(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 584);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_585(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 585);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_586(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 586);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_587(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 587);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_588(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 588);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_589(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 589);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_590(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 590);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_591(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 591);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_592(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 592);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_593(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 593);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_594(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 594);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_595(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 595);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_596(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 596);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_597(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 597);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_598(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 598);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_599(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 599);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_600(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 600);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_601(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 601);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_602(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 602);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_603(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 603);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_604(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 604);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_605(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 605);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_606(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 606);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_607(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 607);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_608(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 608);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_609(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 609);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_610(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 610);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_611(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 611);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_612(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 612);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_613(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 613);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_614(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 614);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_615(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 615);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_616(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 616);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_617(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 617);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_618(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 618);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_619(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 619);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_620(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 620);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_621(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 621);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_622(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 622);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_623(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 623);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_624(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 624);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_625(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 625);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_626(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 626);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_627(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 627);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_628(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 628);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_629(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 629);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_630(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 630);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_631(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 631);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_632(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 632);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_633(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 633);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_634(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 634);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_635(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 635);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_636(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 636);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_637(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 637);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_638(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 638);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_639(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 639);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_640(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 640);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_641(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 641);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_642(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 642);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_643(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 643);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_644(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 644);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_645(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 645);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_646(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 646);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_647(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 647);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_648(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 648);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_649(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 649);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_650(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 650);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_651(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 651);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_652(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 652);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_653(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 653);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_654(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 654);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_655(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 655);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_656(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 656);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_657(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 657);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_658(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 658);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_659(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 659);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_660(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 660);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_661(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 661);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_662(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 662);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_663(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 663);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_664(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 664);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_665(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 665);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_666(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 666);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_667(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 667);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_668(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 668);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_669(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 669);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_670(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 670);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_671(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 671);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_672(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 672);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_673(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 673);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_674(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 674);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_675(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 675);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_676(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 676);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_677(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 677);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_678(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 678);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_679(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 679);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_680(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 680);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_681(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 681);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_682(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 682);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_683(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 683);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_684(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 684);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_685(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 685);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_686(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 686);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_687(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 687);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_688(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 688);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_689(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 689);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_690(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 690);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_691(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 691);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_692(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 692);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_693(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 693);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_694(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 694);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_695(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 695);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_696(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 696);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_697(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 697);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_698(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 698);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_699(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 699);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_700(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 700);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_701(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 701);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_702(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 702);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_703(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 703);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_704(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 704);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_705(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 705);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_706(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 706);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_707(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 707);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_708(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 708);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_709(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 709);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_710(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 710);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_711(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 711);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_712(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 712);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_713(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 713);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_714(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 714);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_715(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 715);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_716(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 716);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_717(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 717);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_718(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 718);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_719(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 719);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_720(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 720);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_721(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 721);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_722(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 722);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_723(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 723);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_724(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 724);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_725(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 725);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_726(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 726);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_727(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 727);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_728(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 728);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_729(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 729);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_730(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 730);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_731(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 731);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_732(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 732);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_733(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 733);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_734(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 734);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_735(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 735);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_736(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 736);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_737(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 737);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_738(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 738);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_739(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 739);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_740(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 740);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_741(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 741);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_742(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 742);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_743(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 743);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_744(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 744);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_745(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 745);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_746(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 746);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_747(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 747);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_748(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 748);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_749(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 749);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_750(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 750);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_751(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 751);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_752(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 752);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_753(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 753);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_754(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 754);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_755(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 755);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_756(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 756);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_757(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 757);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_758(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 758);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_759(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 759);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_760(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 760);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_761(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 761);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_762(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 762);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_763(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 763);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_764(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 764);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_765(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 765);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_766(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 766);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_767(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 767);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_768(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 768);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_769(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 769);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_770(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 770);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_771(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 771);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_772(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 772);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_773(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 773);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_774(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 774);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_775(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 775);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_776(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 776);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_777(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 777);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_778(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 778);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_779(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 779);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_780(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 780);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_781(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 781);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_782(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 782);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_783(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 783);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_784(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 784);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_785(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 785);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_786(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 786);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_787(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 787);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_788(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 788);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_789(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 789);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_790(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 790);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_791(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 791);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_792(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 792);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_793(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 793);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_794(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 794);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_795(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 795);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_796(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 796);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_797(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 797);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_798(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 798);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_799(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 799);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_800(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 800);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_801(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 801);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_802(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 802);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_803(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 803);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_804(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 804);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_805(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 805);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_806(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 806);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_807(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 807);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_808(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 808);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_809(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 809);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_810(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 810);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_811(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 811);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_812(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 812);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_813(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 813);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_814(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 814);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_815(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 815);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_816(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 816);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_817(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 817);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_818(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 818);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_819(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 819);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_820(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 820);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_821(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 821);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_822(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 822);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_823(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 823);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_824(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 824);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_825(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 825);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_826(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 826);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_827(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 827);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_828(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 828);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_829(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 829);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_830(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 830);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_831(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 831);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_832(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 832);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_833(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 833);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_834(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 834);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_835(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 835);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_836(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 836);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_837(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 837);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_838(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 838);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_839(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 839);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_840(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 840);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_841(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 841);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_842(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 842);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_843(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 843);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_844(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 844);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_845(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 845);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_846(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 846);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_847(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 847);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_848(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 848);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_849(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 849);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_850(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 850);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_851(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 851);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_852(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 852);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_853(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 853);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_854(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 854);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_855(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 855);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_856(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 856);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_857(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 857);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_858(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 858);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_859(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 859);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_860(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 860);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_861(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 861);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_862(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 862);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_863(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 863);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_864(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 864);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_865(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 865);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_866(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 866);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_867(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 867);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_868(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 868);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_869(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 869);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_870(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 870);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_871(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 871);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_872(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 872);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_873(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 873);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_874(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 874);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_875(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 875);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_876(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 876);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_877(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 877);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_878(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 878);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_879(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 879);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_880(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 880);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_881(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 881);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_882(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 882);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_883(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 883);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_884(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 884);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_885(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 885);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_886(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 886);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_887(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 887);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_888(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 888);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_889(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 889);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_890(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 890);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_891(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 891);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_892(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 892);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_893(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 893);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_894(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 894);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_895(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 895);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_896(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 896);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_897(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 897);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_898(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 898);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_899(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 899);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_900(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 900);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_901(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 901);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_902(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 902);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_903(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 903);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_904(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 904);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_905(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 905);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_906(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 906);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_907(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 907);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_908(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 908);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_909(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 909);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_910(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 910);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_911(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 911);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_912(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 912);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_913(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 913);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_914(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 914);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_915(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 915);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_916(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 916);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_917(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 917);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_918(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 918);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_919(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 919);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_920(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 920);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_921(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 921);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_922(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 922);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_923(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 923);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_924(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 924);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_925(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 925);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_926(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 926);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_927(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 927);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_928(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 928);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_929(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 929);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_930(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 930);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_931(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 931);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_932(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 932);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_933(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 933);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_934(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 934);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_935(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 935);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_936(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 936);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_937(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 937);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_938(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 938);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_939(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 939);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_940(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 940);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_941(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 941);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_942(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 942);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_943(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 943);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_944(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 944);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_945(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 945);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_946(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 946);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_947(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 947);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_948(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 948);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_949(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 949);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_950(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 950);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_951(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 951);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_952(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 952);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_953(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 953);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_954(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 954);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_955(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 955);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_956(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 956);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_957(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 957);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_958(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 958);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_959(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 959);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_960(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 960);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_961(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 961);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_962(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 962);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_963(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 963);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_964(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 964);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_965(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 965);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_966(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 966);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_967(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 967);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_968(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 968);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_969(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 969);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_970(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 970);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_971(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 971);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_972(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 972);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_973(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 973);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_974(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 974);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_975(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 975);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_976(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 976);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_977(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 977);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_978(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 978);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_979(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 979);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_980(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 980);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_981(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 981);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_982(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 982);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_983(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 983);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_984(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 984);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_985(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 985);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_986(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 986);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_987(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 987);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_988(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 988);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_989(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 989);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_990(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 990);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_991(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 991);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_992(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 992);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_993(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 993);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_994(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 994);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_995(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 995);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_996(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 996);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_997(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 997);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_998(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 998);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_999(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 999);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1000(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1000);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1001(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1001);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1002(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1002);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1003(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1003);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1004(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1004);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1005(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1005);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1006(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1006);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1007(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1007);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1008(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1008);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1009(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1009);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1010(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1010);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1011(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1011);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1012(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1012);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1013(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1013);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1014(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1014);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1015(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1015);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1016(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1016);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1017(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1017);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1018(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1018);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1019(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1019);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1020(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1020);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1021(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1021);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1022(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1022);
+}
+
+/**
+ *
+ */
+static PyObject *sr_apy_kemi_exec_func_1023(PyObject *self, PyObject *args)
+{
+	return sr_apy_kemi_exec_func(self, args, 1023);
+}
+
+/**
+ *
+ */
+static sr_apy_kemi_export_t _sr_apy_kemi_export_list[] = {
+	{ sr_apy_kemi_exec_func_0, NULL},
+	{ sr_apy_kemi_exec_func_1, NULL},
+	{ sr_apy_kemi_exec_func_2, NULL},
+	{ sr_apy_kemi_exec_func_3, NULL},
+	{ sr_apy_kemi_exec_func_4, NULL},
+	{ sr_apy_kemi_exec_func_5, NULL},
+	{ sr_apy_kemi_exec_func_6, NULL},
+	{ sr_apy_kemi_exec_func_7, NULL},
+	{ sr_apy_kemi_exec_func_8, NULL},
+	{ sr_apy_kemi_exec_func_9, NULL},
+	{ sr_apy_kemi_exec_func_10, NULL},
+	{ sr_apy_kemi_exec_func_11, NULL},
+	{ sr_apy_kemi_exec_func_12, NULL},
+	{ sr_apy_kemi_exec_func_13, NULL},
+	{ sr_apy_kemi_exec_func_14, NULL},
+	{ sr_apy_kemi_exec_func_15, NULL},
+	{ sr_apy_kemi_exec_func_16, NULL},
+	{ sr_apy_kemi_exec_func_17, NULL},
+	{ sr_apy_kemi_exec_func_18, NULL},
+	{ sr_apy_kemi_exec_func_19, NULL},
+	{ sr_apy_kemi_exec_func_20, NULL},
+	{ sr_apy_kemi_exec_func_21, NULL},
+	{ sr_apy_kemi_exec_func_22, NULL},
+	{ sr_apy_kemi_exec_func_23, NULL},
+	{ sr_apy_kemi_exec_func_24, NULL},
+	{ sr_apy_kemi_exec_func_25, NULL},
+	{ sr_apy_kemi_exec_func_26, NULL},
+	{ sr_apy_kemi_exec_func_27, NULL},
+	{ sr_apy_kemi_exec_func_28, NULL},
+	{ sr_apy_kemi_exec_func_29, NULL},
+	{ sr_apy_kemi_exec_func_30, NULL},
+	{ sr_apy_kemi_exec_func_31, NULL},
+	{ sr_apy_kemi_exec_func_32, NULL},
+	{ sr_apy_kemi_exec_func_33, NULL},
+	{ sr_apy_kemi_exec_func_34, NULL},
+	{ sr_apy_kemi_exec_func_35, NULL},
+	{ sr_apy_kemi_exec_func_36, NULL},
+	{ sr_apy_kemi_exec_func_37, NULL},
+	{ sr_apy_kemi_exec_func_38, NULL},
+	{ sr_apy_kemi_exec_func_39, NULL},
+	{ sr_apy_kemi_exec_func_40, NULL},
+	{ sr_apy_kemi_exec_func_41, NULL},
+	{ sr_apy_kemi_exec_func_42, NULL},
+	{ sr_apy_kemi_exec_func_43, NULL},
+	{ sr_apy_kemi_exec_func_44, NULL},
+	{ sr_apy_kemi_exec_func_45, NULL},
+	{ sr_apy_kemi_exec_func_46, NULL},
+	{ sr_apy_kemi_exec_func_47, NULL},
+	{ sr_apy_kemi_exec_func_48, NULL},
+	{ sr_apy_kemi_exec_func_49, NULL},
+	{ sr_apy_kemi_exec_func_50, NULL},
+	{ sr_apy_kemi_exec_func_51, NULL},
+	{ sr_apy_kemi_exec_func_52, NULL},
+	{ sr_apy_kemi_exec_func_53, NULL},
+	{ sr_apy_kemi_exec_func_54, NULL},
+	{ sr_apy_kemi_exec_func_55, NULL},
+	{ sr_apy_kemi_exec_func_56, NULL},
+	{ sr_apy_kemi_exec_func_57, NULL},
+	{ sr_apy_kemi_exec_func_58, NULL},
+	{ sr_apy_kemi_exec_func_59, NULL},
+	{ sr_apy_kemi_exec_func_60, NULL},
+	{ sr_apy_kemi_exec_func_61, NULL},
+	{ sr_apy_kemi_exec_func_62, NULL},
+	{ sr_apy_kemi_exec_func_63, NULL},
+	{ sr_apy_kemi_exec_func_64, NULL},
+	{ sr_apy_kemi_exec_func_65, NULL},
+	{ sr_apy_kemi_exec_func_66, NULL},
+	{ sr_apy_kemi_exec_func_67, NULL},
+	{ sr_apy_kemi_exec_func_68, NULL},
+	{ sr_apy_kemi_exec_func_69, NULL},
+	{ sr_apy_kemi_exec_func_70, NULL},
+	{ sr_apy_kemi_exec_func_71, NULL},
+	{ sr_apy_kemi_exec_func_72, NULL},
+	{ sr_apy_kemi_exec_func_73, NULL},
+	{ sr_apy_kemi_exec_func_74, NULL},
+	{ sr_apy_kemi_exec_func_75, NULL},
+	{ sr_apy_kemi_exec_func_76, NULL},
+	{ sr_apy_kemi_exec_func_77, NULL},
+	{ sr_apy_kemi_exec_func_78, NULL},
+	{ sr_apy_kemi_exec_func_79, NULL},
+	{ sr_apy_kemi_exec_func_80, NULL},
+	{ sr_apy_kemi_exec_func_81, NULL},
+	{ sr_apy_kemi_exec_func_82, NULL},
+	{ sr_apy_kemi_exec_func_83, NULL},
+	{ sr_apy_kemi_exec_func_84, NULL},
+	{ sr_apy_kemi_exec_func_85, NULL},
+	{ sr_apy_kemi_exec_func_86, NULL},
+	{ sr_apy_kemi_exec_func_87, NULL},
+	{ sr_apy_kemi_exec_func_88, NULL},
+	{ sr_apy_kemi_exec_func_89, NULL},
+	{ sr_apy_kemi_exec_func_90, NULL},
+	{ sr_apy_kemi_exec_func_91, NULL},
+	{ sr_apy_kemi_exec_func_92, NULL},
+	{ sr_apy_kemi_exec_func_93, NULL},
+	{ sr_apy_kemi_exec_func_94, NULL},
+	{ sr_apy_kemi_exec_func_95, NULL},
+	{ sr_apy_kemi_exec_func_96, NULL},
+	{ sr_apy_kemi_exec_func_97, NULL},
+	{ sr_apy_kemi_exec_func_98, NULL},
+	{ sr_apy_kemi_exec_func_99, NULL},
+	{ sr_apy_kemi_exec_func_100, NULL},
+	{ sr_apy_kemi_exec_func_101, NULL},
+	{ sr_apy_kemi_exec_func_102, NULL},
+	{ sr_apy_kemi_exec_func_103, NULL},
+	{ sr_apy_kemi_exec_func_104, NULL},
+	{ sr_apy_kemi_exec_func_105, NULL},
+	{ sr_apy_kemi_exec_func_106, NULL},
+	{ sr_apy_kemi_exec_func_107, NULL},
+	{ sr_apy_kemi_exec_func_108, NULL},
+	{ sr_apy_kemi_exec_func_109, NULL},
+	{ sr_apy_kemi_exec_func_110, NULL},
+	{ sr_apy_kemi_exec_func_111, NULL},
+	{ sr_apy_kemi_exec_func_112, NULL},
+	{ sr_apy_kemi_exec_func_113, NULL},
+	{ sr_apy_kemi_exec_func_114, NULL},
+	{ sr_apy_kemi_exec_func_115, NULL},
+	{ sr_apy_kemi_exec_func_116, NULL},
+	{ sr_apy_kemi_exec_func_117, NULL},
+	{ sr_apy_kemi_exec_func_118, NULL},
+	{ sr_apy_kemi_exec_func_119, NULL},
+	{ sr_apy_kemi_exec_func_120, NULL},
+	{ sr_apy_kemi_exec_func_121, NULL},
+	{ sr_apy_kemi_exec_func_122, NULL},
+	{ sr_apy_kemi_exec_func_123, NULL},
+	{ sr_apy_kemi_exec_func_124, NULL},
+	{ sr_apy_kemi_exec_func_125, NULL},
+	{ sr_apy_kemi_exec_func_126, NULL},
+	{ sr_apy_kemi_exec_func_127, NULL},
+	{ sr_apy_kemi_exec_func_128, NULL},
+	{ sr_apy_kemi_exec_func_129, NULL},
+	{ sr_apy_kemi_exec_func_130, NULL},
+	{ sr_apy_kemi_exec_func_131, NULL},
+	{ sr_apy_kemi_exec_func_132, NULL},
+	{ sr_apy_kemi_exec_func_133, NULL},
+	{ sr_apy_kemi_exec_func_134, NULL},
+	{ sr_apy_kemi_exec_func_135, NULL},
+	{ sr_apy_kemi_exec_func_136, NULL},
+	{ sr_apy_kemi_exec_func_137, NULL},
+	{ sr_apy_kemi_exec_func_138, NULL},
+	{ sr_apy_kemi_exec_func_139, NULL},
+	{ sr_apy_kemi_exec_func_140, NULL},
+	{ sr_apy_kemi_exec_func_141, NULL},
+	{ sr_apy_kemi_exec_func_142, NULL},
+	{ sr_apy_kemi_exec_func_143, NULL},
+	{ sr_apy_kemi_exec_func_144, NULL},
+	{ sr_apy_kemi_exec_func_145, NULL},
+	{ sr_apy_kemi_exec_func_146, NULL},
+	{ sr_apy_kemi_exec_func_147, NULL},
+	{ sr_apy_kemi_exec_func_148, NULL},
+	{ sr_apy_kemi_exec_func_149, NULL},
+	{ sr_apy_kemi_exec_func_150, NULL},
+	{ sr_apy_kemi_exec_func_151, NULL},
+	{ sr_apy_kemi_exec_func_152, NULL},
+	{ sr_apy_kemi_exec_func_153, NULL},
+	{ sr_apy_kemi_exec_func_154, NULL},
+	{ sr_apy_kemi_exec_func_155, NULL},
+	{ sr_apy_kemi_exec_func_156, NULL},
+	{ sr_apy_kemi_exec_func_157, NULL},
+	{ sr_apy_kemi_exec_func_158, NULL},
+	{ sr_apy_kemi_exec_func_159, NULL},
+	{ sr_apy_kemi_exec_func_160, NULL},
+	{ sr_apy_kemi_exec_func_161, NULL},
+	{ sr_apy_kemi_exec_func_162, NULL},
+	{ sr_apy_kemi_exec_func_163, NULL},
+	{ sr_apy_kemi_exec_func_164, NULL},
+	{ sr_apy_kemi_exec_func_165, NULL},
+	{ sr_apy_kemi_exec_func_166, NULL},
+	{ sr_apy_kemi_exec_func_167, NULL},
+	{ sr_apy_kemi_exec_func_168, NULL},
+	{ sr_apy_kemi_exec_func_169, NULL},
+	{ sr_apy_kemi_exec_func_170, NULL},
+	{ sr_apy_kemi_exec_func_171, NULL},
+	{ sr_apy_kemi_exec_func_172, NULL},
+	{ sr_apy_kemi_exec_func_173, NULL},
+	{ sr_apy_kemi_exec_func_174, NULL},
+	{ sr_apy_kemi_exec_func_175, NULL},
+	{ sr_apy_kemi_exec_func_176, NULL},
+	{ sr_apy_kemi_exec_func_177, NULL},
+	{ sr_apy_kemi_exec_func_178, NULL},
+	{ sr_apy_kemi_exec_func_179, NULL},
+	{ sr_apy_kemi_exec_func_180, NULL},
+	{ sr_apy_kemi_exec_func_181, NULL},
+	{ sr_apy_kemi_exec_func_182, NULL},
+	{ sr_apy_kemi_exec_func_183, NULL},
+	{ sr_apy_kemi_exec_func_184, NULL},
+	{ sr_apy_kemi_exec_func_185, NULL},
+	{ sr_apy_kemi_exec_func_186, NULL},
+	{ sr_apy_kemi_exec_func_187, NULL},
+	{ sr_apy_kemi_exec_func_188, NULL},
+	{ sr_apy_kemi_exec_func_189, NULL},
+	{ sr_apy_kemi_exec_func_190, NULL},
+	{ sr_apy_kemi_exec_func_191, NULL},
+	{ sr_apy_kemi_exec_func_192, NULL},
+	{ sr_apy_kemi_exec_func_193, NULL},
+	{ sr_apy_kemi_exec_func_194, NULL},
+	{ sr_apy_kemi_exec_func_195, NULL},
+	{ sr_apy_kemi_exec_func_196, NULL},
+	{ sr_apy_kemi_exec_func_197, NULL},
+	{ sr_apy_kemi_exec_func_198, NULL},
+	{ sr_apy_kemi_exec_func_199, NULL},
+	{ sr_apy_kemi_exec_func_200, NULL},
+	{ sr_apy_kemi_exec_func_201, NULL},
+	{ sr_apy_kemi_exec_func_202, NULL},
+	{ sr_apy_kemi_exec_func_203, NULL},
+	{ sr_apy_kemi_exec_func_204, NULL},
+	{ sr_apy_kemi_exec_func_205, NULL},
+	{ sr_apy_kemi_exec_func_206, NULL},
+	{ sr_apy_kemi_exec_func_207, NULL},
+	{ sr_apy_kemi_exec_func_208, NULL},
+	{ sr_apy_kemi_exec_func_209, NULL},
+	{ sr_apy_kemi_exec_func_210, NULL},
+	{ sr_apy_kemi_exec_func_211, NULL},
+	{ sr_apy_kemi_exec_func_212, NULL},
+	{ sr_apy_kemi_exec_func_213, NULL},
+	{ sr_apy_kemi_exec_func_214, NULL},
+	{ sr_apy_kemi_exec_func_215, NULL},
+	{ sr_apy_kemi_exec_func_216, NULL},
+	{ sr_apy_kemi_exec_func_217, NULL},
+	{ sr_apy_kemi_exec_func_218, NULL},
+	{ sr_apy_kemi_exec_func_219, NULL},
+	{ sr_apy_kemi_exec_func_220, NULL},
+	{ sr_apy_kemi_exec_func_221, NULL},
+	{ sr_apy_kemi_exec_func_222, NULL},
+	{ sr_apy_kemi_exec_func_223, NULL},
+	{ sr_apy_kemi_exec_func_224, NULL},
+	{ sr_apy_kemi_exec_func_225, NULL},
+	{ sr_apy_kemi_exec_func_226, NULL},
+	{ sr_apy_kemi_exec_func_227, NULL},
+	{ sr_apy_kemi_exec_func_228, NULL},
+	{ sr_apy_kemi_exec_func_229, NULL},
+	{ sr_apy_kemi_exec_func_230, NULL},
+	{ sr_apy_kemi_exec_func_231, NULL},
+	{ sr_apy_kemi_exec_func_232, NULL},
+	{ sr_apy_kemi_exec_func_233, NULL},
+	{ sr_apy_kemi_exec_func_234, NULL},
+	{ sr_apy_kemi_exec_func_235, NULL},
+	{ sr_apy_kemi_exec_func_236, NULL},
+	{ sr_apy_kemi_exec_func_237, NULL},
+	{ sr_apy_kemi_exec_func_238, NULL},
+	{ sr_apy_kemi_exec_func_239, NULL},
+	{ sr_apy_kemi_exec_func_240, NULL},
+	{ sr_apy_kemi_exec_func_241, NULL},
+	{ sr_apy_kemi_exec_func_242, NULL},
+	{ sr_apy_kemi_exec_func_243, NULL},
+	{ sr_apy_kemi_exec_func_244, NULL},
+	{ sr_apy_kemi_exec_func_245, NULL},
+	{ sr_apy_kemi_exec_func_246, NULL},
+	{ sr_apy_kemi_exec_func_247, NULL},
+	{ sr_apy_kemi_exec_func_248, NULL},
+	{ sr_apy_kemi_exec_func_249, NULL},
+	{ sr_apy_kemi_exec_func_250, NULL},
+	{ sr_apy_kemi_exec_func_251, NULL},
+	{ sr_apy_kemi_exec_func_252, NULL},
+	{ sr_apy_kemi_exec_func_253, NULL},
+	{ sr_apy_kemi_exec_func_254, NULL},
+	{ sr_apy_kemi_exec_func_255, NULL},
+	{ sr_apy_kemi_exec_func_256, NULL},
+	{ sr_apy_kemi_exec_func_257, NULL},
+	{ sr_apy_kemi_exec_func_258, NULL},
+	{ sr_apy_kemi_exec_func_259, NULL},
+	{ sr_apy_kemi_exec_func_260, NULL},
+	{ sr_apy_kemi_exec_func_261, NULL},
+	{ sr_apy_kemi_exec_func_262, NULL},
+	{ sr_apy_kemi_exec_func_263, NULL},
+	{ sr_apy_kemi_exec_func_264, NULL},
+	{ sr_apy_kemi_exec_func_265, NULL},
+	{ sr_apy_kemi_exec_func_266, NULL},
+	{ sr_apy_kemi_exec_func_267, NULL},
+	{ sr_apy_kemi_exec_func_268, NULL},
+	{ sr_apy_kemi_exec_func_269, NULL},
+	{ sr_apy_kemi_exec_func_270, NULL},
+	{ sr_apy_kemi_exec_func_271, NULL},
+	{ sr_apy_kemi_exec_func_272, NULL},
+	{ sr_apy_kemi_exec_func_273, NULL},
+	{ sr_apy_kemi_exec_func_274, NULL},
+	{ sr_apy_kemi_exec_func_275, NULL},
+	{ sr_apy_kemi_exec_func_276, NULL},
+	{ sr_apy_kemi_exec_func_277, NULL},
+	{ sr_apy_kemi_exec_func_278, NULL},
+	{ sr_apy_kemi_exec_func_279, NULL},
+	{ sr_apy_kemi_exec_func_280, NULL},
+	{ sr_apy_kemi_exec_func_281, NULL},
+	{ sr_apy_kemi_exec_func_282, NULL},
+	{ sr_apy_kemi_exec_func_283, NULL},
+	{ sr_apy_kemi_exec_func_284, NULL},
+	{ sr_apy_kemi_exec_func_285, NULL},
+	{ sr_apy_kemi_exec_func_286, NULL},
+	{ sr_apy_kemi_exec_func_287, NULL},
+	{ sr_apy_kemi_exec_func_288, NULL},
+	{ sr_apy_kemi_exec_func_289, NULL},
+	{ sr_apy_kemi_exec_func_290, NULL},
+	{ sr_apy_kemi_exec_func_291, NULL},
+	{ sr_apy_kemi_exec_func_292, NULL},
+	{ sr_apy_kemi_exec_func_293, NULL},
+	{ sr_apy_kemi_exec_func_294, NULL},
+	{ sr_apy_kemi_exec_func_295, NULL},
+	{ sr_apy_kemi_exec_func_296, NULL},
+	{ sr_apy_kemi_exec_func_297, NULL},
+	{ sr_apy_kemi_exec_func_298, NULL},
+	{ sr_apy_kemi_exec_func_299, NULL},
+	{ sr_apy_kemi_exec_func_300, NULL},
+	{ sr_apy_kemi_exec_func_301, NULL},
+	{ sr_apy_kemi_exec_func_302, NULL},
+	{ sr_apy_kemi_exec_func_303, NULL},
+	{ sr_apy_kemi_exec_func_304, NULL},
+	{ sr_apy_kemi_exec_func_305, NULL},
+	{ sr_apy_kemi_exec_func_306, NULL},
+	{ sr_apy_kemi_exec_func_307, NULL},
+	{ sr_apy_kemi_exec_func_308, NULL},
+	{ sr_apy_kemi_exec_func_309, NULL},
+	{ sr_apy_kemi_exec_func_310, NULL},
+	{ sr_apy_kemi_exec_func_311, NULL},
+	{ sr_apy_kemi_exec_func_312, NULL},
+	{ sr_apy_kemi_exec_func_313, NULL},
+	{ sr_apy_kemi_exec_func_314, NULL},
+	{ sr_apy_kemi_exec_func_315, NULL},
+	{ sr_apy_kemi_exec_func_316, NULL},
+	{ sr_apy_kemi_exec_func_317, NULL},
+	{ sr_apy_kemi_exec_func_318, NULL},
+	{ sr_apy_kemi_exec_func_319, NULL},
+	{ sr_apy_kemi_exec_func_320, NULL},
+	{ sr_apy_kemi_exec_func_321, NULL},
+	{ sr_apy_kemi_exec_func_322, NULL},
+	{ sr_apy_kemi_exec_func_323, NULL},
+	{ sr_apy_kemi_exec_func_324, NULL},
+	{ sr_apy_kemi_exec_func_325, NULL},
+	{ sr_apy_kemi_exec_func_326, NULL},
+	{ sr_apy_kemi_exec_func_327, NULL},
+	{ sr_apy_kemi_exec_func_328, NULL},
+	{ sr_apy_kemi_exec_func_329, NULL},
+	{ sr_apy_kemi_exec_func_330, NULL},
+	{ sr_apy_kemi_exec_func_331, NULL},
+	{ sr_apy_kemi_exec_func_332, NULL},
+	{ sr_apy_kemi_exec_func_333, NULL},
+	{ sr_apy_kemi_exec_func_334, NULL},
+	{ sr_apy_kemi_exec_func_335, NULL},
+	{ sr_apy_kemi_exec_func_336, NULL},
+	{ sr_apy_kemi_exec_func_337, NULL},
+	{ sr_apy_kemi_exec_func_338, NULL},
+	{ sr_apy_kemi_exec_func_339, NULL},
+	{ sr_apy_kemi_exec_func_340, NULL},
+	{ sr_apy_kemi_exec_func_341, NULL},
+	{ sr_apy_kemi_exec_func_342, NULL},
+	{ sr_apy_kemi_exec_func_343, NULL},
+	{ sr_apy_kemi_exec_func_344, NULL},
+	{ sr_apy_kemi_exec_func_345, NULL},
+	{ sr_apy_kemi_exec_func_346, NULL},
+	{ sr_apy_kemi_exec_func_347, NULL},
+	{ sr_apy_kemi_exec_func_348, NULL},
+	{ sr_apy_kemi_exec_func_349, NULL},
+	{ sr_apy_kemi_exec_func_350, NULL},
+	{ sr_apy_kemi_exec_func_351, NULL},
+	{ sr_apy_kemi_exec_func_352, NULL},
+	{ sr_apy_kemi_exec_func_353, NULL},
+	{ sr_apy_kemi_exec_func_354, NULL},
+	{ sr_apy_kemi_exec_func_355, NULL},
+	{ sr_apy_kemi_exec_func_356, NULL},
+	{ sr_apy_kemi_exec_func_357, NULL},
+	{ sr_apy_kemi_exec_func_358, NULL},
+	{ sr_apy_kemi_exec_func_359, NULL},
+	{ sr_apy_kemi_exec_func_360, NULL},
+	{ sr_apy_kemi_exec_func_361, NULL},
+	{ sr_apy_kemi_exec_func_362, NULL},
+	{ sr_apy_kemi_exec_func_363, NULL},
+	{ sr_apy_kemi_exec_func_364, NULL},
+	{ sr_apy_kemi_exec_func_365, NULL},
+	{ sr_apy_kemi_exec_func_366, NULL},
+	{ sr_apy_kemi_exec_func_367, NULL},
+	{ sr_apy_kemi_exec_func_368, NULL},
+	{ sr_apy_kemi_exec_func_369, NULL},
+	{ sr_apy_kemi_exec_func_370, NULL},
+	{ sr_apy_kemi_exec_func_371, NULL},
+	{ sr_apy_kemi_exec_func_372, NULL},
+	{ sr_apy_kemi_exec_func_373, NULL},
+	{ sr_apy_kemi_exec_func_374, NULL},
+	{ sr_apy_kemi_exec_func_375, NULL},
+	{ sr_apy_kemi_exec_func_376, NULL},
+	{ sr_apy_kemi_exec_func_377, NULL},
+	{ sr_apy_kemi_exec_func_378, NULL},
+	{ sr_apy_kemi_exec_func_379, NULL},
+	{ sr_apy_kemi_exec_func_380, NULL},
+	{ sr_apy_kemi_exec_func_381, NULL},
+	{ sr_apy_kemi_exec_func_382, NULL},
+	{ sr_apy_kemi_exec_func_383, NULL},
+	{ sr_apy_kemi_exec_func_384, NULL},
+	{ sr_apy_kemi_exec_func_385, NULL},
+	{ sr_apy_kemi_exec_func_386, NULL},
+	{ sr_apy_kemi_exec_func_387, NULL},
+	{ sr_apy_kemi_exec_func_388, NULL},
+	{ sr_apy_kemi_exec_func_389, NULL},
+	{ sr_apy_kemi_exec_func_390, NULL},
+	{ sr_apy_kemi_exec_func_391, NULL},
+	{ sr_apy_kemi_exec_func_392, NULL},
+	{ sr_apy_kemi_exec_func_393, NULL},
+	{ sr_apy_kemi_exec_func_394, NULL},
+	{ sr_apy_kemi_exec_func_395, NULL},
+	{ sr_apy_kemi_exec_func_396, NULL},
+	{ sr_apy_kemi_exec_func_397, NULL},
+	{ sr_apy_kemi_exec_func_398, NULL},
+	{ sr_apy_kemi_exec_func_399, NULL},
+	{ sr_apy_kemi_exec_func_400, NULL},
+	{ sr_apy_kemi_exec_func_401, NULL},
+	{ sr_apy_kemi_exec_func_402, NULL},
+	{ sr_apy_kemi_exec_func_403, NULL},
+	{ sr_apy_kemi_exec_func_404, NULL},
+	{ sr_apy_kemi_exec_func_405, NULL},
+	{ sr_apy_kemi_exec_func_406, NULL},
+	{ sr_apy_kemi_exec_func_407, NULL},
+	{ sr_apy_kemi_exec_func_408, NULL},
+	{ sr_apy_kemi_exec_func_409, NULL},
+	{ sr_apy_kemi_exec_func_410, NULL},
+	{ sr_apy_kemi_exec_func_411, NULL},
+	{ sr_apy_kemi_exec_func_412, NULL},
+	{ sr_apy_kemi_exec_func_413, NULL},
+	{ sr_apy_kemi_exec_func_414, NULL},
+	{ sr_apy_kemi_exec_func_415, NULL},
+	{ sr_apy_kemi_exec_func_416, NULL},
+	{ sr_apy_kemi_exec_func_417, NULL},
+	{ sr_apy_kemi_exec_func_418, NULL},
+	{ sr_apy_kemi_exec_func_419, NULL},
+	{ sr_apy_kemi_exec_func_420, NULL},
+	{ sr_apy_kemi_exec_func_421, NULL},
+	{ sr_apy_kemi_exec_func_422, NULL},
+	{ sr_apy_kemi_exec_func_423, NULL},
+	{ sr_apy_kemi_exec_func_424, NULL},
+	{ sr_apy_kemi_exec_func_425, NULL},
+	{ sr_apy_kemi_exec_func_426, NULL},
+	{ sr_apy_kemi_exec_func_427, NULL},
+	{ sr_apy_kemi_exec_func_428, NULL},
+	{ sr_apy_kemi_exec_func_429, NULL},
+	{ sr_apy_kemi_exec_func_430, NULL},
+	{ sr_apy_kemi_exec_func_431, NULL},
+	{ sr_apy_kemi_exec_func_432, NULL},
+	{ sr_apy_kemi_exec_func_433, NULL},
+	{ sr_apy_kemi_exec_func_434, NULL},
+	{ sr_apy_kemi_exec_func_435, NULL},
+	{ sr_apy_kemi_exec_func_436, NULL},
+	{ sr_apy_kemi_exec_func_437, NULL},
+	{ sr_apy_kemi_exec_func_438, NULL},
+	{ sr_apy_kemi_exec_func_439, NULL},
+	{ sr_apy_kemi_exec_func_440, NULL},
+	{ sr_apy_kemi_exec_func_441, NULL},
+	{ sr_apy_kemi_exec_func_442, NULL},
+	{ sr_apy_kemi_exec_func_443, NULL},
+	{ sr_apy_kemi_exec_func_444, NULL},
+	{ sr_apy_kemi_exec_func_445, NULL},
+	{ sr_apy_kemi_exec_func_446, NULL},
+	{ sr_apy_kemi_exec_func_447, NULL},
+	{ sr_apy_kemi_exec_func_448, NULL},
+	{ sr_apy_kemi_exec_func_449, NULL},
+	{ sr_apy_kemi_exec_func_450, NULL},
+	{ sr_apy_kemi_exec_func_451, NULL},
+	{ sr_apy_kemi_exec_func_452, NULL},
+	{ sr_apy_kemi_exec_func_453, NULL},
+	{ sr_apy_kemi_exec_func_454, NULL},
+	{ sr_apy_kemi_exec_func_455, NULL},
+	{ sr_apy_kemi_exec_func_456, NULL},
+	{ sr_apy_kemi_exec_func_457, NULL},
+	{ sr_apy_kemi_exec_func_458, NULL},
+	{ sr_apy_kemi_exec_func_459, NULL},
+	{ sr_apy_kemi_exec_func_460, NULL},
+	{ sr_apy_kemi_exec_func_461, NULL},
+	{ sr_apy_kemi_exec_func_462, NULL},
+	{ sr_apy_kemi_exec_func_463, NULL},
+	{ sr_apy_kemi_exec_func_464, NULL},
+	{ sr_apy_kemi_exec_func_465, NULL},
+	{ sr_apy_kemi_exec_func_466, NULL},
+	{ sr_apy_kemi_exec_func_467, NULL},
+	{ sr_apy_kemi_exec_func_468, NULL},
+	{ sr_apy_kemi_exec_func_469, NULL},
+	{ sr_apy_kemi_exec_func_470, NULL},
+	{ sr_apy_kemi_exec_func_471, NULL},
+	{ sr_apy_kemi_exec_func_472, NULL},
+	{ sr_apy_kemi_exec_func_473, NULL},
+	{ sr_apy_kemi_exec_func_474, NULL},
+	{ sr_apy_kemi_exec_func_475, NULL},
+	{ sr_apy_kemi_exec_func_476, NULL},
+	{ sr_apy_kemi_exec_func_477, NULL},
+	{ sr_apy_kemi_exec_func_478, NULL},
+	{ sr_apy_kemi_exec_func_479, NULL},
+	{ sr_apy_kemi_exec_func_480, NULL},
+	{ sr_apy_kemi_exec_func_481, NULL},
+	{ sr_apy_kemi_exec_func_482, NULL},
+	{ sr_apy_kemi_exec_func_483, NULL},
+	{ sr_apy_kemi_exec_func_484, NULL},
+	{ sr_apy_kemi_exec_func_485, NULL},
+	{ sr_apy_kemi_exec_func_486, NULL},
+	{ sr_apy_kemi_exec_func_487, NULL},
+	{ sr_apy_kemi_exec_func_488, NULL},
+	{ sr_apy_kemi_exec_func_489, NULL},
+	{ sr_apy_kemi_exec_func_490, NULL},
+	{ sr_apy_kemi_exec_func_491, NULL},
+	{ sr_apy_kemi_exec_func_492, NULL},
+	{ sr_apy_kemi_exec_func_493, NULL},
+	{ sr_apy_kemi_exec_func_494, NULL},
+	{ sr_apy_kemi_exec_func_495, NULL},
+	{ sr_apy_kemi_exec_func_496, NULL},
+	{ sr_apy_kemi_exec_func_497, NULL},
+	{ sr_apy_kemi_exec_func_498, NULL},
+	{ sr_apy_kemi_exec_func_499, NULL},
+	{ sr_apy_kemi_exec_func_500, NULL},
+	{ sr_apy_kemi_exec_func_501, NULL},
+	{ sr_apy_kemi_exec_func_502, NULL},
+	{ sr_apy_kemi_exec_func_503, NULL},
+	{ sr_apy_kemi_exec_func_504, NULL},
+	{ sr_apy_kemi_exec_func_505, NULL},
+	{ sr_apy_kemi_exec_func_506, NULL},
+	{ sr_apy_kemi_exec_func_507, NULL},
+	{ sr_apy_kemi_exec_func_508, NULL},
+	{ sr_apy_kemi_exec_func_509, NULL},
+	{ sr_apy_kemi_exec_func_510, NULL},
+	{ sr_apy_kemi_exec_func_511, NULL},
+	{ sr_apy_kemi_exec_func_512, NULL},
+	{ sr_apy_kemi_exec_func_513, NULL},
+	{ sr_apy_kemi_exec_func_514, NULL},
+	{ sr_apy_kemi_exec_func_515, NULL},
+	{ sr_apy_kemi_exec_func_516, NULL},
+	{ sr_apy_kemi_exec_func_517, NULL},
+	{ sr_apy_kemi_exec_func_518, NULL},
+	{ sr_apy_kemi_exec_func_519, NULL},
+	{ sr_apy_kemi_exec_func_520, NULL},
+	{ sr_apy_kemi_exec_func_521, NULL},
+	{ sr_apy_kemi_exec_func_522, NULL},
+	{ sr_apy_kemi_exec_func_523, NULL},
+	{ sr_apy_kemi_exec_func_524, NULL},
+	{ sr_apy_kemi_exec_func_525, NULL},
+	{ sr_apy_kemi_exec_func_526, NULL},
+	{ sr_apy_kemi_exec_func_527, NULL},
+	{ sr_apy_kemi_exec_func_528, NULL},
+	{ sr_apy_kemi_exec_func_529, NULL},
+	{ sr_apy_kemi_exec_func_530, NULL},
+	{ sr_apy_kemi_exec_func_531, NULL},
+	{ sr_apy_kemi_exec_func_532, NULL},
+	{ sr_apy_kemi_exec_func_533, NULL},
+	{ sr_apy_kemi_exec_func_534, NULL},
+	{ sr_apy_kemi_exec_func_535, NULL},
+	{ sr_apy_kemi_exec_func_536, NULL},
+	{ sr_apy_kemi_exec_func_537, NULL},
+	{ sr_apy_kemi_exec_func_538, NULL},
+	{ sr_apy_kemi_exec_func_539, NULL},
+	{ sr_apy_kemi_exec_func_540, NULL},
+	{ sr_apy_kemi_exec_func_541, NULL},
+	{ sr_apy_kemi_exec_func_542, NULL},
+	{ sr_apy_kemi_exec_func_543, NULL},
+	{ sr_apy_kemi_exec_func_544, NULL},
+	{ sr_apy_kemi_exec_func_545, NULL},
+	{ sr_apy_kemi_exec_func_546, NULL},
+	{ sr_apy_kemi_exec_func_547, NULL},
+	{ sr_apy_kemi_exec_func_548, NULL},
+	{ sr_apy_kemi_exec_func_549, NULL},
+	{ sr_apy_kemi_exec_func_550, NULL},
+	{ sr_apy_kemi_exec_func_551, NULL},
+	{ sr_apy_kemi_exec_func_552, NULL},
+	{ sr_apy_kemi_exec_func_553, NULL},
+	{ sr_apy_kemi_exec_func_554, NULL},
+	{ sr_apy_kemi_exec_func_555, NULL},
+	{ sr_apy_kemi_exec_func_556, NULL},
+	{ sr_apy_kemi_exec_func_557, NULL},
+	{ sr_apy_kemi_exec_func_558, NULL},
+	{ sr_apy_kemi_exec_func_559, NULL},
+	{ sr_apy_kemi_exec_func_560, NULL},
+	{ sr_apy_kemi_exec_func_561, NULL},
+	{ sr_apy_kemi_exec_func_562, NULL},
+	{ sr_apy_kemi_exec_func_563, NULL},
+	{ sr_apy_kemi_exec_func_564, NULL},
+	{ sr_apy_kemi_exec_func_565, NULL},
+	{ sr_apy_kemi_exec_func_566, NULL},
+	{ sr_apy_kemi_exec_func_567, NULL},
+	{ sr_apy_kemi_exec_func_568, NULL},
+	{ sr_apy_kemi_exec_func_569, NULL},
+	{ sr_apy_kemi_exec_func_570, NULL},
+	{ sr_apy_kemi_exec_func_571, NULL},
+	{ sr_apy_kemi_exec_func_572, NULL},
+	{ sr_apy_kemi_exec_func_573, NULL},
+	{ sr_apy_kemi_exec_func_574, NULL},
+	{ sr_apy_kemi_exec_func_575, NULL},
+	{ sr_apy_kemi_exec_func_576, NULL},
+	{ sr_apy_kemi_exec_func_577, NULL},
+	{ sr_apy_kemi_exec_func_578, NULL},
+	{ sr_apy_kemi_exec_func_579, NULL},
+	{ sr_apy_kemi_exec_func_580, NULL},
+	{ sr_apy_kemi_exec_func_581, NULL},
+	{ sr_apy_kemi_exec_func_582, NULL},
+	{ sr_apy_kemi_exec_func_583, NULL},
+	{ sr_apy_kemi_exec_func_584, NULL},
+	{ sr_apy_kemi_exec_func_585, NULL},
+	{ sr_apy_kemi_exec_func_586, NULL},
+	{ sr_apy_kemi_exec_func_587, NULL},
+	{ sr_apy_kemi_exec_func_588, NULL},
+	{ sr_apy_kemi_exec_func_589, NULL},
+	{ sr_apy_kemi_exec_func_590, NULL},
+	{ sr_apy_kemi_exec_func_591, NULL},
+	{ sr_apy_kemi_exec_func_592, NULL},
+	{ sr_apy_kemi_exec_func_593, NULL},
+	{ sr_apy_kemi_exec_func_594, NULL},
+	{ sr_apy_kemi_exec_func_595, NULL},
+	{ sr_apy_kemi_exec_func_596, NULL},
+	{ sr_apy_kemi_exec_func_597, NULL},
+	{ sr_apy_kemi_exec_func_598, NULL},
+	{ sr_apy_kemi_exec_func_599, NULL},
+	{ sr_apy_kemi_exec_func_600, NULL},
+	{ sr_apy_kemi_exec_func_601, NULL},
+	{ sr_apy_kemi_exec_func_602, NULL},
+	{ sr_apy_kemi_exec_func_603, NULL},
+	{ sr_apy_kemi_exec_func_604, NULL},
+	{ sr_apy_kemi_exec_func_605, NULL},
+	{ sr_apy_kemi_exec_func_606, NULL},
+	{ sr_apy_kemi_exec_func_607, NULL},
+	{ sr_apy_kemi_exec_func_608, NULL},
+	{ sr_apy_kemi_exec_func_609, NULL},
+	{ sr_apy_kemi_exec_func_610, NULL},
+	{ sr_apy_kemi_exec_func_611, NULL},
+	{ sr_apy_kemi_exec_func_612, NULL},
+	{ sr_apy_kemi_exec_func_613, NULL},
+	{ sr_apy_kemi_exec_func_614, NULL},
+	{ sr_apy_kemi_exec_func_615, NULL},
+	{ sr_apy_kemi_exec_func_616, NULL},
+	{ sr_apy_kemi_exec_func_617, NULL},
+	{ sr_apy_kemi_exec_func_618, NULL},
+	{ sr_apy_kemi_exec_func_619, NULL},
+	{ sr_apy_kemi_exec_func_620, NULL},
+	{ sr_apy_kemi_exec_func_621, NULL},
+	{ sr_apy_kemi_exec_func_622, NULL},
+	{ sr_apy_kemi_exec_func_623, NULL},
+	{ sr_apy_kemi_exec_func_624, NULL},
+	{ sr_apy_kemi_exec_func_625, NULL},
+	{ sr_apy_kemi_exec_func_626, NULL},
+	{ sr_apy_kemi_exec_func_627, NULL},
+	{ sr_apy_kemi_exec_func_628, NULL},
+	{ sr_apy_kemi_exec_func_629, NULL},
+	{ sr_apy_kemi_exec_func_630, NULL},
+	{ sr_apy_kemi_exec_func_631, NULL},
+	{ sr_apy_kemi_exec_func_632, NULL},
+	{ sr_apy_kemi_exec_func_633, NULL},
+	{ sr_apy_kemi_exec_func_634, NULL},
+	{ sr_apy_kemi_exec_func_635, NULL},
+	{ sr_apy_kemi_exec_func_636, NULL},
+	{ sr_apy_kemi_exec_func_637, NULL},
+	{ sr_apy_kemi_exec_func_638, NULL},
+	{ sr_apy_kemi_exec_func_639, NULL},
+	{ sr_apy_kemi_exec_func_640, NULL},
+	{ sr_apy_kemi_exec_func_641, NULL},
+	{ sr_apy_kemi_exec_func_642, NULL},
+	{ sr_apy_kemi_exec_func_643, NULL},
+	{ sr_apy_kemi_exec_func_644, NULL},
+	{ sr_apy_kemi_exec_func_645, NULL},
+	{ sr_apy_kemi_exec_func_646, NULL},
+	{ sr_apy_kemi_exec_func_647, NULL},
+	{ sr_apy_kemi_exec_func_648, NULL},
+	{ sr_apy_kemi_exec_func_649, NULL},
+	{ sr_apy_kemi_exec_func_650, NULL},
+	{ sr_apy_kemi_exec_func_651, NULL},
+	{ sr_apy_kemi_exec_func_652, NULL},
+	{ sr_apy_kemi_exec_func_653, NULL},
+	{ sr_apy_kemi_exec_func_654, NULL},
+	{ sr_apy_kemi_exec_func_655, NULL},
+	{ sr_apy_kemi_exec_func_656, NULL},
+	{ sr_apy_kemi_exec_func_657, NULL},
+	{ sr_apy_kemi_exec_func_658, NULL},
+	{ sr_apy_kemi_exec_func_659, NULL},
+	{ sr_apy_kemi_exec_func_660, NULL},
+	{ sr_apy_kemi_exec_func_661, NULL},
+	{ sr_apy_kemi_exec_func_662, NULL},
+	{ sr_apy_kemi_exec_func_663, NULL},
+	{ sr_apy_kemi_exec_func_664, NULL},
+	{ sr_apy_kemi_exec_func_665, NULL},
+	{ sr_apy_kemi_exec_func_666, NULL},
+	{ sr_apy_kemi_exec_func_667, NULL},
+	{ sr_apy_kemi_exec_func_668, NULL},
+	{ sr_apy_kemi_exec_func_669, NULL},
+	{ sr_apy_kemi_exec_func_670, NULL},
+	{ sr_apy_kemi_exec_func_671, NULL},
+	{ sr_apy_kemi_exec_func_672, NULL},
+	{ sr_apy_kemi_exec_func_673, NULL},
+	{ sr_apy_kemi_exec_func_674, NULL},
+	{ sr_apy_kemi_exec_func_675, NULL},
+	{ sr_apy_kemi_exec_func_676, NULL},
+	{ sr_apy_kemi_exec_func_677, NULL},
+	{ sr_apy_kemi_exec_func_678, NULL},
+	{ sr_apy_kemi_exec_func_679, NULL},
+	{ sr_apy_kemi_exec_func_680, NULL},
+	{ sr_apy_kemi_exec_func_681, NULL},
+	{ sr_apy_kemi_exec_func_682, NULL},
+	{ sr_apy_kemi_exec_func_683, NULL},
+	{ sr_apy_kemi_exec_func_684, NULL},
+	{ sr_apy_kemi_exec_func_685, NULL},
+	{ sr_apy_kemi_exec_func_686, NULL},
+	{ sr_apy_kemi_exec_func_687, NULL},
+	{ sr_apy_kemi_exec_func_688, NULL},
+	{ sr_apy_kemi_exec_func_689, NULL},
+	{ sr_apy_kemi_exec_func_690, NULL},
+	{ sr_apy_kemi_exec_func_691, NULL},
+	{ sr_apy_kemi_exec_func_692, NULL},
+	{ sr_apy_kemi_exec_func_693, NULL},
+	{ sr_apy_kemi_exec_func_694, NULL},
+	{ sr_apy_kemi_exec_func_695, NULL},
+	{ sr_apy_kemi_exec_func_696, NULL},
+	{ sr_apy_kemi_exec_func_697, NULL},
+	{ sr_apy_kemi_exec_func_698, NULL},
+	{ sr_apy_kemi_exec_func_699, NULL},
+	{ sr_apy_kemi_exec_func_700, NULL},
+	{ sr_apy_kemi_exec_func_701, NULL},
+	{ sr_apy_kemi_exec_func_702, NULL},
+	{ sr_apy_kemi_exec_func_703, NULL},
+	{ sr_apy_kemi_exec_func_704, NULL},
+	{ sr_apy_kemi_exec_func_705, NULL},
+	{ sr_apy_kemi_exec_func_706, NULL},
+	{ sr_apy_kemi_exec_func_707, NULL},
+	{ sr_apy_kemi_exec_func_708, NULL},
+	{ sr_apy_kemi_exec_func_709, NULL},
+	{ sr_apy_kemi_exec_func_710, NULL},
+	{ sr_apy_kemi_exec_func_711, NULL},
+	{ sr_apy_kemi_exec_func_712, NULL},
+	{ sr_apy_kemi_exec_func_713, NULL},
+	{ sr_apy_kemi_exec_func_714, NULL},
+	{ sr_apy_kemi_exec_func_715, NULL},
+	{ sr_apy_kemi_exec_func_716, NULL},
+	{ sr_apy_kemi_exec_func_717, NULL},
+	{ sr_apy_kemi_exec_func_718, NULL},
+	{ sr_apy_kemi_exec_func_719, NULL},
+	{ sr_apy_kemi_exec_func_720, NULL},
+	{ sr_apy_kemi_exec_func_721, NULL},
+	{ sr_apy_kemi_exec_func_722, NULL},
+	{ sr_apy_kemi_exec_func_723, NULL},
+	{ sr_apy_kemi_exec_func_724, NULL},
+	{ sr_apy_kemi_exec_func_725, NULL},
+	{ sr_apy_kemi_exec_func_726, NULL},
+	{ sr_apy_kemi_exec_func_727, NULL},
+	{ sr_apy_kemi_exec_func_728, NULL},
+	{ sr_apy_kemi_exec_func_729, NULL},
+	{ sr_apy_kemi_exec_func_730, NULL},
+	{ sr_apy_kemi_exec_func_731, NULL},
+	{ sr_apy_kemi_exec_func_732, NULL},
+	{ sr_apy_kemi_exec_func_733, NULL},
+	{ sr_apy_kemi_exec_func_734, NULL},
+	{ sr_apy_kemi_exec_func_735, NULL},
+	{ sr_apy_kemi_exec_func_736, NULL},
+	{ sr_apy_kemi_exec_func_737, NULL},
+	{ sr_apy_kemi_exec_func_738, NULL},
+	{ sr_apy_kemi_exec_func_739, NULL},
+	{ sr_apy_kemi_exec_func_740, NULL},
+	{ sr_apy_kemi_exec_func_741, NULL},
+	{ sr_apy_kemi_exec_func_742, NULL},
+	{ sr_apy_kemi_exec_func_743, NULL},
+	{ sr_apy_kemi_exec_func_744, NULL},
+	{ sr_apy_kemi_exec_func_745, NULL},
+	{ sr_apy_kemi_exec_func_746, NULL},
+	{ sr_apy_kemi_exec_func_747, NULL},
+	{ sr_apy_kemi_exec_func_748, NULL},
+	{ sr_apy_kemi_exec_func_749, NULL},
+	{ sr_apy_kemi_exec_func_750, NULL},
+	{ sr_apy_kemi_exec_func_751, NULL},
+	{ sr_apy_kemi_exec_func_752, NULL},
+	{ sr_apy_kemi_exec_func_753, NULL},
+	{ sr_apy_kemi_exec_func_754, NULL},
+	{ sr_apy_kemi_exec_func_755, NULL},
+	{ sr_apy_kemi_exec_func_756, NULL},
+	{ sr_apy_kemi_exec_func_757, NULL},
+	{ sr_apy_kemi_exec_func_758, NULL},
+	{ sr_apy_kemi_exec_func_759, NULL},
+	{ sr_apy_kemi_exec_func_760, NULL},
+	{ sr_apy_kemi_exec_func_761, NULL},
+	{ sr_apy_kemi_exec_func_762, NULL},
+	{ sr_apy_kemi_exec_func_763, NULL},
+	{ sr_apy_kemi_exec_func_764, NULL},
+	{ sr_apy_kemi_exec_func_765, NULL},
+	{ sr_apy_kemi_exec_func_766, NULL},
+	{ sr_apy_kemi_exec_func_767, NULL},
+	{ sr_apy_kemi_exec_func_768, NULL},
+	{ sr_apy_kemi_exec_func_769, NULL},
+	{ sr_apy_kemi_exec_func_770, NULL},
+	{ sr_apy_kemi_exec_func_771, NULL},
+	{ sr_apy_kemi_exec_func_772, NULL},
+	{ sr_apy_kemi_exec_func_773, NULL},
+	{ sr_apy_kemi_exec_func_774, NULL},
+	{ sr_apy_kemi_exec_func_775, NULL},
+	{ sr_apy_kemi_exec_func_776, NULL},
+	{ sr_apy_kemi_exec_func_777, NULL},
+	{ sr_apy_kemi_exec_func_778, NULL},
+	{ sr_apy_kemi_exec_func_779, NULL},
+	{ sr_apy_kemi_exec_func_780, NULL},
+	{ sr_apy_kemi_exec_func_781, NULL},
+	{ sr_apy_kemi_exec_func_782, NULL},
+	{ sr_apy_kemi_exec_func_783, NULL},
+	{ sr_apy_kemi_exec_func_784, NULL},
+	{ sr_apy_kemi_exec_func_785, NULL},
+	{ sr_apy_kemi_exec_func_786, NULL},
+	{ sr_apy_kemi_exec_func_787, NULL},
+	{ sr_apy_kemi_exec_func_788, NULL},
+	{ sr_apy_kemi_exec_func_789, NULL},
+	{ sr_apy_kemi_exec_func_790, NULL},
+	{ sr_apy_kemi_exec_func_791, NULL},
+	{ sr_apy_kemi_exec_func_792, NULL},
+	{ sr_apy_kemi_exec_func_793, NULL},
+	{ sr_apy_kemi_exec_func_794, NULL},
+	{ sr_apy_kemi_exec_func_795, NULL},
+	{ sr_apy_kemi_exec_func_796, NULL},
+	{ sr_apy_kemi_exec_func_797, NULL},
+	{ sr_apy_kemi_exec_func_798, NULL},
+	{ sr_apy_kemi_exec_func_799, NULL},
+	{ sr_apy_kemi_exec_func_800, NULL},
+	{ sr_apy_kemi_exec_func_801, NULL},
+	{ sr_apy_kemi_exec_func_802, NULL},
+	{ sr_apy_kemi_exec_func_803, NULL},
+	{ sr_apy_kemi_exec_func_804, NULL},
+	{ sr_apy_kemi_exec_func_805, NULL},
+	{ sr_apy_kemi_exec_func_806, NULL},
+	{ sr_apy_kemi_exec_func_807, NULL},
+	{ sr_apy_kemi_exec_func_808, NULL},
+	{ sr_apy_kemi_exec_func_809, NULL},
+	{ sr_apy_kemi_exec_func_810, NULL},
+	{ sr_apy_kemi_exec_func_811, NULL},
+	{ sr_apy_kemi_exec_func_812, NULL},
+	{ sr_apy_kemi_exec_func_813, NULL},
+	{ sr_apy_kemi_exec_func_814, NULL},
+	{ sr_apy_kemi_exec_func_815, NULL},
+	{ sr_apy_kemi_exec_func_816, NULL},
+	{ sr_apy_kemi_exec_func_817, NULL},
+	{ sr_apy_kemi_exec_func_818, NULL},
+	{ sr_apy_kemi_exec_func_819, NULL},
+	{ sr_apy_kemi_exec_func_820, NULL},
+	{ sr_apy_kemi_exec_func_821, NULL},
+	{ sr_apy_kemi_exec_func_822, NULL},
+	{ sr_apy_kemi_exec_func_823, NULL},
+	{ sr_apy_kemi_exec_func_824, NULL},
+	{ sr_apy_kemi_exec_func_825, NULL},
+	{ sr_apy_kemi_exec_func_826, NULL},
+	{ sr_apy_kemi_exec_func_827, NULL},
+	{ sr_apy_kemi_exec_func_828, NULL},
+	{ sr_apy_kemi_exec_func_829, NULL},
+	{ sr_apy_kemi_exec_func_830, NULL},
+	{ sr_apy_kemi_exec_func_831, NULL},
+	{ sr_apy_kemi_exec_func_832, NULL},
+	{ sr_apy_kemi_exec_func_833, NULL},
+	{ sr_apy_kemi_exec_func_834, NULL},
+	{ sr_apy_kemi_exec_func_835, NULL},
+	{ sr_apy_kemi_exec_func_836, NULL},
+	{ sr_apy_kemi_exec_func_837, NULL},
+	{ sr_apy_kemi_exec_func_838, NULL},
+	{ sr_apy_kemi_exec_func_839, NULL},
+	{ sr_apy_kemi_exec_func_840, NULL},
+	{ sr_apy_kemi_exec_func_841, NULL},
+	{ sr_apy_kemi_exec_func_842, NULL},
+	{ sr_apy_kemi_exec_func_843, NULL},
+	{ sr_apy_kemi_exec_func_844, NULL},
+	{ sr_apy_kemi_exec_func_845, NULL},
+	{ sr_apy_kemi_exec_func_846, NULL},
+	{ sr_apy_kemi_exec_func_847, NULL},
+	{ sr_apy_kemi_exec_func_848, NULL},
+	{ sr_apy_kemi_exec_func_849, NULL},
+	{ sr_apy_kemi_exec_func_850, NULL},
+	{ sr_apy_kemi_exec_func_851, NULL},
+	{ sr_apy_kemi_exec_func_852, NULL},
+	{ sr_apy_kemi_exec_func_853, NULL},
+	{ sr_apy_kemi_exec_func_854, NULL},
+	{ sr_apy_kemi_exec_func_855, NULL},
+	{ sr_apy_kemi_exec_func_856, NULL},
+	{ sr_apy_kemi_exec_func_857, NULL},
+	{ sr_apy_kemi_exec_func_858, NULL},
+	{ sr_apy_kemi_exec_func_859, NULL},
+	{ sr_apy_kemi_exec_func_860, NULL},
+	{ sr_apy_kemi_exec_func_861, NULL},
+	{ sr_apy_kemi_exec_func_862, NULL},
+	{ sr_apy_kemi_exec_func_863, NULL},
+	{ sr_apy_kemi_exec_func_864, NULL},
+	{ sr_apy_kemi_exec_func_865, NULL},
+	{ sr_apy_kemi_exec_func_866, NULL},
+	{ sr_apy_kemi_exec_func_867, NULL},
+	{ sr_apy_kemi_exec_func_868, NULL},
+	{ sr_apy_kemi_exec_func_869, NULL},
+	{ sr_apy_kemi_exec_func_870, NULL},
+	{ sr_apy_kemi_exec_func_871, NULL},
+	{ sr_apy_kemi_exec_func_872, NULL},
+	{ sr_apy_kemi_exec_func_873, NULL},
+	{ sr_apy_kemi_exec_func_874, NULL},
+	{ sr_apy_kemi_exec_func_875, NULL},
+	{ sr_apy_kemi_exec_func_876, NULL},
+	{ sr_apy_kemi_exec_func_877, NULL},
+	{ sr_apy_kemi_exec_func_878, NULL},
+	{ sr_apy_kemi_exec_func_879, NULL},
+	{ sr_apy_kemi_exec_func_880, NULL},
+	{ sr_apy_kemi_exec_func_881, NULL},
+	{ sr_apy_kemi_exec_func_882, NULL},
+	{ sr_apy_kemi_exec_func_883, NULL},
+	{ sr_apy_kemi_exec_func_884, NULL},
+	{ sr_apy_kemi_exec_func_885, NULL},
+	{ sr_apy_kemi_exec_func_886, NULL},
+	{ sr_apy_kemi_exec_func_887, NULL},
+	{ sr_apy_kemi_exec_func_888, NULL},
+	{ sr_apy_kemi_exec_func_889, NULL},
+	{ sr_apy_kemi_exec_func_890, NULL},
+	{ sr_apy_kemi_exec_func_891, NULL},
+	{ sr_apy_kemi_exec_func_892, NULL},
+	{ sr_apy_kemi_exec_func_893, NULL},
+	{ sr_apy_kemi_exec_func_894, NULL},
+	{ sr_apy_kemi_exec_func_895, NULL},
+	{ sr_apy_kemi_exec_func_896, NULL},
+	{ sr_apy_kemi_exec_func_897, NULL},
+	{ sr_apy_kemi_exec_func_898, NULL},
+	{ sr_apy_kemi_exec_func_899, NULL},
+	{ sr_apy_kemi_exec_func_900, NULL},
+	{ sr_apy_kemi_exec_func_901, NULL},
+	{ sr_apy_kemi_exec_func_902, NULL},
+	{ sr_apy_kemi_exec_func_903, NULL},
+	{ sr_apy_kemi_exec_func_904, NULL},
+	{ sr_apy_kemi_exec_func_905, NULL},
+	{ sr_apy_kemi_exec_func_906, NULL},
+	{ sr_apy_kemi_exec_func_907, NULL},
+	{ sr_apy_kemi_exec_func_908, NULL},
+	{ sr_apy_kemi_exec_func_909, NULL},
+	{ sr_apy_kemi_exec_func_910, NULL},
+	{ sr_apy_kemi_exec_func_911, NULL},
+	{ sr_apy_kemi_exec_func_912, NULL},
+	{ sr_apy_kemi_exec_func_913, NULL},
+	{ sr_apy_kemi_exec_func_914, NULL},
+	{ sr_apy_kemi_exec_func_915, NULL},
+	{ sr_apy_kemi_exec_func_916, NULL},
+	{ sr_apy_kemi_exec_func_917, NULL},
+	{ sr_apy_kemi_exec_func_918, NULL},
+	{ sr_apy_kemi_exec_func_919, NULL},
+	{ sr_apy_kemi_exec_func_920, NULL},
+	{ sr_apy_kemi_exec_func_921, NULL},
+	{ sr_apy_kemi_exec_func_922, NULL},
+	{ sr_apy_kemi_exec_func_923, NULL},
+	{ sr_apy_kemi_exec_func_924, NULL},
+	{ sr_apy_kemi_exec_func_925, NULL},
+	{ sr_apy_kemi_exec_func_926, NULL},
+	{ sr_apy_kemi_exec_func_927, NULL},
+	{ sr_apy_kemi_exec_func_928, NULL},
+	{ sr_apy_kemi_exec_func_929, NULL},
+	{ sr_apy_kemi_exec_func_930, NULL},
+	{ sr_apy_kemi_exec_func_931, NULL},
+	{ sr_apy_kemi_exec_func_932, NULL},
+	{ sr_apy_kemi_exec_func_933, NULL},
+	{ sr_apy_kemi_exec_func_934, NULL},
+	{ sr_apy_kemi_exec_func_935, NULL},
+	{ sr_apy_kemi_exec_func_936, NULL},
+	{ sr_apy_kemi_exec_func_937, NULL},
+	{ sr_apy_kemi_exec_func_938, NULL},
+	{ sr_apy_kemi_exec_func_939, NULL},
+	{ sr_apy_kemi_exec_func_940, NULL},
+	{ sr_apy_kemi_exec_func_941, NULL},
+	{ sr_apy_kemi_exec_func_942, NULL},
+	{ sr_apy_kemi_exec_func_943, NULL},
+	{ sr_apy_kemi_exec_func_944, NULL},
+	{ sr_apy_kemi_exec_func_945, NULL},
+	{ sr_apy_kemi_exec_func_946, NULL},
+	{ sr_apy_kemi_exec_func_947, NULL},
+	{ sr_apy_kemi_exec_func_948, NULL},
+	{ sr_apy_kemi_exec_func_949, NULL},
+	{ sr_apy_kemi_exec_func_950, NULL},
+	{ sr_apy_kemi_exec_func_951, NULL},
+	{ sr_apy_kemi_exec_func_952, NULL},
+	{ sr_apy_kemi_exec_func_953, NULL},
+	{ sr_apy_kemi_exec_func_954, NULL},
+	{ sr_apy_kemi_exec_func_955, NULL},
+	{ sr_apy_kemi_exec_func_956, NULL},
+	{ sr_apy_kemi_exec_func_957, NULL},
+	{ sr_apy_kemi_exec_func_958, NULL},
+	{ sr_apy_kemi_exec_func_959, NULL},
+	{ sr_apy_kemi_exec_func_960, NULL},
+	{ sr_apy_kemi_exec_func_961, NULL},
+	{ sr_apy_kemi_exec_func_962, NULL},
+	{ sr_apy_kemi_exec_func_963, NULL},
+	{ sr_apy_kemi_exec_func_964, NULL},
+	{ sr_apy_kemi_exec_func_965, NULL},
+	{ sr_apy_kemi_exec_func_966, NULL},
+	{ sr_apy_kemi_exec_func_967, NULL},
+	{ sr_apy_kemi_exec_func_968, NULL},
+	{ sr_apy_kemi_exec_func_969, NULL},
+	{ sr_apy_kemi_exec_func_970, NULL},
+	{ sr_apy_kemi_exec_func_971, NULL},
+	{ sr_apy_kemi_exec_func_972, NULL},
+	{ sr_apy_kemi_exec_func_973, NULL},
+	{ sr_apy_kemi_exec_func_974, NULL},
+	{ sr_apy_kemi_exec_func_975, NULL},
+	{ sr_apy_kemi_exec_func_976, NULL},
+	{ sr_apy_kemi_exec_func_977, NULL},
+	{ sr_apy_kemi_exec_func_978, NULL},
+	{ sr_apy_kemi_exec_func_979, NULL},
+	{ sr_apy_kemi_exec_func_980, NULL},
+	{ sr_apy_kemi_exec_func_981, NULL},
+	{ sr_apy_kemi_exec_func_982, NULL},
+	{ sr_apy_kemi_exec_func_983, NULL},
+	{ sr_apy_kemi_exec_func_984, NULL},
+	{ sr_apy_kemi_exec_func_985, NULL},
+	{ sr_apy_kemi_exec_func_986, NULL},
+	{ sr_apy_kemi_exec_func_987, NULL},
+	{ sr_apy_kemi_exec_func_988, NULL},
+	{ sr_apy_kemi_exec_func_989, NULL},
+	{ sr_apy_kemi_exec_func_990, NULL},
+	{ sr_apy_kemi_exec_func_991, NULL},
+	{ sr_apy_kemi_exec_func_992, NULL},
+	{ sr_apy_kemi_exec_func_993, NULL},
+	{ sr_apy_kemi_exec_func_994, NULL},
+	{ sr_apy_kemi_exec_func_995, NULL},
+	{ sr_apy_kemi_exec_func_996, NULL},
+	{ sr_apy_kemi_exec_func_997, NULL},
+	{ sr_apy_kemi_exec_func_998, NULL},
+	{ sr_apy_kemi_exec_func_999, NULL},
+	{ sr_apy_kemi_exec_func_1000, NULL},
+	{ sr_apy_kemi_exec_func_1001, NULL},
+	{ sr_apy_kemi_exec_func_1002, NULL},
+	{ sr_apy_kemi_exec_func_1003, NULL},
+	{ sr_apy_kemi_exec_func_1004, NULL},
+	{ sr_apy_kemi_exec_func_1005, NULL},
+	{ sr_apy_kemi_exec_func_1006, NULL},
+	{ sr_apy_kemi_exec_func_1007, NULL},
+	{ sr_apy_kemi_exec_func_1008, NULL},
+	{ sr_apy_kemi_exec_func_1009, NULL},
+	{ sr_apy_kemi_exec_func_1010, NULL},
+	{ sr_apy_kemi_exec_func_1011, NULL},
+	{ sr_apy_kemi_exec_func_1012, NULL},
+	{ sr_apy_kemi_exec_func_1013, NULL},
+	{ sr_apy_kemi_exec_func_1014, NULL},
+	{ sr_apy_kemi_exec_func_1015, NULL},
+	{ sr_apy_kemi_exec_func_1016, NULL},
+	{ sr_apy_kemi_exec_func_1017, NULL},
+	{ sr_apy_kemi_exec_func_1018, NULL},
+	{ sr_apy_kemi_exec_func_1019, NULL},
+	{ sr_apy_kemi_exec_func_1020, NULL},
+	{ sr_apy_kemi_exec_func_1021, NULL},
+	{ sr_apy_kemi_exec_func_1022, NULL},
+	{ sr_apy_kemi_exec_func_1023, NULL},
+	{NULL, NULL}
+};
+
+/**
+ *
+ */
+sr_kemi_t *sr_apy_kemi_export_get(int idx)
+{
+	if(idx<0 || idx>=SR_APY_KEMI_EXPORT_SIZE)
+		return NULL;
+	return _sr_apy_kemi_export_list[idx].ket;
+}
+
+/**
+ *
+ */
+PyCFunction sr_apy_kemi_export_associate(sr_kemi_t *ket)
+{
+	int i;
+	for(i=0; i<SR_APY_KEMI_EXPORT_SIZE; i++) {
+		if(_sr_apy_kemi_export_list[i].ket==NULL) {
+			_sr_apy_kemi_export_list[i].ket = ket;
+			return _sr_apy_kemi_export_list[i].pfunc;
+		}
+		if(_sr_apy_kemi_export_list[i].ket==ket) {
+			return _sr_apy_kemi_export_list[i].pfunc;
+		}
+	}
+	LM_ERR("no more indexing slots\n");
+	return NULL;
+}

--- a/src/modules/app_python3/apy_kemi_export.h
+++ b/src/modules/app_python3/apy_kemi_export.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2016 Daniel-Constantin Mierla (asipto.com)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/**
+ * this file is generated - do not edit
+ */
+
+#ifndef __APY_KEMI_FLIB_H__
+#define __APY_KEMI_FLIB_H__
+
+#include <Python.h>
+#include "../../core/kemi.h"
+
+#define SR_APY_KEMI_EXPORT_SIZE	1024
+
+typedef struct sr_apy_kemi_export {
+	PyCFunction pfunc;
+	sr_kemi_t *ket;
+} sr_apy_kemi_export_t;
+
+sr_kemi_t *sr_apy_kemi_export_get(int idx);
+PyCFunction sr_apy_kemi_export_associate(sr_kemi_t *ket);
+
+#endif

--- a/src/modules/app_python3/doc/Makefile
+++ b/src/modules/app_python3/doc/Makefile
@@ -1,0 +1,4 @@
+docs = app_python.xml
+
+docbook_dir = ../../../../doc/docbook
+include $(docbook_dir)/Makefile.module

--- a/src/modules/app_python3/doc/app_python.xml
+++ b/src/modules/app_python3/doc/app_python.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<book xmlns:xi="http://www.w3.org/2001/XInclude">
+    <bookinfo>
+	<title>app_python Module</title>
+	<productname class="trade">&kamailioname;</productname>
+	<authorgroup>
+	    <author>
+		<firstname>Maxim</firstname>
+		<surname>Sobolev</surname>
+	    </author>
+	    <editor>
+		<firstname>Maxim</firstname>
+		<surname>Sobolev</surname>
+	    </editor>
+	</authorgroup>
+	<copyright>
+	    <year>2010</year>
+	    <holder>Maxim Sobolev</holder>
+	</copyright>
+    </bookinfo>
+    <toc></toc>
+    
+	<xi:include href="app_python_admin.xml"/>
+    
+</book>

--- a/src/modules/app_python3/doc/app_python_admin.xml
+++ b/src/modules/app_python3/doc/app_python_admin.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<!-- Module User's Guide -->
+
+<chapter>
+
+    <title>&adminguide;</title>
+
+    <section>
+	<title>Overview</title>
+	<para>
+		This module allows executing Python scripts from config file,
+		exporting functions to access the SIP message from Python.
+	</para>
+	<para>
+		For some basic examples of Python scripts that can be used with
+		this module, look at the files inside source tree located at
+		'modules/app_python/python_examples/'.
+	</para>
+    </section>
+    <section>
+	<title>Dependencies</title>
+	<section>
+	    <title>&kamailio; Modules</title>
+	    <para>
+		The following modules must be loaded before this module:
+	    	<itemizedlist>
+		    <listitem>
+			<para>
+			    <emphasis>none</emphasis>.
+			</para>
+		    </listitem>
+	    	</itemizedlist>
+	    </para>
+	</section>
+	<section>
+	    <title>External Libraries or Applications</title>
+	    <para>
+		The following libraries or applications must be installed before running
+		&kamailio; with this module loaded:
+	    	<itemizedlist>
+		    <listitem>
+			<para>
+			    <emphasis>python-dev</emphasis> - Python devel library.
+			</para>
+		    </listitem>
+	    	</itemizedlist>
+	    </para>
+	</section>
+    </section>
+    <section>
+	<title>Parameters</title>
+	<section id="app_python.p.load">
+	    <title><varname>load</varname> (string)</title>
+	    <para>
+			The path to the file with Python code to be executed
+			from configuration file.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>/usr/local/etc/kamailio/handler.py</quote>.
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>load</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("app_python", "load", "/usr/local/etc/kamailio/myscript.py")
+...
+</programlisting>
+	    </example>
+	</section>
+
+	<section id="app_python.p.script_name">
+	    <title><varname>script_name</varname> (string)</title>
+	    <para>
+			This is same as "load" parameter, kept for backward compatibility
+			with the older versions of the module.
+	    </para>
+	</section>
+
+	<section id="app_python.p.mod_init_function">
+	    <title><varname>mod_init_function</varname> (string)</title>
+	    <para>
+			The Python function to be executed by this module when
+			it is initialied by &kamailio;.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>mod_init</quote>.
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>mod_init_function</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("app_python", "mod_init_function", "my_mod_init")
+...
+</programlisting>
+	    </example>
+	</section>
+
+	<section id="app_python.p.child_init_method">
+	    <title><varname>child_init_method</varname> (string)</title>
+	    <para>
+			The Python function to be executed by this module when
+			a new worker process (child) is initialied by &kamailio;.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>child_init</quote>.
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>child_init_method</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("app_python", "child_init_method", "my_child_init")
+...
+</programlisting>
+	    </example>
+	</section>
+
+	</section>
+
+    <section>
+	<title>Functions</title>
+ 	<section id="app_python.f.python_exec">
+	    <title>
+		<function moreinfo="none">python_exec(method [, args])</function>
+	    </title>
+	    <para>
+			Execute the Python function with the name given by the parameter 'method'.
+			Optionally can be provided a second string with parameters to be passed
+			to the Python function.
+	    </para>
+	    <para>
+			Both parameters can contain pseudo-variables.
+	    </para>
+		<example>
+		<title><function>python_exec</function> usage</title>
+		<programlisting format="linespecific">
+...
+python_exec("my_python_function");
+python_exec("my_python_function", "my_params");
+python_exec("my_python_function", "$rU");
+...
+</programlisting>
+	    </example>
+	</section>
+
+    </section>
+	<section>
+        <title>RPC Commands</title>
+        <section id="app_python.r.reload">
+            <title>
+            <function moreinfo="none">app_python.reload</function>
+            </title>
+			<para>
+				IMPORTANT: not functional yet (can crash a running instance,
+				use it only for testing).
+			</para>
+            <para>
+            Marks the need to reload the js script.
+            The actual reload is done by every working process when the next
+            call to KEMI config is executed.
+            </para>
+            <para>
+            Name: <emphasis>app_python.reload</emphasis>
+            </para>
+            <para>Parameters: <emphasis>none</emphasis></para>
+            <para>
+            Example:
+            </para>
+            <programlisting  format="linespecific">
+...
+&kamcmd; app_python.reload
+...
+            </programlisting>
+		</section>
+		<section id="app_python.r.api_list">
+            <title>
+            <function moreinfo="none">app_python.api_list</function>
+            </title>
+            <para>
+			List the functions available via Kemi framework.
+            </para>
+            <para>
+            Name: <emphasis>app_python.api_list</emphasis>
+            </para>
+            <para>Parameters: <emphasis>none</emphasis></para>
+            <para>
+            Example:
+            </para>
+            <programlisting  format="linespecific">
+...
+&kamcmd; app_python.api_list
+...
+            </programlisting>
+        </section>
+	</section>
+
+</chapter>
+

--- a/src/modules/app_python3/mod_Core.c
+++ b/src/modules/app_python3/mod_Core.c
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2012 Konstantin Mosesov
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+// Python includes
+#include <Python.h>
+#include "structmember.h"
+
+// Other/system includes
+#include <libgen.h>
+
+// router includes
+#include "../../core/str.h"
+#include "../../core/sr_module.h"
+
+// local includes
+#include "python_exec.h"
+#include "app_python_mod.h"
+#include "python_iface.h"
+#include "python_msgobj.h"
+#include "python_support.h"
+
+#include "mod_Router.h"
+#include "mod_Core.h"
+
+PyObject *_sr_apy_core_module = NULL;
+
+PyMethodDef CoreMethods[] = {
+	{NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef Router_Core_moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "Router.Core",
+        NULL,
+        -1,
+        CoreMethods,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+PyObject* get_core_module(void)
+{
+	_sr_apy_core_module = PyModule_Create(&Router_Core_moduledef);
+
+#ifdef WITH_EXTRA_DEBUG
+	LM_ERR("Module 'Router.Core' has been initialized\n");
+#endif
+
+        return _sr_apy_core_module;
+}
+
+void destroy_mod_Core(void)
+{
+	Py_XDECREF(_sr_apy_core_module);
+#ifdef WITH_EXTRA_DEBUG
+	LM_ERR("Module 'Router.Core' has been destroyed\n");
+#endif
+
+}

--- a/src/modules/app_python3/mod_Core.h
+++ b/src/modules/app_python3/mod_Core.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2012 Konstantin Mosesov
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef	__API__MOD_CORE_H__
+#define	__API__MOD_CORE_H__
+
+#include <Python.h>
+#include <libgen.h>
+
+extern PyObject *_sr_apy_core_module;
+
+extern PyMethodDef CoreMethods[];
+
+void init_mod_Core(void);
+void destroy_mod_Core(void);
+
+#endif

--- a/src/modules/app_python3/mod_Logger.c
+++ b/src/modules/app_python3/mod_Logger.c
@@ -1,0 +1,271 @@
+/**
+ * Copyright (C) 2012 Konstantin Mosesov
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+// Python includes
+#include <Python.h>
+#include "structmember.h"
+
+// Other/system includes
+#include <libgen.h>
+
+// router includes
+#include "../../core/str.h"
+#include "../../core/sr_module.h"
+
+// local includes
+#include "python_exec.h"
+#include "app_python_mod.h"
+#include "python_iface.h"
+#include "python_msgobj.h"
+#include "python_support.h"
+
+#include "mod_Router.h"
+#include "mod_Logger.h"
+
+PyObject *_sr_apy_logger_module = NULL;
+
+/*
+ * Python method: LM_GEN1(self, int log_level, str msg)
+ */
+static PyObject *logger_LM_GEN1(PyObject *self, PyObject *args)
+{
+	int log_level;
+	char *msg;
+
+	if (!PyArg_ParseTuple(args, "is:LM_GEN1", &log_level, &msg))
+		return NULL;
+
+	LM_GEN1(log_level, "%s", msg);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+/*
+ * Python method: LM_GEN2(self, int log_facility, int log_level, str msg)
+ */
+static PyObject *logger_LM_GEN2(PyObject *self, PyObject *args)
+{
+	int log_facility;
+	int log_level;
+	char *msg;
+
+	if(!PyArg_ParseTuple(args, "iis:LM_GEN2", &log_facility, &log_level, &msg))
+		return NULL;
+
+	LM_GEN2(log_facility, log_level, "%s", msg);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+/*
+ * Python method: LM_ALERT(self, str msg)
+ */
+static PyObject *logger_LM_ALERT(PyObject *self, PyObject *args)
+{
+	char *msg;
+
+	if(!PyArg_ParseTuple(args, "s:LM_ALERT", &msg))
+		return NULL;
+
+	LM_ALERT("%s", msg);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+
+/*
+ * Python method: LM_CRIT(self, str msg)
+ */
+static PyObject *logger_LM_CRIT(PyObject *self, PyObject *args)
+{
+	char *msg;
+
+	if(!PyArg_ParseTuple(args, "s:LM_CRIT", &msg))
+		return NULL;
+
+	LM_CRIT("%s", msg);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+/*
+ * Python method: LM_WARN(self, str msg)
+ */
+static PyObject *logger_LM_WARN(PyObject *self, PyObject *args)
+{
+	char *msg;
+
+	if(!PyArg_ParseTuple(args, "s:LM_WARN", &msg))
+		return NULL;
+
+	LM_WARN("%s", msg);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+/*
+ * Python method: LM_NOTICE(self, str msg)
+ */
+static PyObject *logger_LM_NOTICE(PyObject *self, PyObject *args)
+{
+	char *msg;
+
+	if(!PyArg_ParseTuple(args, "s:LM_NOTICE", &msg))
+		return NULL;
+
+	LM_NOTICE("%s", msg);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+/*
+ * Python method: LM_ERR(self, str msg)
+ */
+static PyObject *logger_LM_ERR(PyObject *self, PyObject *args)
+{
+	char *msg;
+
+	if(!PyArg_ParseTuple(args, "s:LM_ERR", &msg))
+		return NULL;
+
+	LM_ERR("%s", msg);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+/*
+ * Python method: LM_INFO(self, str msg)
+ */
+static PyObject *logger_LM_INFO(PyObject *self, PyObject *args)
+{
+	char *msg;
+
+	if(!PyArg_ParseTuple(args, "s:LM_INFO", &msg))
+		return NULL;
+
+	LM_INFO("%s", msg);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+/*
+ * Python method: LM_DBG(self, str msg)
+ */
+static PyObject *logger_LM_DBG(PyObject *self, PyObject *args)
+{
+	char *msg;
+
+	if(!PyArg_ParseTuple(args, "s:LM_DBG", &msg))
+		return NULL;
+
+	LM_DBG("%s", msg);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+PyMethodDef LoggerMethods[] = {
+	{"LM_GEN1",		(PyCFunction)logger_LM_GEN1,		METH_VARARGS, "Print GEN1 message."},
+	{"LM_GEN2",		(PyCFunction)logger_LM_GEN2,		METH_VARARGS, "Print GEN2 message."},
+	{"LM_ALERT",	(PyCFunction)logger_LM_ALERT,		METH_VARARGS, "Print alert message."},
+	{"LM_CRIT",		(PyCFunction)logger_LM_CRIT,		METH_VARARGS, "Print critical message."},
+	{"LM_ERR",		(PyCFunction)logger_LM_ERR,		METH_VARARGS, "Print error message."},
+	{"LM_WARN",		(PyCFunction)logger_LM_WARN,		METH_VARARGS, "Print warning message."},
+	{"LM_NOTICE",	(PyCFunction)logger_LM_NOTICE,		METH_VARARGS, "Print notice message."},
+	{"LM_INFO",		(PyCFunction)logger_LM_INFO,		METH_VARARGS, "Print info message."},
+	{"LM_DBG",		(PyCFunction)logger_LM_DBG,		METH_VARARGS, "Print debug message."},
+	{NULL, 		NULL, 			0, 		NULL}
+};
+
+static struct PyModuleDef Router_Logger_moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "Router.Logger",
+        NULL,
+        -1,
+        LoggerMethods,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+PyObject* get_logger_module(void)
+{
+	_sr_apy_logger_module = PyModule_Create(&Router_Logger_moduledef);
+
+	/*
+	 * Log levels
+	 * Reference: dprint.h
+	 */
+	PyModule_AddObject(_sr_apy_logger_module, "L_ALERT",
+			PyLong_FromLong((long)L_ALERT));
+	PyModule_AddObject(_sr_apy_logger_module, "L_BUG",
+			PyLong_FromLong((long)L_BUG));
+	PyModule_AddObject(_sr_apy_logger_module, "L_CRIT2",
+			PyLong_FromLong((long)L_CRIT2)); /* like L_CRIT, but adds prefix */
+	PyModule_AddObject(_sr_apy_logger_module, "L_CRIT",
+			PyLong_FromLong((long)L_CRIT));  /* no prefix added */
+	PyModule_AddObject(_sr_apy_logger_module, "L_ERR",
+			PyLong_FromLong((long)L_ERR));
+	PyModule_AddObject(_sr_apy_logger_module, "L_WARN",
+			PyLong_FromLong((long)L_WARN));
+	PyModule_AddObject(_sr_apy_logger_module, "L_NOTICE",
+			PyLong_FromLong((long)L_NOTICE));
+	PyModule_AddObject(_sr_apy_logger_module, "L_INFO",
+			PyLong_FromLong((long)L_INFO));
+	PyModule_AddObject(_sr_apy_logger_module, "L_DBG",
+			PyLong_FromLong((long)L_DBG));
+
+	/*
+	 * Facility
+	 * Reference: dprint.h
+	 */
+	PyModule_AddObject(_sr_apy_logger_module, "DEFAULT_FACILITY",
+			PyLong_FromLong((long)DEFAULT_FACILITY));
+
+	Py_INCREF(_sr_apy_logger_module);
+
+#ifdef WITH_EXTRA_DEBUG
+	LM_ERR("Module 'Router.Logger' has been initialized\n");
+#endif
+	return _sr_apy_logger_module;
+
+}
+
+void destroy_mod_Logger(void)
+{
+	Py_XDECREF(_sr_apy_logger_module);
+
+#ifdef WITH_EXTRA_DEBUG
+	LM_ERR("Module 'Router.Logger' has been destroyed\n");
+#endif
+
+}
+

--- a/src/modules/app_python3/mod_Logger.h
+++ b/src/modules/app_python3/mod_Logger.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2012 Konstantin Mosesov
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef	__API__MOD_LOGGER_H__
+#define	__API__MOD_LOGGER_H__
+
+#include <Python.h>
+#include <libgen.h>
+
+extern PyObject *_sr_apy_logger_module;
+
+extern PyMethodDef LoggerMethods[];
+
+void init_mod_Logger(void);
+void destroy_mod_Logger(void);
+
+
+#endif

--- a/src/modules/app_python3/mod_Ranks.c
+++ b/src/modules/app_python3/mod_Ranks.c
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2012 Konstantin Mosesov
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+// Python includes
+#include <Python.h>
+#include "structmember.h"
+
+// Other/system includes
+#include <libgen.h>
+
+// router includes
+#include "../../core/str.h"
+#include "../../core/sr_module.h"
+
+// local includes
+#include "python_exec.h"
+#include "app_python_mod.h"
+#include "python_iface.h"
+#include "python_msgobj.h"
+#include "python_support.h"
+
+#include "mod_Router.h"
+#include "mod_Ranks.h"
+
+PyObject *_sr_apy_ranks_module = NULL;
+
+PyMethodDef RanksMethods[] = {
+	{NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef Router_Ranks_moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "Router.Ranks",
+        NULL,
+        -1,
+        RanksMethods,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+PyObject* get_ranks_module(void)
+{
+	_sr_apy_ranks_module = PyModule_Create(&Router_Ranks_moduledef);
+
+	PyModule_AddObject(_sr_apy_ranks_module, "PROC_MAIN",
+			PyLong_FromLong((long)PROC_MAIN));
+	PyModule_AddObject(_sr_apy_ranks_module, "PROC_TIMER",
+			PyLong_FromLong((long)PROC_TIMER));
+	PyModule_AddObject(_sr_apy_ranks_module, "PROC_RPC",
+			PyLong_FromLong((long)PROC_RPC));
+	PyModule_AddObject(_sr_apy_ranks_module, "PROC_FIFO",
+			PyLong_FromLong((long)PROC_FIFO));
+	PyModule_AddObject(_sr_apy_ranks_module, "PROC_TCP_MAIN",
+			PyLong_FromLong((long)PROC_TCP_MAIN));
+	PyModule_AddObject(_sr_apy_ranks_module, "PROC_UNIXSOCK",
+			PyLong_FromLong((long)PROC_UNIXSOCK));
+	PyModule_AddObject(_sr_apy_ranks_module, "PROC_ATTENDANT",
+			PyLong_FromLong((long)PROC_ATTENDANT));
+	PyModule_AddObject(_sr_apy_ranks_module, "PROC_INIT",
+			PyLong_FromLong((long)PROC_INIT));
+	PyModule_AddObject(_sr_apy_ranks_module, "PROC_NOCHLDINIT",
+			PyLong_FromLong((long)PROC_NOCHLDINIT));
+	PyModule_AddObject(_sr_apy_ranks_module, "PROC_SIPINIT",
+			PyLong_FromLong((long)PROC_SIPINIT));
+	PyModule_AddObject(_sr_apy_ranks_module, "PROC_SIPRPC",
+			PyLong_FromLong((long)PROC_SIPRPC));
+	PyModule_AddObject(_sr_apy_ranks_module, "PROC_MIN",
+			PyLong_FromLong((long)PROC_MIN));
+
+	Py_INCREF(_sr_apy_ranks_module);
+
+#ifdef WITH_EXTRA_DEBUG
+	LM_ERR("Module 'Router.Ranks' has been initialized\n");
+#endif
+
+	return _sr_apy_ranks_module;
+}
+
+void destroy_mod_Ranks(void)
+{
+	Py_XDECREF(_sr_apy_ranks_module);
+
+#ifdef WITH_EXTRA_DEBUG
+	LM_ERR("Module 'Router.Ranks' has been destroyed\n");
+#endif
+
+}
+

--- a/src/modules/app_python3/mod_Ranks.h
+++ b/src/modules/app_python3/mod_Ranks.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2012 Konstantin Mosesov
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef	__API__MOD_RANKS_H__
+#define	__API__MOD_RANKS_H__
+
+#include <Python.h>
+#include <libgen.h>
+
+extern PyObject *_sr_apy_ranks_module;
+
+extern PyMethodDef RanksMethods[];
+
+void init_mod_Ranks(void);
+void destroy_mod_Ranks(void);
+
+#endif

--- a/src/modules/app_python3/mod_Router.c
+++ b/src/modules/app_python3/mod_Router.c
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2012 Konstantin Mosesov
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+// Python includes
+#include <Python.h>
+#include "structmember.h"
+
+// Other/system includes
+#include <libgen.h>
+
+// router includes
+#include "../../core/str.h"
+#include "../../core/sr_module.h"
+
+// local includes
+#include "python_exec.h"
+#include "app_python_mod.h"
+#include "python_iface.h"
+#include "python_msgobj.h"
+#include "python_support.h"
+
+#include "mod_Router.h"
+#include "mod_Core.h"
+#include "mod_Logger.h"
+#include "mod_Ranks.h"
+
+PyObject *_sr_apy_main_module = NULL;
+
+PyMethodDef RouterMethods[] = {
+	{NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef Router_Core_moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "Router",
+        NULL,
+        -1,
+        RouterMethods,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+extern PyObject* get_core_module();
+extern PyObject* get_logger_module();
+extern PyObject* get_ranks_module();
+static PyObject* init_Router(void)
+{
+	_sr_apy_main_module = PyModule_Create(&Router_Core_moduledef);
+    PyModule_AddObject(_sr_apy_main_module, "Core", get_core_module());
+    PyModule_AddObject(_sr_apy_main_module, "Logger", get_logger_module());
+    PyModule_AddObject(_sr_apy_main_module, "Ranks", get_ranks_module());
+
+	Py_INCREF(_sr_apy_main_module);
+
+    return _sr_apy_main_module;
+
+}
+
+extern
+void init_mod_Router(void)
+{
+
+    PyImport_AppendInittab("Router", &init_Router);
+
+#ifdef WITH_EXTRA_DEBUG
+	LM_ERR("Module 'Router' has been initialized\n");
+#endif
+
+}
+
+void destroy_mod_Router(void)
+{
+	Py_XDECREF(_sr_apy_main_module);
+
+#ifdef WITH_EXTRA_DEBUG
+	LM_ERR("Module 'Router' has been destroyed\n");
+#endif
+
+}
+

--- a/src/modules/app_python3/mod_Router.h
+++ b/src/modules/app_python3/mod_Router.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2012 Konstantin Mosesov
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef	__API__MOD_ROUTER_H__
+#define	__API__MOD_ROUTER_H__
+
+#include <Python.h>
+#include <libgen.h>
+
+extern PyObject *_sr_apy_main_module;
+extern PyObject *_sr_apy_main_module_dict;
+
+extern PyMethodDef RouterMethods[];
+
+void init_mod_Router(void);
+void destroy_mod_Router(void);
+
+#endif

--- a/src/modules/app_python3/msgobj_struct.h
+++ b/src/modules/app_python3/msgobj_struct.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2009 Sippy Software, Inc., http://www.sippysoft.com
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+*/
+
+#ifndef _MSGOBJ_STRUCT_H
+#define  _MSGOBJ_STRUCT_H
+
+#include "../../core/parser/msg_parser.h"
+
+#include <Python.h>
+
+typedef struct {
+	PyObject_HEAD
+	struct sip_msg *msg;
+} msgobject;
+
+PyObject *msg_call_function(msgobject *, PyObject *);
+
+#endif

--- a/src/modules/app_python3/python_examples/Loggers.py
+++ b/src/modules/app_python3/python_examples/Loggers.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+"""
+    Script for logging test.
+    Added:   2012-12-03: Created by: Konstantin M. <evilzluk@gmail.com>
+    Changed: 2012-12-11: Changed code to use Router.Logger
+    Changed: 2012-12-11: Changed code to use Router.Ranks
+"""
+
+import Router.Logger as Logger
+import Router.Ranks as Ranks
+
+"""
+    Router.Logger Module Properties:
+       Log Levels:
+           L_ALERT
+           L_BUG
+           L_CRIT2
+           L_CRIT
+           L_ERR
+           L_WARN
+           L_NOTICE
+           L_INFO
+           L_DBG
+
+       Log Facilities:
+           DEFAULT_FACILITY
+
+    Router.Logger Module Methods:
+       LM_GEN1(self, int log_level, str msg)
+       LM_GEN2(self, int log_facility, int log_level, str msg)
+       LM_ALERT(self, str msg)
+       LM_CRIT(self, str msg)
+       LM_ERR(self, str msg)
+       LM_WARN(self, str msg)
+       LM_NOTICE(self, str msg)
+       LM_INFO(self, str msg)
+       LM_DBG(self, str msg)
+
+
+    Router.Ranks Module Properties:
+        PROC_MAIN
+        PROC_TIMER
+        PROC_RPC
+        PROC_FIFO
+        PROC_TCP_MAIN
+        PROC_UNIXSOCK
+        PROC_ATTENDANT
+	PROC_INIT
+	PROC_NOCHLDINIT
+	PROC_SIPINIT
+	PROC_SIPRPC
+	PROC_MIN
+
+"""
+
+class Loggers:
+
+    def __init__(self):
+	pass
+
+    def __del__(self):
+	pass
+
+    def child_init(self, rank):
+	if rank == Ranks.PROC_MAIN:
+	    Logger.LM_ERR("rank is PROC_MAIN")
+	elif rank == Ranks.PROC_TIMER:
+	    Logger.LM_ERR("rank is PROC_TIMER")
+	elif rank == Ranks.PROC_RPC:
+	    Logger.LM_ERR("rank is PROC_RPC")
+	elif rank == Ranks.PROC_FIFO:
+	    Logger.LM_ERR("rank is PROC_FIFO")
+	elif rank == Ranks.PROC_TCP_MAIN:
+	    Logger.LM_ERR("rank is PROC_TCP_MAIN")
+	elif rank == Ranks.PROC_UNIXSOCK:
+	    Logger.LM_ERR("rank is PROC_UNIXSOCK")
+	elif rank == Ranks.PROC_ATTENDANT:
+	    Logger.LM_ERR("rank is PROC_ATTENDANT")
+	elif rank == Ranks.PROC_INIT:
+	    Logger.LM_ERR("rank is PROC_INIT")
+	elif rank == Ranks.PROC_NOCHLDINIT:
+	    Logger.LM_ERR("rank is PROC_NOCHLDINIT")
+	elif rank == Ranks.PROC_SIPINIT:
+	    Logger.LM_ERR("rank is PROC_SIPINIT")
+	elif rank == Ranks.PROC_SIPRPC:
+	    Logger.LM_ERR("rank is PROC_SIPRPC")
+	elif rank == Ranks.PROC_MIN:
+	    Logger.LM_ERR("rank is PROC_MIN")
+
+	return 0
+
+    def TestLoggers(self, msg, args):
+	Logger.LM_GEN1(Logger.L_INFO,                           	"Loggers.py:     LM_GEN1: msg: %s" % str(args))
+	Logger.LM_GEN2(Logger.L_INFO, Logger.DEFAULT_FACILITY,	        "Loggers.py:     LM_GEN2: msg: %s" % str(args))
+	Logger.LM_ALERT(                                        	"Loggers.py:    LM_ALERT: msg: %s" % str(args))
+	Logger.LM_CRIT(                                         	"Loggers.py:     LM_CRIT: msg: %s" % str(args))
+	Logger.LM_ERR(                                          	"Loggers.py:      LM_ERR: msg: %s" % str(args))
+	Logger.LM_WARN(                                         	"Loggers.py:     LM_WARN: msg: %s" % str(args))
+	Logger.LM_NOTICE(                                       	"Loggers.py:   LM_NOTICE: msg: %s" % str(args))
+	Logger.LM_INFO(                                         	"Loggers.py:     LM_INFO: msg: %s" % str(args))
+	Logger.LM_DBG(                                          	"Loggers.py:      LM_DBG: msg: %s" % str(args))
+	return 1
+
+def mod_init():
+    return Loggers()
+

--- a/src/modules/app_python3/python_examples/TestCase_Traceback.py
+++ b/src/modules/app_python3/python_examples/TestCase_Traceback.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+"""
+    Script for traceback test.
+    2012.12.03: Created by: Konstantin M. <evilzluk@gmail.com>
+"""
+
+import pprint
+
+class Loggers:
+
+    def __init__(self):
+	pass
+
+    def __del__(self):
+	pass
+
+    def child_init(self, y):
+	return 0
+
+    def BuggyCode_lvl5(self, a):
+	a / 0
+
+    def BuggyCode_lvl4(self, a):
+	return self.BuggyCode_lvl5(a)
+
+    def BuggyCode_lvl3(self, a):
+	return self.BuggyCode_lvl4(a)
+
+    def BuggyCode_lvl2(self, a):
+	return self.BuggyCode_lvl3(a)
+
+    def BuggyCode(self, a, b=None):
+	return self.BuggyCode_lvl2(a)
+
+
+
+def mod_init():
+    return Loggers()
+
+
+
+if __name__ != "__main__":
+    import Router
+else:
+    mod_init().BuggyCode(0)

--- a/src/modules/app_python3/python_examples/handler.py
+++ b/src/modules/app_python3/python_examples/handler.py
@@ -1,0 +1,26 @@
+import sys
+from Router import LM_ERR
+
+class test:
+    def __init__(self):
+        LM_ERR('test.__init__\n')
+
+    def child_init(self, y):
+        LM_ERR('test.child_init(%d)\n' % y)
+        return 0
+
+    def handler(self, msg, args):
+        LM_ERR('test.handler(%s, %s)\n' % (msg.Type, str(arg)))
+        if msg.Type == 'SIP_REQUEST':
+            if msg.Method == 'INVITE':
+                msg.rewrite_ruri('sip:0022@192.168.2.24:5073')
+            LM_ERR('SIP request, method = %s, RURI = %s, From = %s\n' % (msg.Method, msg.RURI, msg.getHeader('from')))
+            LM_ERR('received from %s:%d\n' % msg.src_address)
+        else:
+            LM_ERR('SIP reply, status = %s\n' % msg.Status)
+            LM_ERR('received from %s:%d\n' % msg.src_address)
+        msg.call_function('append_hf', 'This-is: test\r\n')
+        return 1
+
+def mod_init():
+    return test()

--- a/src/modules/app_python3/python_exec.c
+++ b/src/modules/app_python3/python_exec.c
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2009 Sippy Software, Inc., http://www.sippysoft.com
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <Python.h>
+
+#include "../../core/mem/mem.h"
+#include "../../core/data_lump.h"
+#include "../../core/parser/parse_param.h"
+#include "../../core/parser/msg_parser.h"
+#include "../../core/dprint.h"
+#include "../../core/action.h"
+#include "../../core/config.h"
+#include "../../core/mod_fix.h"
+#include "../../core/parser/parse_uri.h"
+
+#include "python_exec.h"
+#include "app_python_mod.h"
+#include "python_msgobj.h"
+#include "python_support.h"
+
+static sr_apy_env_t _sr_apy_env = {0};
+
+/**
+ *
+ */
+sr_apy_env_t *sr_apy_env_get()
+{
+	return &_sr_apy_env;
+}
+
+static int _sr_apy_exec_pid = 0;
+
+/**
+ *
+ */
+int apy_exec(sip_msg_t *_msg, char *fname, char *fparam, int emode)
+{
+	PyObject *pFunc, *pArgs, *pValue, *pResult;
+	PyObject *pmsg;
+	int rval;
+	sip_msg_t *bmsg;
+	int mpid;
+	int locked = 0;
+
+	bmsg = _sr_apy_env.msg;
+	_sr_apy_env.msg = _msg;
+	mpid = getpid();
+
+	if(_sr_apy_exec_pid!=mpid) {
+		//TODO PyEval_AcquireLock();
+		_sr_apy_exec_pid = mpid;
+		//TODO PyThreadState_Swap(myThreadState);
+		locked = 1;
+	}
+
+	pFunc = PyObject_GetAttrString(_sr_apy_handler_obj, fname);
+	if (pFunc == NULL || !PyCallable_Check(pFunc)) {
+		if(emode==1) {
+			LM_ERR("%s not found or is not callable\n", fname);
+		} else {
+			LM_DBG("%s not found or is not callable\n", fname);
+		}
+		Py_XDECREF(pFunc);
+		if(locked) {
+			_sr_apy_exec_pid = 0;
+			//TODO PyThreadState_Swap(NULL);
+			//TODO PyEvalReleaseLock();
+		}
+		_sr_apy_env.msg = bmsg;
+		if(emode==1) {
+			return -1;
+		} else {
+			return 1;
+		}
+	}
+
+	pmsg = newmsgobject(_msg);
+	if (pmsg == NULL) {
+		LM_ERR("can't create MSGtype instance\n");
+		Py_DECREF(pFunc);
+		if(locked) {
+			_sr_apy_exec_pid = 0;
+			//TODO PyThreadState_Swap(NULL);
+			//TODO PyEvalReleaseLock();
+		}
+		_sr_apy_env.msg = bmsg;
+		return -1;
+	}
+
+	pArgs = PyTuple_New(fparam == NULL ? 1 : 2);
+	if (pArgs == NULL) {
+		LM_ERR("PyTuple_New() has failed\n");
+		msg_invalidate(pmsg);
+		Py_DECREF(pmsg);
+		Py_DECREF(pFunc);
+		if(locked) {
+			_sr_apy_exec_pid = 0;
+			//TODO PyThreadState_Swap(NULL);
+			//TODO PyEvalReleaseLock();
+		}
+		_sr_apy_env.msg = bmsg;
+		return -1;
+	}
+	PyTuple_SetItem(pArgs, 0, pmsg);
+	/* Tuple steals pmsg */
+
+	if (fparam != NULL) {
+		pValue = PyUnicode_FromString(fparam);
+		if (pValue == NULL) {
+			LM_ERR("PyUnicode_FromString(%s) has failed\n", fparam);
+			msg_invalidate(pmsg);
+			Py_DECREF(pArgs);
+			Py_DECREF(pFunc);
+			if(locked) {
+				_sr_apy_exec_pid = 0;
+				//TODO PyThreadState_Swap(NULL);
+				//TODO PyEvalReleaseLock();
+			}
+			_sr_apy_env.msg = bmsg;
+			return -1;
+		}
+		PyTuple_SetItem(pArgs, 1, pValue);
+		/* Tuple steals pValue */
+	}
+
+	pResult = PyObject_CallObject(pFunc, pArgs);
+	msg_invalidate(pmsg);
+	Py_DECREF(pArgs);
+	Py_DECREF(pFunc);
+	if (PyErr_Occurred()) {
+		Py_XDECREF(pResult);
+		python_handle_exception("python_exec2");
+		if(locked) {
+			_sr_apy_exec_pid = 0;
+			//TODO PyThreadState_Swap(NULL);
+			//TODO PyEvalReleaseLock();
+		}
+		_sr_apy_env.msg = bmsg;
+		return -1;
+	}
+
+	if (pResult == NULL) {
+		LM_ERR("PyObject_CallObject() returned NULL\n");
+		if(locked) {
+			_sr_apy_exec_pid = 0;
+			//TODO PyThreadState_Swap(NULL);
+			//TODO PyEvalReleaseLock();
+		}
+		_sr_apy_env.msg = bmsg;
+		return -1;
+	}
+
+	rval = PyLong_AsLong(pResult);
+	Py_DECREF(pResult);
+	if(locked) {
+		_sr_apy_exec_pid = 0;
+		//TODO PyThreadState_Swap(NULL);
+		//TODO PyEval_ReleaseLock();
+	}
+	_sr_apy_env.msg = bmsg;
+	return rval;
+}
+
+/**
+ *
+ */
+int python_exec1(sip_msg_t *_msg, char *method_name, char *foobar)
+{
+	str method = STR_NULL;
+	if(fixup_get_svalue(_msg, (gparam_t*)method_name, &method)<0) {
+		LM_ERR("cannot get the python method to be executed\n");
+		return -1;
+	}
+	return apy_exec(_msg, method.s, NULL, 1);
+}
+
+/**
+ *
+ */
+int python_exec2(sip_msg_t *_msg, char *method_name, char *mystr)
+{
+	str method = STR_NULL;
+	str param = STR_NULL;
+	if(fixup_get_svalue(_msg, (gparam_t*)method_name, &method)<0) {
+		LM_ERR("cannot get the python method to be executed\n");
+		return -1;
+	}
+	if(fixup_get_svalue(_msg, (gparam_t*)mystr, &param)<0) {
+		LM_ERR("cannot get the parameter of the python method\n");
+		return -1;
+	}
+	return apy_exec(_msg, method.s, param.s, 1);
+}

--- a/src/modules/app_python3/python_exec.h
+++ b/src/modules/app_python3/python_exec.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2009 Sippy Software, Inc., http://www.sippysoft.com
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+*/
+
+#ifndef _PYTHON_EXEC_H
+#define  _PYTHON_EXEC_H
+
+#include "../../core/parser/msg_parser.h"
+
+typedef struct sr_apy_env {
+	sip_msg_t *msg;
+} sr_apy_env_t;
+
+sr_apy_env_t *sr_apy_env_get();
+
+int apy_exec(sip_msg_t *_msg, char *fname, char *fparam, int emode);
+int python_exec1(sip_msg_t *, char *, char *);
+int python_exec2(sip_msg_t *, char *, char *);
+
+#endif

--- a/src/modules/app_python3/python_iface.c
+++ b/src/modules/app_python3/python_iface.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2009 Sippy Software, Inc., http://www.sippysoft.com
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+*/
+
+// Python includes
+#include <Python.h>
+
+// router includes
+#include "../../core/action.h"
+#include "../../core/dprint.h"
+#include "../../core/route_struct.h"
+#include "../../core/str.h"
+#include "../../core/sr_module.h"
+
+// local includes
+#include "mod_Router.h"
+#include "mod_Core.h"
+#include "mod_Ranks.h"
+#include "mod_Logger.h"
+
+#include "apy_kemi.h"
+
+
+int ap_init_modules(void)
+{
+	init_mod_Router();
+	/* Python 3:
+	 * this will be done in the Router module initialization
+	init_mod_Core();
+	init_mod_Ranks();
+	init_mod_Logger();
+	*/
+	if(sr_apy_init_ksr()<0) return -1;
+
+	return 0;
+}
+

--- a/src/modules/app_python3/python_iface.h
+++ b/src/modules/app_python3/python_iface.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2009 Sippy Software, Inc., http://www.sippysoft.com
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+*/
+
+#ifndef _PYTHON_IFACE_H
+#define  _PYTHON_IFACE_H
+
+#include <Python.h>
+
+extern PyMethodDef RouterMethods[];
+int ap_init_modules(void);
+
+#endif

--- a/src/modules/app_python3/python_msgobj.c
+++ b/src/modules/app_python3/python_msgobj.c
@@ -1,0 +1,545 @@
+/*
+ * Copyright (C) 2009 Sippy Software, Inc., http://www.sippysoft.com
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <Python.h>
+
+#include "../../core/action.h"
+#include "../../core/mem/mem.h"
+#include "../../core/sr_module.h"
+#include "../../core/dset.h"
+#include "../../core/parser/msg_parser.h"
+
+#include "msgobj_struct.h"
+#include "structmember.h"
+
+static PyTypeObject MSGtype;
+
+#define is_msgobject(v)         ((v)->ob_type == &MSGtype)
+
+msgobject *newmsgobject(struct sip_msg *msg)
+{
+	msgobject *msgp;
+
+	msgp = PyObject_New(msgobject, &MSGtype);
+	if (msgp == NULL)
+		return NULL;
+
+	msgp->msg = msg;
+	return msgp;
+}
+
+void msg_invalidate(msgobject *self)
+{
+	self->msg = NULL;
+}
+
+static void msg_dealloc(msgobject *msgp)
+{
+	PyObject_Del(msgp);
+}
+
+static PyObject *msg_copy(msgobject *self)
+{
+	msgobject *msgp;
+
+	if ((msgp = newmsgobject(self->msg)) == NULL)
+		return NULL;
+
+	return (PyObject *)msgp;
+}
+
+static PyObject *msg_rewrite_ruri(msgobject *self, PyObject *args)
+{
+	str nuri;
+
+	if (self == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if (self->msg == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self->msg is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if ((self->msg->first_line).type != SIP_REQUEST) {
+		PyErr_SetString(PyExc_RuntimeError, "Not a request message - rewrite is not possible.\n");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if(!PyArg_ParseTuple(args, "s:rewrite_ruri", &nuri.s))
+		return NULL;
+
+	nuri.len = strlen(nuri.s);
+
+	if(rewrite_uri(self->msg, &nuri)<0) {
+		LM_ERR("failed to update r-uri with [%.*s]\n", nuri.len, nuri.s);
+	}
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+static PyObject *msg_set_dst_uri(msgobject *self, PyObject *args)
+{
+	str ruri;
+
+	if (self == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if (self->msg == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self->msg is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if ((self->msg->first_line).type != SIP_REQUEST) {
+		PyErr_SetString(PyExc_RuntimeError, "Not a request message - set destination is not possible.\n");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if(!PyArg_ParseTuple(args, "s:set_dst_uri", &ruri.s))
+		return NULL;
+
+	ruri.len = strlen(ruri.s);
+
+	if (set_dst_uri(self->msg, &ruri) < 0) {
+		LM_ERR("Error in set_dst_uri\n");
+		PyErr_SetString(PyExc_RuntimeError, "Error in set_dst_uri\n");
+	}
+	/* dst_uri changes, so it makes sense to re-use the current uri for
+	 * forking */
+	ruri_mark_new(); /* re-use uri for serial forking */
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+static PyObject *msg_getHeader(msgobject *self, PyObject *args)
+{
+	struct hdr_field *hf;
+	str hname, *hbody;
+
+	if (self == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if (self->msg == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self->msg is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if(!PyArg_ParseTuple(args, "s:getHeader", &hname.s))
+		return NULL;
+	hname.len = strlen(hname.s);
+
+	if(parse_headers(self->msg, HDR_EOH_F, 0)<0) {
+		LM_ERR("failed to parse msg headers\n");
+	}
+	hbody = NULL;
+	for (hf = self->msg->headers; hf != NULL; hf = hf->next) {
+		if (hname.len == hf->name.len &&
+				strncasecmp(hname.s, hf->name.s, hname.len) == 0) {
+			hbody = &(hf->body);
+			break;
+		}
+	}
+
+	if (hbody == NULL) {
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	return PyUnicode_FromStringAndSize(hbody->s, hbody->len);
+}
+
+PyObject *msg_call_function(msgobject *self, PyObject *args)
+{
+	int i, rval;
+	char *fname, *arg1, *arg2;
+	sr31_cmd_export_t* fexport;
+	struct action *act;
+	struct run_act_ctx ra_ctx;
+	unsigned mod_ver;
+
+	if (self == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if (self->msg == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self->msg is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	i = PySequence_Size(args);
+	if (i < 1 || i > 3) {
+		PyErr_SetString(PyExc_RuntimeError, "call_function() should " \
+				"have from 1 to 3 arguments");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if(!PyArg_ParseTuple(args, "s|ss:call_function", &fname, &arg1, &arg2))
+		return NULL;
+
+	fexport = find_export_record(fname, i - 1, 0, &mod_ver);
+	if (fexport == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "no such function");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	act = mk_action(MODULE2_T, 4 /* number of (type, value) pairs */,
+			MODEXP_ST, fexport, /* function */
+			NUMBER_ST, 2,       /* parameter number */
+			STRING_ST, arg1,    /* param. 1 */
+			STRING_ST, arg2     /* param. 2 */
+			);
+
+	if (act == NULL) {
+		PyErr_SetString(PyExc_RuntimeError,
+				"action structure could not be created");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if (fexport->fixup != NULL) {
+		if (i >= 3) {
+			rval = fexport->fixup(&(act->val[3].u.data), 2);
+			if (rval < 0) {
+				PyErr_SetString(PyExc_RuntimeError, "Error in fixup (2)");
+				Py_INCREF(Py_None);
+				pkg_free(act);
+				return Py_None;
+			}
+			act->val[3].type = MODFIXUP_ST;
+		}
+		if (i >= 2) {
+			rval = fexport->fixup(&(act->val[2].u.data), 1);
+			if (rval < 0) {
+				PyErr_SetString(PyExc_RuntimeError, "Error in fixup (1)");
+				Py_INCREF(Py_None);
+				pkg_free(act);
+				return Py_None;
+			}
+			act->val[2].type = MODFIXUP_ST;
+		}
+		if (i == 1) {
+			rval = fexport->fixup(0, 0);
+			if (rval < 0) {
+				PyErr_SetString(PyExc_RuntimeError, "Error in fixup (0)");
+				Py_INCREF(Py_None);
+				pkg_free(act);
+				return Py_None;
+			}
+		}
+	}
+
+	init_run_actions_ctx(&ra_ctx);
+	rval = do_action(&ra_ctx, act, self->msg);
+
+	if ((act->val[3].type == MODFIXUP_ST) && (act->val[3].u.data)) {
+		pkg_free(act->val[3].u.data);
+	}
+
+	if ((act->val[2].type == MODFIXUP_ST) && (act->val[2].u.data)) {
+		pkg_free(act->val[2].u.data);
+	}
+
+	pkg_free(act);
+
+	return PyLong_FromLong(rval);
+}
+
+PyDoc_STRVAR(copy_doc,
+		"copy() -> msg object\n\
+		\n\
+		Return a copy (``clone'') of the msg object.");
+
+static PyMethodDef msg_methods[] = {
+	{"copy",          (PyCFunction)msg_copy,          METH_NOARGS,
+		copy_doc},
+	{"rewrite_ruri",  (PyCFunction)msg_rewrite_ruri,  METH_VARARGS,
+		"Rewrite Request-URI."},
+	{"set_dst_uri",   (PyCFunction)msg_set_dst_uri,   METH_VARARGS,
+		"Set destination URI."},
+	{"getHeader",     (PyCFunction)msg_getHeader,     METH_VARARGS,
+		"Get SIP header field by name."},
+	{"call_function", (PyCFunction)msg_call_function, METH_VARARGS,
+		"Invoke function exported by the other module."},
+	{NULL, NULL, 0, NULL} /* sentinel */
+};
+
+static PyObject *msg_getType(msgobject *self, PyObject *unused)
+{
+	const char *rval;
+
+	if (self == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if (self->msg == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self->msg is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	switch ((self->msg->first_line).type)
+	{
+		case SIP_REQUEST:
+			rval = "SIP_REQUEST";
+			break;
+
+		case SIP_REPLY:
+			rval = "SIP_REPLY";
+			break;
+
+		default:
+			rval = "SIP_INVALID";
+			break;
+	}
+
+	return PyUnicode_FromString(rval);
+}
+
+static PyObject *msg_getMethod(msgobject *self, PyObject *unused)
+{
+	str *rval;
+
+	if (self == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if (self->msg == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self->msg is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if ((self->msg->first_line).type != SIP_REQUEST) {
+		PyErr_SetString(PyExc_RuntimeError, "Not a request message - no method available.\n");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+	rval = &((self->msg->first_line).u.request.method);
+	return PyUnicode_FromStringAndSize(rval->s, rval->len);
+}
+
+static PyObject *msg_getStatus(msgobject *self, PyObject *unused)
+{
+	str *rval;
+
+	if (self == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if (self->msg == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self->msg is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if ((self->msg->first_line).type != SIP_REPLY) {
+		PyErr_SetString(PyExc_RuntimeError, "Not a non-reply message - no status available.\n");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	rval = &((self->msg->first_line).u.reply.status);
+	return PyUnicode_FromStringAndSize(rval->s, rval->len);
+}
+
+static PyObject *msg_getRURI(msgobject *self, PyObject *unused)
+{
+	str *rval;
+
+	if (self == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if (self->msg == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self->msg is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if ((self->msg->first_line).type != SIP_REQUEST) {
+		PyErr_SetString(PyExc_RuntimeError, "Not a request message - RURI is not available.\n");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	rval = &((self->msg->first_line).u.request.uri);
+	return PyUnicode_FromStringAndSize(rval->s, rval->len);
+}
+
+static PyObject *msg_get_src_address(msgobject *self, PyObject *unused)
+{
+	PyObject *src_ip, *src_port, *pyRval;
+
+	if (self == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if (self->msg == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self->msg is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	src_ip = PyUnicode_FromString(ip_addr2a(&self->msg->rcv.src_ip));
+	if (src_ip == NULL) {
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	src_port = PyLong_FromLong(self->msg->rcv.src_port);
+	if (src_port == NULL) {
+		Py_DECREF(src_ip);
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	pyRval = PyTuple_Pack(2, src_ip, src_port);
+	Py_DECREF(src_ip);
+	Py_DECREF(src_port);
+	if (pyRval == NULL) {
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	return pyRval;
+}
+
+static PyObject *msg_get_dst_address(msgobject *self, PyObject *unused)
+{
+	PyObject *dst_ip, *dst_port, *pyRval;
+
+	if (self == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	if (self->msg == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "self->msg is NULL");
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	dst_ip = PyUnicode_FromString(ip_addr2a(&self->msg->rcv.dst_ip));
+	if (dst_ip == NULL) {
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	dst_port = PyLong_FromLong(self->msg->rcv.dst_port);
+	if (dst_port == NULL) {
+		Py_DECREF(dst_ip);
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	pyRval = PyTuple_Pack(2, dst_ip, dst_port);
+	Py_DECREF(dst_ip);
+	Py_DECREF(dst_port);
+	if (pyRval == NULL) {
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	return pyRval;
+}
+
+static PyGetSetDef msg_getseters[] = {
+	{"Type",		(getter)msg_getType, NULL, NULL,		"Get message type - \"SIP_REQUEST\" or \"SIP_REPLY\"."},
+	{"Method",		(getter)msg_getMethod, NULL, NULL,		"Get SIP method name."},
+	{"Status",		(getter)msg_getStatus, NULL, NULL,		"Get SIP status code string."},
+	{"RURI",		(getter)msg_getRURI, NULL, NULL,		"Get SIP Request-URI."},
+	{"src_address",	(getter)msg_get_src_address, NULL, NULL,	"Get (IP, port) tuple representing source address of the message."},
+	{"dst_address",	(getter)msg_get_dst_address, NULL, NULL,	"Get (IP, port) tuple representing destination address of the message."},
+	{NULL, NULL, NULL, NULL, NULL}  /* Sentinel */
+};
+
+static PyTypeObject MSGtype = {
+	PyVarObject_HEAD_INIT(NULL, 0)
+	"Router.msg",             /*tp_name*/
+	sizeof(msgobject),        /*tp_basicsize*/
+	0,                        /*tp_itemsize*/
+	/* methods */
+	(destructor)msg_dealloc,  /*tp_dealloc*/
+	0,                        /*tp_print*/
+	0,                        /*tp_getattr*/
+	0,                        /*tp_setattr*/
+	0,                        /*tp_as_sync*/
+	0,                        /*tp_repr*/
+	0,                        /*tp_as_number*/
+	0,                        /*tp_as_sequence*/
+	0,                        /*tp_as_mapping*/
+	0,                        /*tp_hash*/
+	0,                        /*tp_call*/
+	0,                        /*tp_str*/
+	0,                        /*tp_getattro*/
+	0,                        /*tp_setattro*/
+	0,                        /*tp_as_buffer*/
+	Py_TPFLAGS_DEFAULT,       /*tp_flags*/
+	0,                        /*tp_doc*/
+	0,                        /*tp_traverse*/
+	0,                        /*tp_clear*/
+	0,                        /*tp_richcompare*/
+	0,                        /*tp_weaklistoffset*/
+	0,                        /*tp_iter*/
+	0,                        /*tp_iternext*/
+	msg_methods,              /*tp_methods*/
+	0,                        /*tp_members*/
+	msg_getseters,            /*tp_getset*/
+};
+
+int python_msgobj_init(void)
+{
+	Py_TYPE(&MSGtype) = &PyType_Type;
+	if (PyType_Ready(&MSGtype) < 0)
+		return -1;
+	return 0;
+}

--- a/src/modules/app_python3/python_msgobj.h
+++ b/src/modules/app_python3/python_msgobj.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2009 Sippy Software, Inc., http://www.sippysoft.com
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+*/
+
+#ifndef _PYTHON_MSGOBJ_H
+#define  _PYTHON_MSGOBJ_H
+
+#include "../../core/parser/msg_parser.h"
+
+#include <Python.h>
+
+PyObject *newmsgobject(struct sip_msg *);
+int python_msgobj_init(void);
+void msg_invalidate(PyObject *);
+
+#endif

--- a/src/modules/app_python3/python_support.c
+++ b/src/modules/app_python3/python_support.c
@@ -1,0 +1,277 @@
+/*
+ * Copyright (C) 2009 Sippy Software, Inc., http://www.sippysoft.com
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <Python.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include "../../core/dprint.h"
+#include "../../core/mem/mem.h"
+
+#include "app_python_mod.h"
+#include "python_support.h"
+
+void python_handle_exception(const char *fmt, ...)
+{
+	PyObject *pResult;
+	const char *msg;
+	char *buf;
+	size_t buflen, msglen;
+	PyObject *exception, *v, *tb, *args;
+	PyObject *line;
+	int i;
+	char *srcbuf;
+	int exc_exit = 0;
+
+	// We don't want to generate traceback when no errors occurred
+	if (!PyErr_Occurred())
+		return;
+
+	if (fmt == NULL)
+		srcbuf = NULL;
+	else
+		srcbuf = make_message(fmt);
+
+	PyErr_Fetch(&exception, &v, &tb);
+	PyErr_Clear();
+	if (exception == NULL) {
+		LM_ERR("Can't get traceback, PyErr_Fetch() has failed.\n");
+		if (srcbuf) pkg_free(srcbuf);
+		return;
+	}
+
+	PyErr_NormalizeException(&exception, &v, &tb);
+	if (exception == NULL) {
+		LM_ERR("Can't get traceback, PyErr_NormalizeException() has failed.\n");
+		if (srcbuf) pkg_free(srcbuf);
+		return;
+	}
+
+	exc_exit = PyErr_GivenExceptionMatches(exception, PyExc_SystemExit);
+	args = PyTuple_Pack(3, exception, v, tb ? tb : Py_None);
+	Py_XDECREF(exception);
+	Py_XDECREF(v);
+	Py_XDECREF(tb);
+	if (args == NULL) {
+		LM_ERR("Can't get traceback, PyTuple_Pack() has failed.\n");
+		if (srcbuf) pkg_free(srcbuf);
+		return;
+	}
+
+	pResult = PyObject_CallObject(format_exc_obj, args);
+	Py_DECREF(args);
+	if (pResult == NULL) {
+		LM_ERR("Can't get traceback, traceback.format_exception() has failed.\n");
+		if (srcbuf) pkg_free(srcbuf);
+		return;
+	}
+
+	buflen = 1;
+	buf = (char *)pkg_realloc(NULL, buflen * sizeof(char));
+	if (!buf)
+	{
+		LM_ERR("Can't allocate memory (%lu bytes), pkg_realloc() has failed."
+				" Not enough memory.\n", (unsigned long)(buflen * sizeof(char *)));
+		if (srcbuf) pkg_free(srcbuf);
+		return;
+	}
+	memset(buf, 0, buflen * sizeof(char));
+
+	for (i = 0; i < PySequence_Size(pResult); i++) {
+		line = PySequence_GetItem(pResult, i);
+		if (line == NULL) {
+			LM_ERR("Can't get traceback, PySequence_GetItem() has failed.\n");
+			Py_DECREF(pResult);
+			if (buf)
+				pkg_free(buf);
+			if (srcbuf) pkg_free(srcbuf);
+			return;
+		}
+
+		msg = PyUnicode_AsUTF8(line);
+
+		if (msg == NULL) {
+			LM_ERR("Can't get traceback, PyUnicode_AsUTF8() has failed.\n");
+			Py_DECREF(line);
+			Py_DECREF(pResult);
+			if (buf)
+				pkg_free(buf);
+			if (srcbuf) pkg_free(srcbuf);
+			return;
+		}
+
+		msglen = strlen(msg);
+		buflen += ++msglen;
+
+		buf = (char *)pkg_reallocxf(buf, buflen * sizeof(char));
+		if (!buf)
+		{
+			LM_ERR("Can't allocate memory (%lu bytes), pkg_realloc() has failed."
+					" Not enough memory.\n", (unsigned long)(buflen * sizeof(char *)));
+			Py_DECREF(line);
+			Py_DECREF(pResult);
+			if (srcbuf) pkg_free(srcbuf);
+			return;
+		}
+
+		strncat(buf, msg, msglen >= buflen ? buflen-1 : msglen);
+
+		Py_DECREF(line);
+	}
+
+	if (srcbuf == NULL) {
+		if(exc_exit) {
+			LM_DBG("Unhandled exception in the Python code:\n%s", buf);
+		} else {
+			LM_ERR("Unhandled exception in the Python code:\n%s", buf);
+		}
+	} else {
+		if(exc_exit) {
+			LM_DBG("%s: Unhandled exception in the Python code:\n%s", srcbuf, buf);
+		} else {
+			LM_ERR("%s: Unhandled exception in the Python code:\n%s", srcbuf, buf);
+		}
+	}
+
+	if (buf)
+		pkg_free(buf);
+
+	if (srcbuf)
+		pkg_free(srcbuf);
+
+	Py_DECREF(pResult);
+}
+
+
+PyObject *InitTracebackModule()
+{
+	PyObject *pModule, *pTracebackObject;
+
+	pModule = PyImport_ImportModule("traceback");
+	if (pModule == NULL) {
+		LM_ERR("Cannot import module 'traceback'.\n");
+		return NULL;
+	}
+
+	pTracebackObject = PyObject_GetAttrString(pModule, "format_exception");
+	Py_DECREF(pModule);
+	if (pTracebackObject == NULL || !PyCallable_Check(pTracebackObject)) {
+		LM_ERR("AttributeError: 'module' object 'traceback' has no attribute"
+				" 'format_exception'.\n");
+		Py_XDECREF(pTracebackObject);
+		return NULL;
+	}
+
+	return pTracebackObject;
+}
+
+
+char *make_message(const char *fmt, ...)
+{
+	int n;
+	size_t size;
+	char *p, *np;
+	va_list ap;
+
+	size = 100;     /* Guess we need no more than 100 bytes. */
+	p = (char *)pkg_realloc(NULL, size * sizeof(char));
+	if (!p)
+	{
+		LM_ERR("Can't allocate memory (%lu bytes), pkg_malloc() has failed:"
+				" Not enough memory.\n", (unsigned long)(size * sizeof(char)));
+		return NULL;
+	}
+	memset(p, 0, size * sizeof(char));
+
+	while (1)
+	{
+		va_start(ap, fmt);
+		n = vsnprintf(p, size, fmt, ap);
+		va_end(ap);
+
+		if (n > -1 && n < size)
+			return p;
+
+		if (n > -1)    /* glibc 2.1 */
+			size = n+1;
+		else           /* glibc 2.0 */
+			size *= 2;
+
+		np = (char *)pkg_realloc(p, size * sizeof(char));
+		if (!np)
+		{
+			LM_ERR("Can't allocate memory (%lu bytes), pkg_realloc() has failed:"
+					" Not enough memory.\n", (unsigned long)size * sizeof(char));
+			if (p)
+				pkg_free(p);
+			return NULL;
+		}
+		else
+			p = np;
+	}
+
+	return NULL;	// shall not happened, but who knows ;)
+}
+
+char *get_class_name(PyObject *y)
+{
+	PyObject *p;
+	char *name;
+
+	p = PyObject_GetAttrString(y, "__name__");
+	if (p == NULL || p == Py_None)
+	{
+		Py_XDECREF(p);
+		return NULL;
+	}
+
+	name = PyUnicode_AsUTF8(p);
+	Py_XDECREF(p);
+
+	return name;
+}
+
+
+char *get_instance_class_name(PyObject *y)
+{
+	PyObject *p, *n;
+	char *name;
+
+	n = PyObject_GetAttrString(y, "__class__");
+	if (n == NULL || n == Py_None)
+	{
+		Py_XDECREF(n);
+		return NULL;
+	}
+
+	p = PyObject_GetAttrString(n, "__name__");
+	if (p == NULL || p == Py_None)
+	{
+		Py_XDECREF(p);
+		return NULL;
+	}
+
+	name = PyUnicode_AsUTF8(p);
+	Py_XDECREF(p);
+	Py_XDECREF(n);
+
+	return name;
+}

--- a/src/modules/app_python3/python_support.h
+++ b/src/modules/app_python3/python_support.h
@@ -1,0 +1,37 @@
+/* 
+ * Copyright (C) 2009 Sippy Software, Inc., http://www.sippysoft.com
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+*/
+
+#ifndef _PYTHON_SUPPORT_H
+#define  _PYTHON_SUPPORT_H
+
+#include <Python.h>
+#include <stdarg.h>
+
+PyObject *format_exc_obj;
+
+void python_handle_exception(const char *, ...);
+char *make_message(const char *fmt, ...);
+
+PyObject *InitTracebackModule(void);
+char *get_class_name(PyObject *);
+char *get_instance_class_name(PyObject *);
+
+#endif

--- a/src/modules/app_python3/utils/app_python_ctl
+++ b/src/modules/app_python3/utils/app_python_ctl
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# generate the .h file
+
+KEMI_MAX_SIZE=1024
+
+cat > ../apy_kemi_export.h <<EOF
+/**
+ * Copyright (C) 2016 Daniel-Constantin Mierla (asipto.com)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/**
+ * this file is generated - do not edit
+ */
+
+#ifndef __APY_KEMI_FLIB_H__
+#define __APY_KEMI_FLIB_H__
+
+#include <Python.h>
+#include "../../core/kemi.h"
+
+#define SR_APY_KEMI_EXPORT_SIZE	${KEMI_MAX_SIZE}
+
+typedef struct sr_apy_kemi_export {
+	PyCFunction pfunc;
+	sr_kemi_t *ket;
+} sr_apy_kemi_export_t;
+
+sr_kemi_t *sr_apy_kemi_export_get(int idx);
+PyCFunction sr_apy_kemi_export_associate(sr_kemi_t *ket);
+
+#endif
+EOF
+
+# generate the .c file
+
+cat > ../apy_kemi_export.c <<EOF
+/**
+ * Copyright (C) 2016 Daniel-Constantin Mierla (asipto.com)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/**
+ * this file is generated - do not edit
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#include <Python.h>
+
+#include "../../core/dprint.h"
+
+#include "apy_kemi.h"
+#include "apy_kemi_export.h"
+
+EOF
+
+CEND=${KEMI_MAX_SIZE}
+
+for (( c=0; c<CEND; c++ )); do
+	echo >>../apy_kemi_export.c
+	echo "/**" >>../apy_kemi_export.c
+	echo " *" >>../apy_kemi_export.c
+	echo " */" >>../apy_kemi_export.c
+	echo "static PyObject *sr_apy_kemi_exec_func_${c}(PyObject *self, PyObject *args)" >>../apy_kemi_export.c
+	echo "{" >>../apy_kemi_export.c
+	echo "	return sr_apy_kemi_exec_func(self, args, ${c});" >>../apy_kemi_export.c
+	echo "}" >>../apy_kemi_export.c
+done
+
+echo >>../apy_kemi_export.c
+echo "/**" >>../apy_kemi_export.c
+echo " *" >>../apy_kemi_export.c
+echo " */" >>../apy_kemi_export.c
+
+echo "static sr_apy_kemi_export_t _sr_apy_kemi_export_list[] = {" >>../apy_kemi_export.c
+for (( c=0; c<CEND; c++ )); do
+	echo "	{ sr_apy_kemi_exec_func_${c}, NULL}," >>../apy_kemi_export.c
+done
+echo "	{NULL, NULL}" >>../apy_kemi_export.c
+echo "};" >>../apy_kemi_export.c
+
+cat >> ../apy_kemi_export.c <<EOF
+
+/**
+ *
+ */
+sr_kemi_t *sr_apy_kemi_export_get(int idx)
+{
+	if(idx<0 || idx>=SR_APY_KEMI_EXPORT_SIZE)
+		return NULL;
+	return _sr_apy_kemi_export_list[idx].ket;
+}
+
+/**
+ *
+ */
+PyCFunction sr_apy_kemi_export_associate(sr_kemi_t *ket)
+{
+	int i;
+	for(i=0; i<SR_APY_KEMI_EXPORT_SIZE; i++) {
+		if(_sr_apy_kemi_export_list[i].ket==NULL) {
+			_sr_apy_kemi_export_list[i].ket = ket;
+			return _sr_apy_kemi_export_list[i].pfunc;
+		}
+		if(_sr_apy_kemi_export_list[i].ket==ket) {
+			return _sr_apy_kemi_export_list[i].pfunc;
+		}
+	}
+	LM_ERR("no more indexing slots\n");
+	return NULL;
+}
+EOF


### PR DESCRIPTION
First attempt at porting app_python to app_python3.

Mostly symbols names are the same as app_python so these two
modules cannot be loaded together. Exported functions are identical so
in theory scripts need not change.

TODO: reenable thread management

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
- add app_python3 module
- this is a direct port of app_python and aims for feature equivalence
- script reload does not work yet
- disable thread management; fortunately kamailio does not use threads; as the Py3 API is too different;
  trying to avoid deprecated APIs like PyEval_AcquireLock(). 
- TODO: need to reenable threads: use case is python extension module that uses native threads (e.g. gRPC)

