### PR TITLE
core: dns slow queries reporting

### DIFF
--- a/src/core/cfg.lex
+++ b/src/core/cfg.lex
@@ -309,6 +309,7 @@ DNS_TCP_PREF	dns_tcp_pref|dns_tcp_preference
 DNS_TLS_PREF	dns_tls_pref|dns_tls_preference
 DNS_SCTP_PREF	dns_sctp_pref|dns_sctp_preference
 DNS_RETR_TIME	dns_retr_time
+DNS_SLOW_QUERY_MS	dns_slow_query_ms
 DNS_RETR_NO		dns_retr_no
 DNS_SERVERS_NO	dns_servers_no
 DNS_USE_SEARCH	dns_use_search_list
@@ -723,6 +724,8 @@ IMPORTFILE      "import_file"
 								return DNS_SCTP_PREF; }
 <INITIAL>{DNS_RETR_TIME}	{ count(); yylval.strval=yytext;
 								return DNS_RETR_TIME; }
+<INITIAL>{DNS_SLOW_QUERY_MS}	{ count(); yylval.strval=yytext;
+								return DNS_SLOW_QUERY_MS; }
 <INITIAL>{DNS_RETR_NO}	{ count(); yylval.strval=yytext;
 								return DNS_RETR_NO; }
 <INITIAL>{DNS_SERVERS_NO}	{ count(); yylval.strval=yytext;

--- a/src/core/cfg.y
+++ b/src/core/cfg.y
@@ -337,6 +337,7 @@ extern char *default_routename;
 %token DNS_TLS_PREF
 %token DNS_SCTP_PREF
 %token DNS_RETR_TIME
+%token DNS_SLOW_QUERY_MS
 %token DNS_RETR_NO
 %token DNS_SERVERS_NO
 %token DNS_USE_SEARCH
@@ -827,6 +828,8 @@ assign_stm:
 	| DNS_SCTP_PREF error { yyerror("number expected"); }
 	| DNS_RETR_TIME EQUAL NUMBER   { default_core_cfg.dns_retr_time=$3; }
 	| DNS_RETR_TIME error { yyerror("number expected"); }
+	| DNS_SLOW_QUERY_MS EQUAL NUMBER   { default_core_cfg.dns_slow_query_ms=$3; }
+	| DNS_SLOW_QUERY_MS error { yyerror("number expected"); }
 	| DNS_RETR_NO EQUAL NUMBER   { default_core_cfg.dns_retr_no=$3; }
 	| DNS_RETR_NO error { yyerror("number expected"); }
 	| DNS_SERVERS_NO EQUAL NUMBER   { default_core_cfg.dns_servers_no=$3; }

--- a/src/core/cfg_core.c
+++ b/src/core/cfg_core.c
@@ -78,6 +78,7 @@ struct cfg_group_core default_core_cfg = {
 	10,  /*!< tls transport preference (for naptr) */
 	20,  /*!< sctp transport preference (for naptr) */
 	-1, /*!< dns_retr_time */
+	0,  /*!< dns_slow_query_ms */
 	-1, /*!< dns_retr_no */
 	-1, /*!< dns_servers_no */
 	1,  /*!< dns_search_list */
@@ -224,6 +225,8 @@ cfg_def_t core_cfg_def[] = {
 		"sctp protocol preference when doing NAPTR lookups"},
 	{"dns_retr_time",	CFG_VAR_INT,	0, 0, 0, resolv_reinit,
 		"time in s before retrying a dns request"},
+	{"dns_slow_query_ms",	CFG_VAR_INT,	0, 0, 0, resolv_reinit,
+		"max time in ms before a dns request is considered slow"},
 	{"dns_retr_no",		CFG_VAR_INT,	0, 0, 0, resolv_reinit,
 		"number of dns retransmissions before giving up"},
 	{"dns_servers_no",	CFG_VAR_INT,	0, 0, 0, resolv_reinit,

--- a/src/core/cfg_core.h
+++ b/src/core/cfg_core.h
@@ -67,6 +67,7 @@ struct cfg_group_core {
 	int dns_tls_pref;
 	int dns_sctp_pref;
 	int dns_retr_time;
+	int dns_slow_query_ms;
 	int dns_retr_no;
 	int dns_servers_no;
 	int dns_search_list;

--- a/src/core/resolve.h
+++ b/src/core/resolve.h
@@ -65,10 +65,11 @@
 #define RES_ONLY_TYPE 1   /* return only the specified type records */
 #define RES_AR		  2   /* return also the additional records */
 
-/* counter for failed DNS requests
+/* counter for failed/slow DNS requests
 */
 struct dns_counters_h {
     counter_handle_t failed_dns_req;
+    counter_handle_t slow_dns_req;
 };
 
 extern struct dns_counters_h dns_cnts_h;


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

I remember there was some discussion about adding DNS statistics, I think you were part of it  @ngvoice Carsten ? (you may comment on this MR if you have anything to add)

This is adding a parameter to the core `dns_slow_query_ms`

Example:
```
dns_slow_query_ms=100
```

When using the internal resolver any query taking more than `dns_slow_query_ms` will be logged as a warning :
```
dns_slow_query_ms=10 (example with 10ms)
latency_log=0

 5(5960) WARNING: <core> [core/resolve.c:752]: get_record(): res_search[35][us-west-wa.sip.flowroute.com]elapsed[12ms]
 5(5960) WARNING: <core> [core/resolve.c:752]: get_record(): res_search[1][ep-us-west-wa-01.flowroute.com]elapsed[12ms]
```

and a statistic counter will be incremented :
```
kamcmd stats.fetch dns:slow_dns_request
{
    dns.slow_dns_request: 2
}
```

I think this will be a good start to monitor the impact of slow DNS queries on Kamailio.

