### PR TITLE
usrloc: cleanup by server_id.

### DIFF
--- a/src/modules/usrloc/README
+++ b/src/modules/usrloc/README
@@ -1001,9 +1001,7 @@ modparam("usrloc", "rm_expired_delay", 30)
 
 3.47. server_id_filter (int)
 
-   Enable (1) or disable (0) filter records by server_id on load and during cleaning of expired db records.
-   It could be usefull when you want to use the same location table for several kamailio instances which are configured to work in db_mode=1 or db_mode=2 (cache modes).
-   Otherwise one instance of proxy cleans records made by another proxy and that breaks its cache.
+   Enable (1) or disable (0) filter records by server_id on load.
 
    Default value is “0”.
 

--- a/src/modules/usrloc/README
+++ b/src/modules/usrloc/README
@@ -1001,7 +1001,9 @@ modparam("usrloc", "rm_expired_delay", 30)
 
 3.47. server_id_filter (int)
 
-   Enable (1) or disable (0) filter records by server_id on load.
+   Enable (1) or disable (0) filter records by server_id on load and during cleaning of expired db records.
+   It could be usefull when you want to use the same location table for several kamailio instances which are configured to work in db_mode=1 or db_mode=2 (cache modes).
+   Otherwise one instance of proxy cleans records made by another proxy and that breaks its cache.
 
    Default value is “0”.
 

--- a/src/modules/usrloc/doc/usrloc_admin.xml
+++ b/src/modules/usrloc/doc/usrloc_admin.xml
@@ -1201,7 +1201,9 @@ modparam("usrloc", "rm_expired_delay", 30)
 	<section id="usrloc.p.server_id_filter">
 		<title><varname>server_id_filter</varname> (int)</title>
 		<para>
-			Enable (1) or disable (0) filter records by server_id on load.
+			Enable (1) or disable (0) filter records by server_id on load and during cleaning of expired db records.
+                        It could be usefull when you want to use the same location table for several kamailio instances which are configured to work in db_mode=1 or db_mode=2 (cache modes).
+                        Otherwise one instance of proxy cleans records made by another proxy and that breaks its cache.
 		</para>
 		<para>
 		<emphasis>

--- a/src/modules/usrloc/udomain.c
+++ b/src/modules/usrloc/udomain.c
@@ -910,21 +910,20 @@ int db_timer_udomain(udomain_t* _d)
 	vals[1].nul = 0;
 	UL_DB_EXPIRES_SET(&vals[1], 0);
 
-	keys[2] = &srv_id_col;
-	ops[2] = OP_EQ;
-	vals[2].type = DB1_INT;
-	vals[2].nul = 0;
-	vals[2].val.int_val = server_id;
+	if (ul_db_srvid != 0) {
+		keys[2] = &srv_id_col;
+		ops[2] = OP_EQ;
+		vals[2].type = DB1_INT;
+		vals[2].nul = 0;
+		vals[2].val.int_val = server_id;
+		key_num = 3;
+	}
 
 	if (ul_dbf.use_table(ul_dbh, _d->name) < 0) {
 		LM_ERR("use_table failed\n");
 		return -1;
 	}
 	
-	if (ul_db_srvid != 0) {
-		key_num = 3;
-	}
-
 	if (ul_dbf.delete(ul_dbh, keys, ops, vals, key_num) < 0) {
 		LM_ERR("failed to delete from table %s\n",_d->name->s);
 		return -1;

--- a/src/modules/usrloc/udomain.c
+++ b/src/modules/usrloc/udomain.c
@@ -895,9 +895,10 @@ done:
  */
 int db_timer_udomain(udomain_t* _d)
 {
-	db_key_t keys[2];
-	db_op_t  ops[2];
-	db_val_t vals[2];
+	db_key_t keys[3];
+	db_op_t  ops[3];
+	db_val_t vals[3];
+	int key_num = 2;
 
 	keys[0] = &expires_col;
 	ops[0] = "<";
@@ -909,12 +910,22 @@ int db_timer_udomain(udomain_t* _d)
 	vals[1].nul = 0;
 	UL_DB_EXPIRES_SET(&vals[1], 0);
 
+	keys[2] = &srv_id_col;
+	ops[2] = OP_EQ;
+	vals[2].type = DB1_INT;
+	vals[2].nul = 0;
+	vals[2].val.int_val = server_id;
+
 	if (ul_dbf.use_table(ul_dbh, _d->name) < 0) {
 		LM_ERR("use_table failed\n");
 		return -1;
 	}
+	
+	if (ul_db_srvid != 0) {
+		key_num = 3;
+	}
 
-	if (ul_dbf.delete(ul_dbh, keys, ops, vals, 2) < 0) {
+	if (ul_dbf.delete(ul_dbh, keys, ops, vals, key_num) < 0) {
 		LM_ERR("failed to delete from table %s\n",_d->name->s);
 		return -1;
 	}

--- a/src/modules/usrloc/usrloc_mod.c
+++ b/src/modules/usrloc/usrloc_mod.c
@@ -176,7 +176,7 @@ unsigned int init_flag = 0;
 db1_con_t* ul_dbh = 0; /* Database connection handle */
 db_func_t ul_dbf;
 
-/* filter on load by server id */
+/* filter on load and during cleanup by server id */
 unsigned int ul_db_srvid = 0;
 
 /*! \brief

--- a/src/modules/usrloc/usrloc_mod.h
+++ b/src/modules/usrloc/usrloc_mod.h
@@ -100,7 +100,7 @@ extern str ul_xavp_contact_name;
 extern db1_con_t* ul_dbh;   /* Database connection handle */
 extern db_func_t ul_dbf;
 
-/* filter on load by server id */
+/* filter on load and during cleanup by server id */
 extern unsigned int ul_db_srvid;
 
 /*


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
In usrloc module we have server_id_filter parameter which switches on filtering of location records by server id during load. This fix improves this functionality to use this filter in cleanup procedure to avoid cleaning of expired db records which are written by another kamailio instance to keep their cache correct.
