### PR TITLE
core:tcp allow to handle TCP connections with tcp_accept_haproxy=yes flag even message does not contain PROXY protocol header

### DIFF
--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1109,8 +1109,8 @@ int tcpconn_read_haproxy(struct tcp_connection *c) {
 		return 1; /* EOF? Return "no IP change" in any case */
 	}
 	else {
-		/* Wrong protocol */
-		return -1;
+		/* Wrong protocol*/
+		return 2;
 	}
 
 done:
@@ -1163,10 +1163,12 @@ struct tcp_connection* tcpconn_new(int sock, union sockaddr_union* su,
 	if (unlikely(ksr_tcp_accept_haproxy && state == S_CONN_ACCEPT)) {
 		ret = tcpconn_read_haproxy(c);
 		if (ret == -1) {
-			LM_ERR("invalid PROXY protocol header\n");
+			LM_WARN("invalid PROXY protocol header\n");
 			goto error;
 		} else if (ret == 1) {
 			LM_DBG("PROXY protocol did not override IP addresses\n");
+		} else if (ret == 2) {
+			LM_DBG("PROXY protocol header not found or wrong. can't owerride IP adresses\n");
 		}
 	}
 	print_ip("tcpconn_new: new tcp connection: ", &c->rcv.src_ip, "\n");

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1163,7 +1163,7 @@ struct tcp_connection* tcpconn_new(int sock, union sockaddr_union* su,
 	if (unlikely(ksr_tcp_accept_haproxy && state == S_CONN_ACCEPT)) {
 		ret = tcpconn_read_haproxy(c);
 		if (ret == -1) {
-			LM_WARN("invalid PROXY protocol header\n");
+			LM_ERR("invalid PROXY protocol header\n");
 			goto error;
 		} else if (ret == 1) {
 			LM_DBG("PROXY protocol did not override IP addresses\n");

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1168,7 +1168,7 @@ struct tcp_connection* tcpconn_new(int sock, union sockaddr_union* su,
 		} else if (ret == 1) {
 			LM_DBG("PROXY protocol did not override IP addresses\n");
 		} else if (ret == 2) {
-			LM_WARN("PROXY protocol header not found or wrong. can't owerride IP addresses\n");
+			LM_DBG("PROXY protocol header not found. can't owerride IP addresses\n");
 		}
 	}
 	print_ip("tcpconn_new: new tcp connection: ", &c->rcv.src_ip, "\n");

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1168,7 +1168,7 @@ struct tcp_connection* tcpconn_new(int sock, union sockaddr_union* su,
 		} else if (ret == 1) {
 			LM_DBG("PROXY protocol did not override IP addresses\n");
 		} else if (ret == 2) {
-			LM_DBG("PROXY protocol header not found or wrong. can't owerride IP adresses\n");
+			LM_WARN("PROXY protocol header not found or wrong. can't owerride IP addresses\n");
 		}
 	}
 	print_ip("tcpconn_new: new tcp connection: ", &c->rcv.src_ip, "\n");


### PR DESCRIPTION
Covers setups when kamailio behind the service with HAPROXY protocol support but in other hand it also serves requests from other services that available per direct connection (such as B2BUA in the same local network).

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally

#### Description
- function tcpconn_read_haproxy() returns 2 if PROXY header NOT found. 
- Message about no header shown at the debug level.
- No errors
- TCP connection successfully establishes

