### PR TITLE
avpops: avp_subst() support pvar as subst parameter

### DIFF
--- a/src/modules/avpops/doc/avpops_admin.xml
+++ b/src/modules/avpops/doc/avpops_admin.xml
@@ -971,6 +971,36 @@ avp_subst("$avp(i:678)/$avp(i:679)/g", "/(.*)@(.*)/\1@$rd/");
 			processing will use it.
 			</para>
 		</section>
+		<section id="avpops.f.avp_subst_pv">
+			<title>
+				<function moreinfo="none">avp_subst_pv(avps, subst)</function>
+			</title>
+			<para>
+			Same functionality than avp_subst() but seccond parameter will be
+			evaluated first.
+			</para>
+			<para>
+			This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
+			BRANCH_ROUTE, LOCAL_ROUTE and ONREPLY_ROUTE.
+			</para>
+			<example>
+				<title><function>avp_subst_pv</function> usage</title>
+				<programlisting format="linespecific">
+...
+$(avp(src)[*]) = "testME";
+$var(z) = "j";
+$var(y) = "e";
+$var(x) = "/" + $var(y) + "/" + $var(z) + "/gi";
+
+## all this calls will produce the same result "tjstMj"
+avp_subst_pv("$avp(src)", "/e/j/gi");
+avp_subst_pv("$avp(src)", "/" + $var(y) + "/" + $var(z) + "/gi");
+avp_subst_pv("$avp(src)", "/$var(y)/$var(z)/gi");
+avp_subst_pv("$avp(src)", "$var(x)");
+...
+				</programlisting>
+			</example>
+		</section>
 		<section id="avpops.f.avp_op">
 			<title>
 				<function moreinfo="none">avp_op(name,op_value)


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally

#### Description
Allow pvar as second parameter of avp_subst() function
