### PR TITLE
src/Makefile: fix source code revision output

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -348,7 +348,7 @@ modules-cfg modules-list modules-lst:
 	rm -f modules.lst
 	$(MAKE) modules.lst
 
-ifneq ($(wildcard .git),)
+ifneq ($(wildcard ../.git),)
 # if .git/ exists
 repo_ver=$(shell  RV=`git rev-parse --verify --short=6 HEAD 2>/dev/null`;\
 					[ -n "$$RV" ] && \
@@ -358,7 +358,7 @@ repo_ver=$(shell  RV=`git rev-parse --verify --short=6 HEAD 2>/dev/null`;\
 						RV="$$RV"-dirty; echo "$$RV")
 repo_hash=$(subst -dirty,,$(repo_ver))
 repo_state=$(subst %-dirty,dirty,$(findstring -dirty,$(repo_ver)))
-autover_h_dep=.git $(filter-out $(auto_gen), $(sources)) core/cfg.y core/cfg.lex Makefile
+autover_h_dep=../.git $(filter-out $(auto_gen), $(sources)) core/cfg.y core/cfg.lex Makefile
 else
 # else if .git/ does not exist
 repo_ver=


### PR DESCRIPTION
I noticed that ```kamailio -I``` and ```kamailio -V``` do not give git version hash anymore.

This commit fixes at least kamailio -I and -V output, I think.

I don't know / remember if further adjustment is needed for other REPO_ constants.

# Before

```
#define REPO_VER ""
#define REPO_HASH "unknown"
#define REPO_STATE ""
```
```
$ src/kamailio -I|grep Source
Source code revision ID: unknown
```

# After
```
#define REPO_VER "5c48b2"
#define REPO_HASH "5c48b2"
#define REPO_STATE ""
```
```
$ src/kamailio -I|grep Source
Source code revision ID: 5c48b2
```