### PR TITLE
dialog: add dialog init, start end end timestamps to the output of dl…

### DIFF
--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -3075,7 +3075,7 @@ static void rpc_dlg_briefing(rpc_t *rpc, void *c)
 				rpc->fault(c, 500, "Failed to create the structure");
 				return;
 			}
-			if(rpc->struct_add(h, "ddSSSSSd",
+			if(rpc->struct_add(h, "ddSSSSSdddd",
 					"h_entry", dlg->h_entry,
 					"h_id", dlg->h_id,
 					"from_uri", &dlg->from_uri,
@@ -3083,6 +3083,9 @@ static void rpc_dlg_briefing(rpc_t *rpc, void *c)
 					"call-id", &dlg->callid,
 					"from_tag", &dlg->tag[DLG_CALLER_LEG],
 					"to_tag", &dlg->tag[DLG_CALLER_LEG],
+					"init_ts", dlg->init_ts,
+					"start_ts", dlg->start_ts,
+					"end_ts", dlg->end_ts,
 					"state", dlg->state) < 0) {
 				rpc->fault(c, 500, "Failed to add fields");
 				return;


### PR DESCRIPTION
…g.briefing

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
IN some scenarios I found useful to have the timestamps (init, start, end) of the dialog as output of the dlg.briefing command.