### PR TITLE
db_redis: fix schema

### DIFF
--- a/src/lib/srdb1/schema/location.xml
+++ b/src/lib/srdb1/schema/location.xml
@@ -89,6 +89,7 @@
     <column id="expires">
         <name>expires</name>
         <type>datetime</type>
+        <type db="db_redis">time</type>
         <default>&DEFAULT_ALIASES_EXPIRES;</default>
         <default db="oracle">to_date('&DEFAULT_ALIASES_EXPIRES;','yyyy-mm-dd hh24:mi:ss')</default>
         <description>Date and time when this entry expires.</description>
@@ -121,6 +122,7 @@
     <column>
         <name>last_modified</name>
         <type>datetime</type>
+        <type db="db_redis">time</type>
         <default>&DEFAULT_DATETIME;</default>
         <default db="oracle">to_date('&DEFAULT_DATETIME;','yyyy-mm-dd hh24:mi:ss')</default>
         <description>Date and time when this entry was last modified.</description>

--- a/utils/kamctl/db_redis/kamailio/location
+++ b/utils/kamctl/db_redis/kamailio/location
@@ -1,2 +1,2 @@
-id/int,ruid/string,username/string,domain/string,contact/string,received/string,path/string,expires/int,q/double,callid/string,cseq/int,last_modified/int,flags/int,cflags/int,user_agent/string,socket/string,methods/int,instance/string,reg_id/int,server_id/int,connection_id/int,keepalive/int,partition/int,
+id/int,ruid/string,username/string,domain/string,contact/string,received/string,path/string,expires/time,q/double,callid/string,cseq/int,last_modified/time,flags/int,cflags/int,user_agent/string,socket/string,methods/int,instance/string,reg_id/int,server_id/int,connection_id/int,keepalive/int,partition/int,
 9


### PR DESCRIPTION
manual schema changes introduced at c9f2aa71b2e0d4a4f71b3da92f97306e86f93eea were lost by regeneration at 5e0440aa27154c263fc883f3a7cb9680805af6c3

This change sets the types changes at location for db_redis