### PR TITLE
tm: t_continue() - do not print error and return error code

### DIFF
--- a/src/modules/tm/t_suspend.c
+++ b/src/modules/tm/t_suspend.c
@@ -189,7 +189,7 @@ int t_continue_helper(unsigned int hash_index, unsigned int label,
 
 	if (t_lookup_ident_filter(&t, hash_index, label, 1) < 0) {
 		set_t(backup_T, backup_T_branch);
-		LM_ERR("active transaction not found\n");
+		LM_WARN("active transaction not found\n");
 		return -1;
 	}
 


### PR DESCRIPTION
 - t_continue() - do not print error and return error code.
- change func to log INFO so errors are not printed twice (once by tm and once by func call)