### PR TITLE
Add iteration by all DNS NAPTR records

### DIFF
--- a/src/core/resolve.c
+++ b/src/core/resolve.c
@@ -407,6 +407,7 @@ struct naptr_rdata* dns_naptr_parser( unsigned char* msg, unsigned char* end,
 		PKG_MEM_ERROR;
 		goto error;
 	}
+	naptr->skip_record = 0;
 	naptr->order=ntohs(order);
 	naptr->pref=ntohs(pref);
 	

--- a/src/core/resolve.h
+++ b/src/core/resolve.h
@@ -123,6 +123,7 @@ struct naptr_rdata {
 	unsigned char services_len;
 	unsigned char regexp_len;
 	unsigned char repl_len; /* not currently used */
+	unsigned char skip_record;
 	
 	char str_table[1]; /* contains all the strings */
 };


### PR DESCRIPTION
Current stable release support using only one (first by ordering) NAPTR DNS record. 
I didn't find any ideas how to configure possibility for use all supported NAPTR / SRV records. This pull request resolve this issue.

General issue:
PreConditions:

```
# host -t naptr voip.somehost.com
voip.somehost.com has NAPTR record 1 0 "S" "SIPS+D2T" "" _sips._tcp.voip.somehost.com.
voip.somehost.com has NAPTR record 2 0 "S" "SIP+D2U" "" _sip._udp.voip.somehost.com.
```
```
# host -t srv _sips._tcp.voip.somehost.com
_sips._tcp.voip.somehost.com has SRV record 1 1 443 voip.somehost.com.
_sips._tcp.voip.somehost.com has SRV record 2 1 5061 192.168.1.50.
_sips._tcp.voip.somehost.com has SRV record 3 1 5061 10.100.1.20.
```
```
# host -t srv _sip._udp.voip.somehost.com
_sip._udp.voip.somehost.com has SRV record 1 1 5060 voip.somehost.com.
_sip._udp.voip.somehost.com has SRV record 2 1 5060 192.168.1.50.
_sip._udp.voip.somehost.com has SRV record 3 1 5060 10.100.1.20.
```

In my configuration of kamailio I don't see trying to use second by priority NAPTR record:
voip.somehost.com has NAPTR record 2 0 "S" "SIP+D2U" "" _sip._udp.voip.somehost.com.

Kindly ask to share your ideas regarding faced issue and my pull request.
Thank you.
