### PR TITLE
etc/kamailio.cfg: loaded systemdops.so by default

### DIFF
--- a/etc/kamailio.cfg
+++ b/etc/kamailio.cfg
@@ -306,6 +306,8 @@ loadmodule "xmlrpc.so"
 loadmodule "debugger.so"
 #!endif
 
+loadmodule "systemdops.so"
+
 # ----------------- setting module-specific parameters ---------------
 
 


### PR DESCRIPTION
#1762 ## Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2139

#### Description
Enabled systemd notification by default.

Victor@linuxmaniac, is change acceptable for dist not have `systemd`?
For similar RPM dist i goes to delete this sting during packaging rules execution.