### PR TITLE
siptrace: fix tracing messages to database when destination uri not set

### DIFF
--- a/src/modules/siptrace/doc/siptrace_admin.xml
+++ b/src/modules/siptrace/doc/siptrace_admin.xml
@@ -556,6 +556,9 @@ sip_trace("sip:10.1.1.2:5085");
 ...
 sip_trace("sip:10.1.1.2:5085", "$ci-abc");
 ...
+/* trace current dialog; needs to be done on initial INVITE and dialog has to be loaded */
+sip_trace("sip:10.1.1.2:5085", "$ci-abc", "d");
+...
 </programlisting>
 		</example>
 	</section>

--- a/src/modules/siptrace/siptrace.c
+++ b/src/modules/siptrace/siptrace.c
@@ -1011,7 +1011,7 @@ static int w_sip_trace3(sip_msg_t *msg, char *dest, char *correlation_id, char *
 		}
 	}
 
-	if(trace_is_off(msg)) {
+	if(trace_type != SIPTRACE_MESSAGE && trace_is_off(msg)) {
 		LM_DBG("trace off...\n");
 		return 1;
 	}


### PR DESCRIPTION
	New additions to siptrace module broke previous functionality.
If sip_trace was used with no param and destination uri was not set
then the current message would not have been traced to database. The
current fix traces always the current message if siptrace function
was called.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #1942

#### Description
<!-- Describe your changes in detail -->
