### PR TITLE
nathelper: it doesn't ping contacts if ping_nated_only=0

### DIFF
--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -2059,10 +2059,9 @@ static void nh_timer(unsigned int ticks, void *timer_idx)
 		dst.proto = PROTO_UDP;
 		dst.send_sock = send_sock;
 
-		if((flags & sipping_flag) != 0
-				&& (opt.s = build_sipping(
-							&c, send_sock, &path, &ruid, aorhash, &opt.len))
-						   != 0) {
+		int should_send_ping = (flags & sipping_flag) != 0 || ping_nated_only == 0;
+
+		if ( should_send_ping && (opt.s = build_sipping(&c, send_sock, &path, &ruid, aorhash, &opt.len)) != 0) {
 			if(udp_send(&dst, opt.s, opt.len) < 0) {
 				LM_ERR("sip udp_send failed\n");
 			}

--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -1921,6 +1921,7 @@ static void nh_timer(unsigned int ticks, void *timer_idx)
 	unsigned int path_ip = 0;
 	unsigned short path_port = 0;
 	int options = 0;
+	int should_send_ping = 0;
 
 	if((*natping_state) == 0)
 		goto done;
@@ -2059,7 +2060,7 @@ static void nh_timer(unsigned int ticks, void *timer_idx)
 		dst.proto = PROTO_UDP;
 		dst.send_sock = send_sock;
 
-		int should_send_ping = (flags & sipping_flag) != 0 || ping_nated_only == 0;
+		should_send_ping = (flags & sipping_flag) != 0 || ping_nated_only == 0;
 
 		if ( should_send_ping && (opt.s = build_sipping(&c, send_sock, &path, &ruid, aorhash, &opt.len)) != 0) {
 			if(udp_send(&dst, opt.s, opt.len) < 0) {


### PR DESCRIPTION
- nathelper sends ping only if nat flag is specified, but if ping_nated_only=0 it should ping all contact in any case.

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
We need to check presence of nat flag with check of ping_nated_only parameter to avoid situation when flag is not specified by user wants to ping all contacts and don't get any pings.
