### PR TITLE
nathelper: initialize local variable

### DIFF
--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -1644,7 +1644,7 @@ static int ki_fix_nated_sdp(sip_msg_t *msg, int level)
 static int fix_nated_sdp_f(struct sip_msg *msg, char *str1, char *str2)
 {
 	int level;
-	str ip;
+	str ip = {0,0};
 
 	if(fixup_get_ivalue(msg, (gparam_t *)str1, &level) != 0) {
 		LM_ERR("failed to get value for first parameter\n");

--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -1529,7 +1529,7 @@ static inline int replace_sdp_ip(
 		body2.s = oldip.s + oldip.len;
 		body2.len = bodylimit - body2.s;
 		ret = alter_mediaip(
-				msg, &body2, &oldip, pf, &newip, pf, sdp_oldmediaip);
+				msg, &body1, &oldip, pf, &newip, pf, sdp_oldmediaip);
 		if(ret == -1) {
 			LM_ERR("can't alter '%s' IP\n", line);
 			return -1;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

previous PR #1655 was wrong and tests at the time didn't hit the correct path in the code, sorry for that.
this pr reverts #1655 and properly initializes a variable
