### PR TITLE
ims_charging: fixed check result code at mscc level

### DIFF
--- a/src/modules/ims_charging/ims_ro.c
+++ b/src/modules/ims_charging/ims_ro.c
@@ -1361,7 +1361,7 @@ static void resume_on_initial_ccr(int is_timeout, void *param, AAAMessage *cca, 
 	create_cca_fui_avps(fui_action, redirecturi);
 	
 	/* check result code at mscc level */
-	if (ro_cca_data->mscc->resultcode != 2001) {
+	if (ro_cca_data->mscc->resultcode && ro_cca_data->mscc->resultcode != 2001) {
 		LM_DBG("CCA failure at MSCC level with resultcode [%d]\n", ro_cca_data->mscc->resultcode);
 		error_code = RO_RETURN_FALSE;
         goto error1;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #1505

#### Description
according to RFC 4006 the Result-Code in Multiple-Services-Credit-Control AVP is optional.
resume_on_initial_ccr() stops proceeding CCA if no Result-Code in MSCC and goes to error1 even though the Result-Code on CCR itself is 2001 (SUCCESSFUL)
