### PR TITLE
tm: remove unnecessary TMCB_ACK_NEG_IN callback call

### DIFF
--- a/src/modules/tm/t_reply.c
+++ b/src/modules/tm/t_reply.c
@@ -2303,14 +2303,6 @@ int reply_received( struct sip_msg  *p_msg )
 									t, &onsend_params);
 						}
 					}
-					if (unlikely(has_tran_tmcbs(t, TMCB_ACK_NEG_IN))){
-						INIT_TMCB_ONSEND_PARAMS(onsend_params,
-								t->uas.request, p_msg, &uac->request,
-								&uac->request.dst, ack, ack_len,
-								TMCB_LOCAL_F, branch, TYPE_LOCAL_ACK);
-						run_trans_callbacks_off_params(TMCB_ACK_NEG_IN,
-								t, &onsend_params);
-					}
 					shm_free(ack);
 				}
 			} else if (is_local(t) /*&& 200 <= msg_status < 300*/) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #1871

#### Description
<!-- Describe your changes in detail -->
	   - TMCB_ACK_NEG_IN was called in an if branch where the initial
    condition was the message to be an INVITE; this was not affecting
    anything for the moment since this callback wasn't used but in case
    some piece of code would have used this callback it would be called
    not only for hop-by-hop ACKs but also INVITEs


