### PR TITLE
app_python3: implement script reloading

### DIFF
--- a/src/modules/app_python3/app_python_mod.h
+++ b/src/modules/app_python3/app_python_mod.h
@@ -27,5 +27,5 @@
 extern PyObject *_sr_apy_handler_obj;
 extern PyObject *format_exc_obj;
 extern PyThreadState *myThreadState;
-
+int apy_reload_script(void);
 #endif

--- a/src/modules/app_python3/doc/app_python3_admin.xml
+++ b/src/modules/app_python3/doc/app_python3_admin.xml
@@ -191,13 +191,19 @@ python_exec("my_python_function", "$rU");
             <function moreinfo="none">app_python.reload</function>
             </title>
 			<para>
-				IMPORTANT: not functional yet (can crash a running instance,
-				use it only for testing).
+				IMPORTANT: this is not thread-safe. In your Python script
+				do not use C extensions with threads that call into
+				<varname>apy_exec()</varname>.
 			</para>
             <para>
             Marks the need to reload the Python script.
-            The actual reload is done by every working process when the next
-            call to KEMI config is executed.
+            The actual reload is done in each worker when it next invokes a Python method.
+            The module uses a worker process lock to prevent recursive reloads. 
+            </para>
+            <para>
+              This function only reloads the user script and creates a new script object.
+	      It does not reinitialize the interpreter.
+	      E.g., references in the old module remain if not redefined by the new version.
             </para>
             <para>
             Name: <emphasis>app_python.reload</emphasis>

--- a/src/modules/app_python3/python_exec.c
+++ b/src/modules/app_python3/python_exec.c
@@ -30,6 +30,7 @@
 #include "../../core/config.h"
 #include "../../core/mod_fix.h"
 #include "../../core/parser/parse_uri.h"
+#include "../../core/locking.h"
 
 #include "python_exec.h"
 #include "app_python_mod.h"
@@ -46,39 +47,43 @@ sr_apy_env_t *sr_apy_env_get()
 	return &_sr_apy_env;
 }
 
-static int _sr_apy_exec_pid = 0;
-
 #define PY_GIL_ENSURE gstate = PyGILState_Ensure();
 #define PY_GIL_RELEASE PyGILState_Release(gstate);
+#define LOCK_RELEASE if(locked) lock_release(_sr_python_reload_lock);
 
-// #define PY_THREADSTATE_SWAP_IN PyThreadState_Swap(myThreadState);
-// #define PY_THREADSTATE_SWAP_NULL PyThreadState_Swap(NULL);
-#define PY_THREADSTATE_SWAP_IN
-#define PY_THREADSTATE_SWAP_NULL
-
-/**
- *
+/*
+ * copy the logic from app_lua/app_lua_api.c:
+ * reload script if version has changed and we are depth 0
+ * initialized in apy_kemi.c
  */
