### PR TITLE
dialog: run DLGCB_LOADED callbacks when loading dialog from db

### DIFF
--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -714,7 +714,6 @@ static int mod_init(void)
 		}
 	}
 
-	destroy_dlg_callbacks( DLGCB_LOADED );
 
 	/* timer process to send keep alive requests */
 	if(dlg_ka_timer>0 && dlg_ka_interval>0)

--- a/src/modules/dialog/dlg_cb.c
+++ b/src/modules/dialog/dlg_cb.c
@@ -232,6 +232,23 @@ void run_create_callbacks(struct dlg_cell *dlg, struct sip_msg *msg)
 	return;
 }
 
+void run_dlg_load_callbacks(struct dlg_cell *dlg)
+{
+	struct dlg_callback *cb;
+
+	if (load_cbs && load_cbs!=POINTER_CLOSED_MARKER) {
+		for ( cb=load_cbs->first; cb; cb=cb->next ) {
+			params.req = NULL;
+			params.rpl = NULL;
+			params.direction = DLG_DIR_NONE;
+			params.param = &cb->param;
+	
+			cb->callback( dlg, DLGCB_LOADED, &params );
+		}
+  }
+	return;
+}
+
 
 void run_dlg_callbacks( int type ,
 						struct dlg_cell *dlg,

--- a/src/modules/dialog/dlg_cb.h
+++ b/src/modules/dialog/dlg_cb.h
@@ -109,6 +109,7 @@ void run_dlg_callbacks( int type ,
 
 void run_load_callbacks( void );
 
+void run_dlg_load_callbacks(struct dlg_cell *dlg);
 
 /*!
  * \brief Function that returns valid SIP message from given dialog callback parameter struct

--- a/src/modules/dialog/dlg_db_handler.c
+++ b/src/modules/dialog/dlg_db_handler.c
@@ -40,6 +40,7 @@
 #include "../../core/counters.h"
 #include "dlg_hash.h"
 #include "dlg_var.h"
+#include "dlg_cb.h"
 #include "dlg_profile.h"
 #include "dlg_db_handler.h"
 
@@ -493,6 +494,7 @@ int load_dialog_info_from_db(int dlg_hash_size, int fetch_num_rows,
 					get_ticks());
 
 			dlg->dflags = 0;
+  
 			if(mode!=0) {
 				if(loaded_extra<DLG_MAX_DB_LOAD_EXTRA) {
 					dbuid[loaded_extra].h_entry = dlg->h_entry;
@@ -502,6 +504,8 @@ int load_dialog_info_from_db(int dlg_hash_size, int fetch_num_rows,
 					dlg->dflags |= DLG_FLAG_DB_LOAD_EXTRA;
 					loaded_extra_more = 1;
 				}
+			  /* if loading at runtime run the callbacks for the loaded dialog */
+			  run_dlg_load_callbacks(dlg);
 			}
 			next_dialog:
 			;


### PR DESCRIPTION
When a specific dialog is loaded from db via dlg_db_load_callid, the load callbacks are not executed so, for example, a CDR is not generated.
No sure if this should considered a new feature or a bug (and so eventually be backported).