### PR TITLE
core: add support for parsing http/2 replies parsing

### DIFF
--- a/src/core/parser/msg_parser.h
+++ b/src/core/parser/msg_parser.h
@@ -146,9 +146,12 @@ if (  (*tmp==(firstchar) || *tmp==((firstchar) | 32)) &&                  \
 		SIP_VERSION, SIP_VERSION_LEN))
 
 #define IS_HTTP_REPLY(rpl)                                                \
-	((rpl)->first_line.u.reply.version.len >= HTTP_VERSION_LEN && \
+	(((rpl)->first_line.u.reply.version.len >= HTTP_VERSION_LEN && \
 	!strncasecmp((rpl)->first_line.u.reply.version.s,             \
-		HTTP_VERSION, HTTP_VERSION_LEN))
+		HTTP_VERSION, HTTP_VERSION_LEN)) ||                         \
+	((rpl)->first_line.u.reply.version.len >= HTTP2_VERSION_LEN && \
+	!strncasecmp((rpl)->first_line.u.reply.version.s,             \
+		HTTP2_VERSION, HTTP2_VERSION_LEN)))
 
 #define IS_SIP_REPLY(rpl)                                                \
 	((rpl)->first_line.u.reply.version.len >= SIP_VERSION_LEN && \

--- a/src/core/parser/parse_fline.c
+++ b/src/core/parser/parse_fline.c
@@ -96,21 +96,28 @@ char* parse_first_line(char* buffer, unsigned int len, struct msg_start* fl)
 			fl->flags|=FLINE_FLAG_PROTO_SIP;
 			fl->u.reply.version.len=SIP_VERSION_LEN;
 			tmp=buffer+SIP_VERSION_LEN;
-	} else if (http_reply_parse != 0 &&
-		 	(*tmp=='H' || *tmp=='h') &&
+	} else if (http_reply_parse != 0 && (*tmp=='H' || *tmp=='h')) {
 			/* 'HTTP/1.' */
-			strncasecmp( tmp+1, HTTP_VERSION+1, HTTP_VERSION_LEN-1)==0 &&
-			/* [0|1] */
-			((*(tmp+HTTP_VERSION_LEN)=='0') || (*(tmp+HTTP_VERSION_LEN)=='1')) &&
-			(*(tmp+HTTP_VERSION_LEN+1)==' ')  ){ 
-			/* ugly hack to be able to route http replies
-			 * Note: - the http reply must have a via
-			 *       - the message is marked as SIP_REPLY (ugly)
-			 */
-				fl->type=SIP_REPLY;
-				fl->flags|=FLINE_FLAG_PROTO_HTTP;
-				fl->u.reply.version.len=HTTP_VERSION_LEN+1 /*include last digit*/;
-				tmp=buffer+HTTP_VERSION_LEN+1 /* last digit */;
+			if (strncasecmp( tmp+1, HTTP_VERSION+1, HTTP_VERSION_LEN-1)==0 &&
+			  /* [0|1] */
+			  ((*(tmp+HTTP_VERSION_LEN)=='0') || (*(tmp+HTTP_VERSION_LEN)=='1')) &&
+			  (*(tmp+HTTP_VERSION_LEN+1)==' ')  ){ 
+			    /* ugly hack to be able to route http replies
+			    * Note: - the http reply must have a via
+			    *       - the message is marked as SIP_REPLY (ugly)
+			    */
+				  fl->type=SIP_REPLY;
+				  fl->flags|=FLINE_FLAG_PROTO_HTTP;
+				  fl->u.reply.version.len=HTTP_VERSION_LEN+1 /*include last digit*/;
+          tmp=buffer+HTTP_VERSION_LEN+1 /* last digit */;
+			/* 'HTTP/2' */
+			} else if (strncasecmp( tmp+1, HTTP2_VERSION+1, HTTP2_VERSION_LEN-1)==0 &&
+						(*(tmp+HTTP2_VERSION_LEN)==' ')) {
+					fl->type=SIP_REPLY;
+					fl->flags|=FLINE_FLAG_PROTO_HTTP;
+					fl->u.reply.version.len=HTTP2_VERSION_LEN;
+					tmp=buffer+HTTP2_VERSION_LEN;
+			}
 	} else IFISMETHOD( INVITE, 'I' )
 	else IFISMETHOD( CANCEL, 'C')
 	else IFISMETHOD( ACK, 'A' )

--- a/src/core/parser/parse_fline.h
+++ b/src/core/parser/parse_fline.h
@@ -49,6 +49,9 @@
 #define HTTP_VERSION "HTTP/1."
 #define HTTP_VERSION_LEN (sizeof(HTTP_VERSION)-1)
 
+#define HTTP2_VERSION "HTTP/2"
+#define HTTP2_VERSION_LEN (sizeof(HTTP2_VERSION)-1)
+
 #define CANCEL "CANCEL"
 #define ACK    "ACK"
 #define INVITE "INVITE"


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
http_async_client module needs to parse http replies. Currently HTTP/2 is not supported by the core parser. 