### PR TITLE
registrar: add path value to xavp_rcd

### DIFF
--- a/src/modules/registrar/doc/registrar_admin.xml
+++ b/src/modules/registrar/doc/registrar_admin.xml
@@ -771,6 +771,11 @@ request_route {
 				<emphasis>received</emphasis> - the record's received value.
 			</para>
 		</listitem>
+		<listitem>
+			<para>
+				<emphasis>path</emphasis> - the record's path value.
+			</para>
+		</listitem>
 		</itemizedlist>
 		<para>
 			For example. if this parameter is set to 'ulrcd', then values are set in:
@@ -784,6 +789,9 @@ request_route {
 		</listitem>
 		<listitem>
 			<para><emphasis>$xavp(ulrcd[0]=&gt;received)</emphasis></para>
+		</listitem>
+		<listitem>
+			<para><emphasis>$xavp(ulrcd[0]=&gt;path)</emphasis></para>
 		</listitem>
 		</itemizedlist>
 		<para>

--- a/src/modules/registrar/lookup.c
+++ b/src/modules/registrar/lookup.c
@@ -160,6 +160,7 @@ int xavp_rcd_helper(ucontact_t* ptr)
 	str xname_received = { "received", 8};
 	str xname_contact = { "contact", 7};
 	str xname_expires = {"expires", 7};
+	str xname_path = {"path", 4};
 	sr_xval_t xval;
 
 	if(ptr==NULL) return -1;
@@ -189,6 +190,13 @@ int xavp_rcd_helper(ucontact_t* ptr)
 	xval.type = SR_XTYPE_INT;
 	xval.v.i = (int) (ptr->expires - time(0));
 	xavp_add_value(&xname_expires, &xval, xavp);
+
+	if(ptr->path.len > 0) {
+		memset(&xval, 0, sizeof(sr_xval_t));
+		xval.type = SR_XTYPE_STR;
+		xval.v.s = ptr->path;
+		xavp_add_value(&xname_path, &xval, xavp);
+	}
 
 	if(list==NULL) {
 		/* no reg_xavp_rcd xavp in root list - add it */


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally

#### Description
Add path value to xavp_rcd. This is needed when checking if a subscriber is still registered
with a certain parameter in the path.
