### PR TITLE
http_client: http_connect_raw

### DIFF
--- a/src/modules/http_client/doc/http_client_admin.xml
+++ b/src/modules/http_client/doc/http_client_admin.xml
@@ -646,7 +646,7 @@ http_follow_redirect = no
 					</para>
 					<para>
 						<emphasis>data</emphasis> - Data or a pseudo variable holding
-						data to be posted.
+						data to be posted. (may contain pseudo variable)
 					</para>
 					<para>
 						<emphasis>result</emphasis> - The name of a pseudo variable that
@@ -674,6 +674,67 @@ $var(res) = http_connect("apiserver", "/mailbox", "application/json", "{ ok, {20
 xlog("L_INFO", "API-server HTTP connection: $avp(gurka) Result code $var(res)\n");
 
 $var(res) = http_connect("apiserver", "/callroute", "application/json", "$var(jsondata)", "$avp(route)");
+xlog("L_INFO", "API-server HTTP connection: $avp(route) Result code $var(res)\n");
+...
+				</programlisting>
+			</example>
+		</section>
+		<section id="http_client.f.http_connect_raw">
+			<title>
+				<function moreinfo="none">http_connect_raw(connection, url, content_type, data, result)</function>
+			</title>
+			<para>
+				Sends HTTP POST request to a given connection.
+				Similar to http_connect.
+				The only difference is that the data parameter will not be parsed for pseudo variables,
+				therefore it can safely be used for content that may contain "$" character like JSON.
+			</para>
+			<itemizedlist>
+				<listitem>
+					<para>
+						<emphasis>connection</emphasis> - the name of an existing
+						HTTP connection, defined by a httpcon modparam.
+					</para>
+					<para>
+						<emphasis>url</emphasis> - the part of the URL to add to the
+						predefined URL in the connection definition.
+					</para>
+					<para>
+						<emphasis>content_type</emphasis> - Used only when posting
+						data with HTTP POST. An Internet Media type, like
+						"application/json" or "text/plain". Will be added to the
+						HTTP request as a header.
+					</para>
+					<para>
+						<emphasis>data</emphasis> - Data or a pseudo variable holding
+						data to be posted. (will not be parsed for pseudo variable)
+					</para>
+					<para>
+						<emphasis>result</emphasis> - The name of a pseudo variable that
+						will have the data of the response from the HTTP server.
+					</para>
+				</listitem>
+			</itemizedlist>
+			<para>
+			The return value is the HTTP return code (if >=100) or the
+			CURL error code if below 100. See the $curlerror pseudovariable
+			below for more information about CURL error codes.
+	    	        </para>
+			<para>
+			This function can be used from REQUEST_ROUTE,
+			ONREPLY_ROUTE, FAILURE_ROUTE, and BRANCH_ROUTE.
+			</para>
+			<example>
+				<title><function>http_connect_raw()</function> usage</title>
+				<programlisting format="linespecific">
+...
+modparam("http_client", "httpcon", "apiserver=>http://kamailio.org/api/");
+...
+# POST Request
+$var(res) = http_connect_raw("apiserver", "/mailbox", "application/json", "{ ok, {200, ok}}", "$avp(gurka)");
+xlog("L_INFO", "API-server HTTP connection: $avp(gurka) Result code $var(res)\n");
+
+$var(res) = http_connect_war("apiserver", "/callroute", "application/json", "$var(jsondata)", "$avp(route)");
 xlog("L_INFO", "API-server HTTP connection: $avp(route) Result code $var(res)\n");
 ...
 				</programlisting>


### PR DESCRIPTION
similar to http_connect for http/post, however the data parameter is not PV parsed
this way json and any other content can be used without any escaping

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
I have ran into the issue, where a dollar sign was present in the data  : 

https://lists.kamailio.org/pipermail/sr-dev/2009-March/000898.html
```
Try to replace $ with $$ inside the $var(data), something like:

$var(m) = "$";
$var(r) = "$$";
$var(newdata) = $(var(data){s.replace,$var(m),$var(r)});
```
This fix is working, but I thought others could fell into this pitfall and have builtin way to send raw data over http could be best.

By adding a module command to send `http_connect_raw()`

I wonder if this should be called something else ...