### PR TITLE
modules: fix hiredis handling

### DIFF
--- a/src/modules/db_redis/Makefile
+++ b/src/modules/db_redis/Makefile
@@ -19,7 +19,7 @@ else
 	HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags)
 	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs)
 
-ifeq (,$(findstring hiredis,$(HIREDISDEFS)))
+ifneq (,$(findstring hiredis,$(HIREDISDEFS)))
 	DEFS+=-DWITH_HIREDIS_PATH
 endif
 

--- a/src/modules/ndb_redis/Makefile
+++ b/src/modules/ndb_redis/Makefile
@@ -19,7 +19,7 @@ else
 	HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags)
 	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs)
 
-ifeq (,$(findstring hiredis,$(HIREDISDEFS)))
+ifneq (,$(findstring hiredis,$(HIREDISDEFS)))
 	DEFS+=-DWITH_HIREDIS_PATH
 endif
 

--- a/src/modules/topos_redis/Makefile
+++ b/src/modules/topos_redis/Makefile
@@ -19,7 +19,7 @@ else
 	HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags)
 	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs)
 
-ifeq (,$(findstring hiredis,$(HIREDISDEFS)))
+ifneq (,$(findstring hiredis,$(HIREDISDEFS)))
 	DEFS+=-DWITH_HIREDIS_PATH
 endif
 


### PR DESCRIPTION
The define WITH_HIREDIS_PATH causes the source files to include
"<hiredis/hiredis.h>". But the Makefiles check HIREDISDEFS for the
string "hiredis" and set WITH_HIREDIS_PATH if not found. Which is
exactly the opposite of what is needed. This commit corrects the logic.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
