### PR TITLE
Update for Readme Dispatcher module

### DIFF
--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -631,12 +631,16 @@ modparam("dispatcher", "force_dst", 1)
 		<itemizedlist>
 		<listitem>
 			<para>Value 0: If set to 0, only the gateways with state PROBING are tested.
-            After a gateway is probed, the PROBING state is cleared in this mode.</para>
+            After a gateway is probed, the PROBING state is cleared in this mode.
+				This means that no probing will be executed at all only if flag in config file is set to 8/PROBING
+				(please check "Destination List File" for more details), it will probe only one time at startup or 
+				after dispatcher reload.</para>
 		</listitem>
 		<listitem>
 			<para>Value 1: If set to 1, all gateways are tested.  If set to 1 and
 			there is a failure of keepalive to an active gateway, then it is
-			set to TRYING state.</para>
+			set to TRYING state. This means that probing will be executed all the time,
+				but you can skip some servers with flag 4 in config file.</para>
 		</listitem>
 		<listitem>
 			<para>Value 2: if set to 2, only gateways in inactive state with


### PR DESCRIPTION
Update for Readme Dispatcher module. I added some minor comments for dispatcher module, what I think might be useful for somebody.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
