### PR TITLE
dialog: unset DMQ flag on replicated dialog removal

### DIFF
--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -365,6 +365,7 @@ int dlg_dmq_handle_msg(struct sip_msg* msg, peer_reponse_t* resp, dmq_node_t* no
 			}
 			/* prevent DB sync */
 			dlg->dflags |= DLG_FLAG_NEW;
+			dlg->iflags &= ~DLG_IFLAG_DMQ_SYNC;
 			unref++;
 			break;
 


### PR DESCRIPTION
- prevents looping back to other nodes
- reported by Patrick Murphy on sr-users list (https://lists.kamailio.org/pipermail/sr-users/2018-July/102322.html)