### PR TITLE
registrar: clean avp/xavp created at 'usrloc:contact-expired' route_event

### DIFF
--- a/src/modules/registrar/regpv.c
+++ b/src/modules/registrar/regpv.c
@@ -35,6 +35,7 @@
 #include "../../core/action.h"
 #include "../../core/fmsg.h"
 #include "../../core/kemi.h"
+#include "../../core/receive.h"
 #include "../usrloc/usrloc.h"
 #include "registrar.h"
 #include "common.h"
@@ -751,7 +752,7 @@ void reg_ul_expired_contact(ucontact_t* ptr, int type, void* param)
 		}
 	}
 	set_route_type(backup_rt);
-
+	ksr_msg_env_reset();
 	return;
 error:
 	regpv_free_profile(rpp);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally

#### Description
I was creating avp variables at route_event[usrloc:contact-expired] and shared memory was always growing I think this is the same issue #1391 and solved by ad46b115bedec01c52c5a9dcde0756db85ee61ec
