### PR TITLE
db_redis: allow deletion of all rows

### DIFF
--- a/src/modules/db_redis/redis_dbase.c
+++ b/src/modules/db_redis/redis_dbase.c
@@ -1325,6 +1325,12 @@ static int db_redis_perform_delete(const db1_con_t* _h, km_redis_con_t *con, con
         if (tmp)
             db_redis_key_free(&tmp);
 
+        // skip if delete all rows
+        if (!*manual_keys_count) {
+          db_redis_key_free (&query_v);
+          goto skipkeys;
+        }
+
         if (db_redis_key_prepend_string(&query_v, "HMGET", 5) != 0) {
             LM_ERR("Failed to set hmget command to pre-delete query\n");
             goto error;
@@ -1416,6 +1422,7 @@ static int db_redis_perform_delete(const db1_con_t* _h, km_redis_con_t *con, con
         db_vals = NULL;
         db_redis_free_reply(&reply);
 
+      skipkeys:
         if (db_redis_key_add_string(&query_v, "DEL", 3) != 0) {
             LM_ERR("Failed to add del command to delete query\n");
             goto error;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally

#### Description
<!-- Describe your changes in detail -->
Previous version did not allow deletion of all rows in the table although this is allowed as described in section [9.2.9](http://www.asipto.com/pub/kamailio-devel-guide/#c09f_delete) of the Kamailio SIP Server v3.2.0 Development Guide. Former code always assumed filters would be involved so this change skips the filter matching if no filter is applied.