### PR TITLE
siptrace: siptrace: don't calculate message source socket if already set

### DIFF
--- a/src/modules/siptrace/siptrace.c
+++ b/src/modules/siptrace/siptrace.c
@@ -1493,7 +1493,10 @@ int siptrace_net_data_send(sr_event_param_t *evp)
 		return -1;
 
 	new_dst = *nd->dst;
-	new_dst.send_sock = get_send_socket(0, &nd->dst->to, nd->dst->proto);
+
+	if(new_dst.send_sock == 0) {
+		new_dst.send_sock = get_send_socket(0, &nd->dst->to, nd->dst->proto);
+	}
 
 	memset(&sto, 0, sizeof(siptrace_data_t));
 


### PR DESCRIPTION
When trace_mode = 1, the source socket of an outgoing message can be retrieved from the payload passed in the callback of SREV_NET_DATA_SEND. Otherwise, if the socket has been manually forced (setting $fs, calling force_send_socket..), the information will be overwritten and the actual source socket of the outgoing message lost.