### PR TITLE
 kamdbctl: added verification before reinit 

### DIFF
--- a/utils/kamctl/kamdbctl
+++ b/utils/kamctl/kamdbctl
@@ -386,6 +386,13 @@ case $1 in
 	reinit)
 		# delete database and create a new one
 		# create new database structures
+
+		# confirm dropping of database
+		get_answer ask "This will drop your current database and create a new one.\nIt is recommended to backup your database first.\n\nContinue with reinit? (y/n): "
+		if [ "$ANSWER" != "y" ]; then
+			exit 1
+		fi
+
 		shift
 		if [ $# -eq 1 ] ; then
 			DBNAME="$1"

--- a/utils/kamctl/kamdbctl
+++ b/utils/kamctl/kamdbctl
@@ -388,7 +388,8 @@ case $1 in
 		# create new database structures
 
 		# confirm dropping of database
-		get_answer ask "This will drop your current database and create a new one.\nIt is recommended to backup your database first.\n\nContinue with reinit? (y/n): "
+		echo -e "This will drop your current database and create a new one.\nIt is recommended to first backup your database.\n"
+		get_answer ask "Continue with reinit? (y/n): "
 		if [ "$ANSWER" != "y" ]; then
 			exit 1
 		fi


### PR DESCRIPTION
- add get_answer and warning that reinit will drop exisiting database
- even seasoned users forget and theres no backing out
<!-- Kamailio Pull Request Template -->
<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [X] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
If one _accidentally_ runs kamdbctl reinit, there is no easy way to abort without dropping your existing database. Adding the get_answer provides a warning that the database will drop and a method of exiting without damage.