### PR TITLE
dialog: check CSeq careful with track_cseq_updates

### DIFF
--- a/src/modules/dialog/dlg_cseq.c
+++ b/src/modules/dialog/dlg_cseq.c
@@ -73,7 +73,8 @@ static int dlg_cseq_prepare_msg(sip_msg_t *msg)
 		return 1;
 	}
 
-	if (parse_headers(msg, HDR_CSEQ_F, 0)==-1) {
+	if((!msg->cseq && (parse_headers(msg,HDR_CSEQ_F,0)<0 || !msg->cseq))
+		|| !msg->cseq->parsed){
 		LM_DBG("parsing cseq header failed\n");
 		return 2;
 	}


### PR DESCRIPTION
to avoid null pointer access for malformed messages
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
after adding modparam("dialog", "track_cseq_updates", 1) and getting some malformed SIP  kamailio crushed

