### PR TITLE
usrloc: Incorrect date format used to query contacts by expire time.

### DIFF
--- a/src/modules/usrloc/dlist.c
+++ b/src/modules/usrloc/dlist.c
@@ -97,8 +97,6 @@ static inline int get_all_db_ucontacts(void *buf, int len, unsigned int flags,
 	db1_res_t* res = NULL;
 	db_row_t *row;
 	dlist_t *dom;
-	str now;
-	char now_s[25];
 	int port, proto;
 	char *p;
 	str addr;
@@ -121,13 +119,6 @@ static inline int get_all_db_ucontacts(void *buf, int len, unsigned int flags,
 	/* Reserve space for terminating 0000 */
 	len -= sizeof(addr.len);
 
-	/* get the current time in DB format */
-	now.len = 25;
-	now.s = now_s;
-	if (db_time2str_ex( time(0), now.s, &now.len, 0)!=0) {
-		LM_ERR("failed to print now time\n");
-		return -1;
-	}
 	aorhash = 0;
 
 	/* select fields */
@@ -143,7 +134,7 @@ static inline int get_all_db_ucontacts(void *buf, int len, unsigned int flags,
 	ops1[0] = OP_GT;
 	vals1[0].type = DB1_STR;
 	vals1[0].nul = 0;
-	vals1[0].val.str_val = now;
+	UL_DB_EXPIRES_SET(&vals1[0], time(0));
 
 	keys1[1] = &partition_col;
 	ops1[1] = OP_EQ;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
- In the function get_all_db_ucontacts() date was passed to db module as a regular string, but in some cases that leads to incorrect db query, e.g. in case of mongodb. DATATIME format should be used instead of string.
