### PR TITLE
dialog: check xdata length when loading profile from db

### DIFF
--- a/src/modules/dialog/dlg_db_handler.c
+++ b/src/modules/dialog/dlg_db_handler.c
@@ -457,7 +457,7 @@ int load_dialog_info_from_db(int dlg_hash_size, int fetch_num_rows,
 			dlg_set_toroute(dlg, &toroute_name);
 
 			GET_STR_VALUE(xdata, values, 21, 0, 0);
-			if(xdata.s!=NULL && dlg->state!=DLG_STATE_DELETED)
+			if(xdata.len > 0 && xdata.s!=NULL && dlg->state!=DLG_STATE_DELETED)
 			{
 				srjson_InitDoc(&jdoc, NULL);
 				jdoc.buf = xdata;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
When using a backend not supporting "NULL", like Redis, which store it as an empty string, xdata.s can be not null (it contains '\0'). This leads to an error trying to read it as a json document.
Not really a bug, but it leads to the error
"invalid json doc [[]]"
being printed each time a dialog is loaded from db (Redis).