### PR TITLE
mqueue: new RPC command mqueue.fetch

### DIFF
--- a/src/modules/mqueue/doc/mqueue.xml
+++ b/src/modules/mqueue/doc/mqueue.xml
@@ -35,10 +35,19 @@
 		<email>osas@voipembedded.com</email>
 		<affiliation><orgname>VoIP Embedded, Inc.</orgname></affiliation>
 	    </editor>
+	    <editor>
+		<firstname>Julien</firstname>
+		<surname>Chavanton</surname>
+		<email>jchavanton@gmail.com</email>
+	    </editor>
 	</authorgroup>
 	<copyright>
 	    <year>2010</year>
 	    <holder>Elena-Ramona Modroiu (asipto.com)</holder>
+	</copyright>
+	<copyright>
+	    <year>2018</year>
+	    <holder>Julien chavanton, Flowroute</holder>
 	</copyright>
     </bookinfo>
     <toc></toc>

--- a/src/modules/mqueue/doc/mqueue_admin.xml
+++ b/src/modules/mqueue/doc/mqueue_admin.xml
@@ -245,6 +245,28 @@ xlog("L_INFO", "Size of queue is: $var(q_size)\n");
 </programlisting>
 	    </example>
 	</section>
+	<section id="mqueue.r.fetch">
+		<title>mqueue.fetch</title>
+		<para>
+			Fetch a key-value pair from a memory queue.
+		</para>
+		<para>
+			Parameters:
+		</para>
+		<itemizedlist>
+			<listitem>
+				<emphasis>name</emphasis> - the name of memory queue
+			</listitem>
+		</itemizedlist>
+		<example>
+		<title><function>mqueue.fetch</function> usage</title>
+		<programlisting format="linespecific">
+...
+&kamcmd; mqueue.fetch xyz
+...
+</programlisting>
+	    </example>
+	</section>
     </section>
 
 </chapter>

--- a/src/modules/mqueue/mqueue_api.c
+++ b/src/modules/mqueue/mqueue_api.c
@@ -427,6 +427,44 @@ int pv_get_mqk(struct sip_msg *msg, pv_param_t *param,
 /**
  *
  */
+str* get_mqk(str *in)
+{
+	mq_pv_t *mp = NULL;
+
+	if (mq_head_get(in) == NULL)
+	{
+		LM_ERR("mqueue not found: %.*s\n", in->len, in->s);
+		return NULL;
+	}
+
+	mp = mq_pv_get(in);
+	if(mp==NULL || mp->item==NULL || mp->item->key.len<=0)
+		return NULL;
+	return &mp->item->key;
+}
+
+/**
+ *
+ */
+str* get_mqv(str *in)
+{
+	mq_pv_t *mp = NULL;
+
+	if (mq_head_get(in) == NULL)
+	{
+		LM_ERR("mqueue not found: %.*s\n", in->len, in->s);
+		return NULL;
+	}
+
+	mp = mq_pv_get(in);
+	if(mp==NULL || mp->item==NULL || mp->item->val.len<=0)
+		return NULL;
+	return &mp->item->val;
+}
+
+/**
+ *
+ */
 int pv_get_mqv(struct sip_msg *msg, pv_param_t *param,
 		pv_value_t *res)
 {

--- a/src/modules/mqueue/mqueue_api.h
+++ b/src/modules/mqueue/mqueue_api.h
@@ -35,7 +35,8 @@ int pv_get_mqv(struct sip_msg *msg, pv_param_t *param,
 		pv_value_t *res);
 int pv_get_mq_size(struct sip_msg *msg, pv_param_t *param,
 		pv_value_t *res);
-
+str* get_mqk(str *name);
+str* get_mqv(str *name);
 int mq_head_defined(void);
 void mq_destroy(void);
 int mq_head_add(str *name, int msize);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

using this new RPC method we can fetch elements key/value from any queue from an external application. This could be useful in many cases, one use case is with acc_json

```
curl --data-binary '{"jsonrpc":"2.0","id":"1","method":"mqueue.fetch","params": ["MY_QUEUE"]}' -H 'content-type:text/plain;' http://1270.0.1:9999:jsonrpc/ 
{
	"jsonrpc":	"2.0",
	"result":	{
		"key":	"my_key",
		"val":	"{\"time\": 1544217754, \"method\": \"INVITE\","\"}"
	},
	"id":	"1"
}
```

```
kamcmd mqueue.fetch my_queue
error: 404 - Empty queue
```