### PR TITLE
Bugfix issue 1168 - Unregistered Terminating Services (PSI) Configured at HSS

### DIFF
--- a/src/modules/ims_isc/ims_isc_mod.c
+++ b/src/modules/ims_isc/ims_isc_mod.c
@@ -224,6 +224,8 @@ int isc_match_filter(struct sip_msg *msg, char *str1, udomain_t* d) {
     //sometimes s is populated by an ims_getter method cscf_get_terminating_user that alloc memory that must be free-ed at the end
     int free_s = 0;
 
+    //the callback from the Cx interface in case of unreg terminating initial message is a FAILURE_ROUTE. Hence we need an addl. flag
+    int firstflag = 0;
 
     int ret = ISC_RETURN_FALSE;
     isc_mark new_mark, old_mark;
@@ -245,9 +247,10 @@ int isc_match_filter(struct sip_msg *msg, char *str1, udomain_t* d) {
         LM_DBG("Message returned s=%d;h=%d;d=%d;a=%.*s\n", old_mark.skip, old_mark.handling, old_mark.direction, old_mark.aor.len, old_mark.aor.s);
     } else {
         LM_DBG("Starting triggering\n");
+        firstflag = 1;
     }
 
-    if (is_route_type(FAILURE_ROUTE)) {
+    if (is_route_type(FAILURE_ROUTE) && !firstflag) {
         /* need to find the handling for the failed trigger */
         if (dir == DLG_MOBILE_ORIGINATING) {
             k = cscf_get_originating_user(msg, &s);
@@ -345,7 +348,7 @@ int isc_match_filter(struct sip_msg *msg, char *str1, udomain_t* d) {
                 new_mark.skip = m->index + 1;
                 new_mark.handling = m->default_handling;
                 new_mark.aor = s;
-                ret = isc_forward(msg, m, &new_mark);
+                ret = isc_forward(msg, m, &new_mark, firstflag);
                 isc_free_match(m);
                 goto done;
             }
@@ -383,7 +386,7 @@ int isc_match_filter(struct sip_msg *msg, char *str1, udomain_t* d) {
                 new_mark.skip = m->index + 1;
                 new_mark.handling = m->default_handling;
                 new_mark.aor = s;
-                ret = isc_forward(msg, m, &new_mark);
+                ret = isc_forward(msg, m, &new_mark, firstflag);
                 isc_free_match(m);
                 goto done;
             }

--- a/src/modules/ims_isc/isc.c
+++ b/src/modules/ims_isc/isc.c
@@ -56,7 +56,7 @@
  * @param mark  - the isc_mark that should be used to mark the message
  * @returns #ISC_RETURN_TRUE if OK, #ISC_RETURN_ERROR if not
  */
-int isc_forward(struct sip_msg *msg, isc_match *m, isc_mark *mark) {
+int isc_forward(struct sip_msg *msg, isc_match *m, isc_mark *mark, int firstflag) {
 	struct cell *t;
 	unsigned int hash, label;
 	ticks_t fr_timeout, fr_inv_timeout;
@@ -75,7 +75,7 @@ int isc_forward(struct sip_msg *msg, isc_match *m, isc_mark *mark) {
 	memcpy(msg->dst_uri.s, m->server_name.s, m->server_name.len);
 
 	/* append branch if last trigger failed */
-	if (is_route_type(FAILURE_ROUTE))
+	if (is_route_type(FAILURE_ROUTE) && !firstflag)
 		append_branch(msg, &(msg->first_line.u.request.uri), &(msg->dst_uri), 0, Q_UNSPECIFIED, 0, 0, 0, 0, 0, 0);
 
 	// Determines the tm transaction identifiers.

--- a/src/modules/ims_isc/isc.h
+++ b/src/modules/ims_isc/isc.h
@@ -66,7 +66,7 @@ extern int isc_fr_inv_timeout;		/**< default ISC INVITE response timeout in ms *
 /**	SIP Status Code to send to client on Session Termination because AS did not respond */
 
 
-int isc_forward( struct sip_msg *msg, isc_match *m,isc_mark *mark);
+int isc_forward( struct sip_msg *msg, isc_match *m,isc_mark *mark, int firstflag);
 
 
 #endif


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally against Version 5.1.0
- [x] Related to issue #1168 (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
The ims_isc module cannot cope with the fact that asynchronous Response from HSS (Diameter SAA message) is received as "FAILURE_ROUTE". ims_isc module erroneously assumes, it is an answer from the AS. Change: added a "firstflag", which makes a difference between first call (SAA from HSS) and subsequent call (FAILURE ROUTE from AS).