### PR TITLE
Update for Readme Dispatcher module

### DIFF
--- a/src/modules/dispatcher/README
+++ b/src/modules/dispatcher/README
@@ -697,10 +697,10 @@ Note
    Controls what gateways are tested to see if they are reachable.
      * Value 0: If set to 0, only the gateways with state PROBING are
        tested. After a gateway is probed, the PROBING state is cleared in
-       this mode.
+       this mode. This means that no probing will be executed at all and if flag in config file is set to 8/PROBING(please check "Destination List File" for more details), it will probe only one time at startup or reload of dispatcher.
      * Value 1: If set to 1, all gateways are tested. If set to 1 and
        there is a failure of keepalive to an active gateway, then it is
-       set to TRYING state.
+       set to TRYING state. This means that probing will be executed all the time, but you can skip some servers with flag 4.
      * Value 2: if set to 2, only gateways in inactive state with probing
        mode set are tested.
      * Value 3: If set to 3, any gateway with state PROBING is continually
@@ -1388,6 +1388,14 @@ kamcmd dispatcher.set_state ip 3 all
 
    Example:
                 kamcmd dispatcher.list
+                 ...
+DEST: {
+	URI: sip:1.2.3.4
+	FLAGS: AX
+	PRIORITY: 9
+}
+ ...
+ AX - active but not probing, X on the end mens that there no probing enabled. DX for example disabled and no probing.
 
 5.3.  dispatcher.reload
 


### PR DESCRIPTION
Update for Readme Dispatcher module. I added some minor comments for dispatcher module, what I think might be useful for somebody.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
