### PR TITLE
uac: Fix uac_reg_check_password having '9' disabled in hash string.

### DIFF
--- a/src/modules/uac/uac_reg.c
+++ b/src/modules/uac/uac_reg.c
@@ -1238,7 +1238,7 @@ static int uac_reg_check_password(reg_uac_t *reg)
 		return -1;
 	}
 	for(i=0; i<reg->auth_ha1.len; i++) {
-		if(!((reg->auth_ha1.s[i]>='0' && reg->auth_ha1.s[i]<'9')
+		if(!((reg->auth_ha1.s[i]>='0' && reg->auth_ha1.s[i]<='9')
 				|| (reg->auth_ha1.s[i]>='a' && reg->auth_ha1.s[i]<='f')
 				|| (reg->auth_ha1.s[i]>='A' && reg->auth_ha1.s[i]<='F'))) {
 			LM_ERR("invalid char %d in HA1 string: %.*s\n", i,


### PR DESCRIPTION
Fix uac_reg_check_password having '9' disabled in hash string.


#### Pre-Submission Checklist
- [ ] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Previously uac_reg_check_password had check up to <9, which disabled  '9' in hash string. Guess it was just a typo, so i fixed it.