### PR TITLE
dialplan: fix dp_replace() in cmd_export_t struct

### DIFF
--- a/src/modules/dialplan/dialplan.c
+++ b/src/modules/dialplan/dialplan.c
@@ -115,7 +115,7 @@ static cmd_export_t cmds[]={
 		ANY_ROUTE},
 	{"dp_match",(cmd_function)w_dp_match,	2,	fixup_igp_spve,
 		fixup_free_igp_spve, ANY_ROUTE},
-	{"dp_replace",(cmd_function)w_dp_replace,	2,	dp_replace_fixup,
+	{"dp_replace",(cmd_function)w_dp_replace,	3,	dp_replace_fixup,
 		dp_replace_fixup_free, ANY_ROUTE},
 	{0,0,0,0,0,0}
 };


### PR DESCRIPTION
In the struct `int param_no` is set to `2`. But `dp_replace()` has actually three
parameters `(dpid, inval, outvar)`, so kamailio's cfg parser fails when
`dp_replace()` is called:

```
yyparse(): cfg. parser: failed to find command dp_replace (params 3)
yyerror_at(): parse error in config file /etc/kamailio/kamailio.cfg, line 366, column 45: unknown command, missing loadmodule?
```

This commit fixes `int param_no` to address this.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Hi all,

When trying out dp_replace() kamailio (5.1.6) wouldn't start. It was expecting 2 parameters instead of 3. This PR fixes that.

Kind regards,
Seb