### PR TITLE
textops: Fixed remove_hf_exp arguments params

### DIFF
--- a/src/modules/textops/textops.c
+++ b/src/modules/textops/textops.c
@@ -212,7 +212,7 @@ static cmd_export_t cmds[]={
 	{"remove_hf_re",     (cmd_function)remove_hf_re_f,    1,
 		fixup_regexp_null, fixup_free_regexp_null,
 		ANY_ROUTE},
-	{"remove_hf_exp",     (cmd_function)remove_hf_exp_f,  1,
+	{"remove_hf_exp",     (cmd_function)remove_hf_exp_f,  2,
 		fixup_regexp_regexp, fixup_free_regexp_regexp,
 		ANY_ROUTE},
 	{"is_present_hf",    (cmd_function)is_present_hf_f,   1,


### PR DESCRIPTION
Current remove_hf_exp not works as expected. This fix it.