### PR TITLE
core: invoke KEMI ksr_onsend_route() unconditionally in cfgengine

### DIFF
--- a/src/core/onsend.h
+++ b/src/core/onsend.h
@@ -70,7 +70,9 @@ static inline int run_onsend(sip_msg_t* orig_msg, dest_info_t* dst,
 		return 1;
 	}
 	ret=1;
-	if (onsend_rt.rlist[DEFAULT_RT]){
+	// do if onsend_route{} or cfgengine exists
+	keng = sr_kemi_eng_get();
+	if (onsend_rt.rlist[DEFAULT_RT] || keng){
 		onsnd_info.to=&dst->to;
 		onsnd_info.send_sock=dst->send_sock;
 		onsnd_info.buf=buf;
@@ -86,8 +88,7 @@ static inline int run_onsend(sip_msg_t* orig_msg, dest_info_t* dst,
 			orig_msg->fwd_send_flags=dst->send_flags; /* intial value */
 			init_run_actions_ctx(&ra_ctx);
 
-			keng = sr_kemi_eng_get();
-			if(unlikely(keng!=NULL)) {
+			if(keng) {
 				bctx = sr_kemi_act_ctx_get();
 				sr_kemi_act_ctx_set(&ra_ctx);
 				ret=keng->froute(orig_msg, ONSEND_ROUTE, NULL, NULL);


### PR DESCRIPTION

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #1474 (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Currently we need a onsend_route{} (empty is ok) block in config before KEMI ksr_onsend_route() is invoked. The latter will override the route block.

This PR will unconditonally invoke KEMI ksr_onsend_route() so we do not need a placeholder in config.

For discussion: this will unconditionally invoke ksr_onsend_route() so it might break scripts that don't have an implementation. 

I'm not too clear about the error handling in run_onsend(): it's possible that if KEMI ksr_onsend_route throws error (not implemented rather than real error) then the message might be dropped, so this might surprise script writers. Since ksr_onsend_route() is optional it's hard to tell the difference between a real error and "not implemented is not an error".