### PR TITLE
jsonrpcs: fix double free crash

### DIFF
--- a/src/modules/jsonrpcs/jsonrpcs_mod.c
+++ b/src/modules/jsonrpcs/jsonrpcs_mod.c
@@ -1297,7 +1297,6 @@ send_reply:
 	if (!ctx->reply_sent && !(ctx->flags&JSONRPC_DELAYED_REPLY_F)) {
 		ret = jsonrpc_send(ctx);
 	}
-	srjson_DeleteDoc(ctx->jreq);
 	jsonrpc_clean_context(ctx);
 	if (ret < 0) return -1;
 	return 1;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
srjson_DeleteDoc(ctx->jreq) is already called in jsonrpc_clean_context(ctx). Calling it twice causes a crash due to a double free attempt.