### PR TITLE
ims_isc: add-on for third-party registration

### DIFF
--- a/src/modules/ims_isc/checker.c
+++ b/src/modules/ims_isc/checker.c
@@ -393,6 +393,8 @@ static inline isc_match* isc_new_match(ims_filter_criteria *fc, int index) {
 				fc->application_server.service_info.len);
 	}
 	r->index = index;
+	r->include_register_request = fc->application_server.include_register_request;
+	r->include_register_response = fc->application_server.include_register_response;
 	return r;
 }
 

--- a/src/modules/ims_isc/checker.h
+++ b/src/modules/ims_isc/checker.h
@@ -68,6 +68,8 @@ typedef struct {
 	char default_handling;	/**< handling to apply on failure to contact the AS */
 	str service_info;		/**< additional service information */
 	int index;				/**< index of the matching IFC */
+	int include_register_request;	/**< additional flag from the HSS */
+	int include_register_response;	/**< additional flag from the HSS */
 } isc_match;
 
 

--- a/src/modules/ims_isc/doc/ims_isc_admin.xml
+++ b/src/modules/ims_isc/doc/ims_isc_admin.xml
@@ -163,6 +163,14 @@ modparam("ims_isc", "add_p_served_user", 1)
       <para>A positive return code (1) means that the REGISTER message has 
       matched to Initial Filter Criteria and is armed for routing.</para>
 
+      <para>This function handles also the Service Info (if sent by the
+      HSS), the InsertRegisterRequest flag (if sent by the HSS) or the
+      InsertRegisterResponse flag (if sent by the HSS). Either the Service
+      Info OR the original REGISTER request OR the original REGISTER
+      response is added to the body of the REGISTER message, before it is
+      forwarded to the relevant Application Server. Multipart body is not
+      supported in this case.</para>
+ 
       <para>Meaning of the parameters is as follows:</para>
 
       <itemizedlist>

--- a/src/modules/ims_isc/third_party_reg.h
+++ b/src/modules/ims_isc/third_party_reg.h
@@ -63,6 +63,20 @@ extern int isc_expires_grace; 		/**< expires value to add to the expires in the 
  	 	 	 	 	 	 	 	 	 to prevent expiration in AS */
 extern struct tm_binds isc_tmb; 	/**< Structure with pointers to tm funcs 		*/
 
+
+#define CT_NONE 0
+#define CT_SERVICE_INFO 1
+#define CT_REGISTER_REQ 2
+#define CT_REGISTER_RESP 3
+
+/** one (part of a) body for the reg event notification structure */
+/** Currently we restrict the usage of multipart bodies */
+typedef struct body {
+	char content_type;		/* Content-Type header for (one part of the) body*/
+	str content;			/* Content of (one part of the) body */
+} body_t;
+
+
 /** reg event notification structure */
 typedef struct _r_third_party_reg {
 	str req_uri;                    /* AS sip uri:  	*/
@@ -71,8 +85,8 @@ typedef struct _r_third_party_reg {
 	str pvni; 			/* Visited network id 	*/
 	str pani; 			/* Access Network info 	*/
 	str cv; 			/* Charging vector 	*/
-	str service_info;               /* Service info body */
-    str path;                       /* Path header  */
+	body_t body;			/* The body */
+	str path;                       /* Path header  */
 } r_third_party_registration;
 
 int isc_third_party_reg(struct sip_msg *msg, isc_match *m, isc_mark *mark, udomain_t* d);

--- a/src/modules/ims_usrloc_scscf/usrloc.h
+++ b/src/modules/ims_usrloc_scscf/usrloc.h
@@ -201,6 +201,8 @@ typedef struct _ims_application_server {
     str server_name; /**< SIP URL of the app server                      */
     char default_handling; /**< enum SESSION_CONTINUED SESSION_TERMINATED 0..1 */
     str service_info; /**< optional info to be sent to AS 0..1            */
+    int include_register_request;
+    int include_register_response;
 } ims_application_server;
 
 /** Public Identity Structure */


### PR DESCRIPTION
Change in ims_isc/checker.c and ims_isc/checker.h:
   add to isc_match two new flags include_register_request
   and include_register_response in addition to service_info
   Both info are retrieved from HSS during SAR/SAA
Change in ims_isc/third_party_reg.c/.h:
   Add REGISTER Request or REGISTER Response or Service Info
   to the body of the REGISTER message that is sent to the
   AS, if it is requested by content of HSS (SAR/SAA)
Change in ims_registrar_scscf/userdata_parser.c and
          ims_usrloc_scscf/usrloc.h:
   Parse the additional flags, when they are received from HSS
   and store in the subscription.

Conflicts:
	src/modules/ims_isc/third_party_reg.c
	src/modules/ims_rdn/userdata_parser.c

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
         ---> apologies, we did this commit long ago, when we did not know the rules of the project
                 main changes are in ims_isc, two small changes in ims_registrar_scscf and ims_usrloc_scscf
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally based on a local branch derived from 5.1.0
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
The feature is a small add-on to third party registration in S-CSCF
The feature assumes two new flags in HSS database, where additional to the "Service Info XML" an "insertRegisterRequest" flag or an "insertRegisterRepsonse" flag can be set. These flags are sent with the SAR/SAA exchange to the S-CSCF, where the new feature does a prioritization:
If Service Info present -> add service info to body of 3rd Party REGISTER Request
else if insertRegisterRequest -> add original REGISTER request to body of 3rd Party REGISTER request
else if insertRegisterResponse -> add original REGISTER response to body of 3rd Party REGISTER request
else -> add no body to 3rd Party REGISTER request.
Multipart Body is not supported.
More info about the insertRegisterRequest and insertRegisterResponse flags can be found in applicable 3GPP standards.