### PR TITLE
pkg/kamailio: Defined correct dependences for perl module (#1615)

### DIFF
--- a/pkg/kamailio/obs/kamailio.spec
+++ b/pkg/kamailio/obs/kamailio.spec
@@ -552,8 +552,8 @@ Requires:   kamailio = %ver
 Requires:   perl
 BuildRequires:  perl
 %else
-Requires:   mod_perl
-BuildRequires:  mod_perl-devel
+Requires:   perl-libs
+BuildRequires:  perl-ExtUtils-Embed
 %endif
 
 %description    perl


### PR DESCRIPTION
(cherry picked from commit 9ac132ba3a47f13cf7b58839dde34a04348340c9)

User originally reported this for 5.0 branch.
So i created back port for 5.0 branch too 