### PR TITLE
utils: Change sh(1) "test ==" usage to "="

### DIFF
--- a/utils/kamctl/kamdbctl
+++ b/utils/kamctl/kamdbctl
@@ -153,7 +153,7 @@ kamailio_dump()  # pars: <database name>
 		merr "kamailio_dump function takes two param"
 		exit 1
 	fi
-	if [ "$USED_DBENGINE" == "oracle" ]; then
+	if [ "$USED_DBENGINE" = "oracle" ]; then
 		oracle_dump $1 $2
 	elif [ "$PW" = "" ] ; then
 		$DUMP_CMD $1 > $2
@@ -174,7 +174,7 @@ kamailio_restore() #pars: <database name> <filename>
 		merr "kamailio_restore function takes two params"
 		exit 1
 	fi
-	if [ "$USED_DBENGINE" == "oracle" ]; then
+	if [ "$USED_DBENGINE" = "oracle" ]; then
 		oracle_restore $1 $2
 	else
 		sql_query $1 < $2
@@ -290,7 +290,7 @@ kamailio_pframework() #pars: <action>
 case $1 in
 	copy)
 		# copy database to some other name
-		if [ "$USED_DBENGINE" == "berkeley" -o "$USED_DBENGINE" == "dbtext" ] ; then
+		if [ "$USED_DBENGINE" = "berkeley" -o "$USED_DBENGINE" = "dbtext" ] ; then
 			merr "$USED_DBENGINE don't support this operation"
 			exit 1
 		fi
@@ -323,7 +323,7 @@ case $1 in
 		exit $ret
 		;;
 	backup)
-		if [ "$USED_DBENGINE" == "berkeley" -o "$USED_DBENGINE" == "dbtext" ] ; then
+		if [ "$USED_DBENGINE" = "berkeley" -o "$USED_DBENGINE" = "dbtext" ] ; then
 			merr "$USED_DBENGINE don't support this operation"
 			exit 1
 		fi
@@ -337,7 +337,7 @@ case $1 in
 		exit $?
 		;;
 	restore)
-		if [ "$USED_DBENGINE" == "berkeley" -o "$USED_DBENGINE" == "dbtext" ] ; then
+		if [ "$USED_DBENGINE" = "berkeley" -o "$USED_DBENGINE" = "dbtext" ] ; then
 			merr "$USED_DBENGINE don't support this operation"
 			exit 1
 		fi


### PR DESCRIPTION
The POSIX sh(1) specification says that strings are compared with
test(1) (also "[") with "=".  Bash accepts "==" and this leads to
non-portable code.  This commit simply changes "==" within test/[ to
"=".

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [] PR should be backported to stable branches
- [ ] Tested changes locally
- [x] Related to issue #2157

#### Description
This changes instances of "==" as a an operator to test(1) to "=".
I have not yes tested running the script, because I am still working through issues to package kamailio in pkgsrc.  However, this patch avoids a lint-type warning from pkgsrc about non-portable shell script constructs.