### PR TITLE
tls: add support for OpenSSL engine and private keys in HSM

### DIFF
--- a/src/modules/tls/doc/hsm_howto.xml
+++ b/src/modules/tls/doc/hsm_howto.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<section id="tls.hsm_howto" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <sectioninfo>
+    </sectioninfo>
+
+	<title>HSM Howto</title>
+		<para>
+			This documents OpenSSL engine support for private keys in HSM. 
+		</para>
+		<para>
+		        Assumptions: an OpenSSL engine configured with private key. We still require the certificate file
+			and list of CA certificates per a regular TLS configuration.
+		</para>
+		<para>
+		<programlisting>
+AWS CloudHSM Example
+--------------------
+
+...
+# Example for AWS CloudHSM (SafeNet Luna)
+modparam("tls", "engine", "gem")
+modparam("tls", "engine_config", "/usr/local/etc/kamailio/luna.conf")
+modparam("tls", "engine_algorithms", "ALL)
+...
+
+/usr/local/etc/kamailio/luna.cnf is a OpenSSL config format file used to
+bootstrap the engine, e.g., pass the PIN.
+
+...
+# the key kamailio is mandatory
+kamailio = openssl_init
+
+[ openssl_init ]
+engines = engine_section
+
+[ engine_section ]
+# gem is the name of the SafeNet Luna OpenSSL engine
+gem = gem_section
+
+[ gem_section ]
+# from SafeNet documentation
+ENGINE_INIT = 0:20:21:password=1234-ABCD-5678-EFGH
+...
+
+
+Thales nShield Connect
+----------------------
+
+Place holder
+		</programlisting>
+		</para>
+
+
+</section>

--- a/src/modules/tls/doc/params.xml
+++ b/src/modules/tls/doc/params.xml
@@ -1196,4 +1196,56 @@ end
 	    </example>
 	</section>
 
-</section>
+	<section id="tls.p.engine">
+	<title><varname>engine</varname> (string)</title>
+	<para>
+	        If OpenSSL is compiled with engine support this will allow algorithms to be offloaded and
+	        private keys from HSM to be used. Currently only a single global engine is supported.
+		However, private keys can be specified per_domain.
+	</para>
+
+	<para>
+	        To use private keys from the HSM, the name is the HSM key label prefixed by <varname>/engine:</varname>.
+	</para>
+		<programlisting format="linespecific">
+...
+## example for the Gem engine
+modparam("tls", "engine", "gem")
+# can also be set per-domain in tls.cfg
+modparam("tls", "private_key", "/engine:my_HSM_key_label")
+
+## example for engine_pkcs11
+modparam("tls", "engine", "pkcs11")
+modparam("tls", "private_key", "/engine:pkcs11:token=MYTOKEN;object=MYKEYLABEL")
+
+modparam("tls", "engine_conf", "/usr/local/etc/kamailio/openssl.cnf")
+modparam("tls", "engine_algorithms", "ALL")
+...
+                </programlisting>
+	<para>
+		By default OpenSSL engine support  is disabled (NONE). This global param is not supported in the tls config file.
+	</para>
+        </section>
+
+	<section id="tls.p.engine_config">
+	<title><varname>engine_config</varname> (string)</title>
+	<para>
+	        A OpenSSL configuration file to initialize the engine. Typically used to send PIN to HSMs to unlock
+	        private keys. See the HSM howto for an example. This global param is not supported in the tls config file.
+	</para>
+        </section>
+
+
+	<section id="tls.p.engine_algorithms">
+	<title><varname>engine_algorithms</varname> (string)</title>
+	<para>
+	        A list of cryptographic methods to be set as default in the engine.
+	        This is a comma-separated list of values
+	        from ALL RSA DSA DH EC RAND CIPHERS DIGESTS PKEY PKEY_CRYPTO PKEY_ASN1.
+		Not all methods are supported by every engine.
+	</para>
+	<para>
+	        The default is not to set any methods as default. This global param is not supported in the tls config file.
+	</para>
+        </section>
+ </section>

--- a/src/modules/tls/doc/tls.xml
+++ b/src/modules/tls/doc/tls.xml
@@ -271,6 +271,7 @@ make -C modules/tls extra_defs="-DTLS_WR_DEBUG -DTLS_RD_DEBUG"
 	</section>
 
 	<xi:include href="certs_howto.xml"/>
+	<xi:include href="hsm_howto.xml"/>
 	<xi:include href="params.xml"/>
 	<xi:include href="functions.xml"/>
 	<xi:include href="rpc.xml"/>

--- a/src/modules/tls/tls_domain.c
+++ b/src/modules/tls/tls_domain.c
@@ -27,6 +27,13 @@
 #include <stdlib.h>
 #include <openssl/ssl.h>
 #include <openssl/opensslv.h>
+
+#ifndef OPENSSL_NO_ENGINE
+#include <openssl/engine.h>
+#include "tls_map.h"
+extern EVP_PKEY * tls_engine_private_key(const char* key_id);
+#endif
+
 #if OPENSSL_VERSION_NUMBER >= 0x00907000L
 # include <openssl/ui.h>
 #endif
@@ -1113,7 +1120,109 @@ err:
 #endif
 }
 
