### PR TITLE
Non blocking async socket

### DIFF
--- a/src/core/async_task.c
+++ b/src/core/async_task.c
@@ -47,6 +47,7 @@
 static int _async_task_workers = 0;
 static int _async_task_sockets[2];
 static int _async_task_usleep = 0;
+static int _async_nonblock = 0;
 
 int async_task_run(int idx);
 
@@ -78,6 +79,10 @@ int async_task_init_sockets(void)
 		LM_ERR("opening tasks dgram socket pair\n");
 		return -1;
 	}
+
+	if (_async_nonblock)
+		fcntl(_async_task_sockets[1], F_SETFL, fcntl(_async_task_sockets[1], F_GETFL, 0) | O_NONBLOCK);
+
 	LM_DBG("inter-process event notification sockets initialized\n");
 	return 0;
 }
@@ -190,6 +195,17 @@ int async_task_set_workers(int n)
 		return 0;
 
 	_async_task_workers = n;
+
+	return 0;
+}
+
+/**
+ *
+ */
+int async_task_set_nonblock(int n)
+{
+	if(n>0)
+		_async_nonblock = 1;
 
 	return 0;
 }

--- a/src/core/async_task.h
+++ b/src/core/async_task.h
@@ -35,6 +35,7 @@ int async_task_init(void);
 int async_task_child_init(int rank);
 int async_task_initialized(void);
 int async_task_set_workers(int n);
+int async_task_set_nonblock(int n);
 int async_task_push(async_task_t *task);
 int async_task_set_usleep(int n);
 int async_task_workers_get(void);

--- a/src/core/cfg.lex
+++ b/src/core/cfg.lex
@@ -348,6 +348,7 @@ CHILDREN children
 SOCKET_WORKERS socket_workers
 ASYNC_WORKERS async_workers
 ASYNC_USLEEP async_usleep
+ASYNC_NONBLOCK async_nonblock
 CHECK_VIA	check_via
 PHONE2TEL	phone2tel
 MEMLOG		"memlog"|"mem_log"
@@ -780,6 +781,7 @@ IMPORTFILE      "import_file"
 <INITIAL>{SOCKET_WORKERS}	{ count(); yylval.strval=yytext; return SOCKET_WORKERS; }
 <INITIAL>{ASYNC_WORKERS}	{ count(); yylval.strval=yytext; return ASYNC_WORKERS; }
 <INITIAL>{ASYNC_USLEEP}	{ count(); yylval.strval=yytext; return ASYNC_USLEEP; }
+<INITIAL>{ASYNC_NONBLOCK}	{ count(); yylval.strval=yytext; return ASYNC_NONBLOCK; }
 <INITIAL>{CHECK_VIA}	{ count(); yylval.strval=yytext; return CHECK_VIA; }
 <INITIAL>{PHONE2TEL}	{ count(); yylval.strval=yytext; return PHONE2TEL; }
 <INITIAL>{MEMLOG}	{ count(); yylval.strval=yytext; return MEMLOG; }

--- a/src/core/cfg.y
+++ b/src/core/cfg.y
@@ -376,6 +376,7 @@ extern char *default_routename;
 %token SOCKET_WORKERS
 %token ASYNC_WORKERS
 %token ASYNC_USLEEP
+%token ASYNC_NONBLOCK
 %token CHECK_VIA
 %token PHONE2TEL
 %token MEMLOG
@@ -909,6 +910,8 @@ assign_stm:
 	| ASYNC_WORKERS EQUAL error { yyerror("number expected"); }
 	| ASYNC_USLEEP EQUAL NUMBER { async_task_set_usleep($3); }
 	| ASYNC_USLEEP EQUAL error { yyerror("number expected"); }
+	| ASYNC_NONBLOCK EQUAL NUMBER { async_task_set_nonblock($3); }
+	| ASYNC_NONBLOCK EQUAL error { yyerror("number expected"); }
 	| CHECK_VIA EQUAL NUMBER { check_via=$3; }
 	| CHECK_VIA EQUAL error { yyerror("boolean value expected"); }
 	| PHONE2TEL EQUAL NUMBER { phone2tel=$3; }

--- a/src/modules/async/async_sleep.c
+++ b/src/modules/async/async_sleep.c
@@ -298,6 +298,11 @@ int async_send_task(sip_msg_t *msg, cfg_action_t *act, str *cbname)
 		atp->cbname[cbname->len] = '\0';
 		atp->cbname_len = cbname->len;
 	}
-	async_task_push(at);
+
+	if (async_task_push(at)<0) {
+		shm_free(at);
+		return -1;
+	}
+
 	return 0;
 }

--- a/src/modules/db_mysql/km_dbase.c
+++ b/src/modules/db_mysql/km_dbase.c
@@ -186,7 +186,10 @@ int db_mysql_submit_query_async(const db1_con_t* _h, const str* _s)
 	p[1].len = _s->len;
 	strncpy(p[1].s, _s->s, _s->len);
 
-	async_task_push(atask);
+	if (async_task_push(atask)<0) {
+		shm_free(atask);
+		return -1;
+	}
 
 	return 0;
 }

--- a/src/modules/db_unixodbc/dbase.c
+++ b/src/modules/db_unixodbc/dbase.c
@@ -227,7 +227,11 @@ int db_unixodbc_submit_query_async(const db1_con_t* _h, const str* _s)
     p[1].len = _s->len;
     strncpy(p[1].s, _s->s, _s->len);
 
-    async_task_push(atask);
+
+    if (async_task_push(atask)<0) {
+        shm_free(atask);
+        return -1;
+    }
 
     return 0;
 }


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ X] Commit message has the format required by CONTRIBUTING guide
- [ X] Commits are split per component (core, individual modules, libs, utils, ...)
- [ X] Each component has a single commit (if not, squash them into one commit)
- [ X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Operations performed in async workers can be blocking (e.g. DB inserts). Sometimes, under high load, this can lead the unix socket queues to be full, thus blocking the main workers. With this new parameter we can have the choice to open the socket pair in non blocking mode, so returning an error if the task cannot be sent to the async workers.