### PR TITLE
bugfix IMS_Rx dialog callback

### DIFF
--- a/src/modules/ims_dialog/dlg_cb.c
+++ b/src/modules/ims_dialog/dlg_cb.c
@@ -100,15 +100,10 @@ void destroy_dlg_callbacks(unsigned int types)
 	}
 }
 
-int register_dlgcb_nodlg(str *callid, str *ftag, str *ttag, 
-                        int types, dialog_cb f,
+
+int register_dlgcb_nodlg(struct dlg_cell *dlg, int types, dialog_cb f,
                         void *param, param_free_cb ff )
 {
-    struct dlg_cell *dlg;
-    
-    unsigned int dir = DLG_DIR_NONE;
-    dlg = get_dlg(callid, ftag, ttag, &dir); //increments ref count!
-    
     if (!dlg) {
         LM_ERR("Can't find dialog to register callback\n");
         return -1;

--- a/src/modules/ims_dialog/dlg_cb.h
+++ b/src/modules/ims_dialog/dlg_cb.h
@@ -51,8 +51,7 @@ typedef void (param_free_cb) (void *param);
 typedef int (*ims_register_dlgcb_f)(struct dlg_cell* dlg, int cb_types,
 		dialog_cb f, void *param, param_free_cb ff);
 
-typedef int (*ims_register_dlgcb_nodlg_f)(str *callid, str *ftag, str *ttag,
-		int cb_types, dialog_cb f, void *param, param_free_cb ff);
+typedef int (*ims_register_dlgcb_nodlg_f)(struct dlg_cell* dlg, int cb_types, dialog_cb f, void *param, param_free_cb ff);
 
 /* method to set a variable within a dialog */
 //typedef int (*set_dlg_variable_f)( struct dlg_cell* dlg,
@@ -103,7 +102,7 @@ void destroy_dlg_callbacks(unsigned int type);
 
 void destroy_dlg_callbacks_list(struct dlg_callback *cb);
 
-int register_dlgcb_nodlg(str *callid, str *ftag, str *ttag, int types, dialog_cb f, void *param, param_free_cb ff );
+int register_dlgcb_nodlg(struct dlg_cell* dlg, int types, dialog_cb f, void *param, param_free_cb ff);
 int register_dlgcb( struct dlg_cell* dlg, int types, dialog_cb f, void *param, param_free_cb ff);
 
 void run_create_callbacks(struct dlg_cell *dlg, struct sip_msg *msg);

--- a/src/modules/ims_dialog/dlg_handlers.c
+++ b/src/modules/ims_dialog/dlg_handlers.c
@@ -1965,4 +1965,3 @@ struct dlg_cell *dlg_get_msg_dialog(sip_msg_t *msg) {
     return dlg;
 }
 
-

--- a/src/modules/ims_qos/ims_qos_mod.c
+++ b/src/modules/ims_qos/ims_qos_mod.c
@@ -1095,6 +1095,13 @@ static int w_rx_aar(struct sip_msg *msg, char *route, char* dir, char *c_id, int
 				saved_t_data->aar_update = 1; //this is an update aar - we set this so on async_aar we know this is an update and act accordingly
 		}
 
+                dlg = dlgb.get_dlg(msg);
+                if (!dlg) {
+                    LM_ERR("Unable to find dialog and cannot do Rx without it\n");
+                    goto error;
+                }
+                saved_t_data->dlg = dlg;
+
 		LM_DBG("Suspending SIP TM transaction\n");
 		if (tmb.t_suspend(msg, &saved_t_data->tindex, &saved_t_data->tlabel) != 0) {
 				LM_ERR("failed to suspend the TM processing\n");

--- a/src/modules/ims_qos/rx_aar.c
+++ b/src/modules/ims_qos/rx_aar.c
@@ -176,8 +176,7 @@ void async_aar_callback(int is_timeout, void *param, AAAMessage *aaa, long elaps
             passed_rx_session_id->len = 0;
             STR_SHM_DUP(*passed_rx_session_id, aaa->sessionId->data, "cb_passed_rx_session_id");
             LM_DBG("passed rx session id [%.*s]", passed_rx_session_id->len, passed_rx_session_id->s);
-
-            dlgb.register_dlgcb_nodlg(&data->callid, &data->ftag, &data->ttag, DLGCB_TERMINATED | DLGCB_DESTROY | DLGCB_EXPIRED | DLGCB_RESPONSE_WITHIN | DLGCB_CONFIRMED | DLGCB_FAILED, callback_dialog, (void*) (passed_rx_session_id), free_dialog_data);
+            dlgb.register_dlgcb_nodlg( data->dlg, DLGCB_TERMINATED | DLGCB_DESTROY | DLGCB_EXPIRED | DLGCB_RESPONSE_WITHIN | DLGCB_CONFIRMED | DLGCB_FAILED, callback_dialog, (void*) (passed_rx_session_id), free_dialog_data);
         }
         result = CSCF_RETURN_TRUE;
     } else {

--- a/src/modules/ims_qos/rx_aar.h
+++ b/src/modules/ims_qos/rx_aar.h
@@ -72,6 +72,7 @@ typedef struct saved_transaction {
         str ftag;
         str ttag;
 	unsigned int aar_update;
+        struct dlg_cell* dlg;
 } saved_transaction_t;
 
 typedef struct saved_transaction_local {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->
ims_dialog bugfix for registering dialog callbacks
ims_qos bugfix for Rx register dialog callback

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches --> 5.3
- [x] Tested changes locally --> Tested locally based on 5.1.6
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
ims_dialog bugfix for registering dialog callbacks

In Rx scenarios of parallel forking (several INVITEs with same CALLID
and FROMTAG sent to PCSCF) and INVITE for orig and term handled in
same PCSCF (means also INVITEs with identical  CALLID and FROMTAG) the wrong
dialog is selected for registering the callback (i.e. the callback
for sending STR) when 200OK from terminator is processed.
Root cause is that dialog is searched with callid-fromtag-totag but at
the time of dialog insertion (processing of INVITE) no totag is available.
fix is to get ctx dialog at 200OK processing before suspending the
transaction - save dialog until AAA is received - use this dialog for
registering the STR callback.

ims_qos bugfix for Rx register dialog callback

In some scenarios like parallel forking several INVITE with identical
CALLID and FROMTAG sent to PCSCF which inserts dialogues for each INVITE.
When 200OK is received in PCSCF the dialog callback must be registered
for the respective dialog. Currently sometimes the wrong dialog is selected
by searching with CALLID FROMTAG and TOTAG thus leading to problem
no STR is sent at BYE. Fix is to pickup the right dialog before suspending
the transaction during AAR/AAA processing and reuse this saved dialog
after AAA reception for registering the dialog callback.
