### PR TITLE
secfilter: free initial struct of shared memory on mod_destroy

### DIFF
--- a/src/modules/secfilter/secfilter.c
+++ b/src/modules/secfilter/secfilter.c
@@ -664,6 +664,8 @@ static void mod_destroy(void)
 	free_data();
 	/* Destroy lock */
 	lock_destroy(&secf_data->lock);
+	shm_free(secf_data);
+	secf_data = NULL;
 }
 
 


### PR DESCRIPTION
seems that ``secf_data`` was never freed