### PR TITLE
pkg/kamailio/obs: Fixed warning about not existen kamailio group

### DIFF
--- a/pkg/kamailio/obs/kamailio.service
+++ b/pkg/kamailio/obs/kamailio.service
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 Type=simple
 User=kamailio
-Group=daemon
+Group=kamailio
 Environment='CFGFILE=/etc/kamailio/kamailio.cfg'
 Environment='SHM_MEMORY=64'
 Environment='PKG_MEMORY=4'

--- a/pkg/kamailio/obs/kamailio.spec
+++ b/pkg/kamailio/obs/kamailio.spec
@@ -1184,13 +1184,12 @@ install -m644 pkg/kamailio/%{dist_name}/%{dist_version}/sipcapture.sysconfig \
 rm -f %{buildroot}%{_libdir}/kamailio/lib*.so
 
 %pre
-%if 0%{?suse_version}
-if ! /usr/bin/getent group daemon &>/dev/null; then
-    /usr/sbin/groupadd --gid 2 daemon &> /dev/null
-fi
-%endif
 if ! /usr/bin/id kamailio &>/dev/null; then
-       /usr/sbin/useradd -r -g daemon -s /bin/false -c "Kamailio daemon" -d %{_libdir}/kamailio kamailio || \
+       /usr/sbin/useradd --system \
+                         --user-group \
+                         --shell /bin/false \
+                         --comment "Kamailio SIP Server" \
+                         --home-dir %{_rundir}/kamailio kamailio || \
                 %logmsg "Unexpected error adding user \"kamailio\". Aborting installation."
 fi
 

--- a/pkg/kamailio/obs/kamailio.tmpfiles
+++ b/pkg/kamailio/obs/kamailio.tmpfiles
@@ -1,1 +1,1 @@
-D /run/kamailio 0700 kamailio daemon -
+D /run/kamailio 0700 kamailio kamailio -


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Kamailio is installed to systemd as member of "daemon" group.
Fixed not correct group usage in spec file.