### PR TITLE
corex: check not in SHM before PKG free for path

### DIFF
--- a/src/core/parser/msg_parser.c
+++ b/src/core/parser/msg_parser.c
@@ -806,11 +806,14 @@ int set_path_vector(struct sip_msg* msg, str* path)
 
 void reset_path_vector(struct sip_msg* const msg)
 {
-	if (msg->path_vec.s) {
-		pkg_free(msg->path_vec.s);
+	if (!shm_address_in(msg->path_vec.s)) {
+		if (msg->path_vec.s)
+			pkg_free(msg->path_vec.s);
+		msg->path_vec.s = 0;
+		msg->path_vec.len = 0;
+	} else {
+		LM_WARN("Found path_vec that is not in pkg mem!\n");
 	}
-	msg->path_vec.s = 0;
-	msg->path_vec.len = 0;
 }
 
 

--- a/src/modules/corex/corex_lib.c
+++ b/src/modules/corex/corex_lib.c
@@ -63,11 +63,13 @@ int corex_append_branch(sip_msg_t *msg, str *uri, str *qv)
 		msg->dst_uri.len = 0;
 
 		/* if this is a cloned message, don't free the path vector as it was copied into shm memory and will be freed as contiguous block*/
-		if (!(msg->msg_flags&FL_SHM_CLONE)) {
-			if(msg->path_vec.s!=0)
+		if (!shm_address_in(msg->path_vec.s)) {
+			if (msg->path_vec.s)
 				pkg_free(msg->path_vec.s);
 			msg->path_vec.s = 0;
 			msg->path_vec.len = 0;
+		} else {
+			LM_WARN("Found path_vec that is not in pkg mem!\n");
 		}
 	}
 


### PR DESCRIPTION
Do the same for reset_path_vector() in core msg parser.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #1144

#### Description
<!-- Describe your changes in detail -->

Hi,

Please have a look on this old discussion: https://lists.kamailio.org/pipermail/sr-dev/2018-July/047190.html

We have been using the shm_address_in() since then and no other apparent issue found since then.

Please let me know what you think. Also let me know if I can backport this to 5.3.

Thank you,
Stefan