### PR TITLE
tmx: add t_drop

### DIFF
--- a/src/modules/tmx/doc/tmx_admin.xml
+++ b/src/modules/tmx/doc/tmx_admin.xml
@@ -432,6 +432,64 @@ route[MYROUTE] {
 </programlisting>
 		</example>
 	</section>
+    <section id="tmx.f.t_drop">
+        <title>
+            <function moreinfo="none">t_drop([Code])
+            </function>
+        </title>
+        <para>
+        Drops the transaction with error code (500 default).
+        </para>
+        <para>
+        Parameters:.
+        </para>
+        <itemizedlist>
+            <listitem><para>
+                <emphasis>Code</emphasis> - error code to set in uas status.
+            </para></listitem>
+        </itemizedlist>
+        <para>
+        This function can be used in ANY_ROUTE.
+        </para>
+        <example>
+        <title><function>t_drop</function> usage</title>
+        <programlisting format="linespecific">
+...
+route[MYREQ]
+{
+    ## protect from retrans
+    if (!t_newtran()) {
+        xlog("L_ERROR", "$ci|log|failed to create transaction\n");
+        drop;
+    }
+
+    if(some early business use case that requires drop) {
+        xlog("L_INFO", "$ci|log|dropping request\n");
+        t_drop();
+    }
+
+    async_func_that_suspends_and_continues("$anyparam", "TR_OK", "TR_ERROR");
+
+}
+
+failure_route[TR_ERROR]
+{
+    xlog("L_INFO", "$ci|log|failed $T_reply_code $T_reply_reason\n");
+    t_drop();
+}
+
+onreply_route[TR_OK]
+{
+    xlog("L_INFO", "$ci|log|checking transaction result\n");
+   if(some business use case that requires dropping the request) {
+      t_drop();
+   }
+...
+}
+...
+</programlisting>
+        </example>
+    </section>
 
 	<section id="tmx.f.t_reuse_branch">
 		<title>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

we have a use case where we need to drop the request within a transaction, and that is not possible because tm module will always send the final reply.

```
route[MYREQ]
{
    ## protect from retrans
    if (!t_newtran()) {
        xlog("L_ERROR", "$ci|log|failed to create transaction\n");
        drop;
    }

    if(some early business use case that requires drop) {
        xlog("L_INFO", "$ci|log|dropping request\n");
        t_drop();
    }

    async_func_that_suspends_and_continues("$anyparam", "TR_OK", "TR_ERROR");

}

failure_route[TR_ERROR]
{
    xlog("L_INFO", "$ci|log|failed $T_reply_code $T_reply_reason\n");
    t_drop();
}

onreply_route[TR_OK]
{
    xlog("L_INFO", "$ci|log|checking transaction result\n");
   if(some business use case that requires dropping the request) {
      t_drop();
   }
...
}
```
if we use `drop` instead of `t_drop` , we always get a final reply sent to the requestor

not sure if this is the right approach to the problem but at least fixes for us and can start the discussion.
