### PR TITLE
sdpops: fetch and manipulate SDP o= -line sess-version attribute

### DIFF
--- a/src/core/parser/sdp/sdp.c
+++ b/src/core/parser/sdp/sdp.c
@@ -410,6 +410,14 @@ static int parse_sdp_session(str *sdp_body, int session_num, str *cnt_disp, sdp_
 	session = add_sdp_session(_sdp, session_num, cnt_disp);
 	if (session == NULL) return -1;
 
+	/* Get sess-version */
+	tmpstr1.s = o1p;
+	tmpstr1.len = eat_line(o1p,m1p-o1p) - o1p;
+	if ( extract_sess_version(&tmpstr1, &session->o_sess_version) == -1 ) {
+		LM_ERR("can't extract origin sess-version from the message\n");
+		return -1;
+	}
+
 	/* Get origin IP */
 	tmpstr1.s = o1p;
 	tmpstr1.len = bodylimit - tmpstr1.s; /* limit is session limit text */

--- a/src/core/parser/sdp/sdp.h
+++ b/src/core/parser/sdp/sdp.h
@@ -102,6 +102,7 @@ typedef struct sdp_session_cell {
 	int pf;           /**< connection address family: AF_INET/AF_INET6 */
 	str ip_addr;      /**< connection address */
 	/* o=<username> <session id> <version> <network type> <address type> <address> */
+	str o_sess_version; /** < origin session version number */
 	int o_pf;         /**< origin address family: AF_INET/AF_INET6 */
 	str o_ip_addr;    /**< origin address */
 	/* b=<bwtype>:<bandwidth> */

--- a/src/core/parser/sdp/sdp_helpr_funcs.h
+++ b/src/core/parser/sdp/sdp_helpr_funcs.h
@@ -52,6 +52,7 @@ int extract_mediaip(str *body, str *mediaip, int *pf, char *line);
 int extract_media_attr(str *body, str *mediamedia, str *mediaport, str *mediatransport, str *mediapayload, int *is_rtp);
 int extract_bwidth(str *body, str *bwtype, str *bwwitdth);
 int extract_candidate(str *body, sdp_stream_cell_t *stream);
+int extract_sess_version(str* oline, str* sess_version);
 
 /* RFC3605 attributes */
 int extract_rtcp(str *body, str *rtcp);

--- a/src/modules/sdpops/doc/sdpops_admin.xml
+++ b/src/modules/sdpops/doc/sdpops_admin.xml
@@ -574,5 +574,25 @@ if(sdp_get_line_startswith("$avp(mline)", "m=")) {
 		</example>
 	</section>
 	</section>
+
+	<section>
+		<title>Exported Variables</title>
+		<section>
+			<title><varname>$sdp( )</varname></title>
+			<para>Access to SDP attributes</para>
+				<itemizedlist>
+				<listitem><para>
+					<emphasis>$sdp(body)</emphasis> - full SDP body (read only)
+				</para></listitem>
+				<listitem><para>
+					<emphasis>$sdp(sess_version)</emphasis> - sess-version -attribute from SDP o= -line. When set to special value -1, current value is incremented. (read + write)
+				</para></listitem>
+				</itemizedlist>
+			<para>
+			Exported pseudo-variables are also documented at &kamwikilink;
+			</para>
+		</section>
+	</section>
+
 </chapter>
 

--- a/src/modules/sdpops/sdpops_mod.c
+++ b/src/modules/sdpops/sdpops_mod.c
@@ -63,9 +63,13 @@ static int w_sdp_content_sloppy(sip_msg_t* msg, char* foo, char *bar);
 static int w_sdp_with_ice(sip_msg_t* msg, char* foo, char *bar);
 static int w_sdp_get_line_startswith(sip_msg_t* msg, char *foo, char *bar);
 
+static int sdp_get_sess_version(sip_msg_t* msg, str* sess_version, int* sess_version_num);
+static int sdp_set_sess_version(sip_msg_t* msg, str* sess_version, int* sess_version_num);
 
 static int pv_get_sdp(sip_msg_t *msg, pv_param_t *param,
 		pv_value_t *res);
+static int pv_set_sdp(sip_msg_t *msg, pv_param_t *param,
+		int op, pv_value_t *res);
 static int pv_parse_sdp_name(pv_spec_p sp, str *in);
 
 static int mod_init(void);
@@ -128,7 +132,7 @@ static cmd_export_t cmds[] = {
 
 static pv_export_t mod_pvs[] = {
 	{{"sdp", (sizeof("sdp")-1)}, /* */
-		PVT_OTHER, pv_get_sdp, 0,
+		PVT_OTHER, pv_get_sdp, pv_set_sdp,
 		pv_parse_sdp_name, 0, 0, 0},
 
 	{ {0, 0}, 0, 0, 0, 0, 0, 0, 0 }
@@ -1862,6 +1866,118 @@ static int ki_sdp_get_line_startswith(sip_msg_t *msg, str *aname, str *sline)
 	return -1;
 }
 
+static int sdp_get_sess_version(sip_msg_t* msg, str* sess_version, int* sess_version_num)
+{
+	sdp_info_t *sdp = NULL;
+	sdp_session_cell_t* sdp_session;
+	int sdp_session_num;
+
+	sdp_session_num = 0;
+	for(;;)
+	{
+		sdp_session = get_sdp_session(msg, sdp_session_num);
+		if(!sdp_session) break;
+		LM_DBG("sdp_session_num %d sess-version: %.*s\n", sdp_session_num,sdp_session->o_sess_version.len, sdp_session->o_sess_version.s);
+		*sess_version = sdp_session->o_sess_version;
+		sdp_session_num++;
+	}
+
+	LM_DBG("sdp_session_num %d\n", sdp_session_num);
+
+	if ( sdp_session_num > 0 )
+	{
+		if ( str2sint(sess_version, sess_version_num) != -1 )
+		{
+			return 1;
+		}
+	}
+	return -1;
+}
+
+static int sdp_set_sess_version(sip_msg_t* msg, str* disabled_old_sess_version, int* new_sess_version_num)
+{
+	str new_sess_version = STR_NULL;
+	str old_sess_version = STR_NULL;
+	int old_sess_version_num = 0;
+	int autoincrement = 0;
+
+	struct lump* anchor = NULL;
+
+	if ( new_sess_version_num == NULL )
+	{
+		LM_ERR("no *new_sess_version_num\n");
+		return -1;
+	}
+	if ( *new_sess_version_num == -1 )
+	{
+		autoincrement = 1;
+	}
+
+	// get current value and pointer (for lump operations)
+	if ( sdp_get_sess_version(msg, &old_sess_version, &old_sess_version_num) != 1 )
+	{
+		LM_ERR("unable to get current str pointer\n");
+		return -1;
+	}
+
+	if ( autoincrement == 1 )
+	{
+		*new_sess_version_num = old_sess_version_num + 1;
+		if ( *new_sess_version_num < old_sess_version_num )
+		{
+			LM_ERR("autoincrement: new(%d) < old(%d)\n", *new_sess_version_num, old_sess_version_num);
+			return -1;
+		}
+		LM_DBG("old_sess_version_num: %d -> *new_sess_version_num %d\n", old_sess_version_num, *new_sess_version_num);
+	}
+	LM_DBG("old_sess_version_num: %d  autoincrement: %d\n", old_sess_version_num,autoincrement);
+	LM_DBG("*new_sess_version_num: %d  autoincrement: %d\n", *new_sess_version_num,autoincrement);
+
+	char *sid;
+	char buf[INT2STR_MAX_LEN];
+	sid = sint2strbuf(*new_sess_version_num, buf, INT2STR_MAX_LEN, &(new_sess_version.len));
+	if ( sid == 0 )
+	{
+		LM_ERR("sint2strbuf() fail\n");
+		return -1;
+	}
+
+	if ( autoincrement == 1 && ( new_sess_version.len < old_sess_version.len ) )
+	{
+		LM_ERR("autoincrement: new(%d) < old(%.*s)\n", *new_sess_version_num, old_sess_version.len, old_sess_version.s);
+		return -1;
+	}
+
+	new_sess_version.s = sid;
+	new_sess_version.s = pkg_malloc((new_sess_version.len * sizeof(char)));
+	if (new_sess_version.s == NULL)
+	{
+		LM_ERR("Out of pkg memory\n");
+		return -1;
+	}
+
+	memcpy(new_sess_version.s, sid, new_sess_version.len);
+
+	int offset = 0;
+	offset = old_sess_version.s - msg->buf;
+	anchor = del_lump(msg, offset, old_sess_version.len, 0);
+	if (anchor == NULL)
+	{
+		LM_ERR("del_lump failed\n");
+		pkg_free(new_sess_version.s);
+		return -1;
+	}
+
+	if (insert_new_lump_after(anchor, new_sess_version.s, new_sess_version.len, 0) == 0)
+	{
+		LM_ERR("insert_new_lump_after failed\n");
+		pkg_free(new_sess_version.s);
+		return -1;
+	}
+
+	return 1;
+}
+
 /**
  *
  */
@@ -1911,6 +2027,8 @@ static int pv_get_sdp(sip_msg_t *msg, pv_param_t *param,
 		pv_value_t *res)
 {
 	sdp_info_t *sdp = NULL;
+	str sess_version = STR_NULL;
+	int sess_version_num = 0;
 
 	if(msg==NULL || param==NULL)
 		return -1;
@@ -1928,12 +2046,55 @@ static int pv_get_sdp(sip_msg_t *msg, pv_param_t *param,
 
 	switch(param->pvn.u.isname.name.n)
 	{
+
+/* body */
 		case 0:
+			LM_DBG("param->pvn.u.isname.name.n=0\n");
 			return pv_get_strval(msg, param, res, &sdp->raw_sdp);
+/* sess_version */
+		case 1:
+			if ( sdp_get_sess_version(msg, &sess_version, &sess_version_num) == 1 )
+			{
+				if ( sess_version.len > 0 && sess_version.s != NULL)
+				{
+					return pv_get_intstrval(msg, param, res, sess_version_num, &sess_version);
+				}
+			}
+			return pv_get_null(msg, param, res);
+
 		default:
 			return pv_get_null(msg, param, res);
 	}
 }
+
+static int pv_set_sdp(sip_msg_t *msg, pv_param_t *param,
+		int op, pv_value_t *res)
+{
+	LM_DBG("res->flags: %d\n", res->flags);
+	if ( res->flags & PV_TYPE_INT ) LM_DBG("PV_TYPE_INT: %d\n",PV_TYPE_INT);
+	if ( res->flags & PV_VAL_INT ) LM_DBG("PV_VAL_INT: %d\n",PV_VAL_INT);
+	if ( res->flags & PV_VAL_STR ) LM_DBG("PV_VAL_STR: %d\n",PV_VAL_STR);
+
+	LM_DBG("param.pvn.u.isname.name.n = %d\n",param->pvn.u.isname.name.n);
+	if (param->pvn.u.isname.name.n == 1)
+	{
+	// sdp(sess_version)
+		if ( !(res->flags & PV_VAL_INT) )
+		{
+			LM_ERR("expected integer\n");
+			return -1;
+		}
+		LM_DBG("do $sdp(sess_version) = %d\n", res->ri);
+		return sdp_set_sess_version(msg, NULL, &res->ri);
+	}
+	else
+	{
+		LM_ERR("unknown PV\n");
+		return -1;
+	}
+	return -1;
+}
+
 
 /**
  *
@@ -1948,6 +2109,11 @@ static int pv_parse_sdp_name(pv_spec_p sp, str *in)
 		case 4:
 			if(strncmp(in->s, "body", 4)==0)
 				sp->pvp.pvn.u.isname.name.n = 0;
+			else goto error;
+		break;
+		case 12:
+			if(strncmp(in->s, "sess_version", 12)==0)
+				sp->pvp.pvn.u.isname.name.n = 1;
 			else goto error;
 		break;
 		default:


### PR DESCRIPTION
#### Pre-Submission Checklist

- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules

#### Type Of Change

- [X] New feature (non-breaking change which adds new functionality)

#### Checklist:

- [X] Tested changes locally


#### Description

Add PV $sdp(sess_version) for reading and writing SDP o= -line attribute sess-version.
Special integer value -1 increments current value.