### PR TITLE
kamctl: added secfilter to dbtext

### DIFF
--- a/utils/kamctl/dbtext/kamailio/secfilter
+++ b/utils/kamctl/dbtext/kamailio/secfilter
@@ -1,0 +1,1 @@
+id(int,auto) action(int) type(int) data(string)

--- a/utils/kamctl/dbtext/kamailio/version
+++ b/utils/kamctl/dbtext/kamailio/version
@@ -49,6 +49,7 @@ rls_watchers:3
 rtpengine:1
 rtpproxy:1
 sca_subscriptions:2
+secfilter:1
 silo:8
 sip_trace:4
 speed_dial:2


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Added secfilter module scheme to dbtext, as per using `kamdbctl create` with DBTEXT, was getting following error
```
cp: cannot stat '/usr/share/kamailio//dbtext/kamailio/secfilter': No such file or directory
```
With this patch error is gone. Secfilter DBTEXT scheme is taken from SQLite scheme.
