### PR TITLE
pv: adding xavp_copy

### DIFF
--- a/src/core/xavp.c
+++ b/src/core/xavp.c
@@ -693,11 +693,16 @@ struct str_list *xavp_get_list_key_names(sr_xavp_t *xavp)
 	return result;
 }
 
+sr_xavp_t *xavp_clone_level_nodata(sr_xavp_t *xold)
+{
+	return xavp_clone_level_nodata_with_new_name(xold, &xold->name);
+}
+
 /**
  * clone the xavp without values that are custom data
  * - only one list level is cloned, other sublists are ignored
  */
-sr_xavp_t *xavp_clone_level_nodata(sr_xavp_t *xold)
+sr_xavp_t *xavp_clone_level_nodata_with_new_name(sr_xavp_t *xold, str *dst_name)
 {
 	sr_xavp_t *xnew = NULL;
 	sr_xavp_t *navp = NULL;
@@ -713,13 +718,13 @@ sr_xavp_t *xavp_clone_level_nodata(sr_xavp_t *xold)
 		LM_INFO("xavp value type is 'data' - ignoring in clone\n");
 		return NULL;
 	}
-	xnew = xavp_new_value(&xold->name, &xold->val);
+	xnew = xavp_new_value(dst_name, &xold->val);
 	if(xnew==NULL)
 	{
 		LM_ERR("cannot create cloned root xavp\n");
 		return NULL;
 	}
-	LM_DBG("cloned root xavp [%.*s]\n", xold->name.len, xold->name.s);
+	LM_DBG("cloned root xavp [%.*s] >> [%.*s]\n", xold->name.len, xold->name.s, dst_name->len, dst_name->s);
 
 	if(xold->val.type!=SR_XTYPE_XAVP)
 	{

--- a/src/core/xavp.h
+++ b/src/core/xavp.h
@@ -102,6 +102,7 @@ sr_xavp_t *xavp_extract(str *name, sr_xavp_t **list);
 void xavp_print_list(sr_xavp_t **head);
 
 sr_xavp_t *xavp_clone_level_nodata(sr_xavp_t *xold);
+sr_xavp_t *xavp_clone_level_nodata_with_new_name(sr_xavp_t *xold, str *dst_name);
 
 sr_xavp_t* xavp_get_child(str *rname, str *cname);
 sr_xavp_t* xavp_get_child_with_ival(str *rname, str *cname);

--- a/src/modules/pv/doc/pv_admin.xml
+++ b/src/modules/pv/doc/pv_admin.xml
@@ -265,6 +265,49 @@ if (not_empty("$var(foo)")) {
 				</programlisting>
 			</example>
 		</section>
+		<section id="pv.f.xavp_copy">
+			<title>
+				<function moreinfo="none">xavp_copy(source_name, source_index, destination_name)</function>
+			</title>
+			<para>
+				Copy one XAVP.
+			</para>
+			<para>
+				The parameters can be variables or strings.
+				First parameter is the source XAVP name.
+				Second parameter is the source XAVP stack index, use 0 to copy the last assigned XAVP.
+				Third parameter is the destination XAVP name, if found the XAVP will be appended else it will be created.
+			</para>
+			<para>
+			Function can be used from ANY ROUTE.
+			</para>
+			<example>
+				<title><function>xavp_copy</function> usage</title>
+				<programlisting format="linespecific">
+...
+# Using xavp_copy to reorder an existing xavp stack
+$xavp(a=&gt;x) = "a-0-x";
+$xavp(a[0]=&gt;y) = "a-0-y";
+$xavp(a=&gt;x) = "a-1-x";
+$xavp(a[0]=&gt;y) = "a-1-y";
+xinfo("$$xavp(a[0]) = [$xavp(a[0]=&gt;x)][$xavp(a[0]=&gt;y)]\n");
+xinfo("$$xavp(a[1]) = [$xavp(a[1]=&gt;x)][$xavp(a[1]=&gt;y)]\n");
+# reorder
+$var(source_index) = 1;
+$var(destination_name) = "b";
+xavp_copy("a", "$var(source_index)", "$var(destination_name)");
+xavp_copy("a", "0", "$var(destination_name)");
+xinfo("reordered: $$xavp(b[0]) = [$xavp(b[0]=&gt;x)][$xavp(b[0]=&gt;y)]\n");
+xinfo("reordered: $$xavp(b[1]) = [$xavp(b[1]=&gt;x)][$xavp(b[1]=&gt;y)]\n");
+# results in:
+# INFO: $xavp(a[0]) = [a-1-x][a-1-y]
+# INFO: $xavp(a[1]) = [a-0-x][a-0-y]
+# INFO: reordered: $xavp(b[0]) = [a-0-x][a-0-y]
+# INFO: reordered: $xavp(b[1]) = [a-1-x][a-1-y]
+...
+				</programlisting>
+			</example>
+		</section>
 		<section id="pv.f.xavp_params_explode">
 			<title>
 				<function moreinfo="none">xavp_params_explode(sparams, xname)</function>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change

- [x] New feature (non-breaking change which adds new functionality)

#### Checklist:
- [x] Tested changes locally

#### Description
proposal for `xavp_copy()`
param1: source xavp name
param2: source xavp index
param3: destination xavp name

The command will copy only one specific xavp from the stack.
If the destination xavp stack exist it will append else it will create a new one, it seems to be more or less compatible to what we do with XAVP in general.

We can now reorder xavp stack like in the following example :

```
route[TEST] {
        $xavp(a=>x) = "a-0-x";
        $xavp(a[0]=>y) = "a-0-y";
        $xavp(a=>x) = "a-1-x";
        $xavp(a[0]=>y) = "a-1-y";
        xinfo("$$xavp(a[0]) = [$xavp(a[0]=>x)][$xavp(a[0]=>y)]\n");
        xinfo("$$xavp(a[1]) = [$xavp(a[1]=>x)][$xavp(a[1]=>y)]\n");

        $var(src_idx) = 1;
        $var(v) = "b";
        xavp_copy("a", "$var(src_idx)", "$var(v)");
        $var(src_idx) = 0;
        xavp_copy("a", "$var(src_idx)", "$var(v)");
        xinfo("$$xavp(b[0]) = [$xavp(b[0]=>x)][$xavp(b[0]=>y)]\n");
        xinfo("$$xavp(b[1]) = [$xavp(b[1]=>x)][$xavp(b[1]=>y)]\n");
}
```

```
 2(137) INFO: <script>: $xavp(a[0]) = [a-1-x][a-1-y]
 2(137) INFO: <script>: $xavp(a[1]) = [a-0-x][a-0-y]
 2(137) INFO: pv [pv.c:827]: w_xavp_copy(): xavp_copy(new): $xavp(a[1]) >> $xavp(b)
 2(137) INFO: pv [pv.c:833]: w_xavp_copy(): xavp_copy(append): $xavp(a[0]) >> $xavp(b)
 2(137) INFO: <script>: $xavp(b[0]) = [a-0-x][a-0-y]
 2(137) INFO: <script>: $xavp(b[1]) = [a-1-x][a-1-y]
```