### PR TITLE
ipops: Fixed mask for 172.16.0.0/12 network

### DIFF
--- a/src/modules/ipops/detailed_ip_type.c
+++ b/src/modules/ipops/detailed_ip_type.c
@@ -45,7 +45,7 @@ static ip4_node IPv4ranges[IPv4RANGES_SIZE] = {
         { 0xc0a80000,  "PRIVATE",    0xffff0000 },  // 192.168/16
         { 0xa9fe0000,  "LINK-LOCAL", 0xffff0000 },  // 169.254/16
         { 0xc6120000,  "RESERVED",   0xfffe0000 },  // 198.18/15
-        { 0xac100000,  "PRIVATE",    0xfffe0000 },  // 172.16/12
+        { 0xac100000,  "PRIVATE",    0xfff00000 },  // 172.16/12
         { 0x64400000,  "SHARED",     0xffc00000 },  // 100.64/10
         { 0x7f000000,  "LOOPBACK",   0xff000000 },  // 127.0/8
         { 0x0a000000,  "PRIVATE",    0xff000000 },  // 10/8


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [ ] Tested changes locally
- [x] Related to issue #1906

#### Description
Fixed typo in 172.16.0.0/12 network mask