### PR TITLE
core: Fix the cfg framework variable input type default

### DIFF
--- a/src/core/cfg/cfg.c
+++ b/src/core/cfg/cfg.c
@@ -94,7 +94,7 @@ int cfg_declare(char *group_name, cfg_def_t *def, void *values, int def_size,
 
 		/* verify the type of the input */
 		if (CFG_INPUT_MASK(def[i].type)==0) {
-			def[i].type |= def[i].type << CFG_INPUT_SHIFT;
+			def[i].type |= CFG_VAR_MASK(def[i].type) << CFG_INPUT_SHIFT;
 		} else {
 			if ((CFG_INPUT_MASK(def[i].type) != CFG_VAR_MASK(def[i].type) << CFG_INPUT_SHIFT)
 			&& (def[i].on_change_cb == 0)) {


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

What the affected line of code really wants to achieve is: if an
accepted inputs type mask is not specified then default to accepting
only the actual variable type. So we must mask the var type first,
then shift it by `CFG_INPUT_SHIFT`, before or-ing it with the rest.

What happened before was that the entire type was shifted, and that
included var type, input type and flags. What we end up with is some
additional higher bits set (for flags). I actually discovered this while
adding an additional flag that was meant to mark variables as private,
only accessible through an internal API (not available to modules such
as cfg_rpc).