### PR TITLE
ims_ipsec_pcscf: closing mnl_socket in some exceptional situations

### DIFF
--- a/src/modules/ims_ipsec_pcscf/cmd.c
+++ b/src/modules/ims_ipsec_pcscf/cmd.c
@@ -338,15 +338,18 @@ static int create_ipsec_tunnel(const struct ip_addr *remote_addr, ipsec_t* s)
     if(remote_addr->af == AF_INET){
         if(str2ipbuf(&ipsec_listen_addr, &ipsec_addr) < 0){
             LM_ERR("Unable to convert ipsec addr4 [%.*s]\n", ipsec_listen_addr.len, ipsec_listen_addr.s);
+            close_mnl_socket(sock);
             return 0;
         }
     } else if(remote_addr->af == AF_INET6){
         if(str2ip6buf(&ipsec_listen_addr6, &ipsec_addr) < 0){
             LM_ERR("Unable to convert ipsec addr6 [%.*s]\n", ipsec_listen_addr6.len, ipsec_listen_addr6.s);
+            close_mnl_socket(sock);
             return 0;
         }
     } else {
         LM_ERR("Unsupported AF %d\n", remote_addr->af);
+        close_mnl_socket(sock);
         return 0;
     }
 
@@ -355,6 +358,7 @@ static int create_ipsec_tunnel(const struct ip_addr *remote_addr, ipsec_t* s)
     memset(remote_addr_str, 0, sizeof(remote_addr_str));
     if(inet_ntop(remote_addr->af, remote_addr->u.addr, remote_addr_str, sizeof(remote_addr_str)) == NULL) {
         LM_CRIT("Error converting remote IP address: %s\n", strerror(errno));
+        close_mnl_socket(sock);
         return -1;
     }
 
@@ -401,6 +405,7 @@ static int destroy_ipsec_tunnel(str remote_addr, ipsec_t* s, unsigned short rece
     // convert 'remote_addr' ip string to ip_addr_t
     if(str2ipxbuf(&remote_addr, &ip_addr) < 0){
         LM_ERR("Unable to convert remote address [%.*s]\n", remote_addr.len, remote_addr.s);
+        close_mnl_socket(sock);
         return -1;
     }
 


### PR DESCRIPTION
- fix leak socket when error handling errors in creation or destruction ipsec tunnel

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Fixed socket leak on error during ipsec tunnel creation or destruction.