### PR TITLE
pv: pv_time minor fix

### DIFF
--- a/src/modules/pv/pv_time.c
+++ b/src/modules/pv/pv_time.c
@@ -313,6 +313,11 @@ int pv_get_timeval(struct sip_msg *msg, pv_param_t *param,
 			}
 			return pv_get_uintval(msg, param, res, (unsigned int)_timeval_ts.tv_sec);
 		case 3:
+			if(gettimeofday(&_timeval_ts, NULL)!=0)
+                        {
+                                LM_ERR("unable to get time val attributes\n");
+                                return pv_get_null(msg, param, res);
+                        }
 			return pv_get_uintval(msg, param, res, (unsigned int)_timeval_ts.tv_usec);
 		case 4:
 			if(gettimeofday(&tv, NULL)!=0)


### PR DESCRIPTION
Pseudo variable $TV(un) - microseconds (not cached) wasn't working.  Calling gettimeofday function fixes it.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X ] Commit message has the format required by CONTRIBUTING guide
- [X ] Commits are split per component (core, individual modules, libs, utils, ...)
- [X ] Each component has a single commit (if not, squash them into one commit)
- [X ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X ] PR should be backported to stable branches
- [X ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Pseudo variable $TV(un) - microseconds (not cached) wasn't working.  Calling gettimeofday function fixes it.