### PR TITLE
pv: adding xavp_copy with destination index

### DIFF
--- a/src/modules/pv/pv.c
+++ b/src/modules/pv/pv.c
@@ -536,6 +536,7 @@ static int is_int(struct sip_msg* msg, char* pvar, char* s2);
 static int pv_typeof(sip_msg_t *msg, char *pv, char *t);
 static int pv_not_empty(sip_msg_t *msg, char *pv, char *s2);
 static int w_xavp_copy(sip_msg_t *msg, char *src_name, char *src_idx, char *dst_name);
+static int w_xavp_copy_dst(sip_msg_t *msg, char *src_name, char *src_idx, char *dst_name, char *dst_idx);
 static int w_xavp_params_explode(sip_msg_t *msg, char *pparams, char *pxname);
 static int w_xavp_params_implode(sip_msg_t *msg, char *pxname, char *pvname);
 static int w_xavp_child_seti(sip_msg_t *msg, char *prname, char *pcname,
@@ -583,6 +584,8 @@ static cmd_export_t cmds[]={
 		2, fixup_spve_spve, fixup_free_spve_spve,
 		ANY_ROUTE},
 	{"xavp_copy", (cmd_function)w_xavp_copy, 3, pv_xavp_copy_fixup, 0,
+		ANY_ROUTE},
+	{"xavp_copy", (cmd_function)w_xavp_copy_dst, 4, pv_xavp_copy_fixup, 0,
 		ANY_ROUTE},
 	{"xavp_params_implode", (cmd_function)w_xavp_params_implode,
 		2, fixup_spve_str, fixup_free_spve_str,
@@ -820,9 +823,19 @@ static int ki_xavp_print(sip_msg_t* msg)
  */
 static int w_xavp_copy(sip_msg_t *msg, char *_src_name, char *_src_idx, char *_dst_name)
 {
+	return w_xavp_copy_dst(msg, _src_name, _src_idx, _dst_name, NULL);
+}
+
+/**
+ *
+ */
+static int w_xavp_copy_dst(sip_msg_t *msg, char *_src_name, char *_src_idx, char *_dst_name, char *_dst_idx)
+{
 	str src_name;
 	int src_idx;
 	str dst_name;
+	int dst_idx;
+
 	if(get_str_fparam(&src_name, msg, (gparam_p)_src_name) != 0) {
 		LM_ERR("xavp_copy: missing source\n");
 		return -1;
@@ -840,31 +853,68 @@ static int w_xavp_copy(sip_msg_t *msg, char *_src_name, char *_src_idx, char *_d
 		LM_ERR("xavp_copy: missing can not find source xavp [%.*s]\n", src_name.len, src_name.s);
 		return -1;
 	}
-	// Check if destination exist, if it does we will append, similar to XAVP assigment
-	sr_xavp_t *dst_xavp = xavp_get(&dst_name, NULL);
+
+	sr_xavp_t *dst_xavp = NULL;
+	LM_DBG("xavp_copy: dst_name xavp [%.*s]\n", dst_name.len, dst_name.s);
 	sr_xavp_t *new_xavp = xavp_clone_level_nodata_with_new_name(src_xavp, &dst_name);
 	if (!new_xavp) {
 		LM_ERR("error cloning xavp\n");
 		return -1;
 	}
-	if (!dst_xavp) {
-		LM_DBG("xavp_copy(new): $xavp(%.*s[%d]) >> $xavp(%.*s)\n", src_name.len, src_name.s, src_idx, dst_name.len, dst_name.s);
-		if(xavp_add(new_xavp, NULL)<0) {
-			LM_ERR("error adding new xavp\n");
-			xavp_destroy_list(&dst_xavp);
+
+	if (_dst_idx) {
+		if(get_int_fparam(&dst_idx, msg, (gparam_t*)_dst_idx)<0) {
+			LM_ERR("failed to get the dst_idx value\n");
+			return -1;
+		}
+		dst_xavp = xavp_get_by_index(&dst_name, dst_idx, NULL);
+		if(!dst_xavp) {
+			LM_ERR("xavp_copy: missing can not find destination xavp [%.*s]\n", dst_name.len, dst_name.s);
+			xavp_destroy_list(&new_xavp);
+			return -1;
+		}
+
+		LM_DBG("xavp_copy(replace): $xavp(%.*s[%d]) >> $xavp(%.*s[%d])\n", src_name.len, src_name.s, src_idx, dst_name.len, dst_name.s, dst_idx);
+		if(dst_idx == 0) {
+			if(xavp_add(new_xavp, NULL)<0) {
+				LM_ERR("error adding new xavp\n");
+				xavp_destroy_list(&new_xavp);
+				return -1;
+			}
+		} else {
+			sr_xavp_t *prev_xavp = xavp_get_by_index(&dst_name, dst_idx-1, NULL);
+			if(!prev_xavp) {
+				LM_ERR("error inserting xavp, parent not found $xavp(%.*s[%d])\n", dst_name.len, dst_name.s, dst_idx);
+				xavp_destroy_list(&new_xavp);
+				return -1;
+			}
+			xavp_add_after(new_xavp, prev_xavp);
+		}
+		if(xavp_rm(dst_xavp, NULL)<0) {
+			LM_ERR("can not remove the exiting index $xavp(%.*s[%d])\n", dst_name.len, dst_name.s, dst_idx);
 			return -1;
 		}
 	} else {
-		LM_DBG("xavp_copy(append): $xavp(%.*s[%d]) >> $xavp(%.*s)\n", src_name.len, src_name.s, src_idx, dst_name.len, dst_name.s);
-		if(xavp_add_last(new_xavp, &dst_xavp)<0) {
-			LM_ERR("error appending new xavp\n");
-			xavp_destroy_list(&dst_xavp);
-			return -1;
+		// Check if destination exist, if it does we will append, similar to XAVP assigment
+		dst_xavp = xavp_get(&dst_name, NULL);
+		if (!dst_xavp) {
+			LM_DBG("xavp_copy(new): $xavp(%.*s[%d]) >> $xavp(%.*s)\n", src_name.len, src_name.s, src_idx, dst_name.len, dst_name.s);
+			if(xavp_add(new_xavp, NULL)<0) {
+				LM_ERR("error adding new xavp\n");
+				xavp_destroy_list(&dst_xavp);
+				return -1;
+			}
+		} else {
+			LM_DBG("xavp_copy(append): $xavp(%.*s[%d]) >> $xavp(%.*s)\n", src_name.len, src_name.s, src_idx, dst_name.len, dst_name.s);
+			if(xavp_add_last(new_xavp, &dst_xavp)<0) {
+				LM_ERR("error appending new xavp\n");
+				xavp_destroy_list(&dst_xavp);
+				return -1;
+			}
 		}
 	}
 	return 1;
 }
-
 
 /**
  *
@@ -1424,7 +1474,7 @@ int pv_xavp_copy_fixup(void **param, int param_no)
 {
 	if(param_no == 1 || param_no == 3)
 		return fixup_var_str_12(param, param_no);
-	if (param_no == 2)
+	if (param_no == 2 || param_no == 4)
 		return fixup_var_int_12(param, param_no);
 	LM_ERR("invalid parameter count [%d]\n", param_no);
 	return -1;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

MR to add another xavp_copy function taking 4 params

```
 xavc_copy("source_name", "source_index", "destination_name", "destination_index")
```

This will let the user copy to a specific position in the stack (replacing its value).
This would bring coherent behaviour compared to assign to a specific index vs appending.

Example : swapping xavp in and existing stack:
(second and third elements)
```
$xavp(a=>x) = "a-0-x";
$xavp(a[0]=>y) = "a-0-y";
$xavp(a=>x) = "a-1-x";
$xavp(a[0]=>y) = "a-1-y";
$xavp(a=>x) = "a-2-x";
$xavp(a[0]=>y) = "a-2-y";

# INFO: <script>: NEW $xavp(a[0]) = [a-2-x][a-2-y]
# INFO: <script>: NEW $xavp(a[1]) = [a-1-x][a-1-y]
# INFO: <script>: NEW $xavp(a[2]) = [a-0-x][a-0-y]

xavp_copy("a", "1", "c");
xavp_copy("a", "2", "a", "1");
xavp_copy("c", "0", "a", "2");

# INFO: <script>: AFTER $xavp(a[0]) = [a-2-x][a-2-y]
# INFO: <script>: AFTER $xavp(a[1]) = [a-0-x][a-0-y]
# INFO: <script>: AFTER $xavp(a[2]) = [a-1-x][a-1-y]
```