### PR TITLE
sipcapture: initialize variable

### DIFF
--- a/src/modules/sipcapture/sipcapture.c
+++ b/src/modules/sipcapture/sipcapture.c
@@ -2499,7 +2499,8 @@ int receive_logging_json_msg(char *buf, unsigned int len,
 	struct timezone tz;
 	time_t epoch_time_as_time_t;
 
-	str tmp, corrtmp, table;
+	str tmp, table;
+	str corrtmp = STR_NULL;
 	_capture_mode_data_t *c = NULL;
 
 	c = capture_def;


### PR DESCRIPTION
#### Pre-Submission Checklist

- [✓] Commit message has the format required by CONTRIBUTING guide
- [✓] Commits are split per component (core, individual modules, libs, utils, ...)
- [✓] Each component has a single commit (if not, squash them into one commit)
- [✓] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change

- [✓] Small bug fix (non-breaking change which fixes an issue)

#### Checklist:

- [✓] PR should be backported to stable branches
- [✓] Tested changes locally


#### Description

After enabling clang -Wall on, this warning showed up:

> sipcapture.c:2580:5: warning: variable 'corrtmp' is used uninitialized whenever 'if' condition is false
>       [-Wsometimes-uninitialized]
>         if(correlation_id) {
>            ^~~~~~~~~~~~~~
