### PR TITLE
tls: add verify_client support

### DIFF
--- a/src/modules/tls/doc/params.xml
+++ b/src/modules/tls/doc/params.xml
@@ -1043,6 +1043,7 @@ modparam("tls", "renegotiation", 1)
 			<listitem><para>tls_method - (str) - TLS methods</para></listitem>
 			<listitem><para>verify_certificate - (bool) - see modparam</para></listitem>
 			<listitem><para>require_certificate - (bool) - see modparam</para></listitem>
+			<listitem><para>verify_client - (str) - see modparam</para></listitem>
 			<listitem><para>private_key - (str) - see modparam</para></listitem>
 			<listitem><para>certificate - (str) - see modparam</para></listitem>
 			<listitem><para>verify_depth - (int) - see modparam</para></listitem>
@@ -1339,4 +1340,55 @@ modparam("tls", "engine_algorithms", "ALL")
 	        The default is not to set any methods as default. This global param is not supported in the tls config file.
 	</para>
         </section>
+
+	<section id="tls.p.verify_client">
+	<title><varname>verify_client</varname> (string)</title>
+	<para>
+		Replaces verify_certificate and require_certificate modparam and tls.cfg
+		parameters by providing additional opportunistic connection establishment,
+		even with unverifiable certificates (optional_no_ca).
+	</para>
+	<para>
+		This is useful for allowing connections from SIP phones with self-signed
+		certificates, signed by unrecognized root CAs, expired certificates, etc.
+	</para>
+	<para>
+		The following values have respective behaviors:
+	</para>
+	<itemizedlist>
+		<listitem><para>off - no client certificate request performed.</para></listitem>
+		<listitem><para>on - require a verified certificate from the client.</para></listitem>
+		<listitem><para>optional - ask client for certificate. If one is provided, it must
+				be verified. Allowing missing certificate.</para></listitem>
+		<listitem><para>optional_no_ca - ask client for certificate. Opportunistically try to
+				verify certificate. Allow connection regardless of whether there is
+				no certificate or whether certificate is present (verified or not).
+				Note that verification status can be retrieved via $tls_peer_verified.</para></listitem>
+	<itemizedlist>
+	<para>
+		Default value is 'off' (no client certificate request performed).
+	</para>
+	<example>
+		<title>Set <varname>verify_client</varname> modparam parameter</title>
+		<programlisting>
+...
+modparam("tls", "verify_client", "on")
+...
+		</programlisting>
+	</example>
+	<example>
+		<title>Set <varname>verify_client</varname> tls.cfg parameter</title>
+		<programlisting>
+[server:1.2.3.4:5061]
+method = TLSv1
+verify_client = on
+...
+
+[server:5.6.7.8:5061]
+method = TLSv1.2
+verify_client = optional_no_ca
+...
+		</programlisting>
+	</example>
+	</section>
  </section>

--- a/src/modules/tls/doc/params.xml
+++ b/src/modules/tls/doc/params.xml
@@ -1344,9 +1344,9 @@ modparam("tls", "engine_algorithms", "ALL")
 	<section id="tls.p.verify_client">
 	<title><varname>verify_client</varname> (string)</title>
 	<para>
-		Replaces verify_certificate and require_certificate modparam and tls.cfg
-		parameters by providing additional opportunistic connection establishment,
-		even with unverifiable certificates (optional_no_ca).
+		Provides an alternative to verify_certificate and require_certificate modparam and tls.cfg
+		parameters, and creates an additional opportunistic connection establishment option for connections with
+		with unverifiable certificates (optional_no_ca).
 	</para>
 	<para>
 		This is useful for allowing connections from SIP phones with self-signed
@@ -1364,10 +1364,19 @@ modparam("tls", "engine_algorithms", "ALL")
 				verify certificate. Allow connection regardless of whether there is
 				no certificate or whether certificate is present (verified or not).
 				Note that verification status can be retrieved via $tls_peer_verified.</para></listitem>
-	<itemizedlist>
+	</itemizedlist>
 	<para>
 		Default value is 'off' (no client certificate request performed).
 	</para>
