### PR TITLE
fixes & improvements

### DIFF
--- a/src/core/cfg.lex
+++ b/src/core/cfg.lex
@@ -1718,7 +1718,7 @@ static int sr_pop_yy_state()
 
 /* define/ifdef support */
 
-#define MAX_DEFINES    256
+#define MAX_DEFINES    512
 static ksr_ppdefine_t pp_defines[MAX_DEFINES];
 static int pp_num_defines = 0;
 static int pp_define_type = 0;
@@ -1728,7 +1728,7 @@ static int pp_define_index = -1;
  * ifdef(defined), ifndef(undefined), or the opposite of these
  * two, but in an else branch
  */
-#define MAX_IFDEFS    256
+#define MAX_IFDEFS    512
 static int pp_ifdef_stack[MAX_IFDEFS];
 static int pp_sptr = 0; /* stack pointer */
 

--- a/src/core/timer.h
+++ b/src/core/timer.h
@@ -62,6 +62,7 @@ extern pid_t slow_timer_pid;
 
 /* deprecated, old, kept for compatibility */
 typedef void (timer_function)(unsigned int ticks, void* param);
+typedef void (timer_function_w)(unsigned int ticks, int worker, void* param);
 /* deprecated, old, kept for compatibility
 	get_ticks()*TIMER_TICK used to be the time in s
 	for new code, use get_ticks_raw() and one of the macros defined in
@@ -70,6 +71,7 @@ typedef void (timer_function)(unsigned int ticks, void* param);
 
 /*function prototype to execute on mili-second based basic timers */
 typedef void (utimer_function)(unsigned int uticks, void* param);
+typedef void (utimer_function_w)(unsigned int uticks, int worker, void* param);
 
 struct timer_ln; /* forward decl */
 /* new

--- a/src/core/timer_proc.h
+++ b/src/core/timer_proc.h
@@ -58,6 +58,8 @@ int register_basic_timers(int timers);
  */
 int fork_basic_timer(int child_id, char* desc, int make_sock,
 						timer_function* f, void* param, int interval);
+int fork_basic_timer_w(int child_id, char* desc, int make_sock,
+						timer_function_w* f, int worker, void* param, int interval);
 
 #define fork_dummy_timer fork_basic_timer
 
@@ -80,6 +82,8 @@ int fork_basic_timer(int child_id, char* desc, int make_sock,
  */
 int fork_basic_utimer(int child_id, char* desc, int make_sock,
 						timer_function* f, void* param, int uinterval);
+int fork_basic_utimer_w(int child_id, char* desc, int make_sock,
+						timer_function_w* f, int worker, void* param, int uinterval);
 /**
  * \brief Forks a timer process based on the local timer
  *

--- a/src/core/xavp.c
+++ b/src/core/xavp.c
@@ -714,14 +714,11 @@ sr_xavp_t *xavp_clone_level_nodata(sr_xavp_t *xold)
 			if(navp==NULL)
 			{
 				LM_ERR("cannot create cloned embedded xavp\n");
-				if(xnew->val.v.xavp == NULL)
-				{
-					shm_free(xnew);
-					return NULL;
-				} else {
-					xavp_destroy_list(&navp);
-					return NULL;
+				if(xnew->val.v.xavp != NULL) {
+					xavp_destroy_list(&xnew->val.v.xavp);
 				}
+				shm_free(xnew);
+				return NULL;
 			}
 			LM_DBG("cloned inner xavp [%.*s]\n", oavp->name.len, oavp->name.s);
 			if(xnew->val.v.xavp == NULL)

--- a/src/modules/presence/subscribe.c
+++ b/src/modules/presence/subscribe.c
@@ -760,7 +760,7 @@ subs_t *_pres_subs_last_sub = NULL;
  * version 21
  * flags 22
  * user_agent 23
- *
+ * sockinfo 24
  */
 
 int pv_parse_subscription_name(pv_spec_p sp, str *in)
@@ -822,6 +822,8 @@ int pv_parse_subscription_name(pv_spec_p sp, str *in)
 				sp->pvp.pvn.u.isname.name.n = 9;
 			} else if(strncmp(in->s, "from_tag", 8) == 0) {
 				sp->pvp.pvn.u.isname.name.n = 11;
+			} else if(strncmp(in->s, "sockinfo", 8) == 0) {
+				sp->pvp.pvn.u.isname.name.n = 24;
 			} else {
 				goto error;
 			};
@@ -961,6 +963,8 @@ int pv_get_subscription(struct sip_msg *msg, pv_param_t *param, pv_value_t *res)
 		return pv_get_sintval(msg, param, res, _pres_subs_last_sub->flags);
 	} else if(param->pvn.u.isname.name.n == 23) {
 		return pv_get_strval(msg, param, res, &_pres_subs_last_sub->user_agent);
+	} else if(param->pvn.u.isname.name.n == 24) {
+		return pv_get_strval(msg, param, res, &_pres_subs_last_sub->sockinfo_str);
 	}
 
 	LM_ERR("unknown specifier\n");

