### PR TITLE
app_python3: update Python3 detection mechanism

### DIFF
--- a/src/modules/app_python3/Makefile
+++ b/src/modules/app_python3/Makefile
@@ -11,18 +11,16 @@ NAME=app_python3.so
 # but no testing has been done with that.
 PYTHON3?=python3
 
-PYTHON3_VERSION=${shell ${PYTHON3} -c "import distutils.sysconfig;print(distutils.sysconfig.get_config_var('VERSION'))"}
-PYTHON3_LIBDIR=${shell ${PYTHON3} -c "import distutils.sysconfig;print(distutils.sysconfig.get_config_var('LIBDIR'))"}
-PYTHON3_LDFLAGS=${shell ${PYTHON3} -c "import distutils.sysconfig;print(distutils.sysconfig.get_config_var('LINKFORSHARED'))"}
-PYTHON3_INCDIR=${shell ${PYTHON3} -c "import distutils.sysconfig;print(distutils.sysconfig.get_python_inc())"}
-
-LIBS=${shell ${PYTHON3}-config --ldflags}
+LIBS=${shell \
+	tmp_py3_libs=$$(${PYTHON3}-config --ldflags --embed) || \
+	tmp_py3_libs=$$(${PYTHON3}-config --ldflags); \
+	echo $$tmp_py3_libs}
 
 ifeq ($(OS), freebsd)
 LIBS+=-pthread
 endif
 
-DEFS+=-I${PYTHON3_INCDIR}
+DEFS+=${shell ${PYTHON3}-config --includes}
 
 include ../../Makefile.modules
 


### PR DESCRIPTION
This commit

  - removes the python calls whose output is never actually used.

  - changes the include discovery to use python3(.x)-config. This is
    preferable because it also works for cross-compiling. Calling
    python3(.x) directly will always provide host flags, which for
    cross-compiling is not feasible.

  - updates LDFLAGS discovery to also work with >= Python 3.8. To
    achieve this python3(.x)-config is first run with the argument
    "--embed". If this does not succeed (exit status 1)
    python3(.x)-config is run again without "--embed". This is the
    method suggested by Python upstream to provide backwards
    compatibility. See [1] for more details.

[1] https://docs.python.org/3/whatsnew/3.8.html

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Hi all,

While trying to get app_python3 going on OpenWrt I stumbled over this. We're cross-compiling and I got the wrong includes (host includes instead of target includes).

And then there was also the "-lpython3.x" missing because we're using python 3.8 which doesn't provide this linker flags by default anymore. So once I tried to load the module on the target device it threw an error:

```
Fri Apr 10 18:52:13 2020 daemon.err kamailio[15622]:  0(15622) ERROR: <core> [core/sr_module.c:512]: load_module(): could not open module </usr/lib/kamailio/modules/app_python3.so>: Error relocating /usr/lib/kamailio/modules/app_python3.so: PyTuple_New: symbol not found
Fri Apr 10 18:52:13 2020 daemon.err kamailio[15622]:  0(15622) CRITICAL: <core> [core/cfg.y:3543]: yyerror_at(): parse error in config file /etc/kamailio/kamailio.cfg, line 124, column 12-27: failed to load module
```

This pull requested fixes this.

Kind regards,
Seb