### PR TITLE
usrloc: fix memory leak on DB_ONLY mode on RPC commands

### DIFF
--- a/src/modules/usrloc/ul_rpc.c
+++ b/src/modules/usrloc/ul_rpc.c
@@ -421,6 +421,7 @@ static void ul_rpc_lookup(rpc_t* rpc, void* ctx)
 
 	if (rpc->add(ctx, "{", &th) < 0)
 	{
+		release_urecord(rec);
 		unlock_udomain(dom, &aor);
 		rpc->fault(ctx, 500, "Internal error creating outer rpc");
 		return;
@@ -429,6 +430,7 @@ static void ul_rpc_lookup(rpc_t* rpc, void* ctx)
 				"AoR", &aor,
 				"Contacts", &ih)<0)
 	{
+		release_urecord(rec);
 		unlock_udomain(dom, &aor);
 		rpc->fault(ctx, 500, "Internal error creating aor struct");
 		return;
@@ -439,12 +441,13 @@ static void ul_rpc_lookup(rpc_t* rpc, void* ctx)
 		if (VALID_CONTACT( con, act_time)) {
 			rpl_tree++;
 			if (rpc_dump_contact(rpc, ctx, ih, con) == -1) {
+				release_urecord(rec);
 				unlock_udomain(dom, &aor);
 				return;
 			}
 		}
 	}
-
+	release_urecord(rec);
 	unlock_udomain( dom, &aor);
 
 	if (rpl_tree==0) {
@@ -533,17 +536,20 @@ static void ul_rpc_rm_contact(rpc_t* rpc, void* ctx)
 
 	ret = get_ucontact( rec, &contact, &rpc_ul_cid, &rpc_ul_path, RPC_UL_CSEQ+1, &con);
 	if (ret < 0) {
+		release_urecord(rec);
 		unlock_udomain( dom, &aor);
 		rpc->fault(ctx, 500, "Internal error (can't get contact)");
 		return;
 	}
 	if (ret > 0) {
+		release_urecord(rec);
 		unlock_udomain( dom, &aor);
 		rpc->fault(ctx, 404, "Contact not found");
 		return;
 	}
 
 	if (delete_ucontact(rec, con) < 0) {
+		release_urecord(rec);
 		unlock_udomain( dom, &aor);
 		rpc->fault(ctx, 500, "Internal error (can't delete contact)");
 		return;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally

#### Description
<!-- Describe your changes in detail -->
release_urecord() needs to be called in order to clean ucontacts created on get_urecord() when mode is DB_ONLY