### PR TITLE
AUTH_USERNAME_EXPIRED auth api return code

### DIFF
--- a/src/modules/auth/api.h
+++ b/src/modules/auth/api.h
@@ -39,6 +39,7 @@
  */
 typedef enum auth_cfg_result {
 	AUTH_USER_MISMATCH = -8,    /*!< Auth user != From/To user */
+	AUTH_USERNAME_EXPIRED = -7, /*!< Ephemeral auth username expired */
 	AUTH_NONCE_REUSED = -6,     /*!< Returned if nonce is used more than once */
 	AUTH_NO_CREDENTIALS = -5,   /*!< Credentials missing */
 	AUTH_STALE_NONCE = -4,      /*!< Stale nonce */


### PR DESCRIPTION
This pull request adds AUTH_USERNAME_EXPIRED auth api return code and uses it in ephemeral authentication when username has expired.  Script can then tell the user about the expiration with a suitable response.