### PR TITLE
packaging: Fix typo in kamailio.spec

### DIFF
--- a/pkg/kamailio/obs/kamailio.spec
+++ b/pkg/kamailio/obs/kamailio.spec
@@ -15,7 +15,7 @@
 %bcond_without kazoo
 %bcond_without memcached
 %bcond_without perl
-%bcond_without rebbitmq
+%bcond_without rabbitmq
 %bcond_without redis
 %bcond_without sctp
 %bcond_without websocket
@@ -35,7 +35,7 @@
 %bcond_without kazoo
 %bcond_without memcached
 %bcond_without perl
-%bcond_without rebbitmq
+%bcond_without rabbitmq
 %bcond_without redis
 %bcond_without sctp
 %bcond_without websocket
@@ -55,7 +55,7 @@
 %bcond_without kazoo
 %bcond_without memcached
 %bcond_without perl
-%bcond_without rebbitmq
+%bcond_without rabbitmq
 %bcond_without redis
 %bcond_without sctp
 %bcond_without websocket
@@ -75,7 +75,7 @@
 %bcond_with kazoo
 %bcond_without memcached
 %bcond_without perl
-%bcond_with rebbitmq
+%bcond_with rabbitmq
 %bcond_with redis
 %bcond_without sctp
 %bcond_without websocket
@@ -96,7 +96,7 @@
 %bcond_without kazoo
 %bcond_without memcached
 %bcond_without perl
-%bcond_without rebbitmq
+%bcond_without rabbitmq
 %bcond_without redis
 %bcond_without sctp
 %bcond_without websocket
@@ -116,7 +116,7 @@
 %bcond_with kazoo
 %bcond_without memcached
 %bcond_without perl
-%bcond_with rebbitmq
+%bcond_with rabbitmq
 %bcond_without redis
 %bcond_without sctp
 %bcond_without websocket
@@ -136,7 +136,7 @@
 %bcond_with kazoo
 %bcond_with memcached
 %bcond_with perl
-%bcond_with rebbitmq
+%bcond_with rabbitmq
 %bcond_with redis
 %bcond_with sctp
 %bcond_with websocket
@@ -156,7 +156,7 @@
 %bcond_with kazoo
 %bcond_with memcached
 %bcond_without perl
-%bcond_without rebbitmq
+%bcond_without rabbitmq
 %bcond_without redis
 %bcond_with sctp
 %bcond_with websocket


### PR DESCRIPTION
#### Pre-Submission Checklist

- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change

- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:

- [x] PR should be backported to stable branches - _probably_
- [ ] Tested changes locally (_not applicable_)
- [ ] Related to issue #XXXX (_not applicable_)

#### Description

There is a number of occurrences in `pkg/kamailio/obs/kamailio.spec` of `%bcond_with|without rebbitmq`. Note the `e` in `rebbitmq`.

Since the condition to include the `rabbitmq` package (line 633) is `%if %{with rabbitmq}` (with an `a`), this conditional statement would not have the intended effect.

If this was not a deliberate typo for some reason, this commit addresses the issue by changing all `%bcond_with|without` occurrences of `rebbitmq` to `rabbitmq`.

