### PR TITLE
kamailio.service: fixed RunTimeDir Permission Error

### DIFF
--- a/pkg/kamailio/obs/kamailio.service
+++ b/pkg/kamailio/obs/kamailio.service
@@ -7,9 +7,13 @@ After=network-online.target
 Type=simple
 User=kamailio
 Group=daemon
+PermissionsStartOnly=true
 Environment='CFGFILE=/etc/kamailio/kamailio.cfg'
 Environment='SHM_MEMORY=64'
 Environment='PKG_MEMORY=4'
+RuntimeDirectory=kamailio
+RuntimeDirectoryMode=0755
+PIDFile=/var/run/kamailio/kamailio.pid
 EnvironmentFile=-/etc/sysconfig/kamailio
 ExecStart=/usr/sbin/kamailio -DD -P /var/run/kamailio/kamailio.pid -f $CFGFILE -m $SHM_MEMORY -M $PKG_MEMORY
 Restart=on-failure


### PR DESCRIPTION


<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
kamailo.service  file: fixed RunTime Dir Permission Error
When starting Kamailio on Centos 7 with systemctl , it gives "/var/run/kamailio Permission denied error" to create kamailio.pid file.
- RuntimeDirectory defines folder name in /var/run
- RuntimeDirectoryMode creates folder in path /var/run/ as given User:Group with permission
- PermissionsStartOnly applies on ExecStart for permission-related execution options