### PR TITLE
dmq_usrloc: replicate_socket_info using dmq

### DIFF
--- a/src/modules/dmq_usrloc/dmq_usrloc.c
+++ b/src/modules/dmq_usrloc/dmq_usrloc.c
@@ -36,6 +36,7 @@ static int child_init(int);
 
 int dmq_usrloc_enable = 0;
 int _dmq_usrloc_sync = 1;
+int _dmq_usrloc_replicate_socket_info = 0;
 int _dmq_usrloc_batch_size = 0;
 int _dmq_usrloc_batch_msg_contacts = 1;
 int _dmq_usrloc_batch_msg_size = 60000;
@@ -49,6 +50,7 @@ MODULE_VERSION
 static param_export_t params[] = {
 	{"enable", INT_PARAM, &dmq_usrloc_enable},
 	{"sync",   INT_PARAM, &_dmq_usrloc_sync},
+	{"replicate_socket_info",   INT_PARAM, &_dmq_usrloc_replicate_socket_info},
 	{"batch_msg_contacts",   INT_PARAM, &_dmq_usrloc_batch_msg_contacts},
 	{"batch_msg_size",   INT_PARAM, &_dmq_usrloc_batch_msg_size},
 	{"batch_size",   INT_PARAM, &_dmq_usrloc_batch_size},

--- a/src/modules/dmq_usrloc/doc/dmq_usrloc_admin.xml
+++ b/src/modules/dmq_usrloc/doc/dmq_usrloc_admin.xml
@@ -249,6 +249,39 @@ modparam("dmq_usrloc", "usrloc_domain", "my_domain")
 </programlisting>
 		</example>
 	</section>
+	<section id="usrloc_dmq.p.replicate_socket_info">
+		<title><varname>replicate_socket_info</varname> (int)</title>
+		<para>
+			The parameter controls whether the socket replication is active or not.
+			This is important for anycast scenarios.
+			The value can be:
+			<itemizedlist>
+			<listitem>
+			<para>
+				0 - disabled
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				1 - enabled
+			</para>
+			</listitem>
+			</itemizedlist>
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>replicate_socket_info</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dmq_usrloc", "replicate_socket_info", 0)
+...
+</programlisting>
+	</example>
+	</section>
 	</section>
 
 </chapter>


### PR DESCRIPTION
 - replicate_socket_info using dmq through a new modparam
 - useful for anycast scenarios
