### PR TITLE
tm: add support for dropping messages in local-request event route

### DIFF
--- a/src/core/error.h
+++ b/src/core/error.h
@@ -48,6 +48,7 @@
 #define E_Q_EMPTY       -16 /* Empty q */
 #define E_Q_TOO_BIG     -17 /* q too big (> 1) */
 #define E_Q_DEC_MISSING -18 /* Decimal part missing */
+#define E_DROP          -19 /* Dropped in script */
 
 
 

--- a/src/modules/tm/uac.c
+++ b/src/modules/tm/uac.c
@@ -273,6 +273,9 @@ static inline int t_run_local_req(
 	tm_global_ctx_id.msgid=lreq.id;
 	tm_global_ctx_id.pid=lreq.pid;
 	set_t(new_cell, T_BR_UNDEFINED);
+  
+	init_run_actions_ctx(&ra_ctx);
+	
 	if(goto_on_local_req>=0) {
 		run_top_route(event_rt.rlist[goto_on_local_req], &lreq, &ra_ctx);
 	} else {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Currently it is not possible to drop a local generated message in tm:local-request event route because there is no context associated when running the event route. With this PR I tried to solve this introducing a new returned error (E_DROP) and a context into t_run_local_req.