### PR TITLE
 sqlops: sqlops_do_query - Make result parameter optional in C API

### DIFF
--- a/src/modules/sqlops/sql_api.c
+++ b/src/modules/sqlops/sql_api.c
@@ -703,8 +703,7 @@ int sqlops_do_query(str *scon, str *squery, str *sres)
 		LM_ERR("invalid connection [%.*s]\n", scon->len, scon->s);
 		goto error;
 	}
-	res = sql_get_result(sres);
-	if(res==NULL)
+	if (sres && ((res = sql_get_result(sres)) == NULL))
 	{
 		LM_ERR("invalid result [%.*s]\n", sres->len, sres->s);
 		goto error;

--- a/src/modules/sqlops/sql_api.c
+++ b/src/modules/sqlops/sql_api.c
@@ -697,16 +697,27 @@ int sqlops_do_query(str *scon, str *squery, str *sres)
 	sql_con_t *con = NULL;
 	sql_result_t *res = NULL;
 
+	if (scon == NULL || scon->s == NULL)
+	{
+		LM_ERR("invalid connection name\n");
+		goto error;
+	}
+
 	con = sql_get_connection(scon);
 	if(con==NULL)
 	{
 		LM_ERR("invalid connection [%.*s]\n", scon->len, scon->s);
 		goto error;
 	}
-	if (sres && ((res = sql_get_result(sres)) == NULL))
+	/* Result parameter is optional */
+	if (sres && sres->s)
 	{
-		LM_ERR("invalid result [%.*s]\n", sres->len, sres->s);
-		goto error;
+		res = sql_get_result(sres);
+		if(res==NULL)
+		{
+			LM_ERR("invalid result [%.*s]\n", sres->len, sres->s);
+			goto error;
+		}
 	}
 	if(sql_do_query(con, squery, res)<0)
 		goto error;
@@ -722,6 +733,12 @@ error:
 int sqlops_get_value(str *sres, int i, int j, sql_val_t **val)
 {
 	sql_result_t *res = NULL;
+
+	if (sres == NULL || sres->s == NULL)
+	{
+		LM_ERR("invalid result name\n");
+		goto error;
+	}
 
 	res = sql_get_result(sres);
 	if(res==NULL)
@@ -753,6 +770,12 @@ int sqlops_is_null(str *sres, int i, int j)
 {
 	sql_result_t *res = NULL;
 
+	if (sres == NULL || sres->s == NULL)
+	{
+		LM_ERR("invalid result name\n");
+		goto error;
+	}
+
 	res = sql_get_result(sres);
 	if(res==NULL)
 	{
@@ -783,6 +806,12 @@ int sqlops_get_column(str *sres, int i, str *col)
 {
 	sql_result_t *res = NULL;
 
+	if (sres == NULL || sres->s == NULL)
+	{
+		LM_ERR("invalid result name\n");
+		goto error;
+	}
+
 	res = sql_get_result(sres);
 	if(res==NULL)
 	{
@@ -807,6 +836,12 @@ int sqlops_num_columns(str *sres)
 {
 	sql_result_t *res = NULL;
 
+	if (sres == NULL || sres->s == NULL)
+	{
+		LM_ERR("invalid result name\n");
+		goto error;
+	}
+
 	res = sql_get_result(sres);
 	if(res==NULL)
 	{
@@ -824,6 +859,12 @@ error:
 int sqlops_num_rows(str *sres)
 {
 	sql_result_t *res = NULL;
+
+	if (sres == NULL || sres->s == NULL)
+	{
+		LM_ERR("invalid result name\n");
+		goto error;
+	}
 
 	res = sql_get_result(sres);
 	if(res==NULL)
@@ -843,6 +884,12 @@ void sqlops_reset_result(str *sres)
 {
 	sql_result_t *res = NULL;
 
+	if (sres == NULL || sres->s == NULL)
+	{
+		LM_ERR("invalid result name\n");
+		return;
+	}
+
 	res = sql_get_result(sres);
 	if(res==NULL)
 	{
@@ -860,6 +907,12 @@ void sqlops_reset_result(str *sres)
 int sqlops_do_xquery(sip_msg_t *msg, str *scon, str *squery, str *xavp)
 {
 	sql_con_t *con = NULL;
+
+	if (scon == NULL || scon->s == NULL)
+	{
+		LM_ERR("invalid connection name\n");
+		goto error;
+	}
 
 	con = sql_get_connection(scon);
 	if(con==NULL)


### PR DESCRIPTION
Make the result string parameter optional in the sqlops_do_query C API function