+#ifndef OPENSSL_NO_ENGINE
+/*
+ * Implement a hash map from SSL_CTX to private key
+ * as HSM keys need to be process local
+ */
+static map_void_t private_key_map;
 
+/**
+ * @brief Return a private key from the lookup table
+ * @param p SSL_CTX*
+ * @return EVP_PKEY on success, NULL on error
+ */
+EVP_PKEY* tls_lookup_private_key(SSL_CTX* ctx)
+{
+	void *pkey;
+	char ctx_str[64];
+	snprintf(ctx_str, 64, "SSL_CTX-%p", ctx);
+	pkey =  map_get(&private_key_map, ctx_str);
+	LM_DBG("Private key lookup for %s: %p\n", ctx_str, pkey);
+	if (pkey)
+		return *(EVP_PKEY**)pkey;
+	else
+		return NULL;
+}
+
+
+
+/**
+ * @brief Load a private key from an OpenSSL engine
+ * @param d TLS domain
+ * @return 0 on success, -1 on error
+ *
+ * Do this in mod_child() as PKCS#11 libraries are not guaranteed
+ * to be fork() safe
+ *
+ * private_key setting which starts with /engine: is assumed to be
+ * an HSM key and not a file-based key
+ *
+ * We store the private key in a local memory hash table as
+ * HSM keys must be process-local. We use the SSL_CTX* address
+ * as the key. We cannot put the key into d->ctx[i] as that is
+ * in shared memory.
+ */
+static int load_engine_private_key(tls_domain_t* d)
+{
+	int idx, ret_pwd, i;
+	EVP_PKEY *pkey;
+	int procs_no;
+	char ctx_str[64];
+
+	if (!d->pkey_file.s || !d->pkey_file.len) {
+		DBG("%s: No private key specified\n", tls_domain_str(d));
+		return 0;
+	}
+	if (strncmp(d->pkey_file.s, "/engine:", 8) != 0)
+		return 0;
+	procs_no = get_max_procs();
+	for (i = 0; i<procs_no; i++) {
+		snprintf(ctx_str, 64, "SSL_CTX-%p", d->ctx[i]);
+		for(idx = 0, ret_pwd = 0; idx < 3; idx++) {
+			if (i) {
+				map_set(&private_key_map, ctx_str, pkey);
+				ret_pwd = 1;
+			} else {
+				pkey = tls_engine_private_key(d->pkey_file.s+8);
+				if (pkey) {
+					map_set(&private_key_map, ctx_str, pkey);
+					// store the key for i = 0 to perform certificate sanity check
+					ret_pwd = SSL_CTX_use_PrivateKey(d->ctx[i], pkey);
+				} else {
+					ret_pwd = 0;
+				}
+			}
+			if (ret_pwd) {
+				break;
+			} else {
+				ERR("%s: Unable to load private key '%s'\n",
+				    tls_domain_str(d), d->pkey_file.s);
+				TLS_ERR("load_private_key:");
+				continue;
+			}
+		}
+
+		if (!ret_pwd) {
+			ERR("%s: Unable to load engine key label '%s'\n",
+			    tls_domain_str(d), d->pkey_file.s);
+			TLS_ERR("load_private_key:");
+			return -1;
+		}
+		if (i == 0 && !SSL_CTX_check_private_key(d->ctx[i])) {
+			ERR("%s: Key '%s' does not match the public key of the"
+			    " certificate\n", tls_domain_str(d), d->pkey_file.s);
+			TLS_ERR("load_engine_private_key:");
+			return -1;
+		}
+	}
+
+
+	LM_INFO("%s: Key '%s' successfully loaded\n",
+		tls_domain_str(d), d->pkey_file.s);
+	return 0;
+}
+#endif
 /**
  * @brief Load a private key from a file 
  * @param d TLS domain
@@ -1137,8 +1246,19 @@ static int load_private_key(tls_domain_t* d)
 		SSL_CTX_set_default_passwd_cb_userdata(d->ctx[i], d->pkey_file.s);
 		
 		for(idx = 0, ret_pwd = 0; idx < 3; idx++) {
+#ifndef OPENSSL_NO_ENGINE
+			// in PROC_INIT skip loading HSM keys due to
+			// fork() issues with PKCS#11 libaries
+			if (strncmp(d->pkey_file.s, "/engine:", 8) != 0) {
+				ret_pwd = SSL_CTX_use_PrivateKey_file(d->ctx[i], d->pkey_file.s,
+					SSL_FILETYPE_PEM);
+			} else {
+				ret_pwd = 1;
+			}
+#else
 			ret_pwd = SSL_CTX_use_PrivateKey_file(d->ctx[i], d->pkey_file.s,
 					SSL_FILETYPE_PEM);
+#endif
 			if (ret_pwd) {
 				break;
 			} else {
@@ -1155,7 +1275,12 @@ static int load_private_key(tls_domain_t* d)
 			TLS_ERR("load_private_key:");
 			return -1;
 		}
-		
+#ifndef OPENSSL_NO_ENGINE
+		if (strncmp(d->pkey_file.s, "/engine:", 8) == 0) {
+			// skip private key validity check for HSM keys
+			continue;
+		}
+#endif
 		if (!SSL_CTX_check_private_key(d->ctx[i])) {
 			ERR("%s: Key '%s' does not match the public key of the"
 					" certificate\n", tls_domain_str(d), d->pkey_file.s);
@@ -1170,6 +1295,36 @@ static int load_private_key(tls_domain_t* d)
 }
 
 
+#ifndef OPENSSL_NO_ENGINE
+/**
+ * @brief Initialize engine private keys
+ *
+ * PKCS#11 libraries are not guaranteed to be fork() safe
+ * so we fix private keys in the child
+ */
+int tls_fix_engine_keys(tls_domains_cfg_t* cfg, tls_domain_t* srv_defaults,
+				tls_domain_t* cli_defaults)
+{
+	tls_domain_t* d;
+	d = cfg->srv_list;
+	while(d) {
+		if (load_engine_private_key(d) < 0) return -1;
+		d = d->next;
+	}
+
+	d = cfg->cli_list;
+	while(d) {
+		if (load_engine_private_key(d) < 0) return -1;
+		d = d->next;
+	}
+
+	if (load_engine_private_key(cfg->srv_default) < 0) return -1;
+	if (load_engine_private_key(cfg->cli_default) < 0) return -1;
+
+	return 0;
+
+}
+#endif
 /**
  * @brief Initialize attributes of all domains from default domains if necessary
  *

--- a/src/modules/tls/tls_map.c
+++ b/src/modules/tls/tls_map.c
@@ -1,0 +1,195 @@
+/** 
+ * Copyright (c) 2014 rxi
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT license. See LICENSE for details.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../core/mem/mem.h"
+#include "tls_map.h"
+
+struct map_node_t {
+  unsigned hash;
+  void *value;
+  map_node_t *next;
+  /* char key[]; */
+  /* char value[]; */
+};
+
+
+static unsigned map_hash(const char *str) {
+  unsigned hash = 5381;
+  while (*str) {
+    hash = ((hash << 5) + hash) ^ *str++;
+  }
+  return hash;
+}
+
+
+static map_node_t *map_newnode(const char *key, void *value, int vsize) {
+  map_node_t *node;
+  int ksize = strlen(key) + 1;
+  int voffset = ksize + ((sizeof(void*) - ksize) % sizeof(void*));
+  node = pkg_malloc(sizeof(*node) + voffset + vsize);
+  if (!node) return NULL;
+  memcpy(node + 1, key, ksize);
+  node->hash = map_hash(key);
+  node->value = ((char*) (node + 1)) + voffset;
+  memcpy(node->value, value, vsize);
+  return node;
+}
+
+
+static int map_bucketidx(map_base_t *m, unsigned hash) {
+  /* If the implementation is changed to allow a non-power-of-2 bucket count,
+   * the line below should be changed to use mod instead of AND */
+  return hash & (m->nbuckets - 1);
+}
+
+
+static void map_addnode(map_base_t *m, map_node_t *node) {
+  int n = map_bucketidx(m, node->hash);
+  node->next = m->buckets[n];
+  m->buckets[n] = node;
+}
+
+
+static int map_resize(map_base_t *m, int nbuckets) {
+  map_node_t *nodes, *node, *next;
+  map_node_t **buckets;
+  int i; 
+  /* Chain all nodes together */
+  nodes = NULL;
+  i = m->nbuckets;
+  while (i--) {
+    node = (m->buckets)[i];
+    while (node) {
+      next = node->next;
+      node->next = nodes;
+      nodes = node;
+      node = next;
+    }
+  }
+  /* Reset buckets */
+  buckets = realloc(m->buckets, sizeof(*m->buckets) * nbuckets);
+  if (buckets != NULL) {
+    m->buckets = buckets;
+    m->nbuckets = nbuckets;
+  }
+  if (m->buckets) {
+    memset(m->buckets, 0, sizeof(*m->buckets) * m->nbuckets);
+    /* Re-add nodes to buckets */
+    node = nodes;
+    while (node) {
+      next = node->next;
+      map_addnode(m, node);
+      node = next;
+    }
+  }
+  /* Return error code if realloc() failed */
+  return (buckets == NULL) ? -1 : 0;
+}
+
+
+static map_node_t **map_getref(map_base_t *m, const char *key) {
+  unsigned hash = map_hash(key);
+  map_node_t **next;
+  if (m->nbuckets > 0) {
+    next = &m->buckets[map_bucketidx(m, hash)];
+    while (*next) {
+      if ((*next)->hash == hash && !strcmp((char*) (*next + 1), key)) {
+        return next;
+      }
+      next = &(*next)->next;
+    }
+  }
+  return NULL;
+}
+
+
+void map_deinit_(map_base_t *m) {
+  map_node_t *next, *node;
+  int i;
+  i = m->nbuckets;
+  while (i--) {
+    node = m->buckets[i];
+    while (node) {
+      next = node->next;
+      pkg_free(node);
+      node = next;
+    }
+  }
+  pkg_free(m->buckets);
+}
+
+
+void *map_get_(map_base_t *m, const char *key) {
+  map_node_t **next = map_getref(m, key);
+  return next ? (*next)->value : NULL;
+}
+
+
+int map_set_(map_base_t *m, const char *key, void *value, int vsize) {
+  int n, err;
+  map_node_t **next, *node;
+  /* Find & replace existing node */
+  next = map_getref(m, key);
+  if (next) {
+    memcpy((*next)->value, value, vsize);
+    return 0;
+  }
+  /* Add new node */
+  node = map_newnode(key, value, vsize);
+  if (node == NULL) goto fail;
+  if (m->nnodes >= m->nbuckets) {
+    n = (m->nbuckets > 0) ? (m->nbuckets << 1) : 1;
+    err = map_resize(m, n);
+    if (err) goto fail;
+  }
+  map_addnode(m, node);
+  m->nnodes++;
+  return 0;
+  fail:
+  if (node) pkg_free(node);
+  return -1;
+}
+
+
+void map_remove_(map_base_t *m, const char *key) {
+  map_node_t *node;
+  map_node_t **next = map_getref(m, key);
+  if (next) {
+    node = *next;
+    *next = (*next)->next;
+    pkg_free(node);
+    m->nnodes--;
+  }
+}
+
+
+map_iter_t map_iter_(void) {
+  map_iter_t iter;
+  iter.bucketidx = -1;
+  iter.node = NULL;
+  return iter;
+}
+
+
+const char *map_next_(map_base_t *m, map_iter_t *iter) {
+  if (iter->node) {
+    iter->node = iter->node->next;
+    if (iter->node == NULL) goto nextBucket;
+  } else {
+    nextBucket:
+    do {
+      if (++iter->bucketidx >= m->nbuckets) {
+        return NULL;
+      }
+      iter->node = m->buckets[iter->bucketidx];
+    } while (iter->node == NULL);
+  }
+  return (char*) (iter->node + 1);
+}

