### PR TITLE
kex: added process description for rpc command pkg.stats

### DIFF
--- a/src/modules/kex/pkg_stats.c
+++ b/src/modules/kex/pkg_stats.c
@@ -240,7 +240,7 @@ static void rpc_pkg_stats(rpc_t* rpc, void* ctx)
 				_pkg_proc_stats_list[i].total_size = _pkg_proc_stats_list[0].total_size;
 				_pkg_proc_stats_list[i].rank = PROC_NOCHLDINIT;
 			}
-			if(rpc->struct_add(th, "dddddddd",
+			if(rpc->struct_add(th, "dddddddds",
 							"entry",     i,
 							"pid",       _pkg_proc_stats_list[i].pid,
 							"rank",      _pkg_proc_stats_list[i].rank,
@@ -248,7 +248,8 @@ static void rpc_pkg_stats(rpc_t* rpc, void* ctx)
 							"free",      _pkg_proc_stats_list[i].available,
 							"real_used", _pkg_proc_stats_list[i].real_used,
 							"total_size",  _pkg_proc_stats_list[i].total_size,
-							"total_frags", _pkg_proc_stats_list[i].total_frags
+							"total_frags", _pkg_proc_stats_list[i].total_frags,
+							"desc",pt[i].desc
 						)<0)
 			{
 				rpc->fault(ctx, 500, "Internal error creating rpc");


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Minor addition to output of RPC command pkg.stats, the description available next to PID and its memory utilization will help during monitoring of memory utilization(or leaks) by specific modules. Without name printed the PID was required to be matched with the output of "kamctl ps"

**Old output**:
```
{
        entry: 2
        pid: 13723
        used: 2616752
        free: 13180048
        real_used: 3597168
        total_size: 16777216
        total_frags: 2
}
```

**New output:**
```
{
        entry: 14
        pid: 29413
        rank: -1
        used: 2615808
        free: 13181200
        real_used: 3596016
        total_size: 16777216
        total_frags: 1
        desc: USRLOC Timer
}
```
