### PR TITLE
pkg/kamailio: Fixed db_redis RPM packaging after ee95675

### DIFF
--- a/pkg/kamailio/Makefile
+++ b/pkg/kamailio/Makefile
@@ -40,7 +40,7 @@ src.rpm: tar
 	mv ../../kamailio-$(RELEASE)_src.tar.gz ${RPMBUILD_TOP}/SOURCES/${DIST_ARCHIVE}
 	sed -i -e 's/setup -n %{name}-%{ver}/setup -n kamailio-$(RELEASE)/' obs/kamailio.spec
 	rpmbuild ${RPMBUILD_OPT} -bs obs/kamailio.spec
-	mv ${RPMBUILD_TOP}/SRPMS/kamailio-$(RELEASE).*.src.rpm ../..
+	mv ${RPMBUILD_TOP}/SRPMS/kamailio-$(RELEASE)*.src.rpm ../..
 	rm -Rf ${RPMBUILD_TOP}
 
 # build rpm packages

--- a/pkg/kamailio/obs/kamailio.spec
+++ b/pkg/kamailio/obs/kamailio.spec
@@ -1005,7 +1005,11 @@ ln -s ../obs pkg/kamailio/centos/7
 %if 0%{?fedora} || 0%{?suse_version}
 export FREERADIUS=1
 %endif
-make cfg prefix=/usr basedir=%{buildroot} cfg_prefix=%{buildroot} doc_prefix=%{buildroot} \
+make cfg prefix=/usr \
+    basedir=%{buildroot} \
+    cfg_prefix=%{buildroot} \
+    doc_prefix=%{buildroot} \
+    share_prefix=%{_prefix} \
     doc_dir=%{_docdir}/kamailio/ \
     cfg_target=%{_sysconfdir}/kamailio/ modules_dirs="modules"
 make


### PR DESCRIPTION

Please look ticket #1676

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #1676

#### Description
RPM packaging for `5.2` release
Also wanted for `5.1` branch