--- a/src/modules/tls/tls_map.h
+++ b/src/modules/tls/tls_map.h
@@ -1,0 +1,77 @@
+/** 
+ * Copyright (c) 2014 rxi
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT license. See LICENSE for details.
+ */
+
+#ifndef _TLS_MAP_H
+#define _TLS_MAP_H
+
+#include <string.h>
+
+#define MAP_VERSION "0.1.0"
+
+struct map_node_t;
+typedef struct map_node_t map_node_t;
+
+typedef struct {
+  map_node_t **buckets;
+  unsigned nbuckets, nnodes;
+} map_base_t;
+
+typedef struct {
+  unsigned bucketidx;
+  map_node_t *node;
+} map_iter_t;
+
+
+#define map_t(T)\
+  struct { map_base_t base; T *ref; T tmp; }
+
+
+#define map_init(m)\
+  memset(m, 0, sizeof(*(m)))
+
+
+#define map_deinit(m)\
+  map_deinit_(&(m)->base)
+
+
+#define map_get(m, key)\
+  ( (m)->ref = map_get_(&(m)->base, key) )
+
+
+#define map_set(m, key, value)\
+  ( (m)->tmp = (value),\
+    map_set_(&(m)->base, key, &(m)->tmp, sizeof((m)->tmp)) )
+
+
+#define map_remove(m, key)\
+  map_remove_(&(m)->base, key)
+
+
+#define map_iter(m)\
+  map_iter_()
+
+
+#define map_next(m, iter)\
+  map_next_(&(m)->base, iter)
+
+
+void map_deinit_(map_base_t *m);
+void *map_get_(map_base_t *m, const char *key);
+int map_set_(map_base_t *m, const char *key, void *value, int vsize);
+void map_remove_(map_base_t *m, const char *key);
+map_iter_t map_iter_(void);
+const char *map_next_(map_base_t *m, map_iter_t *iter);
+
+
+typedef map_t(void*) map_void_t;
+typedef map_t(char*) map_str_t;
+typedef map_t(int) map_int_t;
+typedef map_t(char) map_char_t;
+typedef map_t(float) map_float_t;
+typedef map_t(double) map_double_t;
+
+#endif /* _TLS_MAP_H */

