### PR TITLE
utils/db_berkeley: fixed unused var

### DIFF
--- a/utils/db_berkeley/kambdb_recover.c
+++ b/utils/db_berkeley/kambdb_recover.c
@@ -816,11 +816,11 @@ table_p create_table(char *_s)
 */
 int load_metadata_columns(table_p _tp, char* line)
 {
-	int ret,n,len;
+	int n,len;
 	char *s = NULL;
 	char cn[64], ct[16];
 	column_p col;
-	ret = n = len = 0;
+	n = len = 0;
 	
 	if(!_tp) return -1;
 	if(_tp->ncols!=0) return 0;


### PR DESCRIPTION
kambdb_recover.c: In function 'load_metadata_columns':
kambdb_recover.c:819:6: warning: variable 'ret' set but not used [-Wunused-but-set-variable]
  819 |  int ret,n,len;
      |      ^~~

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Fixed not used vars on Fedora 31