+	<para>
+		Recommendation: when using this parameter, do not use verify_certificate or
+		require_certificate parameters. Conversion table is as follows:
+	</para>
+	<itemizedlist>
+		<listitem><para>verify_certificate=0, require_certificate=0 => verify_client="off"</listitem></para>
+		<listitem><para>verify_certificate=1, require_certificate=0 => verify_client="optional"</listitem></para>
+		<listitem><para>verify_certificate=1, require_certificate=1 => verify_client="on"</listitem></para>
+	</itemizedlist>
 	<example>
 		<title>Set <varname>verify_client</varname> modparam parameter</title>
 		<programlisting>
@@ -1379,6 +1388,7 @@ modparam("tls", "verify_client", "on")
 	<example>
 		<title>Set <varname>verify_client</varname> tls.cfg parameter</title>
 		<programlisting>
+...
 [server:1.2.3.4:5061]
 method = TLSv1
 verify_client = on

--- a/src/modules/tls/tls_cfg.c
+++ b/src/modules/tls/tls_cfg.c
@@ -41,6 +41,7 @@ struct cfg_group_tls default_tls_cfg = {
 	0, /* verify_certificate */
 	9, /* verify_depth */
 	0, /* require_certificate */
+	STR_STATIC_INIT("off"), /* verify_client */
 	STR_NULL, /* private_key (default value set in fix_tls_cfg) */
 	STR_NULL, /* ca_list (default value set in fix_tls_cfg) */
 	STR_NULL, /* crl (default value set in fix_tls_cfg) */
@@ -155,6 +156,8 @@ cfg_def_t	tls_cfg_def[] = {
 		" verification go in the search for a trusted CA" },
 	{"require_certificate", CFG_VAR_INT | CFG_READONLY, 0, 1, 0, 0,
 		"if enabled a certificate will be required from clients" },
+	{"verify_client", CFG_VAR_STR | CFG_READONLY, 0, 0, 0, 0,
+		"set to off (default), on, optional, or optional_no_ca" },
 	{"private_key", CFG_VAR_STR | CFG_READONLY, 0, 0, 0, 0,
 		"name of the file containing the private key (pem format), if not"
 		" contained in the certificate file" },

--- a/src/modules/tls/tls_cfg.h
+++ b/src/modules/tls/tls_cfg.h
@@ -46,6 +46,7 @@ struct cfg_group_tls {
 	int verify_cert;
 	int verify_depth;
 	int require_cert;
+	str verify_client;
 	str private_key;
 	str ca_list;
 	str crl;

--- a/src/modules/tls/tls_config.c
+++ b/src/modules/tls/tls_config.c
@@ -154,6 +154,15 @@ static cfg_option_t ksr_tls_token_any[] = {
 };
 
 
+static cfg_option_t verify_client_params[] = {
+	{"off",            .val = TLS_VERIFY_CLIENT_OFF},
+	{"on",             .val = TLS_VERIFY_CLIENT_ON},
+	{"optional",       .val = TLS_VERIFY_CLIENT_OPTIONAL},
+	{"optional_no_ca", .val = TLS_VERIFY_CLIENT_OPTIONAL_NO_CA},
+	{0}
+};
+
+
 static cfg_option_t options[] = {
 	{"method",              .param = methods, .f = cfg_parse_enum_opt},
 	{"tls_method",          .param = methods, .f = cfg_parse_enum_opt},
@@ -173,6 +182,7 @@ static cfg_option_t options[] = {
 	{"server_name",         .f = cfg_parse_str_opt, .flags = CFG_STR_SHMMEM},
 	{"server_name_mode",    .f = cfg_parse_int_opt},
 	{"server_id",           .f = cfg_parse_str_opt, .flags = CFG_STR_SHMMEM},
+	{"verify_client",       .param = verify_client_params, .f = cfg_parse_enum_opt},
 	{0}
 };
 
@@ -199,6 +209,9 @@ static void update_opt_variables(void)
 	options[15].param = &_ksr_tls_domain->server_name;
 	options[16].param = &_ksr_tls_domain->server_name_mode;
 	options[17].param = &_ksr_tls_domain->server_id;
+	for(i = 0; verify_client_params[i].name; i++) {
+		verify_client_params[i].param = &domain->verify_client;
+	}
 }
 
 
@@ -513,6 +526,24 @@ int tls_parse_method(str* method)
 		return -1;
 	}
 #endif
+
+	return opt->val;
+}
+
+/*
+ * Convert TLS verify_client string to integer
+ */
+int tls_parse_verify_client(str* verify_client)
+{
+	cfg_option_t* opt;
+
+	if (!verify_client) {
+		LM_BUG("Invalid parameter value\n");
+		return -1;
+	}
+
+	opt = cfg_lookup_token(verify_client_params, verify_client);
+	if (!opt) return -1;
 
 	return opt->val;
 }