--- a/src/modules/tls/tls_server.c
+++ b/src/modules/tls/tls_server.c
@@ -379,7 +379,10 @@ static void tls_dump_cert_info(char* s, X509* cert)
 }
 
 
-
+#ifndef OPENSSL_NO_ENGINE
+// lookup HSM keys in process-local memory
+EVP_PKEY * tls_lookup_private_key(SSL_CTX*);
+#endif
 /** wrapper around SSL_accept, usin SSL return convention.
  * It will also log critical errors and certificate debugging info.
  * @param c - tcp connection with tls (extra_data must be a filled
@@ -410,6 +413,12 @@ int tls_accept(struct tcp_connection *c, int* error)
 		BUG("Invalid connection state %d (bug in TLS code)\n", tls_c->state);
 		goto err;
 	}
+#ifndef OPENSSL_NO_ENGINE
+	/* check if we have a HSM key */
+	EVP_PKEY *pkey = tls_lookup_private_key(SSL_get_SSL_CTX(ssl));
+	if (pkey)
+		SSL_use_PrivateKey(ssl, pkey);
+#endif
 	ret = SSL_accept(ssl);
 	if (unlikely(ret == 1)) {
 		DBG("TLS accept successful\n");
@@ -475,6 +484,13 @@ int tls_connect(struct tcp_connection *c, int* error)
 		BUG("Invalid connection state %d (bug in TLS code)\n", tls_c->state);
 		goto err;
 	}
