### PR TITLE
ims_registrar_pcscf: Update tmp security only if there are sec-agree …

### DIFF
--- a/src/modules/ims_registrar_pcscf/save.c
+++ b/src/modules/ims_registrar_pcscf/save.c
@@ -354,9 +354,11 @@ int save_pending(struct sip_msg* _m, udomain_t* _d) {
 	}
 
     // Update security parameters
-    if(ul.update_temp_security(_d, sec_params->type, sec_params, pcontact) != 0)
-    {
-        LM_ERR("Error updating temp security\n");
+    if(sec_params) {
+        if(ul.update_temp_security(_d, sec_params->type, sec_params, pcontact) != 0)
+        {
+            LM_ERR("Error updating temp security\n");
+        }
     }
 
 	ul.unlock_udomain(_d, &ci.via_host, ci.via_port, ci.via_prot);


### PR DESCRIPTION
…params in the message

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ X] Commit message has the format required by CONTRIBUTING guide
- [ X] Commits are split per component (core, individual modules, libs, utils, ...)
- [ X] Each component has a single commit (if not, squash them into one commit)
- [ X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X ] PR should be backported to stable branches
- [X ] Tested changes locally
- [X ] Related to issue #1526 

#### Description
<!-- Describe your changes in detail -->
If a register is received without sec-agree parameters, a NULL pointer is deferenced, which causes segfault.