### PR TITLE
rr: Add new return value for preloaded route set to loose_route()

### DIFF
--- a/src/modules/rr/doc/rr_admin.xml
+++ b/src/modules/rr/doc/rr_admin.xml
@@ -364,7 +364,7 @@ modparam("rr", "ignore_sips", 1)
 
         <listitem>
           <para><emphasis>2</emphasis> - route calculation based on
-	  flow-token has been successful</para>
+          flow-token has been successful</para>
         </listitem>
 
         <listitem>
@@ -375,6 +375,11 @@ modparam("rr", "ignore_sips", 1)
         <listitem>
           <para><emphasis>-2</emphasis> - outbound flow-token shows evidence
           of tampering</para>
+        </listitem>
+
+        <listitem>
+          <para><emphasis>-3</emphasis> - next hop is taken from
+          a preloaded route set</para>
         </listitem>
       </itemizedlist>
 

--- a/src/modules/rr/loose.c
+++ b/src/modules/rr/loose.c
@@ -48,6 +48,7 @@
 #define RR_OB_DRIVEN 2		/*!< The next hop is determined from the route set based on flow-token */
 #define NOT_RR_DRIVEN -1	/*!< The next hop is not determined from the route set */
 #define FLOW_TOKEN_BROKEN -2	/*!< Outbound flow-token shows evidence of tampering */
+#define RR_PRELOADED -3		/*!< The next hop is determined from a preloaded route set */
 
 #define RR_ROUTE_PREFIX ROUTE_PREFIX "<"
 #define RR_ROUTE_PREFIX_LEN (sizeof(RR_ROUTE_PREFIX)-1)
@@ -840,7 +841,7 @@ static inline int after_loose(struct sip_msg* _m, int preloaded)
 			}
 			if (res > 0) { /* No next route found */
 				LM_DBG("No next URI found\n");
-				status = (preloaded ? NOT_RR_DRIVEN : RR_DRIVEN);
+				status = (preloaded ? RR_PRELOADED : RR_DRIVEN);
 				goto done;
 			}
 			rt = (rr_t*)hdr->parsed;
@@ -873,7 +874,7 @@ static inline int after_loose(struct sip_msg* _m, int preloaded)
 					}
 				if (res > 0) { /* No next route found */
 					LM_DBG("no next URI found\n");
-					status = (preloaded ? NOT_RR_DRIVEN : RR_DRIVEN);
+					status = (preloaded ? RR_PRELOADED : RR_DRIVEN);
 					goto done;
 				}
 				rt = (rr_t*)hdr->parsed;


### PR DESCRIPTION
Instead of returning just -1 (error), return a dedicated value. Now it is
possible to detect from the script if a preloaded Route header was removed
that pointed at the local proxy.

The new return code is kept negative, so all code checking for failure response
keeps working.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
