### PR TITLE
dialplan: add reload_delta parameter

### DIFF
--- a/src/modules/dialplan/dialplan.c
+++ b/src/modules/dialplan/dialplan.c
@@ -87,6 +87,7 @@ dp_param_p default_par2 = NULL;
 int dp_fetch_rows = 1000;
 int dp_match_dynamic = 0;
 int dp_append_branch = 1;
+int dp_reload_delta = 5;
 
 static time_t *dp_rpc_reload_time = NULL;
 
@@ -105,6 +106,7 @@ static param_export_t mod_params[]={
 	{ "fetch_rows",		PARAM_INT,	&dp_fetch_rows },
 	{ "match_dynamic",	PARAM_INT,	&dp_match_dynamic },
 	{ "append_branch",	PARAM_INT,	&dp_append_branch },
+	{ "reload_delta",	PARAM_INT,	&dp_reload_delta },
 	{0,0,0}
 };
 
@@ -181,6 +183,9 @@ static int mod_init(void)
 
 	if(dp_fetch_rows<=0)
 		dp_fetch_rows = 1000;
+
+	if(dp_reload_delta<0)
+		dp_reload_delta = 5;
 
 	if(init_data() != 0) {
 		LM_ERR("could not initialize data\n");
@@ -619,7 +624,7 @@ static void dialplan_rpc_reload(rpc_t* rpc, void* ctx)
 		rpc->fault(ctx, 500, "Not ready for reload");
 		return;
 	}
-	if(*dp_rpc_reload_time!=0 && *dp_rpc_reload_time > time(NULL) - 5) {
+	if(*dp_rpc_reload_time!=0 && *dp_rpc_reload_time > time(NULL) - dp_reload_delta) {
 		LM_ERR("ongoing reload\n");
 		rpc->fault(ctx, 500, "ongoing reload");
 		return;

--- a/src/modules/dialplan/doc/dialplan_admin.xml
+++ b/src/modules/dialplan/doc/dialplan_admin.xml
@@ -410,6 +410,33 @@ modparam("dialplan", "append_branch", 0)
 		</example>
 	</section>
 
+	<section id="dialplan.p.reload_delta">
+		<title><varname>reload_delta</varname> (int)</title>
+		<para>
+		The number of seconds that have to be waited before executing a new reload
+		of dialplan rules. By default there is a rate limiting of maximum one reload
+		in five seconds.
+		</para>
+		<para>
+		If set to 0, no rate limit is configured. Note carefully: use this configuration
+		only in tests environments because executing two dialplan reloads at the same
+		time can cause to kamailio to crash.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>5</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>reload_delta</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dialplan", "reload_delta", 1)
+...
+		</programlisting>
+		</example>
+	</section>
+
 	</section>
 
 
@@ -620,8 +647,9 @@ xlog("translated to var $var(y) \n");
 		<function moreinfo="none">dp_reload()</function>
 		</title>
 		<para>
-		Reload the translation rules from the database. Note that there is
-		a rate limiting of maximum one reload in five seconds.
+		Reload the translation rules from the database. Note that there is a
+		rate limiting defined by 'reload_delta' paramenter. By default is allowed
+		maximum one reload in five seconds.
 		</para>
 		<para>
 		Name: <emphasis>dp_reload</emphasis>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
In commit 99d5da8d595961063249f871a5d150474fa6f317 a mechanism for basic safety in case of  concurent rpc reload were added. This works fine but it is limiting our test scenarios where multiple changes should happen quickly.

The new dialplan paramenter reload_delta allows everyone to configure rpc reload rate limit to the preferred number of seconds.
In case the parameter is not specified. the default value is 5 seconds.