### PR TITLE
rtpengine : crash is fixed and codec flags added to doc

### DIFF
--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -334,11 +334,11 @@ modparam("rtpengine", "rtpengine_retr", 2)
 	<section id="rtpengine.p.extra_id_pv">
 		<title><varname>extra_id_pv</varname> (string)</title>
 		<para>
-			The parameter sets the PV definition to use when the <quote>b</quote>
+			The parameter sets the PV definition to use when the <quote>via-branch</quote>
 			parameter is used on rtpengine_delete(), rtpengine_offer(),
 			rtpengine_answer() or rtpengine_manage() command.
 		</para><para>
-			Default is empty, the <quote>b</quote> parameter may not be used then.
+			Default is empty, the <quote>via-branch</quote> parameter may not be used then.
 		</para>
 		<example>
 		<title>Set <varname>extra_id_pv</varname> parameter</title>

--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -2331,6 +2331,12 @@ rtpengine_offer();
                                 recording calls to provide custom additional information. More details about this are found
                                 in the rtpengine README.
 				</para></listitem>
+				<listitem><para>
+				<emphasis>transcode=...</emphasis> - allows codecs to be added to the list of offered codecs even 
+				if they were not present in the original list of codecs. In this case, the transcoding engine 
+				will be engaged. Only codecs that are supported for both decoding and encoding can be added in 
+				this manner. More details about this are found in the rtpengine README.                                
+				</para></listitem>
 			</itemizedlist>
 			<para>
 			 Check also the documentation of RTPEngine, these flags are documented there as well:

--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -281,7 +281,7 @@ modparam("rtpengine", "rtpengine_allow_op", 1)
 	<section id="rtpengine.p.queried_nodes_limit">
 		<title><varname>queried_nodes_limit</varname> (integer)</title>
 		<para>
-		The total number of nodes inside a set (sets are configurable via rtpengine_sock function) to be queried 
+		The total number of nodes inside a set (sets are configurable via rtpengine_sock function) to be queried
 		before giving up establishing a session. This brings more flexibility in case checking all rtpengines
 		would take too long. Max limit is 30.
 		</para>
@@ -2217,7 +2217,7 @@ rtpengine_offer();
 				should be used. See also the next set of flags below.
 				</para></listitem>
 				<listitem><para>
-				<emphasis>RTP/AVP, RTP/SAVP, UDP/TLS/RTP/SAVP, RTP/AVPF, RTP/SAVPF, UDP/TLS/RTP/SAVPF</emphasis> - these 
+				<emphasis>RTP/AVP, RTP/SAVP, UDP/TLS/RTP/SAVP, RTP/AVPF, RTP/SAVPF, UDP/TLS/RTP/SAVPF</emphasis> - these
 				serve as an alternative, more explicit way to select between the different &rtp; protocols
 				and profiles supported by the &rtp; proxy. For example, giving the flag
 				<quote>RTP/SAVPF</quote> has the same effect as giving the two flags
@@ -2332,10 +2332,24 @@ rtpengine_offer();
                                 in the rtpengine README.
 				</para></listitem>
 				<listitem><para>
-				<emphasis>transcode=...</emphasis> - allows codecs to be added to the list of offered codecs even 
-				if they were not present in the original list of codecs. In this case, the transcoding engine 
-				will be engaged. Only codecs that are supported for both decoding and encoding can be added in 
-				this manner. More details about this are found in the rtpengine README.                                
+				<emphasis>codec-transcode=...</emphasis> - allows codecs to be added to the list of offered codecs even
+				if they were not present in the original list of codecs. In this case, the transcoding engine
+				will be engaged. Only codecs that are supported for both decoding and encoding can be added in
+				this manner. More details about this are found in the rtpengine README.
+				</para></listitem>
+
+				<listitem><para>
+				<emphasis>codec-strip=...</emphasis> - strips given codec from sdp
+				</para></listitem>
+
+				<listitem><para>
+				<emphasis>codec-offer=...</emphasis> - offer given codec from sdp.More details about this are found in the rtpengine README.
+				</para></listitem>
+
+				<listitem><para>
+				<emphasis>codec-mask=...</emphasis> - Similar to strip except that codecs listed here will still be accepted
+				and used for transcoding on the offering side.Useful only in combination with codec-transcode. <emphasis>all</emphasis> keyword
+				can be used to mask all offered codecs
 				</para></listitem>
 			</itemizedlist>
 			<para>
@@ -2380,6 +2394,13 @@ onreply_route[2]
         rtpengine_offer();
 ...
 }
+...
+if (has_body("application/sdp")) {
+		if (rtpengine_offer("codec-mask=all codec-transcode=PCMU codec-transcode=PCMA"))
+				t_on_reply("1");
+}
+
+...
 </programlisting>
                 </example>
 	</section>
@@ -2863,4 +2884,3 @@ $ &kamcmd; rtpengine.get_hash_total
 	</section>
 
 </chapter>
-

--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -218,7 +218,7 @@ static int pv_parse_var(str *inp, pv_elem_t **outp, int *got_any);
 static int mos_label_stats_parse(struct minmax_mos_label_stats *mmls);
 static void parse_call_stats(bencode_item_t *, struct sip_msg *);
 
-static int control_cmd_tos = -1; 
+static int control_cmd_tos = -1;
 static int rtpengine_allow_op = 0;
 static struct rtpp_node **queried_nodes_ptr = NULL;
 static pid_t mypid;
