### PR TITLE
dispatcher: add ping_from attribute

### DIFF
--- a/src/modules/dispatcher/dispatch.h
+++ b/src/modules/dispatcher/dispatch.h
@@ -169,6 +169,7 @@ typedef struct _ds_attrs {
 	int weight;
 	int rweight;
 	int congestion_control;
+	str ping_from;
 } ds_attrs_t;
 
 typedef struct _ds_latency_stats {

--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -1829,6 +1829,10 @@ onreply_route {
 					It is used for sending the SIP traffic as well as
 					OPTIONS keepalives.
 				</listitem>
+				<listitem>
+					'ping_from' - used to set the From URI in OPTIONS keepalives.
+					It overwrites the general ds_ping_from parameter.
+				</listitem>
 			</itemizedlist>
 		</para>
 		</section>
@@ -1848,7 +1852,7 @@ setid(int) destination(sip uri) flags(int,opt) priority(int,opt) attrs(str,opt)
 		</para>
 		<programlisting format="linespecific">
 ...
-1 sip:127.0.0.1:5080 0 0 duid=abc;socket=udp:192.168.0.125:5060;my=xyz
+1 sip:127.0.0.1:5080 0 0 duid=abc;socket=udp:192.168.0.125:5060;my=xyz;ping_from=sip:myproxy.com
 ...
 </programlisting>
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
I was looking for a solution to set a dedicated From URI in OPTIONS
requests to a specific dispatcher target.

ds_ping_from (
https://www.kamailio.org/docs/modules/devel/modules/dispatcher.html#dispatcher.p.ds_ping_from)
applies globally, while I needed the granularity of a single target.

I can just add an attribute to the others, e.g. instead of

```
1 sip:127.0.0.1:7070 <http://127.0.0.1:7070> 0 1
```

something like:

```
1 sip:127.0.0.1:7070 <http://127.0.0.1:7070> 0 1 ping_from=sip.custom.com
```

When the ping_from attribute is not specified, the general ds_ping_from
applies and is used.

This would save me from a solution like intercepting the outgoing OPTIONS
and manipulating the From header.