### PR TITLE
usrloc: udomain_contact_expired_cb fix memory leak

### DIFF
--- a/src/modules/usrloc/udomain.c
+++ b/src/modules/usrloc/udomain.c
@@ -1019,7 +1019,7 @@ int udomain_contact_expired_cb(db1_con_t* _c, udomain_t* _d)
 
 			if ( (c=mem_insert_ucontact(r, &contact, ci)) == 0) {
 				LM_ERR("inserting contact failed\n");
-				free_ucontact(c);
+				release_urecord(r);
 				unlock_udomain(_d, &user);
 				goto error;
 			}
@@ -1029,7 +1029,7 @@ int udomain_contact_expired_cb(db1_con_t* _c, udomain_t* _d)
 				run_ul_callbacks( UL_CONTACT_EXPIRE, c);
 			}
 			c->state = CS_SYNC;
-			free_ucontact(c);
+			release_urecord(r);
 			unlock_udomain(_d, &user);
 		}
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
9757bb8c0e2fea5173f4fa3dd7798d61759f04af introduced a memory leak due to not cleaning all the ucontacts created at get_urecord() so every time that there are expired contacts in the db we will leave some ucontacts in shared mem and will be never free

This only happens on DB_ONLY mode
