### PR TITLE
KEMI: add support for array and dict datatypes

### DIFF
--- a/src/core/kemi.c
+++ b/src/core/kemi.c
@@ -2393,6 +2393,34 @@ void sr_kemi_xval_null(sr_kemi_xval_t *xval, int rmode)
 /**
  *
  */
+void sr_kemi_dict_item_free(sr_kemi_dict_item_t *item)
+{
+	sr_kemi_dict_item_t *v;
+
+	while(item) {
+		if (item->vtype == SR_KEMIP_ARRAY || item->vtype == SR_KEMIP_DICT) {
+			sr_kemi_dict_item_free(item->v.dict);
+		}
+		v = item;
+		item = item->next;
+		pkg_free(v);
+	}
+}
+
+/**
+ *
+ */
+void sr_kemi_xval_free(sr_kemi_xval_t *xval)
+{
+	if(xval && (xval->vtype == SR_KEMIP_ARRAY || xval->vtype == SR_KEMIP_DICT))
+	{
+		sr_kemi_dict_item_free(xval->v.dict);
+	}
+}
+
+/**
+ *
+ */
 static sr_kemi_xval_t* sr_kemi_pv_get_mode(sip_msg_t *msg, str *pvn, int rmode)
 {
 	pv_spec_t *pvs;

--- a/src/core/kemi.h
+++ b/src/core/kemi.h
@@ -32,6 +32,8 @@
 #define SR_KEMIP_BOOL	(1<<2)	/* type boolean (0/1) */
 #define SR_KEMIP_XVAL	(1<<3)	/* type extended value (integer, str*, ...) */
 #define SR_KEMIP_NULL	(1<<4)	/* type NULL */
+#define SR_KEMIP_DICT	(1<<5)	/* type dictionary */
+#define SR_KEMIP_ARRAY	(1<<6)	/* type array */
 
 #define SR_KEMI_FALSE	0
 #define SR_KEMI_TRUE	1
@@ -66,11 +68,24 @@ typedef union {
 	str s;
 } sr_kemi_val_t;
 
+typedef struct sr_kemi_dict_item
+{
+	struct sr_kemi_dict_item *next;
+	str name;
+	int vtype;
+	union {
+		int n;
+		str s;
+		struct sr_kemi_dict_item *dict;
+	} v;
+} sr_kemi_dict_item_t;
+
 typedef struct sr_kemi_xval {
 	int vtype;
 	union {
 		int n;
 		str s;
+		sr_kemi_dict_item_t *dict;
 	} v;
 } sr_kemi_xval_t;
 
@@ -208,5 +223,5 @@ sr_kemi_t* sr_kemi_exports_get_pv(void);
 #define SR_KEMI_XVAL_NULL_PRINT 1
 #define SR_KEMI_XVAL_NULL_EMPTY 2
 void sr_kemi_xval_null(sr_kemi_xval_t *xval, int rmode);
-
+void sr_kemi_xval_free(sr_kemi_xval_t *xval);
 #endif


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to https://lists.kamailio.org/pipermail/sr-dev/2020-April/056481.html

#### Description
Added ARRAY and DICT data types and implement support in app_lua
