### PR TITLE
core: fixed segmentation fault when handling multipart bodies

### DIFF
--- a/src/core/msg_translator.c
+++ b/src/core/msg_translator.c
@@ -1838,10 +1838,10 @@ int check_boundaries(struct sip_msg *msg, struct dest_info *send_info)
 			tmp.len = get_line(lb_t->s);
 			if(tmp.len!=b.len || strncmp(b.s, tmp.s, b.len)!=0)
 			{
-				LM_DBG("malformed bondary in the middle\n");
+				LM_DBG("malformed boundary in the middle\n");
 				memcpy(pb, b.s, b.len); body.len = body.len + b.len;
 				pb = pb + b.len;
-				t = lb_t->s.s - (lb_t->s.s + tmp.len);
+				t = lb_t->next->s.s - (lb_t->s.s + tmp.len);
 				memcpy(pb, lb_t->s.s+tmp.len, t); pb = pb + t;
 				/*LM_DBG("new chunk[%d][%.*s]\n", t, t, pb-t);*/
 			}


### PR DESCRIPTION
Function check_boundaries() in msg_translator.c not handling property the length of the buffers when it needs to repair the boundary, getting a negative lenght and causing a segmentation fault.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #1758 

#### Description
<!-- Describe your changes in detail -->
Function check_boundaries() in msg_translator.c not handling property the length of the buffers when it needs to repair the boundary, getting a negative lenght and causing a segmentation fault.