### PR TITLE
acc: generating duplicates

### DIFF
--- a/src/core/flags.c
+++ b/src/core/flags.c
@@ -52,6 +52,11 @@ int resetflag( struct sip_msg* msg, flag_t flag ) {
 	return 1;
 }
 
+int resetflags( struct sip_msg* msg, flag_t flags ) {
+	msg->flags &= ~ flags;
+	return 1;
+}
+
 int isflagset( struct sip_msg* msg, flag_t flag ) {
 	return (msg->flags & (1<<flag)) ? 1 : -1;
 }

--- a/src/core/flags.h
+++ b/src/core/flags.h
@@ -44,6 +44,7 @@ struct sip_msg;
 
 int setflag( struct sip_msg* msg, flag_t flag );
 int resetflag( struct sip_msg* msg, flag_t flag );
+int resetflags( struct sip_msg* msg, flag_t flags );
 int isflagset( struct sip_msg* msg, flag_t flag );
 
 

--- a/src/modules/acc/acc.c
+++ b/src/modules/acc/acc.c
@@ -526,7 +526,7 @@ int is_eng_acc_on(sip_msg_t *msg)
 	}
 	while(e) {
 		if(e->flags & 1) {
-			if(msg->flags & e->acc_flag) {
+			if(isflagset(msg, e->acc_flag) == 1) {
 				return 1;
 			}
 		}
@@ -549,7 +549,7 @@ int is_eng_mc_on(sip_msg_t *msg)
 	}
 	while(e) {
 		if(e->flags & 1) {
-			if(msg->flags & e->missed_flag) {
+			if(isflagset(msg, e->missed_flag) == 1) {
 				return 1;
 			}
 		}
@@ -579,15 +579,15 @@ int acc_run_engines(struct sip_msg *msg, int type, int *reset)
 	inf.leg_info = leg_info;
 	while(e) {
 		if(e->flags & 1) {
-			if((type==0) && (msg->flags&(e->acc_flag))) {
+			if((type==0) && isflagset(msg, e->acc_flag) == 1) {
 				LM_DBG("acc event for engine: %s\n", e->name);
 				e->acc_req(msg, &inf);
-				if(reset) *reset |= e->acc_flag;
+				if(reset) *reset |= 1 << e->acc_flag;
 			}
-			if((type==1) && (msg->flags&(e->missed_flag))) {
+			if((type==1) && isflagset(msg, e->missed_flag) == 1) {
 				LM_DBG("missed event for engine: %s\n", e->name);
 				e->acc_req(msg, &inf);
-				if(reset) *reset |= e->missed_flag;
+				if(reset) *reset |= 1 << e->missed_flag;
 			}
 		}
 		e = e->next;

--- a/src/modules/acc/acc_logic.c
+++ b/src/modules/acc/acc_logic.c
@@ -463,15 +463,6 @@ static inline void acc_onreply_in(struct cell *t, struct sip_msg *req,
 	}
 }
 
-static void reset_acc_flags(struct sip_msg *req, int flags_to_reset) {
-	int x;
-	for (x=0;x<32;x++) {
-		if (flags_to_reset & 1<<x) {
-			resetflag(req, x);
-			LM_DBG("reset[%d]\n", x);
-		}
-	}
-}
 
 /* initiate a report if we previously enabled MC accounting for this t */
 static inline void on_missed(struct cell *t, struct sip_msg *req,
@@ -529,7 +520,7 @@ static inline void on_missed(struct cell *t, struct sip_msg *req,
 	 * These can't be reset in the blocks above, because
 	 * it would skip accounting if the flags are identical
 	 */
-	reset_acc_flags(req, flags_to_reset);
+	resetflags(req, flags_to_reset);
 
 	if (new_uri_bk.len>=0) {
 		req->new_uri = new_uri_bk;

--- a/src/modules/acc_diameter/acc_diameter_mod.c
+++ b/src/modules/acc_diameter/acc_diameter_mod.c
@@ -143,9 +143,9 @@ static int mod_init( void )
 	memset(&_acc_diameter_engine, 0, sizeof(acc_engine_t));
 
 	if(diameter_flag != -1)
-		_acc_diameter_engine.acc_flag	   = 1<<diameter_flag;
+		_acc_diameter_engine.acc_flag	   = diameter_flag;
 	if(diameter_missed_flag != -1)
-		_acc_diameter_engine.missed_flag = 1<<diameter_missed_flag;
+		_acc_diameter_engine.missed_flag = diameter_missed_flag;
 	_acc_diameter_engine.acc_req     = acc_diameter_send_request;
 	_acc_diameter_engine.acc_init    = acc_diameter_init;
 	memcpy(_acc_diameter_engine.name, "diameter", 8);

--- a/src/modules/acc_json/acc_json_mod.c
+++ b/src/modules/acc_json/acc_json_mod.c
@@ -129,9 +129,9 @@ static int mod_init(void)
 	memset(&_acc_json_engine, 0, sizeof(acc_engine_t));
 
 	if(acc_flag != -1)
-		_acc_json_engine.acc_flag = 1 << acc_flag;
+		_acc_json_engine.acc_flag = acc_flag;
 	if(acc_missed_flag != -1)
-		_acc_json_engine.missed_flag = 1 << acc_missed_flag;
+		_acc_json_engine.missed_flag = acc_missed_flag;
 	_acc_json_engine.acc_req = acc_json_send_request;
 	_acc_json_engine.acc_init = acc_json_init;
 	memcpy(_acc_json_engine.name, "json", 4);

--- a/src/modules/acc_radius/acc_radius_mod.c
+++ b/src/modules/acc_radius/acc_radius_mod.c
@@ -142,9 +142,9 @@ static int mod_init(void)
 	memset(&_acc_radius_engine, 0, sizeof(acc_engine_t));
 
 	if(radius_flag != -1)
-		_acc_radius_engine.acc_flag = 1 << radius_flag;
+		_acc_radius_engine.acc_flag = radius_flag;
 	if(radius_missed_flag != -1)
-		_acc_radius_engine.missed_flag = 1 << radius_missed_flag;
+		_acc_radius_engine.missed_flag = radius_missed_flag;
 	_acc_radius_engine.acc_req = acc_radius_send_request;
 	_acc_radius_engine.acc_init = acc_radius_init;
 	memcpy(_acc_radius_engine.name, "radius", 6);


### PR DESCRIPTION
on missed / failed calls issue #1673


#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (not tested with all scenarios, review could confirm that this is not introducing regressions)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #1673 

#### Description
problem with confusion when using  flags (integer value vs bit position value)
proposed solution is using the flags helpers functions `isflagset`, etc. where possible. 