### PR TITLE
kamctl: make jsonrpc filter portable

### DIFF
--- a/utils/kamctl/kamctl.base
+++ b/utils/kamctl/kamctl.base
@@ -715,7 +715,7 @@ filter_json()
 	$AWK 'function ltrim(s) { sub(/^[ \t\r\n]+/, "", s); return s }
 		BEGIN { line=0; IGNORECASE=1; }
 		{ line++; }
-		NR == 1 && /^{.+"id"[ \t]*:[ \t]*[0-9]+[ \t]*}$/ { print; next; }
+		NR == 1 && /^[{].+"id"[ \t]*:[ \t]*[0-9]+[ \t]*}$/ { print; next; }
 		NR == 1 && /^200 OK/ { next; }
 		/^[ \t]*"jsonrpc":[ \t]*"2.0"/ { print; next; }
 		/^[ \t]*"result":[ \t]*\[.+/ {


### PR DESCRIPTION
The filter has a regex looking for a literal '{' in the beginning of a
line. Some awk implementations interpret this as a meta character, so
the regex is deemed broken. Example with busybox awk (POSIX):

`root@hank2:~# kamctl ps`
`awk: bad regex '^{.+"id"[ 	]*:[ 	]*[0-9]+[ 	]*}$': Invalid contents of {}`
`root@hank2:~#`

To fix this enclose the character in square brackets. This always
matches for a literal '{' and is portable.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #1429 

#### Description

Hi all,

I was trying to run kamctl on OpenWrt and the regex failed. I found a (closed) issue and the remedy was to use gawk. But it's actually easy to fix in the regex and if I can use busybox's awk I don't need to install gawk, so it saves some space. OpenWrt is usually run on embedded so space is often an issue :)

Thanks for looking at this!

Kind regards,
Seb