### PR TITLE
Replaced working with bson utf8 string inside db_mongodb_convert_bson function

### DIFF
--- a/src/modules/db_mongodb/mongodb_dbase.c
+++ b/src/modules/db_mongodb/mongodb_dbase.c
@@ -631,10 +631,11 @@ static int db_mongodb_convert_bson(const db1_con_t* _h, db1_res_t* _r,
                   (uint32_t*)&VAL_BLOB(dval).len, (const uint8_t**)&VAL_BLOB(dval).s);
 				break;
 
-			case BSON_TYPE_UTF8:
+			case BSON_TYPE_UTF8: {
 				char* rstring = (char*)bson_iter_utf8 (piter, &i32tmp);
 				db_str2val(DB1_STRING, dval, rstring, i32tmp, 1);
 				break;
+			}
 
 			case BSON_TYPE_OID:
 				break;

--- a/src/modules/db_mongodb/mongodb_dbase.c
+++ b/src/modules/db_mongodb/mongodb_dbase.c
@@ -632,8 +632,8 @@ static int db_mongodb_convert_bson(const db1_con_t* _h, db1_res_t* _r,
 				break;
 
 			case BSON_TYPE_UTF8:
-                char* rstring = (char*)bson_iter_utf8 (piter, &i32tmp);
-                db_str2val(DB1_STRING, dval, rstring, i32tmp, 1);
+				char* rstring = (char*)bson_iter_utf8 (piter, &i32tmp);
+				db_str2val(DB1_STRING, dval, rstring, i32tmp, 1);
 				break;
 
 			case BSON_TYPE_OID:

--- a/src/modules/db_mongodb/mongodb_dbase.c
+++ b/src/modules/db_mongodb/mongodb_dbase.c
@@ -632,7 +632,8 @@ static int db_mongodb_convert_bson(const db1_con_t* _h, db1_res_t* _r,
 				break;
 
 			case BSON_TYPE_UTF8:
-				VAL_STRING(dval) = (char*)bson_iter_utf8 (piter, &i32tmp);
+                char* rstring = (char*)bson_iter_utf8 (piter, &i32tmp);
+                db_str2val(DB1_STRING, dval, rstring, i32tmp, 1);
 				break;
 
 			case BSON_TYPE_OID:


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #1507 

#### Description
<!-- Describe your changes in detail -->

During query operations string fields inside result structure db1_res_t could be corrupted because of incorrect usage of bson memory. 

This issue is reproduced when we need to read more than 150 documents from the database. 

Firstly bson_iter_utf8 function returns pointer to memory which is allocated by bson library. It looks like this memory is used multiple times (some kind of circular buffer). So the data must be copied into Kamailio memory instead storing that pointer. The original pointer becomes invalid after some time.

Secondly, this pointer must not be freed by the caller of bson_iter_utf8. At the current version bson allocated pointer is freed by Kamailio function pkg_free like it is was allocated by pkg_malloc.