### PR TITLE
sanity: use debug log level when content length header is missing

### DIFF
--- a/src/modules/sanity/sanity.c
+++ b/src/modules/sanity/sanity.c
@@ -582,7 +582,7 @@ int check_cl(sip_msg_t* msg) {
 		}
 		LM_DBG("check_cl passed\n");
 	} else {
-		LM_WARN("content length header missing in request\n");
+		LM_DBG("content length header missing in request\n");
 	}
 
 	return SANITY_CHECK_PASSED;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This is to align behavior with the remaining checks. The example configuration enable the content length sanity check and prior to this change would warn when SIP messages without body were received.