--- a/src/modules/tls/tls_config.c
+++ b/src/modules/tls/tls_config.c
@@ -210,7 +210,7 @@ static void update_opt_variables(void)
 	options[16].param = &_ksr_tls_domain->server_name_mode;
 	options[17].param = &_ksr_tls_domain->server_id;
 	for(i = 0; verify_client_params[i].name; i++) {
-		verify_client_params[i].param = &domain->verify_client;
+		verify_client_params[i].param = &_ksr_tls_domain->verify_client;
 	}
 }
 

--- a/src/modules/tls/tls_config.h
+++ b/src/modules/tls/tls_config.h
@@ -44,5 +44,9 @@ tls_domains_cfg_t* tls_load_config(str* filename);
  */
 int tls_parse_method(str* method);
 
+/*
+ * Convert TLS verify_client string to integer
+ */
+int tls_parse_verify_client(str* verify_client);
 
 #endif /* _TLS_CONFIG_H */

--- a/src/modules/tls/tls_domain.c
+++ b/src/modules/tls/tls_domain.c
@@ -49,6 +49,7 @@ extern EVP_PKEY * tls_engine_private_key(const char* key_id);
 #include "tls_init.h"
 #include "tls_domain.h"
 #include "tls_cfg.h"
+#include "tls_verify.h"
 
 /*
  * ECDHE is enabled only on OpenSSL 1.0.0e and later.
@@ -174,6 +175,7 @@ tls_domain_t* tls_new_domain(int type, struct ip_addr *ip, unsigned short port)
 	d->verify_cert = -1;
 	d->verify_depth = -1;
 	d->require_cert = -1;
+	d->verify_client = -1;
 	return d;
 }
 
@@ -352,6 +354,9 @@ static int ksr_tls_fill_missing(tls_domain_t* d, tls_domain_t* parent)
 	
 	if (d->verify_depth == -1) d->verify_depth = parent->verify_depth;
 	LOG(L_INFO, "%s: verify_depth=%d\n", tls_domain_str(d), d->verify_depth);
+
+	if (d->verify_client == -1) d->verify_client = parent->verify_client;
+	LOG(L_INFO, "%s: verify_client=%d\n", tls_domain_str(d), d->verify_client);
 
 	return 0;
 }
@@ -686,12 +691,12 @@ static int set_verification(tls_domain_t* d)
 	int verify_mode, i;
 	int procs_no;
 
-	if (d->require_cert) {
+	if (d->require_cert || d->verify_client == TLS_VERIFY_CLIENT_ON) {
 		verify_mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 		LOG(L_INFO, "%s: %s MUST present valid certificate\n", 
 			tls_domain_str(d), d->type & TLS_DOMAIN_SRV ? "Client" : "Server");
 	} else {
-		if (d->verify_cert) {
+		if (d->verify_cert || d->verify_client >= TLS_VERIFY_CLIENT_OPTIONAL) {
 			verify_mode = SSL_VERIFY_PEER;
 			if (d->type & TLS_DOMAIN_SRV) {
 				LOG(L_INFO, "%s: IF client provides certificate then it"
@@ -711,12 +716,17 @@ static int set_verification(tls_domain_t* d)
 			}
 		}
 	}
-	
+
 	procs_no=get_max_procs();
 	for(i = 0; i < procs_no; i++) {
-		SSL_CTX_set_verify(d->ctx[i], verify_mode, 0);
+		if (d->verify_client >= TLS_VERIFY_CLIENT_OPTIONAL_NO_CA) {
+			/* Note that actual verification result is available in $tls_peer_verified */
+			SSL_CTX_set_verify(d->ctx[i], verify_mode, verify_callback_unconditional_success);
+		} else {
+			SSL_CTX_set_verify(d->ctx[i], verify_mode, 0);
+		}
 		SSL_CTX_set_verify_depth(d->ctx[i], d->verify_depth);
