### PR TITLE
db_mysql: remove build warning, unneeded include

### DIFF
--- a/src/modules/db_mysql/km_dbase.c
+++ b/src/modules/db_mysql/km_dbase.c
@@ -35,7 +35,6 @@
 #include <string.h>
 #include <mysql.h>
 #include <errmsg.h>
-#include <mysql_version.h>
 #include "../../core/mem/mem.h"
 #include "../../core/dprint.h"
 #include "../../core/async_task.h"


### PR DESCRIPTION
mysql_version.h is already included at mysql.h

> In file included from km_dbase.c:38:
> /usr/include/mariadb/mysql_version.h:3:2: warning: This file should not be included by clients, include only <mysql.h> [-W#warnings]
> #warning This file should not be included by clients, include only <mysql.h>
>  ^
> 1 warning generated.
