### PR TITLE
Small portability fixes (NetBSD)

### DIFF
--- a/src/Makefile.defs
+++ b/src/Makefile.defs
@@ -2056,7 +2056,7 @@ ifeq ($(OS), netbsd)
 		C_DEFS+=-DHAVE_SELECT
 	endif
 	YACC=yacc
-	LIBS=
+	LIBS=-lm
 endif
 
 # OS X support, same as freebsd

--- a/src/Makefile.defs
+++ b/src/Makefile.defs
@@ -210,9 +210,18 @@ endif
 
 endif
 
+# dlopen requires -ldl on some systems, but not others.  Until there
+# is clarity on which require -ldl, add just enough ifeq to fix
+# systems known not to use it.
+ifeq ($(OS), netbsd)
+LIBDL=""
+else
+LIBDL="-ldl"
+endif
+
 ifeq ($(LIBSSL_SET_MUTEX_SHARED), 1)
 CC_PMUTEX_OPTS = -pthread -DKSR_PTHREAD_MUTEX_SHARED
-LD_PMUTEX_OPTS = -pthread -rdynamic -ldl -Wl,-Bsymbolic-functions
+LD_PMUTEX_OPTS = -pthread -rdynamic $(LIBDL) -Wl,-Bsymbolic-functions
 else
 CC_PMUTEX_OPTS =
 LD_PMUTEX_OPTS =


### PR DESCRIPTION
#### Pre-Submission Checklist
- [ x] Commit message has the format required by CONTRIBUTING guide
- [ x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ x] Each component has a single commit (if not, squash them into one commit)
- [ x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ x] PR should be backported to stable branches (5.3 would be nice; earlier doesn't help me)
- [x] Tested changes locally (with these, the build gets vastly further)

#### Description
This PR has two changes for building on NetBSD.

One is simply adding -lm to the link line for kamailio, as math functions are used.

The other is changing the use of -ldl to a variable, leaving that at -ldl most places, and setting it to empty on NetBSD.  (NetBSD does not have a /usr/lib/libdl.* and dlopen does not require any link line arguments.)

I am pretty sure that my changes won't affect the build on non-NetBSD.

Thanks,
Greg