### PR TITLE
db_postgres: Fixed blob hex encoding (#1255)

### DIFF
--- a/src/modules/db_postgres/km_pg_con.c
+++ b/src/modules/db_postgres/km_pg_con.c
@@ -52,6 +52,7 @@ struct pg_con *db_postgres_new_connection(struct db_id *id)
 	int i = 0;
 	const char *keywords[10], *values[10];
 	char to[16];
+	PGresult   *res;
 
 	LM_DBG("db_id = %p\n", id);
 
@@ -140,6 +141,15 @@ struct pg_con *db_postgres_new_connection(struct db_id *id)
 		}
 	}
 #endif
+
+	res = PQexec(ptr->con, "SET bytea_output=escape");
+	if (PQresultStatus(res) != PGRES_COMMAND_OK)
+	{
+		LM_ERR("cannot set blob output escaping format\n");
+		PQclear(res);
+		goto err;
+	}
+	PQclear(res);
 
 	return ptr;
 


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Required for postgresql usage in kazoo cluster