### PR TITLE
dialplan: don't try to translate on dp_match()

### DIFF
--- a/src/modules/dialplan/dialplan.c
+++ b/src/modules/dialplan/dialplan.c
@@ -481,8 +481,9 @@ static int dp_replace_helper(sip_msg_t *msg, int dpid, str *input,
 		pv_spec_t *pvd)
 {
 	dpl_id_p idp;
-	str output = STR_NULL;
+	str tmp = STR_NULL;
 	str attrs = STR_NULL;
+	str *output = NULL;
 	str *outattrs = NULL;
 
 	if ((idp = select_dpid(dpid)) ==0) {
@@ -491,16 +492,19 @@ static int dp_replace_helper(sip_msg_t *msg, int dpid, str *input,
 	}
 
 	outattrs = (!attr_pvar)?NULL:&attrs;
-	if (dp_translate_helper(msg, input, &output, idp, outattrs)!=0) {
+	output = (!pvd)?NULL:&tmp;
+	if (dp_translate_helper(msg, input, output, idp, outattrs)!=0) {
 		LM_DBG("could not translate %.*s "
 				"with dpid %i\n", input->len, input->s, idp->dp_id);
 		return -1;
 	}
-	LM_DBG("input %.*s with dpid %i => output %.*s\n",
-			input->len, input->s, idp->dp_id, output.len, output.s);
+	if (output) {
+		LM_DBG("input %.*s with dpid %i => output %.*s\n",
+				input->len, input->s, idp->dp_id, output->len, output->s);
+	}
 
 	/* set the output */
-	if (dp_update(msg, pvd, &output, outattrs) !=0){
+	if (dp_update(msg, pvd, output, outattrs) !=0){
 		LM_ERR("cannot set the output\n");
 		return -1;
 	}

--- a/src/modules/dialplan/dp_repl.c
+++ b/src/modules/dialplan/dp_repl.c
@@ -699,6 +699,9 @@ repl:
 					attrs->len, attrs->s);
 		}
 	}
+	if(!output) {
+		return 0;
+	}
 	if(rulep->tflags&DP_TFLAGS_PV_SUBST) {
 		re_list = dpl_dynamic_pcre_list(msg, &rulep->subst_exp);
 		if(re_list==NULL) {


### PR DESCRIPTION
```
INFO: <script>: SET_DST trying to get dialplan from dpid:101000 - ci'1cf77cbb5baebdbd0e8635e1116aa713@PBX-2797.xpbx.foehn.co.uk'
DEBUG: dialplan [dialplan.c:232]: dp_get_ivalue(): searching 15
DEBUG: dialplan [dialplan.c:240]: dp_get_ivalue(): dpid is 101000 from pv argument
DEBUG: dialplan [dialplan.c:249]: dp_get_svalue(): searching 7 
DEBUG: dialplan [dialplan.c:345]: dp_translate_f(): input is 0034654205681
DEBUG: dialplan [dp_repl.c:606]: dp_translate_helper(): regex operator testing over [0034654205681]
DEBUG: dialplan [dp_repl.c:681]: dp_translate_helper(): found a matching rule 0x7f065c2818d0: pr 1, match_exp ^00([1-9][0-35-9]|[1-35-9][0-9])[0-9]+$
DEBUG: dialplan [dp_repl.c:688]: dp_translate_helper(): the rule's attrs are cli=+34654205682;action=0
DEBUG: dialplan [dp_repl.c:699]: dp_translate_helper(): the copied attributes are: cli=+34654205682;action=0
ERROR: dialplan [dp_repl.c:439]: rule_translate(): the string 0034654205681 matched the match_exp ^00([1-9][0-35-9]|[1-35-9][0-9])[0-9]+$ but not the subst_exp ^([1-9][0-9]{8})$!
ERROR: dialplan [dp_repl.c:730]: dp_translate_helper(): could not build the output
DEBUG: dialplan [dialplan.c:350]: dp_translate_f(): could not translate 0034654205681 with dpid 101000
INFO: <script>: SET_DST  no valid subst_exp for '0034654205681' trying to match - ci='1cf77cbb5baebdbd0e8635e1116aa713@PBX-2797.xpbx.foehn.co.uk'
DEBUG: dialplan [dp_repl.c:606]: dp_translate_helper(): regex operator testing over [0034654205681]
DEBUG: dialplan [dp_repl.c:681]: dp_translate_helper(): found a matching rule 0x7f065c2818d0: pr 1, match_exp ^00([1-9][0-35-9]|[1-35-9][0-9])[0-9]+$
DEBUG: dialplan [dp_repl.c:688]: dp_translate_helper(): the rule's attrs are cli=+34654205682;action=0
DEBUG: dialplan [dp_repl.c:699]: dp_translate_helper(): the copied attributes are: cli=+34654205682;action=0
DEBUG: <script>: SET_DST $var(dp_attrs):cli=+34654205682;action=0 action:0 - ci='1cf77cbb5baebdbd0e8635e1116aa713@PBX-2797.xpbx.foehn.co.uk'
```
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #1952

#### Description

changing ``dp_replace_helper()`` to pass a NULL value indicating no output is needed ( no need to do subst ) to ``dp_translate_helper()``