+#ifndef OPENSSL_NO_ENGINE
+	// lookup HSM private key in process-local memory
+	EVP_PKEY *pkey = tls_lookup_private_key(SSL_get_SSL_CTX(ssl));
+	if (pkey) {
+		SSL_use_PrivateKey(ssl, pkey);
+	}
+#endif
 	ret = SSL_connect(ssl);
 	if (unlikely(ret == 1)) {
 		DBG("TLS connect successful\n");


### PR DESCRIPTION
- Rebased to: dc8faaf57a9c85b

-----
- add support for OpenSSL engine and loading private keys from HSM
- for when kamailio is a TLS edge proxy and needs to use HSM
- currently we initialize the engine in worker processes as PKCS#11
  libraries are not guaranteed to be fork() safe

- new config params
    - engine: name the OpenSSL engine
    - engine_config: an OpenSSL config format file used to bootstrap engines
    - engine_algorithms: list of algorithms to delegate to the engine

- tested with Gemalto SafeNet Luna (AWS CloudHSM) with RSA and EC private keys
  TLSv1.2 and PFS cipher suites

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
- add support for OpenSSL engine and loading private keys from HSM
- for when kamailio is a TLS edge proxy and needs to use HSM
- currently we initialize the engine in worker processes as PKCS#11
  libraries are not guaranteed to be fork() safe

- new config params
    - engine: name the OpenSSL engine
    - engine_config: an OpenSSL config format file used to bootstrap engines
    - engine_algorithms: list of algorithms to delegate to the engine

- tested with Gemalto SafeNet Luna (AWS CloudHSM) with RSA and EC private keys
  TLSv1.2 and PFS cipher suites