### PR TITLE
xhttp_rpc: documentation correction

### DIFF
--- a/src/modules/xhttp_rpc/doc/xhttp_rpc_admin.xml
+++ b/src/modules/xhttp_rpc/doc/xhttp_rpc_admin.xml
@@ -125,7 +125,7 @@ modparam("xhttp_rpc", "xhttp_rpc_root", "http_rpc")
 		<title>Set <varname>xhttp_rpc_buf_size</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("xhttp", "xhttp_rpc_buf_size", 1024)
+modparam("xhttp_rpc", "xhttp_rpc_buf_size", 1024)
 ...
 </programlisting>
 		</example>


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
- The documentation in the README file had the
  wrong module name in the modparam in the
  example for the xhttp_rpc_buf_size parameter.
  Corrected this in section 4.2.

