### PR TITLE
dialog: fix typo in warn message

### DIFF
--- a/src/modules/dialog/dlg_db_handler.c
+++ b/src/modules/dialog/dlg_db_handler.c
@@ -643,14 +643,14 @@ static int load_dialog_vars_from_db(int fetch_num_rows, int mode,
 					}
 					dlg = dlg->next;
 					if (!dlg) {
-						LM_WARN("insonsistent data: the dialog h_entry/h_id does not exist!\n");
+						LM_WARN("inconsistent data: the dialog h_entry/h_id does not exist!\n");
 					}
 				}
 				if(mode==1 && mval!=NULL) {
 					dlg_unlock(d_table, &(d_table->entries[VAL_INT(values)]));
 				}
 			} else {
-				LM_WARN("insonsistent data: the h_entry in the DB does not exist!\n");
+				LM_WARN("inconsistent data: the h_entry in the DB does not exist!\n");
 			}
 		}
 


### PR DESCRIPTION

- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
