### PR TITLE
core: fix compilation error

### DIFF
--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -50,6 +50,7 @@
 #include <sys/uio.h>  /* writev*/
 #include <netdb.h>
 #include <stdlib.h> /*exit() */
+#include <stdint.h> /* UINT32_MAX */
 
 #include <unistd.h>
 


### PR DESCRIPTION
#### Pre-Submission Checklist

- [✓] Commit message has the format required by CONTRIBUTING guide
- [✓] Commits are split per component
- [✓] Each component has a single commit
- [✓] No commits to README files for modules

#### Type Of Change

- [✓] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:

- [ ] PR should be backported to stable branches
- [✓] Tested changes locally
- [✓] Related to issue #1765

#### Description

Macro constant UINT32_MAX is defined in <stdint.h>.
GCC and Clang does not complain on Ubuntu 16
GCC and Clang complains on FreeBSD 11.

Backporting not needed, PROXY feature only in development branch 5.3.