+extern gen_lock_t* _sr_python_reload_lock;
+extern int *_sr_python_reload_version;
+extern int _sr_python_local_version;
+
 int apy_exec(sip_msg_t *_msg, char *fname, char *fparam, int emode)
 {
 	PyObject *pFunc, *pArgs, *pValue, *pResult;
 	PyObject *pmsg;
-	int rval;
+	int rval = -1;
 	sip_msg_t *bmsg;
-	int mpid;
-	int locked = 0;
 	PyGILState_STATE gstate;
-	
-	bmsg = _sr_apy_env.msg;
-	_sr_apy_env.msg = _msg;
-	mpid = getpid();
+	int locked = 0;
 
-	if(_sr_apy_exec_pid!=mpid) {
-		PY_GIL_ENSURE
-		_sr_apy_exec_pid = mpid;
-		PY_THREADSTATE_SWAP_IN
+	if (lock_try(_sr_python_reload_lock) == 0) {
+		if(_sr_python_reload_version && *_sr_python_reload_version != _sr_python_local_version) {
+			LM_INFO("Reloading script %d->%d\n", _sr_python_local_version, *_sr_python_reload_version);
+			if (apy_reload_script()) {
+				LM_ERR("Error reloading script\n");
+			} else {
+				_sr_python_local_version = *_sr_python_reload_version;
+			}
+		}
 		locked = 1;
 	}
+
+	bmsg = _sr_apy_env.msg;
+	_sr_apy_env.msg = _msg;
+	PY_GIL_ENSURE
 
 	pFunc = PyObject_GetAttrString(_sr_apy_handler_obj, fname);
 	if (pFunc == NULL || !PyCallable_Check(pFunc)) {
@@ -88,16 +93,12 @@ int apy_exec(sip_msg_t *_msg, char *fname, char *fparam, int emode)
 			LM_DBG("%s not found or is not callable\n", fname);
 		}
 		Py_XDECREF(pFunc);
-		if(locked) {
-			_sr_apy_exec_pid = 0;
-			PY_THREADSTATE_SWAP_NULL
-			PY_GIL_RELEASE
-		}
 		_sr_apy_env.msg = bmsg;
 		if(emode==1) {
-			return -1;
+			goto err;
 		} else {
-			return 1;
+			rval = 1;
+			goto err;
 		}
 	}
 
@@ -105,13 +106,8 @@ int apy_exec(sip_msg_t *_msg, char *fname, char *fparam, int emode)
 	if (pmsg == NULL) {
 		LM_ERR("can't create MSGtype instance\n");
 		Py_DECREF(pFunc);
-		if(locked) {
-			_sr_apy_exec_pid = 0;
-			PY_THREADSTATE_SWAP_NULL
-			PY_GIL_RELEASE
-		}
 		_sr_apy_env.msg = bmsg;
-		return -1;
+		goto err;
 	}
 
 	pArgs = PyTuple_New(fparam == NULL ? 1 : 2);
@@ -120,13 +116,8 @@ int apy_exec(sip_msg_t *_msg, char *fname, char *fparam, int emode)
 		msg_invalidate(pmsg);
 		Py_DECREF(pmsg);
 		Py_DECREF(pFunc);
-		if(locked) {
-			_sr_apy_exec_pid = 0;
-			PY_THREADSTATE_SWAP_NULL
-			PY_GIL_RELEASE
-		}
 		_sr_apy_env.msg = bmsg;
-		return -1;
+		goto err;
 	}
 	PyTuple_SetItem(pArgs, 0, pmsg);
 	/* Tuple steals pmsg */
@@ -138,13 +129,8 @@ int apy_exec(sip_msg_t *_msg, char *fname, char *fparam, int emode)
 			msg_invalidate(pmsg);
 			Py_DECREF(pArgs);
 			Py_DECREF(pFunc);
-			if(locked) {
-				_sr_apy_exec_pid = 0;
-				PY_THREADSTATE_SWAP_NULL
-				PY_GIL_RELEASE
-			}
 			_sr_apy_env.msg = bmsg;
-			return -1;
+			goto err;
 		}
 		PyTuple_SetItem(pArgs, 1, pValue);
 		/* Tuple steals pValue */
@@ -157,34 +143,22 @@ int apy_exec(sip_msg_t *_msg, char *fname, char *fparam, int emode)
 	if (PyErr_Occurred()) {
 		Py_XDECREF(pResult);
 		python_handle_exception("python_exec2");
-		if(locked) {
-			_sr_apy_exec_pid = 0;
-			PY_THREADSTATE_SWAP_NULL
-			PY_GIL_RELEASE
-		}
 		_sr_apy_env.msg = bmsg;
-		return -1;
+		goto err;
 	}
 
 	if (pResult == NULL) {
 		LM_ERR("PyObject_CallObject() returned NULL\n");
-		if(locked) {
-			_sr_apy_exec_pid = 0;
-			PY_THREADSTATE_SWAP_NULL
-			PY_GIL_RELEASE
-		}
 		_sr_apy_env.msg = bmsg;
-		return -1;
+		goto err;
 	}
 
 	rval = PyLong_AsLong(pResult);
 	Py_DECREF(pResult);
-	if(locked) {
-		_sr_apy_exec_pid = 0;
-		PY_THREADSTATE_SWAP_NULL
-		PY_GIL_RELEASE
-	}
 	_sr_apy_env.msg = bmsg;
+ err:
+	PY_GIL_RELEASE
+	LOCK_RELEASE
 	return rval;
 }
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Implement script reloading by copying the method used in app_lua: the version of the script is incremented by RPC. 

For each worker, the next time it handles a method, python_exec.c:apy_exec() 
will check for a newer version and reload, if necessary.

Set a lock so the script reload only occurs at depth 0 (in the unlikely case
that apy_exec() is called recursively).

This is not thread-safe as we are using a process-wide lock: don't call back
into apy_exec() from a Python C extension that uses threads.

For Pythonistas, we are reloading the module, not reinitializing the interpreter.
Standard caveats about reloading modules apply. E.g, references in the old module
that are not redefined in the newer module remain.
