### PR TITLE
Microsleep

### DIFF
--- a/src/modules/async/README
+++ b/src/modules/async/README
@@ -10,7 +10,7 @@ Daniel-Constantin Mierla
 
    <miconda@gmail.com>
 
-   Copyright © 2011-2016 asipto.com
+   Copyright (c) 2011-2016 asipto.com
      __________________________________________________________________
 
    Table of Contents
@@ -26,20 +26,26 @@ Daniel-Constantin Mierla
         3. Parameters
 
               3.1. workers (int)
+              3.2. ms_timer (int)
 
         4. Functions
 
               4.1. async_route(routename, seconds)
-              4.2. async_sleep(seconds)
-              4.3. async_task_route(routename)
+              4.2. async_ms_route(routename, milliseconds)
+              4.3. async_sleep(seconds)
+              4.4. async_ms_sleep(milliseconds)
+              4.5. async_task_route(routename)
 
    List of Examples
 
    1.1. Set workers parameter
-   1.2. async_route usage
-   1.3. async_sleep usage
-   1.4. async_workers usage
-   1.5. async_task_route usage
+   1.2. Set ms_timer parameter
+   1.3. async_route usage
+   1.4. async_ms_route usage
+   1.5. async_sleep usage
+   1.6. async_ms_sleep usage
+   1.7. async_workers usage
+   1.8. async_task_route usage
 
 Chapter 1. Admin Guide
 
@@ -54,12 +60,15 @@ Chapter 1. Admin Guide
    3. Parameters
 
         3.1. workers (int)
+        3.2. ms_timer (int)
 
    4. Functions
 
         4.1. async_route(routename, seconds)
-        4.2. async_sleep(seconds)
-        4.3. async_task_route(routename)
+        4.2. async_ms_route(routename, milliseconds)
+        4.3. async_sleep(seconds)
+        4.4. async_ms_sleep(milliseconds)
+        4.5. async_task_route(routename)
 
 1. Overview
 
@@ -94,6 +103,7 @@ Chapter 1. Admin Guide
 3. Parameters
 
    3.1. workers (int)
+   3.2. ms_timer (int)
 
 3.1. workers (int)
 
@@ -107,11 +117,27 @@ Chapter 1. Admin Guide
 modparam("async", "workers", 2)
 ...
 
+3.2. ms_timer (int)
+
+   Enables millisecond timer for async_ms_sleep() and async_ms_route()
+   functions. The integer value is the timer resolution in milliseconds.
+   ms_timer = 1 enables 1 millisecond timer but generates higher load on
+   the system. ms_timer = 20 enables 20 ms timer.
+
+   Default value is 0.
+
+   Example 1.2. Set ms_timer parameter
+...
+modparam("async", "ms_timer", 1)
+...
+
 4. Functions
 
    4.1. async_route(routename, seconds)
-   4.2. async_sleep(seconds)
-   4.3. async_task_route(routename)
+   4.2. async_ms_route(routename, milliseconds)
+   4.3. async_sleep(seconds)
+   4.4. async_ms_sleep(milliseconds)
+   4.5. async_task_route(routename)
 
 4.1.  async_route(routename, seconds)
 
@@ -134,7 +160,7 @@ modparam("async", "workers", 2)
 
    This function can be used from REQUEST_ROUTE.
 