--- a/src/modules/pv/pv_trans.c
+++ b/src/modules/pv/pv_trans.c
@@ -1389,29 +1389,24 @@ int tr_eval_uri(struct sip_msg *msg, tr_param_t *tp, int subtype,
 			}
 			break;
 		case TR_URI_TOSOCKET:
-			if(msg==NULL) {
+			if(get_valid_proto_string(_tr_parsed_uri.proto, 1, 0, &sproto)<0) {
+				LM_WARN("unknown transport protocol\n");
 				val->rs = _tr_empty;
 				break;
-			} else {
-				if(get_valid_proto_string(msg->rcv.proto, 1, 0, &sproto)<0) {
-					LM_WARN("unknown transport protocol\n");
-					val->rs = _tr_empty;
-					break;
-				}
-				tr_set_crt_buffer();
-				val->rs.len = snprintf(_tr_buffer, TR_BUFFER_SIZE,
-						"%.*s:%.*s:%d", sproto.len, sproto.s,
-						_tr_parsed_uri.host.len, _tr_parsed_uri.host.s,
-						(_tr_parsed_uri.port_no!=0)
-								?(int)_tr_parsed_uri.port_no:5060);
-				if(val->rs.len<=0 || val->rs.len>=TR_BUFFER_SIZE) {
-					LM_WARN("error converting uri to socket address [%.*s]\n",
-							_tr_uri.len, _tr_uri.s);
-					val->rs = _tr_empty;
-					break;
-				}
-				val->rs.s = _tr_buffer;
 			}
+			tr_set_crt_buffer();
+			val->rs.len = snprintf(_tr_buffer, TR_BUFFER_SIZE,
+					"%.*s:%.*s:%d", sproto.len, sproto.s,
+					_tr_parsed_uri.host.len, _tr_parsed_uri.host.s,
+					(_tr_parsed_uri.port_no!=0)
+							?(int)_tr_parsed_uri.port_no:5060);
+			if(val->rs.len<=0 || val->rs.len>=TR_BUFFER_SIZE) {
+				LM_WARN("error converting uri to socket address [%.*s]\n",
+						_tr_uri.len, _tr_uri.s);
+				val->rs = _tr_empty;
+				break;
+			}
+			val->rs.s = _tr_buffer;
 			break;
 		default:
 			LM_ERR("unknown subtype %d\n",
@@ -2684,7 +2679,7 @@ char* tr_parse_uri(str* in, trans_t *t)
 	} else if(name.len==6 && strncasecmp(name.s, "scheme", 6)==0) {
 		t->subtype = TR_URI_SCHEME;
 		goto done;
-	} else if(name.len==6 && strncasecmp(name.s, "tosocket", 8)==0) {
+	} else if(name.len==8 && strncasecmp(name.s, "tosocket", 8)==0) {
 		t->subtype = TR_URI_TOSOCKET;
 		goto done;
 	}

--- a/src/modules/rtimer/rtimer_mod.c
+++ b/src/modules/rtimer/rtimer_mod.c
@@ -74,8 +74,14 @@ static int child_init(int);
 
 int stm_t_param(modparam_t type, void* val);
 int stm_e_param(modparam_t type, void* val);
-void stm_timer_exec(unsigned int ticks, void *param);
+void stm_timer_exec(unsigned int ticks, int worker, void *param);
+void stm_main_timer_exec(unsigned int ticks, void *param);
+int stm_get_worker(struct sip_msg *msg, pv_param_t *param, pv_value_t *res);
 
+static pv_export_t rtimer_pvs[] = {
+	{{"rtimer_worker", (sizeof("rtimer_worker")-1)}, PVT_OTHER, stm_get_worker, 0,	0, 0, 0, 0},
+	{ {0, 0}, 0, 0, 0, 0, 0, 0, 0 }
+};
 
 static param_export_t params[]={
 	{"timer",             PARAM_STRING|USE_FUNC_PARAM, (void*)stm_t_param},
@@ -91,7 +97,7 @@ struct module_exports exports= {
 	0,
 	params,
 	0,           /* exported RPC methods */
-	0,           /* exported pseudo-variables */
+	rtimer_pvs,  /* exported pseudo-variables */
 	0,
 	mod_init,    /* module initialization function */
 	child_init,  /* per-child init function */
@@ -121,7 +127,7 @@ static int mod_init(void)
 	{
 		if(it->mode==0)
 		{
-			if(register_timer(stm_timer_exec, (void*)it, it->interval)<0)
+			if(register_timer(stm_main_timer_exec, (void*)it, it->interval)<0)
 			{
 				LM_ERR("failed to register timer function\n");
 				return -1;
@@ -156,15 +162,15 @@ static int child_init(int rank)
 			         i, it->name.len, it->name.s);
 			if(it->flags & RTIMER_INTERVAL_USEC)
 			{
-				if(fork_basic_utimer(PROC_TIMER, si_desc, 1 /*socks flag*/,
-								stm_timer_exec, (void*)it, it->interval
+				if(fork_basic_utimer_w(PROC_TIMER, si_desc, 1 /*socks flag*/,
+								stm_timer_exec, i, (void*)it, it->interval
 								/*usec*/)<0) {
 					LM_ERR("failed to start utimer routine as process\n");
 					return -1; /* error */
 				}
 			} else {
-				if(fork_basic_timer(PROC_TIMER, si_desc, 1 /*socks flag*/,
-								stm_timer_exec, (void*)it, it->interval
+				if(fork_basic_timer_w(PROC_TIMER, si_desc, 1 /*socks flag*/,
+								stm_timer_exec, i, (void*)it, it->interval
 								/*sec*/)<0) {
 					LM_ERR("failed to start timer routine as process\n");
 					return -1; /* error */
@@ -177,13 +183,21 @@ static int child_init(int rank)
 	return 0;
 }
 
-void stm_timer_exec(unsigned int ticks, void *param)
+int rt_worker = 0;
+
+void stm_main_timer_exec(unsigned int ticks, void *param)
+{
+	stm_timer_exec(ticks, 0, param);
+}
+
+void stm_timer_exec(unsigned int ticks, int worker, void *param)
 {
 	stm_timer_t *it;
 	stm_route_t *rt;
 	sip_msg_t *fmsg;
 	sr_kemi_eng_t *keng = NULL;
 	str evname = str_init("rtimer");
+	rt_worker = worker;
 
 	if(param==NULL)
 		return;
@@ -382,3 +396,7 @@ int stm_e_param(modparam_t type, void *val)
 	return 0;
 }
 
+int stm_get_worker(struct sip_msg *msg, pv_param_t *param, pv_value_t *res)
+{
+	return pv_get_sintval(msg, param, res, rt_worker);
+}

--- a/src/modules/tm/t_funcs.h
+++ b/src/modules/tm/t_funcs.h
@@ -191,6 +191,7 @@ int  t_add_transaction( struct sip_msg* p_msg  );
 
 /* returns 1 if everything was OK or -1 for error */
 int t_release_transaction( struct cell *trans );
+typedef int (*trelease_t)(struct cell *t);
 
 
 int get_ip_and_port_from_uri( str* uri , unsigned int *param_ip,

--- a/src/modules/tm/tm_load.c
+++ b/src/modules/tm/tm_load.c
@@ -141,6 +141,7 @@ int load_tm( struct tm_binds *tmb)
 	tmb->t_load_contacts = t_load_contacts;
 	tmb->t_next_contacts = t_next_contacts;
 	tmb->set_fr = t_set_fr;
+	tmb->t_release_transaction = t_release_transaction;
 	return 1;
 }
 

--- a/src/modules/tm/tm_load.h
+++ b/src/modules/tm/tm_load.h
@@ -128,6 +128,7 @@ struct tm_binds {
 	cmd_function	t_load_contacts;
 	cmd_function	t_next_contacts;
 	tset_fr_f set_fr;
+	trelease_t      t_release_transaction;
 };
 
 typedef struct tm_binds tm_api_t;

--- a/src/modules/tmx/tmx_mod.c
+++ b/src/modules/tmx/tmx_mod.c
@@ -715,9 +715,7 @@ static int ki_t_drop_rcode(sip_msg_t* msg, int rcode)
 	}
 
 	t->uas.status = (unsigned int)rcode;
-	if(t_is_request_route(msg) == 1) {
-		_tmx_tmb.t_release(msg);
-	}
+	_tmx_tmb.t_release_transaction(t);
 	return 0;
 }
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

- added a worker_id for timer routines. when using rtimer in script with mode=4 there's no way to know which of the workers is in use. this is useful for db queries based on slot
- fixed {uri.tosocket} transformation
- added t_release_transaction to tm api
- use t_release_transaction in tmx `t_drop`
- fixed xavp_clone_level_nodata
- add sockinfo to $subs
- increase `MAX_DEFINES` as we run out of  `defines`

Note: please use rebase instead of merge for this PR

to backport:
- https://github.com/kamailio/kamailio/commit/eea9c5f72b73df9c3d898cff18dced6b7f72c7d4
- https://github.com/kamailio/kamailio/commit/e3ed896d80171feba78d3292484a09f0016e68e0
- https://github.com/kamailio/kamailio/commit/b4696169e8b464da01774b1e40af677f941c803b

