### PR TITLE
dialog: add new dlg_reset_property function

### DIFF
--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -245,7 +245,7 @@ static cmd_export_t cmds[]={
 			0, ANY_ROUTE },
 	{"dlg_set_property", (cmd_function)w_dlg_set_property,1,fixup_spve_null,
 			0, ANY_ROUTE },
-    {"dlg_reset_property", (cmd_function)w_dlg_reset_property,1,fixup_spve_null,
+	{"dlg_reset_property", (cmd_function)w_dlg_reset_property,1,fixup_spve_null,
             0, ANY_ROUTE }, 			
 	{"dlg_remote_profile", (cmd_function)w_dlg_remote_profile, 5, fixup_dlg_remote_profile,
 			0, ANY_ROUTE },
@@ -1342,36 +1342,36 @@ static int ki_dlg_reset_property(sip_msg_t *msg, str *pval)
 	dlg_cell_t *d;
 
 	if(pval->len<=0) {
-			LM_ERR("empty property value\n");
-			return -1;
+		LM_ERR("empty property value\n");
+		return -1;
 	}
 	if ( (dctx=dlg_get_dlg_ctx())==NULL )
-			return -1;
+		return -1;
 
 	if(pval->len==6 && strncmp(pval->s, "ka-src", 6)==0) {
-			dctx->iflags &= ~(DLG_IFLAG_KA_SRC);
-			d = dlg_get_by_iuid(&dctx->iuid);
-			if(d!=NULL) {
-					d->iflags &= ~(DLG_IFLAG_KA_SRC);
-					dlg_release(d);
-			}
+		dctx->iflags &= ~(DLG_IFLAG_KA_SRC);
+		d = dlg_get_by_iuid(&dctx->iuid);
+		if(d!=NULL) {
+			d->iflags &= ~(DLG_IFLAG_KA_SRC);
+			dlg_release(d);
+		}
 	} else if(pval->len==6 && strncmp(pval->s, "ka-dst", 6)==0) {
-			dctx->iflags &= ~(DLG_IFLAG_KA_DST);
-			d = dlg_get_by_iuid(&dctx->iuid);
-			if(d!=NULL) {
-					d->iflags &= ~(DLG_IFLAG_KA_DST);
-					dlg_release(d);
-			}
+		dctx->iflags &= ~(DLG_IFLAG_KA_DST);
+		d = dlg_get_by_iuid(&dctx->iuid);
+		if(d!=NULL) {
+			d->iflags &= ~(DLG_IFLAG_KA_DST);
+			dlg_release(d);
+		}
 	} else if(pval->len==15 && strncmp(pval->s, "timeout-noreset", 15)==0) {
-			dctx->iflags &= ~(DLG_IFLAG_TIMER_NORESET);
-			d = dlg_get_by_iuid(&dctx->iuid);
-			if(d!=NULL) {
-					d->iflags &= ~(DLG_IFLAG_TIMER_NORESET);
-					dlg_release(d);
-			}
+		dctx->iflags &= ~(DLG_IFLAG_TIMER_NORESET);
+		d = dlg_get_by_iuid(&dctx->iuid);
+		if(d!=NULL) {
+			d->iflags &= ~(DLG_IFLAG_TIMER_NORESET);
+			dlg_release(d);
+		}
 	} else {
-			LM_ERR("unknown property value [%.*s]\n", pval->len, pval->s);
-			return -1;
+		LM_ERR("unknown property value [%.*s]\n", pval->len, pval->s);
+		return -1;
 	}
 
 	return 1;
@@ -1386,8 +1386,8 @@ static int w_dlg_reset_property(struct sip_msg *msg, char *prop, char *s2)
 
 	if(fixup_get_svalue(msg, (gparam_t*)prop, &val)!=0)
 	{
-			LM_ERR("no property value\n");
-			return -1;
+		LM_ERR("no property value\n");
+		return -1;
 	}
 
 	return ki_dlg_reset_property(msg, &val);

--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -176,6 +176,7 @@ static int w_dlg_isflagset(struct sip_msg *msg, char *flag, str *s2);
 static int w_dlg_resetflag(struct sip_msg *msg, char *flag, str *s2);
 static int w_dlg_setflag(struct sip_msg *msg, char *flag, char *s2);
 static int w_dlg_set_property(struct sip_msg *msg, char *prop, char *s2);
+static int w_dlg_reset_property(struct sip_msg *msg, char *prop, char *s2);
 static int w_dlg_manage(struct sip_msg*, char*, char*);
 static int w_dlg_bye(struct sip_msg*, char*, char*);
 static int w_dlg_refer(struct sip_msg*, char*, char*);
@@ -244,6 +245,8 @@ static cmd_export_t cmds[]={
 			0, ANY_ROUTE },
 	{"dlg_set_property", (cmd_function)w_dlg_set_property,1,fixup_spve_null,
 			0, ANY_ROUTE },
+    {"dlg_reset_property", (cmd_function)w_dlg_reset_property,1,fixup_spve_null,
+            0, ANY_ROUTE }, 			
 	{"dlg_remote_profile", (cmd_function)w_dlg_remote_profile, 5, fixup_dlg_remote_profile,
 			0, ANY_ROUTE },
 	{"dlg_set_ruri",       (cmd_function)w_dlg_set_ruri,  0, NULL,
@@ -1328,6 +1331,66 @@ static int w_dlg_set_property(struct sip_msg *msg, char *prop, char *s2)
 	}
 
 	return ki_dlg_set_property(msg, &val);
+}
+
+/**
+ *
+ */
+static int ki_dlg_reset_property(sip_msg_t *msg, str *pval)
+{
+	dlg_ctx_t *dctx;
+	dlg_cell_t *d;
+
+	if(pval->len<=0) {
+			LM_ERR("empty property value\n");
+			return -1;
+	}
+	if ( (dctx=dlg_get_dlg_ctx())==NULL )
+			return -1;
+
+	if(pval->len==6 && strncmp(pval->s, "ka-src", 6)==0) {
+			dctx->iflags &= ~(DLG_IFLAG_KA_SRC);
+			d = dlg_get_by_iuid(&dctx->iuid);
+			if(d!=NULL) {
+					d->iflags &= ~(DLG_IFLAG_KA_SRC);
+					dlg_release(d);
+			}
+	} else if(pval->len==6 && strncmp(pval->s, "ka-dst", 6)==0) {
+			dctx->iflags &= ~(DLG_IFLAG_KA_DST);
+			d = dlg_get_by_iuid(&dctx->iuid);
+			if(d!=NULL) {
+					d->iflags &= ~(DLG_IFLAG_KA_DST);
+					dlg_release(d);
+			}
+	} else if(pval->len==15 && strncmp(pval->s, "timeout-noreset", 15)==0) {
+			dctx->iflags &= ~(DLG_IFLAG_TIMER_NORESET);
+			d = dlg_get_by_iuid(&dctx->iuid);
+			if(d!=NULL) {
+					d->iflags &= ~(DLG_IFLAG_TIMER_NORESET);
+					dlg_release(d);
+			}
+	} else {
+			LM_ERR("unknown property value [%.*s]\n", pval->len, pval->s);
+			return -1;
+	}
+
+	return 1;
+}
+
+/**
+ *
+ */
+static int w_dlg_reset_property(struct sip_msg *msg, char *prop, char *s2)
+{
+	str val;
+
+	if(fixup_get_svalue(msg, (gparam_t*)prop, &val)!=0)
+	{
+			LM_ERR("no property value\n");
+			return -1;
+	}
+
+	return ki_dlg_reset_property(msg, &val);
 }
 
 static int w_dlg_set_timeout_by_profile3(struct sip_msg *msg, char *profile,

--- a/src/modules/dialog/doc/dialog_admin.xml
+++ b/src/modules/dialog/doc/dialog_admin.xml
@@ -2376,6 +2376,48 @@ if(has_totag()) {
 </programlisting>
 		</example>
 	</section>
+
+	<section id="dialog.f.dlg_reset_property">
+		<title>
+		<function moreinfo="none">dlg_reset_property(attr)</function>
+		</title>
+		<para>
+			Reset a dialog property - an attribute that enable/disable
+			various behaviours (e.g., sending keep alive requests).
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>attr</emphasis> - name of property. It can be:
+				<itemizedlist>
+					<listitem>
+						'ka-src' - send keep alive OPTION requests to caller
+					</listitem>
+					<listitem>
+						'ka-dst' - send keep alive OPTION requests to callee
+					</listitem>
+					<listitem>
+						'timeout-noreset' - don't reset timeout on in-dialog messages reception
+					</listitem>
+				</itemizedlist>
+			</para>
+		</listitem>
+		</itemizedlist>
+		<para>
+			This function can be used from ANY_ROUTE.
+		</para>
+		<example>
+		<title><function>dlg_reset_property</function> usage</title>
+		<programlisting format="linespecific">
+...
+dlg_reset_property("ka-src");
+dlg_reset_property("ka-dst");
+dlg_reset_property("timeout-noreset");
+...
+
+</programlisting>
+		</example>
+	</section>
 	</section>
 
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
    - new dlg_reset_property() function is added to disable the previously enabled dialog module behaviour.
      e.g. stop sending keep-alive OPTIONS messages.