### PR TITLE
siptrace: safety check for transaction when checking ACK

### DIFF
--- a/src/modules/siptrace/siptrace.c
+++ b/src/modules/siptrace/siptrace.c
@@ -874,16 +874,18 @@ static int sip_trace_helper(sip_msg_t *msg, dest_info_t *dst, str *duri,
 			orig_t = tmb.t_gett();
 			if(tmb.t_lookup_request(msg,0,&canceled)) {
 				t_invite = tmb.t_gett();
-				if (t_invite->uas.request->msg_flags & FL_SIPTRACE) {
-					LM_DBG("Transaction is already been traced, skipping.\n");
-					ret = 1;
+				if (t_invite!=T_NULL_CELL) {
+					if (t_invite->uas.request->msg_flags & FL_SIPTRACE) {
+						LM_DBG("Transaction is already been traced, skipping.\n");
+						ret = 1;
+					}
+					tmb.t_release_transaction( t_invite );
+					tmb.t_unref(msg);
 				}
-				tmb.t_release_transaction( t_invite );
-				tmb.t_unref(msg);
-				tmb.t_sett(orig_t, T_BR_UNDEFINED);
-				if (ret)
-					return 1;
 			}
+			tmb.t_sett(orig_t, T_BR_UNDEFINED);
+			if (ret)
+				return 1;
 		}
 
 		if (trace_type == SIPTRACE_DIALOG && dlgb.get_dlg == NULL) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Testing with moderate load I had a crash in siptrace, in the newly added check for ACK for negative replies. Analyzing the core, the crash was caused by the invite transaction being 0x0 when t_gett is called after t_lookup_request. I was not able to reproduce it (how can t_lookup_request return 1 and then the transaction being 0x0?), but I've added a check to avoid crashing.