### PR TITLE
db_redis: fix compilation warning

### DIFF
--- a/src/modules/db_redis/redis_table.c
+++ b/src/modules/db_redis/redis_table.c
@@ -627,7 +627,7 @@ int db_redis_parse_schema(km_redis_con_t *con) {
     char full_path[_POSIX_PATH_MAX + 1];
     int path_len;
     struct stat fstat;
-    unsigned char c;
+    char c;
 
     enum {
         DBREDIS_SCHEMA_COLUMN_ST,


### PR DESCRIPTION
> CC (clang) [M db_redis.so]		redis_table.o
> redis_table.c:728:27: warning: comparison of constant -1 with expression of type 'unsigned char' is always false [-Wtautological-constant-out-of-range-compare]
>                     if (c == EOF) {
>                        ~ ^  ~~~
> redis_table.c:754:27: warning: comparison of constant -1 with expression of type 'unsigned char' is always false [-Wtautological-constant-out-of-range-compare]
>                     if (c == EOF) {
>                         ~ ^  ~~~
> redis_table.c:794:40: warning: comparison of constant -1 with expression of type 'unsigned char' is always true [-Wtautological-constant-out-of-range-compare]
>                     if (c != '\n' && c != EOF) {
>                                     ~ ^  ~~~
> redis_table.c:807:20: warning: comparison of constant -1 with expression of type 'unsigned char' is always true [-Wtautological-constant-out-of-range-compare]
>         } while (c != EOF);
>                  ~ ^  ~~~