### PR TITLE
evapi:return code and log fixed for no evapi client while sending

### DIFF
--- a/src/modules/evapi/evapi_dispatch.c
+++ b/src/modules/evapi/evapi_dispatch.c
@@ -728,6 +728,7 @@ int _evapi_relay(str *evdata, str *ctag, int unicast)
 
 	int len;
 	int sbsize;
+	int evapi_send_count;
 	evapi_msg_t *emsg;
 
 	LM_DBG("relaying event data [%.*s] (%d)\n",
@@ -781,7 +782,12 @@ int _evapi_relay(str *evdata, str *ctag, int unicast)
 		cfg_update();
 		LM_DBG("dispatching [%p] [%.*s] (%d)\n", emsg,
 				emsg->data.len, emsg->data.s, emsg->data.len);
-		evapi_dispatch_notify(emsg);
+		evapi_send_count = evapi_dispatch_notify(emsg);
+                if (evapi_send_count == 0) {
+			shm_free(emsg); 
+			LM_ERR("no evapi client to send the message, failed to send message\n");
+			return -1; 
+		}
 		shm_free(emsg);
 	}
 	return 0;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Right now, if there is no evapi client to send message then no logs are getting printed. This make us to not set the alert if send failed. After this changes if there is no evapi client we are going to get that in line like send_failed.