-		
+
 	}
 	return 0;
 }

--- a/src/modules/tls/tls_domain.h
+++ b/src/modules/tls/tls_domain.h
@@ -91,6 +91,19 @@ enum tls_domain_type {
 #define KSR_TLS_SNM_STRICT 0 /**< Match server_name only */
 #define KSR_TLS_SNM_INCDOM 1 /**< Match server_name and subdomains */
 #define KSR_TLS_SNM_SUBDOM 2 /**< Match subdomains only */
+
+
+/**
+ * TLS "verify_client" options
+ */
+enum tls_verify_client_options {
+	TLS_VERIFY_CLIENT_OFF = 0,
+	TLS_VERIFY_CLIENT_ON = 1,
+	TLS_VERIFY_CLIENT_OPTIONAL = 2,
+	TLS_VERIFY_CLIENT_OPTIONAL_NO_CA = 3
+};
+
+
 /**
  * separate configuration per ip:port
  */
@@ -111,6 +124,7 @@ typedef struct tls_domain {
 	str server_name;
 	int server_name_mode;
 	str server_id;
+	int verify_client;
 	struct tls_domain* next;
 } tls_domain_t;
 

--- a/src/modules/tls/tls_mod.c
+++ b/src/modules/tls/tls_mod.c
@@ -108,6 +108,7 @@ static tls_domain_t mod_params = {
 	{0, 0},           /* Server name (SNI) */
 	0,                /* Server name (SNI) mode */
 	{0, 0},           /* Server id */
+	TLS_VERIFY_CLIENT_OFF,             /* Verify client */
 	0                 /* next */
 };
 
@@ -132,6 +133,7 @@ tls_domain_t srv_defaults = {
 	{0, 0},           /* Server name (SNI) */
 	0,                /* Server name (SNI) mode */
 	{0, 0},           /* Server id */
+	TLS_VERIFY_CLIENT_OFF,             /* Verify client */
 	0                 /* next */
 };
 
@@ -173,6 +175,7 @@ tls_domain_t cli_defaults = {
 	{0, 0},           /* Server name (SNI) */
 	0,                /* Server name (SNI) mode */
 	{0, 0},           /* Server id */
+	TLS_VERIFY_CLIENT_OFF,             /* Verify client */
 	0                 /* next */
 };
 
@@ -206,6 +209,7 @@ static param_export_t params[] = {
 	{"verify_certificate",  PARAM_INT,    &default_tls_cfg.verify_cert  },
 	{"verify_depth",        PARAM_INT,    &default_tls_cfg.verify_depth },
 	{"require_certificate", PARAM_INT,    &default_tls_cfg.require_cert },
+	{"verify_client",       PARAM_STR,    &default_tls_cfg.verify_client},
 	{"private_key",         PARAM_STR,    &default_tls_cfg.private_key  },
 	{"ca_list",             PARAM_STR,    &default_tls_cfg.ca_list      },
 	{"certificate",         PARAM_STR,    &default_tls_cfg.certificate  },
@@ -296,6 +300,7 @@ static tls_domains_cfg_t* tls_use_modparams(void)
 static int mod_init(void)
 {
 	int method;
+	int verify_client;
 
 	if (tls_disable){
 		LM_WARN("tls support is disabled "
@@ -329,6 +334,13 @@ static int mod_init(void)
 	mod_params.cert_file = cfg_get(tls, tls_cfg, certificate);
 	mod_params.cipher_list = cfg_get(tls, tls_cfg, cipher_list);
 	mod_params.server_name = cfg_get(tls, tls_cfg, server_name);
+	/* Convert verify_client parameter to integer */
+	verify_client = tls_parse_verify_client(&cfg_get(tls, tls_cfg, verify_client));
+	if (verify_client < 0) {
+		LM_ERR("Invalid tls_method parameter value\n");
+		return -1;
+	}
+	mod_params.verify_client = verify_client;
 
 	tls_domains_cfg =
 			(tls_domains_cfg_t**)shm_malloc(sizeof(tls_domains_cfg_t*));

--- a/src/modules/tls/tls_rpc.c
+++ b/src/modules/tls/tls_rpc.c
@@ -219,13 +219,14 @@ static void tls_options(rpc_t* rpc, void* c)
 {
 	void* handle;
 	rpc->add(c, "{", &handle);
-	rpc->struct_add(handle, "dSdddSSSSdSSdddddddddddddd",
+	rpc->struct_add(handle, "dSdddSSSSSdSSdddddddddddddd",
 		"force_run",	cfg_get(tls, tls_cfg, force_run),
 		"method",		&cfg_get(tls, tls_cfg, method),
 		"verify_certificate", cfg_get(tls, tls_cfg, verify_cert),
 
 		"verify_depth",		cfg_get(tls, tls_cfg, verify_depth),
 		"require_certificate",	cfg_get(tls, tls_cfg, require_cert),
+		"verify_client",	&cfg_get(tls, tls_cfg, verify_client),
 		"private_key",		&cfg_get(tls, tls_cfg, private_key),
 		"ca_list",			&cfg_get(tls, tls_cfg, ca_list),
 		"certificate",		&cfg_get(tls, tls_cfg, certificate),

--- a/src/modules/tls/tls_verify.c
+++ b/src/modules/tls/tls_verify.c
@@ -127,3 +127,9 @@ int verify_callback(int pre_verify_ok, X509_STORE_CTX *ctx) {
 	LM_NOTICE("tls init - verify return: %d\n", pre_verify_ok);
 	return(pre_verify_ok);
 }
+
+
+int verify_callback_unconditional_success(int pre_verify_ok, X509_STORE_CTX *ctx) {
+	LM_NOTICE("Post-verification callback: unconditional success\n");
+	return 1;
+}

--- a/src/modules/tls/tls_verify.h
+++ b/src/modules/tls/tls_verify.h
@@ -33,4 +33,9 @@ at each step during the chain of certificates (this function
 is not the certificate_verification one!). */
 int verify_callback(int pre_verify_ok, X509_STORE_CTX *ctx);
 
+/* Post-verification callback handler which unconditionally returns 1 (success)
+   Note that actual verification result can be retrieved through TLS PVs after-the-fact
+ */
+int verify_callback_unconditional_success(int pre_verify_ok, X509_STORE_CTX *ctx);
+
 #endif /* _TLS_VERIFY_H */


### PR DESCRIPTION
Note: See below for more info about motivation of this feature.

#### Pre-Submission Checklist
- [ * ] Commit message has the format required by CONTRIBUTING guide
- [ * ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ * ] Each component has a single commit (if not, squash them into one commit)
- [ * ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ * ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [ * ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

This feature aims to replace require_certificate and verify_certificate params with a single option, verify_client: 
* Provides flexibility: require_certificate and verify_certificate are both booleans, so there are only 4 max combinations of params, and only 3 of them make sense (require_certificate=1 and verify_certificate=0 does not).  In contrast, verify_client is a list of enumerated values, which can be more gracefully expanded by adding additional behaviors to the enum.
* Motivation for this feature is to enable optional_no_ca behavior, described in the docbook; Without this feature, that behavior cannot be represented by any combination of require_certificate and verify_certificate.  I figured if I need to add another variable to support desired behavior, it may as well be one that can hold more than just boolean values.
* This feature was inspired from a similar one in Nginx; that software has a similar "ssl_verify_client" option that takes the same "on", "off", "optional", and "optional_no_ca" values, which effectively implement the same feature.  Note that there is no shared code between implementations, and that these behaviors are implemented (in both cases) via a very thin layer of glue code on top of the OpenSSL library.
* Note that the only function definition in tls_verify.c, verify_callback(int pre_verify_ok, X509_STORE_CTX *ctx), has been compiled into the kamailio binary, but apparently not used.  Rather than modify the existing function, I added a simple 1-line function (2 if you count the log message too) to enable this feature.

Please let me know if I can answer any questions.  Thanks!