### PR TITLE
Small fixes to dialplan module when an avp is used as subst_exp

### DIFF
--- a/src/modules/dialplan/dp_repl.c
+++ b/src/modules/dialplan/dp_repl.c
@@ -432,7 +432,7 @@ int rule_translate(sip_msg_t *msg, str *instr, dpl_node_t *rule,
 		/*search for the pattern from the compiled subst_exp*/
 		if (pcre_exec(subst_comp, NULL, instr->s, instr->len,
 					0, 0, ovector, 3 * (MAX_REPLACE_WITH + 1)) <= 0) {
-			LM_ERR("the string %.*s matched "
+			LM_DBG("the string %.*s matched "
 					"the match_exp %.*s but not the subst_exp %.*s!\n",
 					instr->len, instr->s,
 					rule->match_exp.len, rule->match_exp.s,
@@ -721,6 +721,13 @@ repl:
 			pkg_free(re_list);
 			re_list = rt;
 		} while(re_list);
+		if(rez<0) {
+			LM_ERR("the string %.*s matched "
+				"the match_exp %.*s but not the subst_exp %.*s!\n",
+				input->len, input->s,
+				rulep->match_exp.len, rulep->match_exp.s,
+				rulep->subst_exp.len, rulep->subst_exp.s);
+		}
 	}
 	else {
 		if(rule_translate(msg, input, rulep, rulep->subst_comp, output)!=0){

--- a/src/modules/dialplan/dp_repl.c
+++ b/src/modules/dialplan/dp_repl.c
@@ -700,7 +700,7 @@ repl:
 		}
 	}
 	if(rulep->tflags&DP_TFLAGS_PV_SUBST) {
-		re_list = dpl_dynamic_pcre_list(msg, &rulep->match_exp);
+		re_list = dpl_dynamic_pcre_list(msg, &rulep->subst_exp);
 		if(re_list==NULL) {
 			/* failed to compile dynamic pcre -- ignore */
 			LM_DBG("failed to compile dynamic pcre[%.*s]\n",


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
If an AVP is used as subst_exp then each contained value is evaluated against the string.
In case a value doesn't match, a noisy error line was printed in the log. The patch fix this behavior in the following way:
 - printing just a debug line per each not matching value
 - printing an error line only if all the values fail the match

Additionally fixed the improper usage of match_exp instead of subst_exp when both values contain an AVP.