### PR TITLE
Fix returning multiple IP's for a cached DNS entry

### DIFF
--- a/src/core/dns_cache.c
+++ b/src/core/dns_cache.c
@@ -2304,6 +2304,7 @@ inline static struct hostent* dns_entry2he(struct dns_hash_entry* e)
 						return 0;
 				}
 				memcpy(p_addr[i], ip, len);
+				rr_no++;
 	}
 	if (i==0){
 		LM_DBG("no good records found (%d) for %.*s (%d)\n",


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
The method `dns_entry2he` was returning 10 `hostent` structures, containing the same record, because the rr counter was never updated (10 being the value of `DNS_HE_MAX_ADDR`).

With this fix, the cache correctly returns all records found by the resolver.

In the documentation of `dns_int_match_ip`, it says:
>> At this moment, the function might not check all the IP addresses as returned by dns_sys_match_ip(), because the internal resolver targets to discover the first address to be used for relaying SIP traffic.

I believe that with this patch, `dns_int_match_ip` now also works for DNS entries with multiple values. I'm not sure about mixed ipv4/ipv6 though.