-   Example 1.2. async_route usage
+   Example 1.3. async_route usage
 ...
 request_route {
     ...
@@ -147,7 +173,42 @@ route[RESUME] {
 }
 ...
 
-4.2.  async_sleep(seconds)
+4.2.  async_ms_route(routename, milliseconds)
+
+   Simulate a sleep of 'milliseconds' and then continue the processing of
+   the SIP request with the route[routename]. In case of internal errors,
+   the function returns false, otherwise the function exits the execution
+   of the script at that moment (return 0 behaviour). This function works
+   only if the ms_timer parameter has a value greater then 0.
+
+   The routename parameter can be a static string or a dynamic string
+   value with config variables.
+
+   The sleep parameter represent the number of milliseconds to suspend the
+   processing of a SIP request. Maximum value is 30000 (30 sec). The
+   parameter can be a static integer or a variable holding an integer.
+
+   Since the SIP request handling is resumed in another process, the
+   config file execution state is practically lost. Therefore beware that
+   the execution of config after resume will end once the route[routename]
+   is finished.
+
+   This function can be used from REQUEST_ROUTE.
+
+   Example 1.4. async_ms_route usage
+...
+request_route {
+    ...
+    async_ms_route("RESUME", "250");
+    ...
+}
+route[RESUME] {
+   send_reply("404", "Not found");
+   exit;
+}
+...
+
+4.3.  async_sleep(seconds)
 
    Simulate a sleep of 'seconds' and then continue the processing of SIP
    request with the next action. In case of internal errors, the function
@@ -159,14 +220,49 @@ route[RESUME] {
 
    This function can be used from REQUEST_ROUTE.
 
-   Example 1.3. async_sleep usage
+   Example 1.5. async_sleep usage
 ...
 async_sleep("4");
 send_reply("404", "Not found");
 exit;
 ...
 
-4.3.  async_task_route(routename)
+4.4.  async_ms_sleep(milliseconds)
+
+   Simulate a sleep of 'milliseconds' and then continue the processing of
+   SIP request with the next action. In case of internal errors, the
+   function returns false. This function works only if the ms_timer
+   parameter has a value greater then 0.
+
+   The sleep parameter represent the number of milliseconds to suspend the
+   processing of SIP request. Maximum value is 30000 (30 sec). The
+   parameter can be a static integer or a variable holding an integer.
+
+   This function can be used from REQUEST_ROUTE.
+
+   Example 1.6. async_ms_sleep usage
+...
+route[REQUESTSHAPER] {
+        $var(res) = http_connect("leakybucket",
+                                 "/add?key=$fd", $null, $null,"$avp(delay)");
+        $var(d) = $(avp(delay){s.int});
+        if ($var(d) > 0) {
+                # Delay the request by $avp(delay) ms
+                async_ms_sleep("$var(d)");
+                if (!t_relay()) {
+                        sl_reply_error();
+                }
+                exit;
+        }
+        # No delay
+        if (!t_relay()) {
+                sl_reply_error();
+        }
+        exit;
+}
+...
+
+4.5.  async_task_route(routename)
 
    Continue the processing of the SIP request with the route[routename] in
    one of the processes from core asynchronous framework. The core
@@ -178,7 +274,7 @@ exit;
    async_workers core parameter in the configuration file. See the core
    cookbook for more information.
 
-   Example 1.4. async_workers usage
+   Example 1.7. async_workers usage
 ...
 # Enable 8 worker processes used by async and other modules
 async_workers=8
@@ -198,7 +294,7 @@ async_workers=8
 
    This function can be used from REQUEST_ROUTE.
 
-   Example 1.5. async_task_route usage
+   Example 1.8. async_task_route usage
 ...
 request_route {
     ...

--- a/src/modules/async/async_mod.c
+++ b/src/modules/async/async_mod.c
@@ -114,7 +114,7 @@ static int mod_init(void)
 		return -1;
 	}
 
-	register_basic_timers(async_workers);
+	register_basic_timers(async_workers + 1);
 
 	return 0;
 }
@@ -140,6 +140,7 @@ static int child_init(int rank)
 			return -1; /* error */
 		}
 	}
