### PR TITLE
registrar: add new xavp_rcd_mask parameter

### DIFF
--- a/src/modules/registrar/doc/registrar_admin.xml
+++ b/src/modules/registrar/doc/registrar_admin.xml
@@ -809,6 +809,37 @@ modparam("registrar", "xavp_rcd", "ulrcd")
 		</example>
 	</section>
 
+	<section id="registrar.p.xavp_rcd_mask">
+		<title><varname>xavp_rcd_mask</varname> (int)</title>
+		<para>
+			Defines what values to skip when xavp_rcd is stored.
+		</para>
+		<itemizedlist>
+		<listitem><para>1 - <emphasis>ruid</emphasis></para></listitem>
+		<listitem><para>2 - <emphasis>contact</emphasis></para></listitem>
+		<listitem><para>4 - <emphasis>expires</emphasis></para></listitem>
+		<listitem><para>8 - <emphasis>received</emphasis></para></listitem>
+		<listitem><para>16 - <emphasis>path</emphasis></para></listitem>
+		</itemizedlist>
+		<para>
+		<emphasis>
+			Default value is 0 (none).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>xavp_rcd_mask</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+# skip path value
+modparam("registrar", "xavp_rcd_mask", 16)
+...
+# skip path and expires values
+modparam("registrar", "xavp_rcd_mask", 20)
+...
+		</programlisting>
+		</example>
+	</section>
+
 	<section id="registrar.p.gruu_enabled">
 		<title><varname>gruu_enabled</varname> (integer)</title>
 		<para>

--- a/src/modules/registrar/lookup.c
+++ b/src/modules/registrar/lookup.c
@@ -169,29 +169,36 @@ int xavp_rcd_helper(ucontact_t* ptr)
 
 	list = xavp_get(&reg_xavp_rcd, NULL);
 	xavp = list ? &list->val.v.xavp : &new_xavp;
-	memset(&xval, 0, sizeof(sr_xval_t));
-	xval.type = SR_XTYPE_STR;
-	xval.v.s = ptr->ruid;
-	xavp_add_value(&xname_ruid, &xval, xavp);
 
-	if(ptr->received.len > 0) {
+	if(!(reg_xavp_rcd_mask & AVP_RCD_RUID)) {
+		memset(&xval, 0, sizeof(sr_xval_t));
+		xval.type = SR_XTYPE_STR;
+		xval.v.s = ptr->ruid;
+		xavp_add_value(&xname_ruid, &xval, xavp);
+	}
+
+	if(!(reg_xavp_rcd_mask & AVP_RCD_RCV) && (ptr->received.len > 0)) {
 		memset(&xval, 0, sizeof(sr_xval_t));
 		xval.type = SR_XTYPE_STR;
 		xval.v.s = ptr->received;
 		xavp_add_value(&xname_received, &xval, xavp);
 	}
 
-	memset(&xval, 0, sizeof(sr_xval_t));
-	xval.type = SR_XTYPE_STR;
-	xval.v.s = ptr->c;
-	xavp_add_value(&xname_contact, &xval, xavp);
+	if(!(reg_xavp_rcd_mask & AVP_RCD_CNT)) {
+		memset(&xval, 0, sizeof(sr_xval_t));
+		xval.type = SR_XTYPE_STR;
+		xval.v.s = ptr->c;
+		xavp_add_value(&xname_contact, &xval, xavp);
+	}
 
-	memset(&xval, 0, sizeof(sr_xval_t));
-	xval.type = SR_XTYPE_INT;
-	xval.v.i = (int) (ptr->expires - time(0));
-	xavp_add_value(&xname_expires, &xval, xavp);
+	if(!(reg_xavp_rcd_mask & AVP_RCD_EXP)) {
+		memset(&xval, 0, sizeof(sr_xval_t));
+		xval.type = SR_XTYPE_INT;
+		xval.v.i = (int) (ptr->expires - time(0));
+		xavp_add_value(&xname_expires, &xval, xavp);
+	}
 
-	if(ptr->path.len > 0) {
+	if(!(reg_xavp_rcd_mask & AVP_RCD_PATH) && (ptr->path.len > 0)) {
 		memset(&xval, 0, sizeof(sr_xval_t));
 		xval.type = SR_XTYPE_STR;
 		xval.v.s = ptr->path;

--- a/src/modules/registrar/lookup.h
+++ b/src/modules/registrar/lookup.h
@@ -60,6 +60,10 @@ int lookup_to_dset(struct sip_msg* _m, udomain_t* _d, str* _uri);
  */
 int lookup_branches(sip_msg_t *msg, udomain_t *d);
 
+/*! \brief
+ * add xavp with details of the record (ruid, ...)
+ */
+int xavp_rcd_helper(ucontact_t* ptr);
 
 /*! \brief
  * Return true if the AOR in the Request-URI is registered,

--- a/src/modules/registrar/registrar.c
+++ b/src/modules/registrar/registrar.c
@@ -126,7 +126,7 @@ int_str rcv_avp_name;
 
 str reg_xavp_cfg = {0};
 str reg_xavp_rcd = {0};
-
+int reg_xavp_rcd_mask = 0;
 int reg_use_domain = 0;
 
 int sock_flag = -1;
@@ -238,6 +238,7 @@ static param_export_t params[] = {
 	{"path_check_local",   INT_PARAM, &path_check_local                     },
 	{"xavp_cfg",           PARAM_STR, &reg_xavp_cfg     					},
 	{"xavp_rcd",           PARAM_STR, &reg_xavp_rcd     					},
+	{"xavp_rcd_mask",      INT_PARAM, &reg_xavp_rcd_mask   					},
 	{"gruu_enabled",       INT_PARAM, &reg_gruu_enabled    					},
 	{"outbound_mode",      INT_PARAM, &reg_outbound_mode					},
 	{"regid_mode",         INT_PARAM, &reg_regid_mode					},

--- a/src/modules/registrar/registrar.h
+++ b/src/modules/registrar/registrar.h
@@ -67,6 +67,12 @@ extern int contact_max_size; /* configurable using module parameter "contact_max
  *   increases! */
 #define REG_FLOW_TIMER_MAX	999
 
+#define AVP_RCD_RUID	1
+#define AVP_RCD_CNT		2
+#define AVP_RCD_EXP		4
+#define AVP_RCD_RCV		8
+#define AVP_RCD_PATH	16
+
 extern int nat_flag;
 extern int tcp_persistent_flag;
 extern int received_avp;
@@ -96,7 +102,7 @@ extern int sock_flag;
 
 extern str reg_xavp_cfg;
 extern str reg_xavp_rcd;
-
+extern int reg_xavp_rcd_mask;
 extern usrloc_api_t ul;/*!< Structure containing pointers to usrloc functions*/
 
 extern sl_api_t slb;


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to PR #2162

#### Description
As discussed on #2162 with this change it's possible to decide witch xavp_rcd values will be stored using the new module parameter xavp_rcd_mask

Using the same helper function on build_contact() so the behavior is consistant. Before only ruid and expires where stored when build_contact() was called.
