### PR TITLE
presence: add delete_same_subs modparam

### DIFF
--- a/src/modules/presence/doc/presence_admin.xml
+++ b/src/modules/presence/doc/presence_admin.xml
@@ -951,6 +951,26 @@ modparam("presence", "pres_subs_mode", 0)
 	</example>
 </section>
 
+<section id="presence.p.delete_same_subs">
+	<title><varname>delete_same_subs</varname> (integer)</title>
+	<para>
+		Enable deleting of subscriptions with the same presence uri and callid.
+	</para>
+	<para>
+		<emphasis>
+			Default value is 0 (disabled behavior).
+		</emphasis>
+	</para>
+	<example>
+		<title>Set <varname>delete_same_subs</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("presence", "delete_same_subs", 1)
+...
+</programlisting>
+	</example>
+</section>
+
 </section>
 
 <section>

--- a/src/modules/presence/hash.h
+++ b/src/modules/presence/hash.h
@@ -56,6 +56,8 @@ struct presentity;
 #define PKG_MEM_TYPE 1 << 1
 #define SHM_MEM_TYPE 1 << 2
 
+extern int pres_delete_same_subs;
+
 /* subscribe hash entry */
 struct subscription;
 
@@ -135,5 +137,7 @@ int update_phtable(struct presentity *presentity, str pres_uri, str body);
 int delete_phtable(str *pres_uri, int event);
 
 void destroy_phtable(void);
+
+int delete_db_subs(str* to_tag, str* from_tag, str* callid);
 
 #endif

--- a/src/modules/presence/presence.c
+++ b/src/modules/presence/presence.c
@@ -169,6 +169,7 @@ str pres_xavp_cfg = {0};
 int pres_retrieve_order = 0;
 str pres_retrieve_order_by = str_init("priority");
 int pres_enable_dmq = 0;
+int pres_delete_same_subs = 0;
 
 int db_table_lock_type = 1;
 db_locking_t db_table_lock = DB_LOCKING_WRITE;
@@ -245,6 +246,7 @@ static param_export_t params[]={
 	{ "cseq_offset",            PARAM_INT, &pres_cseq_offset},
 	{ "enable_dmq",             PARAM_INT, &pres_enable_dmq},
 	{ "pres_subs_mode",         PARAM_INT, &_pres_subs_mode},
+	{ "delete_same_subs",       PARAM_INT, &pres_delete_same_subs},
 	{0,0,0}
 };
 /* clang-format on */


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

We have some user agents that make another subscribe with the same callid, when IP changes. Need to delete the old subscription in that case.