+	
 	if(fork_basic_utimer(PROC_TIMER, "ASYNC MOD MILLI TIMER SINGLETON", 1 /*socks flag*/,
 			   async_mstimer_exec, NULL, 1000 /*1 millisecond*/)
 			< 0) {

--- a/src/modules/async/async_mod.c
+++ b/src/modules/async/async_mod.c
@@ -41,17 +41,20 @@
 MODULE_VERSION
 
 static int async_workers = 1;
+static int async_ms_timer = 0;
 
 static int mod_init(void);
 static int child_init(int);
 static void mod_destroy(void);
 
 static int w_async_sleep(sip_msg_t *msg, char *sec, char *str2);
-static int fixup_async_sleep(void **param, int param_no);
 static int w_async_ms_sleep(sip_msg_t *msg, char *sec, char *str2);
-static int fixup_async_ms_sleep(void **param, int param_no);
+static int fixup_async_sleep(void **param, int param_no);
+
 static int w_async_route(sip_msg_t *msg, char *rt, char *sec);
+static int w_async_ms_route(sip_msg_t *msg, char *rt, char *sec);
 static int fixup_async_route(void **param, int param_no);
+
 static int w_async_task_route(sip_msg_t *msg, char *rt, char *p2);
 static int fixup_async_task_route(void **param, int param_no);
 
@@ -62,9 +65,11 @@ struct tm_binds tmb;
 static cmd_export_t cmds[]={
 	{"async_route", (cmd_function)w_async_route, 2, fixup_async_route,
 		0, REQUEST_ROUTE|FAILURE_ROUTE},
+	{"async_ms_route", (cmd_function)w_async_ms_route, 2, fixup_async_route,
+		0, REQUEST_ROUTE|FAILURE_ROUTE},
 	{"async_sleep", (cmd_function)w_async_sleep, 1, fixup_async_sleep,
 		0, REQUEST_ROUTE|FAILURE_ROUTE},
-	{"async_ms_sleep", (cmd_function)w_async_ms_sleep, 1, fixup_async_ms_sleep,
+	{"async_ms_sleep", (cmd_function)w_async_ms_sleep, 1, fixup_async_sleep,
 		0, REQUEST_ROUTE|FAILURE_ROUTE},
 	{"async_task_route", (cmd_function)w_async_task_route, 1, fixup_async_task_route,
 		0, REQUEST_ROUTE|FAILURE_ROUTE},
@@ -73,6 +78,7 @@ static cmd_export_t cmds[]={
 
 static param_export_t params[]={
 	{"workers",     INT_PARAM,   &async_workers},
+	{"ms_timer",    INT_PARAM,   &async_ms_timer},
 	{0, 0, 0}
 };
 
@@ -109,12 +115,17 @@ static int mod_init(void)
 		return -1;
 	}
 
-	if(async_init_ms_timer_list() < 0) {
-		LM_ERR("cannot initialize internal structure\n");
-		return -1;
+        if(async_ms_timer == 0) {
+                LM_INFO("ms_timer is set to 0. Disabling async_ms_sleep and async_ms_route functions\n");
+        } else {
+		if(async_init_ms_timer_list() < 0) {
+			LM_ERR("cannot initialize internal structure\n");
+			return -1;
+		}
+                LM_INFO("Enabled async_ms_sleep and async_ms_route functions with resolution of %dms\n", async_ms_timer);
 	}
 
-	register_basic_timers(async_workers + 1);
+	register_basic_timers(async_workers + (async_ms_timer > 0));
 
 	return 0;
 }
@@ -141,10 +152,10 @@ static int child_init(int rank)
 		}
 	}
 	
-	if(fork_basic_utimer(PROC_TIMER, "ASYNC MOD MILLI TIMER SINGLETON", 1 /*socks flag*/,
-			   async_mstimer_exec, NULL, 1000 /*1 millisecond*/)
+	if((async_ms_timer > 0) && fork_basic_utimer(PROC_TIMER, "ASYNC MOD MILLI TIMER SINGLETON", 1 /*socks flag*/,
+			   async_mstimer_exec, NULL, 1000 * async_ms_timer /*milliseconds*/)
 			< 0) {
-		LM_ERR("failed to register milisecond timer singleton routine as process (%d)\n", i);
+		LM_ERR("failed to register millisecond timer singleton as process (%d)\n", i);
 		return -1; /* error */
 	}
 
@@ -267,30 +278,6 @@ static int fixup_async_sleep(void **param, int param_no)
 /**
  *
  */
-static int fixup_async_ms_sleep(void **param, int param_no)
-{
-	async_param_t *ap;
-	if(param_no != 1)
-		return 0;
-	ap = (async_param_t *)pkg_malloc(sizeof(async_param_t));
-	if(ap == NULL) {
-		LM_ERR("no more pkg memory available\n");
-		return -1;
-	}
-	memset(ap, 0, sizeof(async_param_t));
-	ap->u.paction = get_action_from_param(param, param_no);
-	if(fixup_igp_null(param, param_no) < 0) {
-		pkg_free(ap);
-		return -1;
-	}
-	ap->pinterval = (gparam_t *)(*param);
-	*param = (void *)ap;
-	return 0;
-}
-
-/**
- *
- */
 int ki_async_route(sip_msg_t *msg, str *rn, int s)
 {
 	cfg_action_t *act = NULL;
@@ -327,7 +314,71 @@ int ki_async_route(sip_msg_t *msg, str *rn, int s)
 /**
  *
  */
+int ki_async_ms_route(sip_msg_t *msg, str *rn, int s)
+{
+	cfg_action_t *act = NULL;
+	int ri;
+	sr_kemi_eng_t *keng = NULL;
+
+	if(faked_msg_match(msg)) {
+		LM_ERR("invalid usage for faked message\n");
+		return -1;
+	}
+
+	keng = sr_kemi_eng_get();
+	if(keng == NULL) {
+		ri = route_lookup(&main_rt, rn->s);
+		if(ri >= 0) {
+			act = main_rt.rlist[ri];
+			if(act == NULL) {
+				LM_ERR("empty action lists in route block [%.*s]\n", rn->len,
+						rn->s);
+				return -1;
+			}
+		} else {
+			LM_ERR("route block not found: %.*s\n", rn->len, rn->s);
+			return -1;
+		}
+	}
+
+	if(async_ms_sleep(msg, s, act, rn) < 0)
+		return -1;
+	/* force exit in config */
+	return 0;
+}
+
+/**
+ *
+ */
 static int w_async_route(sip_msg_t *msg, char *rt, char *sec)
+{
+	int s;
+	str rn;
+
+	if(msg == NULL)
+		return -1;
+
+	if(async_workers <= 0) {
+		LM_ERR("no async mod timer workers\n");
+		return -1;
+	}
+
+	if(fixup_get_svalue(msg, (gparam_t *)rt, &rn) != 0) {
+		LM_ERR("no async route block name\n");
+		return -1;
+	}
+
+	if(fixup_get_ivalue(msg, (gparam_t *)sec, &s) != 0) {
+		LM_ERR("no async interval value\n");
+		return -1;
+	}
+	return ki_async_route(msg, &rn, s);
+}
+
+/**
+ *
+ */
+static int w_async_ms_route(sip_msg_t *msg, char *rt, char *sec)
 {
 	int s;
 	str rn;

--- a/src/modules/async/async_mod.c
+++ b/src/modules/async/async_mod.c
@@ -131,6 +131,12 @@ static int child_init(int rank)
 			return -1; /* error */
 		}
 	}
+	if(fork_basic_utimer(PROC_TIMER, "ASYNC MOD MILLI TIMER SINGLETON", 1 /*socks flag*/,
+			   async_mstimer_exec, NULL, 1000 /*1 millisecond*/)
+			< 0) {
+		LM_ERR("failed to register milisecond timer singleton routine as process (%d)\n", i);
+		return -1; /* error */
+	}
 
 	return 0;
 }

--- a/src/modules/async/async_sleep.h
+++ b/src/modules/async/async_sleep.h
@@ -45,6 +45,7 @@ int async_destroy_timer_list(void);
 int async_sleep(sip_msg_t *msg, int seconds, cfg_action_t *act, str *cbname);
 
 void async_timer_exec(unsigned int ticks, void *param);
+void async_mstimer_exec(unsigned int ticks, void *param);
 
 int async_send_task(sip_msg_t *msg, cfg_action_t *act, str *cbname);
 

--- a/src/modules/async/async_sleep.h
+++ b/src/modules/async/async_sleep.h
@@ -39,12 +39,13 @@ typedef struct async_param {
 /* clang-format on */
 
 int async_init_timer_list(void);
-
 int async_destroy_timer_list(void);
-
 int async_sleep(sip_msg_t *msg, int seconds, cfg_action_t *act, str *cbname);
-
 void async_timer_exec(unsigned int ticks, void *param);
+
+int async_init_ms_timer_list(void);
+int async_destroy_ms_timer_list(void);
+int async_ms_sleep(sip_msg_t *msg, int milliseconds, cfg_action_t *act, str *cbname);
 void async_mstimer_exec(unsigned int ticks, void *param);
 
 int async_send_task(sip_msg_t *msg, cfg_action_t *act, str *cbname);

--- a/src/modules/async/doc/async_admin.xml
+++ b/src/modules/async/doc/async_admin.xml
@@ -88,6 +88,28 @@ modparam("async", "workers", 2)
 </programlisting>
 		</example>
 	</section>
+	<section>
+		<title><varname>ms_timer</varname> (int)</title>
+		<para>
+			Enables millisecond timer for async_ms_sleep() and async_ms_route() functions.
+			The integer value is the timer resolution in milliseconds.
+			ms_timer = 1 enables 1 millisecond timer but generates higher load on the system.
+			ms_timer = 20 enables 20 ms timer. 
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>ms_timer</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("async", "ms_timer", 1)
+...
+</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>
@@ -137,6 +159,52 @@ route[RESUME] {
 </programlisting>
 	    </example>
 	</section>
+	<section id="async.f.async_ms_route">
+	    <title>
+		<function moreinfo="none">async_ms_route(routename, milliseconds)</function>
+	    </title>
+	    <para>
+		Simulate a sleep of 'milliseconds' and then continue the processing of the SIP
+		request with the route[routename]. In case of internal errors, the
+		function returns false, otherwise the function exits the execution of
+		the script at that moment (return 0 behaviour).
+		This function works only if the ms_timer parameter has a value greater then 0.
+		</para>
+		<para>
+		The routename parameter can be a static string or a dynamic string
+		value with config variables.
+		</para>
+		<para>
+		The sleep parameter represent the number of milliseconds to suspend the
+		processing of a SIP request. Maximum value is 30000 (30 sec). The parameter can be
+		a static integer or a variable holding an integer.
+		</para>
+		<para>
+		Since the SIP request handling is resumed in another process,
+		the config file execution state is practically lost. Therefore beware
+		that the execution of config after resume will end once the
+		route[routename] is finished.
+		</para>
+		<para>
+		This function can be used from REQUEST_ROUTE.
+		</para>
+		<example>
+		<title><function>async_ms_route</function> usage</title>
+		<programlisting format="linespecific">
+...
+request_route {
+    ...
+    async_ms_route("RESUME", "250");
+    ...
+}
+route[RESUME] {
+   send_reply("404", "Not found");
+   exit;
+}
+...
+</programlisting>
+	    </example>
+	</section>
 
 	<section id="async.f.async_sleep">
 	    <title>
@@ -162,6 +230,51 @@ route[RESUME] {
 async_sleep("4");
 send_reply("404", "Not found");
 exit;
+...
+</programlisting>
+	    </example>
+	</section>
+
+	<section id="async.f.async_ms_sleep">
+	    <title>
+		<function moreinfo="none">async_ms_sleep(milliseconds)</function>
+	    </title>
+	    <para>
+		Simulate a sleep of 'milliseconds' and then continue the processing of SIP
+		request with the next action. In case of internal errors, the function
+		returns false.
+		This function works only if the ms_timer parameter has a value greater then 0.
+		</para>
+		<para>
+		The sleep parameter represent the number of milliseconds to suspend the
+		processing of SIP request. Maximum value is 30000 (30 sec). The parameter can be
+		a static integer or a variable holding an integer.
+		</para>
+		<para>
+		This function can be used from REQUEST_ROUTE.
+		</para>
+		<example>
+		<title><function>async_ms_sleep</function> usage</title>
+		<programlisting format="linespecific">
+...
+route[REQUESTSHAPER] {
+        $var(res) = http_connect("leakybucket", 
+        			 "/add?key=$fd", $null, $null,"$avp(delay)");
+        $var(d) = $(avp(delay){s.int});
+	if ($var(d) > 0) {
+		# Delay the request by $avp(delay) ms
+		async_ms_sleep("$var(d)");
+		if (!t_relay()) {
+			sl_reply_error();
+		}
+		exit;
+	} 
+	# No delay
+	if (!t_relay()) {
+		sl_reply_error();
+	}
+        exit;
+}
 ...
 </programlisting>
 	    </example>


### PR DESCRIPTION
This is a ringless implementation of millisecond precision timer and millisecond async_sleep function.
I've added the functionality to the current async mod but this can me moved to a dedicated module.

For now only the async_ms_sleep is implemented but async_ms_route is just a few lines. 

Anyway how should I proceed with cleanup so this can be accepted ?

With millisecond precision sleep one can easily implement a leaky bucket request shaper that delays incoming requests to achieve perfect rate limits per customer/sip-trunk/whatever without dropping requests. No more spikes and no more 503s.

I've implemented external HTTP microservice that returns millisecond delays per dialog initiating request and tested it with SIPP with 3 flows/streams each with 250 CAPS.  No leaks nor other issues in 24hrs of testing. 

