### PR TITLE
Makefile: give warning when old modules directory is found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ KSR_DIR ?= src/
 # default target for makefile
 .DEFAULT_GOAL := default
 
+ifneq ($(wildcard modules),)
+$(warning "old Kamailio modules directory found, you should clean that")
+endif
 
 # strip the src/ from the path to modules
 SMODPARAM=


### PR DESCRIPTION
For some reason, I sometimes have obsolete `modules` -subdirectory in top level source directory.
It seems to happen after going back and forth in Kamailio 4.x git branches and then back to 5.x.

When that happens, Makefile target "modules" does not correctly start building:
```
$ gmake modules
gmake: 'modules' is up to date.
```

Proposed patch tries to draw attention into such situation:
```
$ gmake modules
Makefile:14: "old Kamailio modules directory found, you should clean that"
gmake: 'modules' is up to date.
```

I think `git clean` could clean such leftovers but I am not brave enough to propose running that automatically.

Tested on FreeBSD 11.2 (GNU Make 4.2.1) and Ubuntu 16.04 (GNU Make 4.1).