@@ -375,7 +375,7 @@ static param_export_t params[] = {
 	{"queried_nodes_limit",   INT_PARAM, &default_rtpengine_cfg.queried_nodes_limit    },
 	{"rtpengine_tout_ms",     INT_PARAM, &default_rtpengine_cfg.rtpengine_tout_ms      },
 	{"rtpengine_allow_op",    INT_PARAM, &rtpengine_allow_op     },
-	{"control_cmd_tos",       INT_PARAM, &control_cmd_tos        }, 
+	{"control_cmd_tos",       INT_PARAM, &control_cmd_tos        },
 	{"db_url",                PARAM_STR, &rtpp_db_url            },
 	{"table_name",            PARAM_STR, &rtpp_table_name        },
 	{"setid_col",             PARAM_STR, &rtpp_setid_col         },
@@ -1992,6 +1992,10 @@ static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg, enu
 		if (str_key_val_prefix(&key, "transcode", &val, &s)
 				|| str_key_val_prefix(&key, "codec-transcode", &val, &s))
 		{
+			if(s.len<=0 && s.s==NULL){
+				LM_ERR(" %.*s key needs codec value \n",key.len,key.s);
+				goto next;
+			}
 			if (!ng_flags->codec_transcode) {
 				ng_flags->codec_transcode = bencode_list(ng_flags->dict->buffer);
 				bencode_dictionary_add(ng_flags->codec, "transcode",
@@ -2002,6 +2006,10 @@ static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg, enu
 		}
 
 		if (str_key_val_prefix(&key, "codec-strip", &val, &s)) {
+			if(s.len<=0 && s.s==NULL){
+				LM_ERR(" %.*s key needs codec value \n",key.len,key.s);
+				goto next;
+			}
 			if (!ng_flags->codec_strip) {
 				ng_flags->codec_strip = bencode_list(ng_flags->dict->buffer);
 				bencode_dictionary_add(ng_flags->codec, "strip",
@@ -2012,6 +2020,10 @@ static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg, enu
 		}
 
 		if (str_key_val_prefix(&key, "codec-offer", &val, &s)) {
+			if(s.len<=0 && s.s==NULL){
+				LM_ERR(" %.*s key needs codec value \n",key.len,key.s);
+				goto next;
+			}
 			if (!ng_flags->codec_offer) {
 				ng_flags->codec_offer = bencode_list(ng_flags->dict->buffer);
 				bencode_dictionary_add(ng_flags->codec, "offer",
@@ -2022,6 +2034,10 @@ static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg, enu
 		}
 
 		if (str_key_val_prefix(&key, "codec-mask", &val, &s)) {
+			if(s.len<=0 && s.s==NULL){
+				LM_ERR(" %.*s key needs codec value \n",key.len,key.s);
+				goto next;
+			}
 			if (!ng_flags->codec_mask) {
 				ng_flags->codec_mask = bencode_list(ng_flags->dict->buffer);
 				bencode_dictionary_add(ng_flags->codec, "mask",

--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -699,6 +699,9 @@ static inline int str_prefix(const str *p, const char *q, str *out) {
 /* handle either "foo-bar" or "foo=bar" from flags */
 static inline int str_key_val_prefix(const str *p, const char *q, const str *v, str *out) {
 	if (str_eq(p, q)) {
+		if(!v->s || !v->len)
+			return 0;
+
 		*out = *v;
 		return 1;
 	}
@@ -1992,10 +1995,6 @@ static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg, enu
 		if (str_key_val_prefix(&key, "transcode", &val, &s)
 				|| str_key_val_prefix(&key, "codec-transcode", &val, &s))
 		{
-			if(s.len<=0 && s.s==NULL){
-				LM_ERR(" %.*s key needs codec value \n",key.len,key.s);
-				goto next;
-			}
 			if (!ng_flags->codec_transcode) {
 				ng_flags->codec_transcode = bencode_list(ng_flags->dict->buffer);
 				bencode_dictionary_add(ng_flags->codec, "transcode",
@@ -2006,10 +2005,6 @@ static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg, enu
 		}
 
 		if (str_key_val_prefix(&key, "codec-strip", &val, &s)) {
-			if(s.len<=0 && s.s==NULL){
-				LM_ERR(" %.*s key needs codec value \n",key.len,key.s);
-				goto next;
-			}
 			if (!ng_flags->codec_strip) {
 				ng_flags->codec_strip = bencode_list(ng_flags->dict->buffer);
 				bencode_dictionary_add(ng_flags->codec, "strip",
@@ -2020,10 +2015,6 @@ static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg, enu
 		}
 
 		if (str_key_val_prefix(&key, "codec-offer", &val, &s)) {
-			if(s.len<=0 && s.s==NULL){
-				LM_ERR(" %.*s key needs codec value \n",key.len,key.s);
-				goto next;
-			}
 			if (!ng_flags->codec_offer) {
 				ng_flags->codec_offer = bencode_list(ng_flags->dict->buffer);
 				bencode_dictionary_add(ng_flags->codec, "offer",
@@ -2034,10 +2025,6 @@ static int parse_flags(struct ng_flags_parse *ng_flags, struct sip_msg *msg, enu
 		}
 
 		if (str_key_val_prefix(&key, "codec-mask", &val, &s)) {
-			if(s.len<=0 && s.s==NULL){
-				LM_ERR(" %.*s key needs codec value \n",key.len,key.s);
-				goto next;
-			}
 			if (!ng_flags->codec_mask) {
 				ng_flags->codec_mask = bencode_list(ng_flags->dict->buffer);
 				bencode_dictionary_add(ng_flags->codec, "mask",


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Kamailio crashes when codec-flags value are not setted with codecs. it is fixed.
codec-flags information added to document.
An example is added to document.