### PR TITLE
registrar: add use_expired_contacts config param

### DIFF
--- a/src/modules/registrar/config.c
+++ b/src/modules/registrar/config.c
@@ -40,7 +40,8 @@ struct cfg_group_registrar	default_registrar_cfg = {
 		0,	/* retry_after */
 		0,	/* case_sensitive */
 		Q_UNSPECIFIED,	/* default_q */
-		1	/* append_branches */
+		1,	/* append_branches */
+		0	/* use_expired_contacts */
 	};
 
 void	*registrar_cfg = &default_registrar_cfg;
@@ -68,5 +69,7 @@ cfg_def_t	registrar_cfg_def[] = {
 		"The parameter represents default q value for new contacts."}, /* Q_UNSPECIFIED is -1 */
 	{"append_branches",	CFG_VAR_INT ,			0, 0, 0, 0,
 		"If set to 1(default), lookup will put all contacts found in msg structure"},
+	{"use_expired_contacts",CFG_VAR_INT ,			0, 0, 0, 0,
+		"Toggles using expired contacts as if they were active."},
 	{0, 0, 0, 0, 0, 0}
 };

--- a/src/modules/registrar/config.h
+++ b/src/modules/registrar/config.h
@@ -36,6 +36,7 @@ struct cfg_group_registrar {
 	unsigned int	case_sensitive;
 	qvalue_t	default_q;
 	unsigned int	append_branches;
+	unsigned int	use_expired_contacts;
 };
 
 extern struct cfg_group_registrar	default_registrar_cfg;

--- a/src/modules/registrar/doc/registrar_admin.xml
+++ b/src/modules/registrar/doc/registrar_admin.xml
@@ -1100,6 +1100,46 @@ request_route {
 		</programlisting>
 		</example>
 	</section>
+
+
+	<section id="registrar.p.use_expired_contacts">
+		<title><varname>use_expired_contacts</varname> (int)</title>
+
+		<para>
+			Allow/Disallow the usage of the expired contacts.
+		</para>
+
+		<itemizedlist>
+		<listitem>
+			<para>
+				<emphasis>0</emphasis> Disallow the usage of the expired contacts.
+			</para>
+		</listitem>
+		<listitem>
+			<para>
+				<emphasis>1</emphasis> Allow the usage of the expired contacts.
+			</para>
+		</listitem>
+		</itemizedlist>
+
+		<para>
+		<emphasis>
+			Default value is 0 (Disallow).
+		</emphasis>
+		</para>
+
+		<example>
+		<title>Set <varname>use_expired_contacts</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("registrar", "use_expired_contacts", 1)
+...
+
+kamcmd cfg.set_now_int registrar use_expired_contacts 1
+kamcmd cfg.set_now_int registrar use_expired_contacts 0
+		</programlisting>
+		</example>
+	</section>
 	</section>
 
 	

--- a/src/modules/registrar/lookup.c
+++ b/src/modules/registrar/lookup.c
@@ -304,7 +304,7 @@ int lookup_helper(struct sip_msg* _m, udomain_t* _d, str* _uri, int _mode)
 		ret = -1;
 		/* look first for an un-expired and suported contact */
 		while (ptr) {
-			if(VALID_CONTACT(ptr,act_time)) {
+			if(VALID_CONTACT(ptr,act_time) || cfg_get(registrar,registrar_cfg,use_expired_contacts)) {
 				if(allowed_method(_m,ptr)) {
 					/* match on instance, if pub-gruu */
 					if(inst.len>0) {
@@ -346,7 +346,7 @@ int lookup_helper(struct sip_msg* _m, udomain_t* _d, str* _uri, int _mode)
 		aor = *ptr->aor;
 		/* test if not expired and contact with suported method */
 		if(ptr) {
-			if(!(VALID_CONTACT(ptr,act_time))) {
+			if(!(VALID_CONTACT(ptr,act_time) || cfg_get(registrar,registrar_cfg,use_expired_contacts))) {
 				goto done;
 			} else if(!allowed_method(_m,ptr)) {
 				ret=-2;
@@ -485,7 +485,7 @@ int lookup_helper(struct sip_msg* _m, udomain_t* _d, str* _uri, int _mode)
 	if (!cfg_get(registrar, registrar_cfg, append_branches)) goto done;
 
 	for( ; ptr ; ptr = ptr->next ) {
-		if (VALID_CONTACT(ptr, act_time) && allowed_method(_m, ptr)
+		if ((VALID_CONTACT(ptr, act_time) || cfg_get(registrar,registrar_cfg,use_expired_contacts)) && allowed_method(_m, ptr)
 				&& reg_lookup_filter_match(ptr)) {
 			path_dst.len = 0;
 			if(ptr->path.s && ptr->path.len) {
@@ -847,7 +847,7 @@ int registered4(struct sip_msg* _m, udomain_t* _d, str* _uri, int match_flag,
 
 		get_act_time();
 		for (ptr = r->contacts; ptr; ptr = ptr->next) {
-			if(!VALID_CONTACT(ptr, act_time)) continue;
+			if(!(VALID_CONTACT(ptr, act_time) || cfg_get(registrar,registrar_cfg,use_expired_contacts))) continue;
 			if (match_callid.s && /* optionally enforce tighter matching w/ Call-ID */
 				match_callid.len > 0 &&
 				(match_callid.len != ptr->callid.len ||

--- a/src/modules/registrar/registrar.c
+++ b/src/modules/registrar/registrar.c
@@ -248,6 +248,7 @@ static param_export_t params[] = {
 	{"event_callback",     PARAM_STR, &reg_event_callback				},
 	{"lookup_filter_mode", INT_PARAM, &reg_lookup_filter_mode			},
 	{"min_expires_mode",   PARAM_INT, &reg_min_expires_mode				},
+	{"use_expired_contacts",  INT_PARAM, &default_registrar_cfg.use_expired_contacts	 },
 	{0, 0, 0}
 };
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

    Allow/Disallow the usage of the expired contacts.
    
    Useful when some problems happen with new REGISTERs; allow the usage
    of old REGISTERed contacts.
    
    Default value is 0 meaning "disallow the usage of the expired contacts".
    (no changes to existing behavior)
    
    Value can be set dinamically via:
      kamcmd cfg.set_now_int registrar use_expired_contacts 1
