### PR TITLE
Proper deallocation for the ipsec parameters in contact for IMS PCSCF modules

### DIFF
--- a/src/modules/ims_registrar_pcscf/sec_agree.h
+++ b/src/modules/ims_registrar_pcscf/sec_agree.h
@@ -32,6 +32,4 @@
  */
 security_t* cscf_get_security(struct sip_msg *msg);
 
-void free_security_t(security_t *params);
-
 #endif // SEC_AGREE_H

--- a/src/modules/ims_usrloc_pcscf/pcontact.c
+++ b/src/modules/ims_usrloc_pcscf/pcontact.c
@@ -112,6 +112,11 @@ void free_ppublic(ppublic_t* _p)
 	shm_free(_p);
 }
 
+
+// The same piece of code also lives in modules/ims_registrar_pcscf/sec_agree.c
+// Function - parse_sec_agree()
+// goto label - cleanup
+// Keep them in sync!
 void free_security(security_t* _p)
 {
     if (!_p)
@@ -137,8 +142,9 @@ void free_security(security_t* _p)
         case SECURITY_TLS:
             shm_free(_p->data.tls);
         break;
-
-        default: // Nothing to deallocate
+        
+        case SECURITY_NONE:
+            //Nothing to deallocate
         break;
     }
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X ] Commit message has the format required by CONTRIBUTING guide
- [ X] Commits are split per component (core, individual modules, libs, utils, ...)
- [ X] Each component has a single commit (if not, squash them into one commit)
- [ X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
The patch contains two fixes for sec-agree parameters handling in:
- module ims_registar_pcscf: ealg is read in wrong field of struct ipsec_t (was in r_alg, shoud be in r_ealg)
- modules ims_registar_pcscf and ims_userloc_pcscf: struct ipsec_t is correctly deallocated from contact.