### PR TITLE
dialog: Add setting to loop BYE through proxy

### DIFF
--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -103,6 +103,7 @@ static char* profiles_nv_s = NULL;
 str dlg_extra_hdrs = {NULL,0};
 static int db_fetch_rows = 200;
 static int db_skip_load = 0;
+static int dlg_keep_proxy_rr = 0;
 int initial_cbs_inscript = 1;
 int dlg_wait_ack = 1;
 static int dlg_timer_procs = 0;
@@ -322,6 +323,7 @@ static param_export_t mod_params[]={
 	{ "end_timeout",           PARAM_INT, &dlg_end_timeout          },
 	{ "h_id_start",            PARAM_INT, &dlg_h_id_start           },
 	{ "h_id_step",             PARAM_INT, &dlg_h_id_step            },
+	{ "keep_proxy_rr",         INT_PARAM, &dlg_keep_proxy_rr        },
 	{ 0,0,0 }
 };
 
@@ -528,6 +530,11 @@ static int mod_init(void)
 		return -1;
 	}
 
+	if (dlg_keep_proxy_rr < 0 || dlg_keep_proxy_rr > 3) {
+		LM_ERR("invalid value for keep_proxy_rr\n");
+		return -1;
+	}
+
 	if (timeout_spec.s) {
 		if ( pv_parse_spec(&timeout_spec, &timeout_avp)==0
 				&& (timeout_avp.type!=PVT_AVP)){
@@ -655,7 +662,7 @@ static int mod_init(void)
 
 	/* init handlers */
 	init_dlg_handlers( rr_param, dlg_flag,
-		timeout_spec.s?&timeout_avp:0, default_timeout, seq_match_mode);
+		timeout_spec.s?&timeout_avp:0, default_timeout, seq_match_mode, dlg_keep_proxy_rr);
 
 	/* init timer */
 	if (init_dlg_timer(dlg_ontimeout)!=0) {

--- a/src/modules/dialog/dlg_handlers.h
+++ b/src/modules/dialog/dlg_handlers.h
@@ -55,7 +55,7 @@
  */
 void init_dlg_handlers(char *rr_param, int dlg_flag,
 		pv_spec_t *timeout_avp, int default_timeout,
-		int seq_match_mode);
+		int seq_match_mode, int keep_proxy_rr);
 
 
 /*!

--- a/src/modules/dialog/dlg_hash.c
+++ b/src/modules/dialog/dlg_hash.c
@@ -394,6 +394,12 @@ void destroy_dlg(struct dlg_cell *dlg)
 	if (dlg->cseq[DLG_CALLEE_LEG].s)
 		shm_free(dlg->cseq[DLG_CALLEE_LEG].s);
 
+	if (dlg->route_set[DLG_CALLER_LEG].s)
+		shm_free(dlg->route_set[DLG_CALLER_LEG].s);
+
+	if (dlg->route_set[DLG_CALLEE_LEG].s)
+		shm_free(dlg->route_set[DLG_CALLEE_LEG].s);
+
 	if (dlg->toroute_name.s)
 		shm_free(dlg->toroute_name.s);
 
@@ -518,7 +524,6 @@ struct dlg_cell* build_new_dlg( str *callid, str *from_uri, str *to_uri,
 int dlg_set_leg_info(struct dlg_cell *dlg, str* tag, str *rr, str *contact,
 					str *cseq, unsigned int leg)
 {
-	char *p;
 	str cs = {"0", 1};
 
 	/* if we don't have cseq, set it to 0 */
@@ -528,7 +533,7 @@ int dlg_set_leg_info(struct dlg_cell *dlg, str* tag, str *rr, str *contact,
 
 	if(dlg->tag[leg].s)
 		shm_free(dlg->tag[leg].s);
-	dlg->tag[leg].s = (char*)shm_malloc( tag->len + rr->len );
+	dlg->tag[leg].s = (char*)shm_malloc(tag->len);
 
 	if(dlg->cseq[leg].s) {
 		if (dlg->cseq[leg].len < cs.len) {
@@ -548,8 +553,17 @@ int dlg_set_leg_info(struct dlg_cell *dlg, str* tag, str *rr, str *contact,
 		dlg->contact[leg].s = (char*)shm_malloc( contact->len );
 	}
 
+	if(dlg->route_set[leg].s) {
+		if (dlg->route_set[leg].len < rr->len) {
+			shm_free(dlg->route_set[leg].s);
+			dlg->route_set[leg].s = (char*)shm_malloc(rr->len);
+		}
+	} else {
+		dlg->route_set[leg].s = (char*)shm_malloc(rr->len);
+	}
+
 	if ( dlg->tag[leg].s==NULL || dlg->cseq[leg].s==NULL
-			|| dlg->contact[leg].s==NULL) {
+			|| dlg->contact[leg].s==NULL || dlg->route_set[leg].s==NULL) {
 		LM_ERR("no more shm mem\n");
 		if (dlg->tag[leg].s)
 		{
@@ -566,20 +580,23 @@ int dlg_set_leg_info(struct dlg_cell *dlg, str* tag, str *rr, str *contact,
 			shm_free(dlg->contact[leg].s);
 			dlg->contact[leg].s = NULL;
 		}
+		if (dlg->route_set[leg].s)
+		{
+			shm_free(dlg->route_set[leg].s);
+			dlg->route_set[leg].s = NULL;
+		}
 
 		return -1;
 	}
-	p = dlg->tag[leg].s;
 
 	/* tag */
 	dlg->tag[leg].len = tag->len;
-	memcpy( p, tag->s, tag->len);
-	p += tag->len;
+	memcpy( dlg->tag[leg].s, tag->s, tag->len);
+
 	/* rr */
 	if (rr->len) {
-		dlg->route_set[leg].s = p;
 		dlg->route_set[leg].len = rr->len;
-		memcpy( p, rr->s, rr->len);
+		memcpy(dlg->route_set[leg].s, rr->s, rr->len);
 	}
 
 	/* contact */
@@ -673,6 +690,55 @@ int dlg_update_contact(struct dlg_cell * dlg, unsigned int leg, str *ct)
 
 	LM_DBG("contact of leg[%d] is %.*s\n", leg,
 			dlg->contact[leg].len, dlg->contact[leg].s);
+done:
+	dlg_unlock(d_table, d_entry);
+	return 0;
+error:
+	dlg_unlock(d_table, d_entry);
+	LM_ERR("not more shm mem\n");
+	return -1;
+}
+
+
+/*!
+ * \brief Update or set the routeset for an existing dialog
+ * \param dlg dialog
+ * \param leg must be either DLG_CALLER_LEG, or DLG_CALLEE_LEG
+ * \param rr routeset
+ * \return 0 on success, -1 on failure
+ */
+int dlg_update_rr_set(struct dlg_cell * dlg, unsigned int leg, str *rr)
+{
+	dlg_entry_t *d_entry;
+
+	d_entry = &(d_table->entries[dlg->h_entry]);
+
+	dlg_lock(d_table, d_entry);
+
+	if ( dlg->route_set[leg].s ) {
+		if(dlg->route_set[leg].len == rr->len
+				&& memcmp(dlg->route_set[leg].s, rr->s, rr->len)==0) {
+			LM_DBG("same route_set for leg[%d] - [%.*s]\n", leg,
+				dlg->route_set[leg].len, dlg->route_set[leg].s);
+			goto done;
+		}
+		if (dlg->route_set[leg].len < rr->len) {
+			shm_free(dlg->route_set[leg].s);
+			dlg->route_set[leg].s = (char*)shm_malloc(rr->len);
+			if (dlg->route_set[leg].s==NULL)
+				goto error;
+		}
+	} else {
+		dlg->route_set[leg].s = (char*)shm_malloc(rr->len);
+		if (dlg->route_set[leg].s==NULL)
+			goto error;
+	}
+
+	memcpy( dlg->route_set[leg].s, rr->s, rr->len );
+	dlg->route_set[leg].len = rr->len;
+
+	LM_DBG("route_set of leg[%d] is %.*s\n", leg,
+			dlg->route_set[leg].len, dlg->route_set[leg].s);
 done:
 	dlg_unlock(d_table, d_entry);
 	return 0;

--- a/src/modules/dialog/dlg_hash.h
+++ b/src/modules/dialog/dlg_hash.h
@@ -292,6 +292,15 @@ int dlg_update_contact(struct dlg_cell * dlg, unsigned int leg, str *ct);
 int dlg_update_cseq(dlg_cell_t *dlg, unsigned int leg, str *cseq);
 
 /*!
+ * \brief Update or set the routeset for an existing dialog
+ * \param dlg dialog
+ * \param leg must be either DLG_CALLER_LEG, or DLG_CALLEE_LEG
+ * \param rr routeset
+ * \return 0 on success, -1 on failure
+ */
+int dlg_update_rr_set(struct dlg_cell * dlg, unsigned int leg, str *rr);
+
+/*!
  * \brief Set time-out route
  * \param dlg dialog
  * \param route name of route

--- a/src/modules/dialog/doc/dialog_admin.xml
+++ b/src/modules/dialog/doc/dialog_admin.xml
@@ -1604,6 +1604,42 @@ modparam("dialog", "h_id_step", 10)
 
 	</section>
 
+	<section id="dialog.p.keep_proxy_rr">
+		<title><varname>keep_proxy_rr</varname> (string)</title>
+		<para>
+			Whether to keep the record-route header added by the proxy.
+			When enabled, it will keep this proxy&apos;s record-route
+			header from the reply. The result is that generated requests
+			like the BYE from the dlg_end_dlg mi function will pass
+			through the proxy (looped).
+		</para>
+		<para>
+			Valid values are:
+		</para>
+		<itemizedlist>
+			<listitem><para>
+				<emphasis>0</emphasis> - Don&apos;t keep any proxy Record-Route headers
+			</para></listitem>
+			<listitem><para>
+				<emphasis>1</emphasis> - Keep Record-route headers for the callee leg
+			</para></listitem>
+			<listitem><para>
+				<emphasis>2</emphasis> - Keep Record-route headers for the caller leg
+			</para></listitem>
+			<listitem><para>
+				<emphasis>3</emphasis> - Keep Record-route headers for both legs
+			</para></listitem>
+		</itemizedlist>
+		<emphasis>
+			Default value is <quote>0</quote>.
+		</emphasis>
+		<title>Set <varname>dlg_keep_proxy_rr</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dialog", "keep_proxy_rr", 1)
+</programlisting>
+		</example>
+	</section>
 
 	<section>
 	<title>Functions</title>


### PR DESCRIPTION
The setting "keep_proxy_rr" will add the Record-Route headers added by the
proxy to the route_set stored in the dialog. When in use, sending locally
generated in-dialog requests will loop back to the proxy with a proper
Record-Route header, including any parameters.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally on 5.1, compile tested on master
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
