### PR TITLE
tm: flag core to use forced socket when uac socket is set

### DIFF
--- a/src/modules/tm/uac.c
+++ b/src/modules/tm/uac.c
@@ -428,6 +428,12 @@ static inline int t_uac_prepare(uac_req_t *uac_r,
 	/* new message => take the dialog send_socket if set, or the default
 	  send_socket if not*/
 	SND_FLAGS_INIT(&snd_flags);
+
+	if (uac_r->dialog->send_sock != NULL)
+	{
+		snd_flags.f |= SND_F_FORCE_SOCKET;
+	}
+
 #ifdef USE_DNS_FAILOVER
 	if ((uri2dst2(cfg_get(core, core_cfg, use_dns_failover) ? &new_cell->uac[0].dns_h : 0,
 			&dst, uac_r->dialog->send_sock, snd_flags,


### PR DESCRIPTION
#### Pre-Submission Checklist

- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:

- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

While testing Kamailio instance with multiple interfaces I noticed that dispatcher probing does not use the socket defined on dispatcher ```list_file```.
By setting flag ```SND_F_FORCE_SOCKET```, in tm module, dispatcher probing or tm t_uac_send() is sourced as per ```socket``` attribute.

Tested on FreeBSD 11.1 and Ubuntu 16.04.