### PR TITLE
pkg/kamailio/alpine: Fixed docker image build for 5.2 branch

### DIFF
--- a/pkg/kamailio/alpine/APKBUILD
+++ b/pkg/kamailio/alpine/APKBUILD
@@ -271,6 +271,12 @@ snapshot() {
 }
 
 prepare() {
+	# Workarround for broken hiredis-devel package (0.13.3-r1)
+	sudo sed -i -e 's:prefix=/usr/local:prefix=/usr:' \
+	            -e 's:^libdir.*$:libdir=${exec_prefix}/lib:' \
+	            -e 's:^includedir.*:includedir=${prefix}/include/hiredis:' \
+	            /usr/lib/pkgconfig/hiredis.pc
+
 	default_prepare
 	cd "$builddir"
 


### PR DESCRIPTION
This PR is need for `5.2` branch.
On next stable Alpine release this will be fixed and we revert back this PR