### PR TITLE
Modules: rr adding is_direction to kemi

### DIFF
--- a/src/modules/rr/rr_mod.c
+++ b/src/modules/rr/rr_mod.c
@@ -418,6 +418,27 @@ static int w_is_direction(struct sip_msg *msg,char *dir, char *foo)
 	return ((is_direction(msg,(int)(long)dir)==0)?1:-1);
 }
 
+static int ki_is_direction(struct sip_msg *msg,str *dir)
+{
+	char *s;
+        int n;
+
+        if (!append_fromtag) {
+                LM_ERR("usage of \"is_direction\" function requires parameter"
+                                "\"append_fromtag\" enabled!!");
+                return E_CFG;
+        }
+       	s = (char*) dir->s;
+        if ( strcasecmp(s,"downstream")==0 ) {
+        	n = RR_FLOW_DOWNSTREAM;
+      	} else if ( strcasecmp(s,"upstream")==0 ) {
+                n = RR_FLOW_UPSTREAM;
+        } else {
+         	LM_ERR("unknown direction '%s'\n",s);
+                        return E_CFG;
+        }
+	return ((is_direction(msg,n)==0)?1:-1);
+}
 
 /*
  * Return the URI of the topmost Route-Header.
@@ -720,7 +741,11 @@ static sr_kemi_t sr_kemi_rr_exports[] = {
 		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
-
+	{ str_init("rr"), str_init("is_direction"),
+                SR_KEMIP_INT, ki_is_direction,
+                { SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
+                        SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+        },
 	{ {0, 0}, {0, 0}, 0, NULL, { 0, 0, 0, 0, 0, 0 } }
 };
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
is_direction(string) method is imported to kemi app_lua. this method will help to identify the direction of subsequent request.
<!-- Describe your changes in detail -->
