### PR TITLE
Sipcapture fix hep attributes

### DIFF
--- a/src/modules/sipcapture/hep.c
+++ b/src/modules/sipcapture/hep.c
@@ -493,7 +493,7 @@ int parsing_hepv3_message(char *buf, unsigned int len)
 	ri.bind_address = si;
 
 	if(payload != NULL) {
-		/* and now recieve message */
+		/* and now receive message */
 		if(hg->proto_t->data == 5)
 			receive_logging_json_msg(payload, payload_len, hg, "rtcp_capture");
 		else if(hg->proto_t->data == 32)

--- a/src/modules/sipcapture/sipcapture.c
+++ b/src/modules/sipcapture/sipcapture.c
@@ -2421,7 +2421,7 @@ int raw_capture_rcv_loop(int rsock, int port1, int port2, int ipip)
 			ri.bind_address = si;
 
 
-			/* and now recieve message */
+			/* and now receive message */
 			receive_msg(buf + offset, len, &ri);
 			if(si)
 				pkg_free(si);

--- a/src/modules/sipcapture/sipcapture.c
+++ b/src/modules/sipcapture/sipcapture.c
@@ -3043,14 +3043,6 @@ static int pv_parse_hep_name(pv_spec_p sp, str *in)
 					else
 						goto error;
 				} break;
-		case 6: {
-					if(!strncmp(in->s, "src_ip", 6))
-						sp->pvp.pvn.u.isname.name.n = 2;
-					else if(!strncmp(in->s, "dst_ip", 6))
-						sp->pvp.pvn.u.isname.name.n = 3;
-					else
-						goto error;
-				} break;
 		case 7: {
 					if(!strncmp(in->s, "version", 7))
 						sp->pvp.pvn.u.isname.name.n = 0;
@@ -3073,27 +3065,12 @@ error:
 
 static int pv_get_hep(struct sip_msg *msg, pv_param_t *param, pv_value_t *res)
 {
-	static char sc_buf_ip[IP_ADDR_MAX_STR_SIZE + 12];
-	int sc_buf_ip_len;
-
 	if(param == NULL)
 		return -1;
 
 	switch(param->pvn.u.isname.name.n) {
 		case 0:
 			return pv_get_uintval(msg, param, res, hep_version(msg));
-		case 1:
-			return pv_get_uintval(msg, param, res, hep_version(msg));
-		case 2:
-			sc_buf_ip_len = ip_addr2sbuf(
-					&msg->rcv.src_ip, sc_buf_ip, sizeof(sc_buf_ip) - 1);
-			sc_buf_ip[sc_buf_ip_len] = 0;
-			return pv_get_strlval(msg, param, res, sc_buf_ip, sc_buf_ip_len);
-		case 3:
-			sc_buf_ip_len = ip_addr2sbuf(
-					&msg->rcv.dst_ip, sc_buf_ip, sizeof(sc_buf_ip) - 1);
-			sc_buf_ip[sc_buf_ip_len] = 0;
-			return pv_get_strlval(msg, param, res, sc_buf_ip, sc_buf_ip_len);
 		default:
 			return hepv3_get_chunk(msg, msg->buf, msg->len,
 					param->pvn.u.isname.name.n, param, res);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
`$hep(...)` pseudovariable returns wrong values for keys `src_ip`, `dst_ip` and `0x001`. This patch removes the keys `src_ip` and `dst_ip` (`$si` resp. `$Ri` can be used for these values). `0x001` now correctly returns IP protocol family (`AF_INET`, `AF_INET6` ...).

Needs doc fixes on pseudovariable wiki page.