### PR TITLE
siptrace: siptrace: fix memory leak in fake replies tracing

### DIFF
--- a/src/modules/siptrace/siptrace.c
+++ b/src/modules/siptrace/siptrace.c
@@ -1383,7 +1383,7 @@ static void trace_onreq_out(struct cell *t, int type, struct tmcb_params *ps)
 	}
 
 	if(sip_trace_msg_attrs(msg, &sto) < 0) {
-		return;
+		return; 
 	}
 
 	if(ps->send_buf.len > 0) {
@@ -1616,7 +1616,7 @@ static void trace_onreply_out(struct cell *t, int type, struct tmcb_params *ps)
 	}
 
 	if(sip_trace_msg_attrs(msg, &sto) < 0) {
-		return;
+		goto end;
 	}
 
 	if(faked == 0) {
@@ -1662,7 +1662,7 @@ static void trace_onreply_out(struct cell *t, int type, struct tmcb_params *ps)
 	sto.status.s = int2strbuf(ps->code, statusbuf, INT2STR_MAX_LEN, &sto.status.len);
 	if(sto.status.s == 0) {
 		LM_ERR("failure to get the status string\n");
-		return;
+		goto end;
 	}
 
 	memset(&to_ip, 0, sizeof(struct ip_addr));
@@ -1700,7 +1700,7 @@ static void trace_onreply_out(struct cell *t, int type, struct tmcb_params *ps)
 end:
 	if (faked && parsed_f) {
 		free_from(msg->from->parsed);
-    msg->from->parsed = NULL;
+		msg->from->parsed = NULL;
 	}
 }
 

--- a/src/modules/siptrace/siptrace.c
+++ b/src/modules/siptrace/siptrace.c
@@ -1569,6 +1569,7 @@ static void trace_onreply_out(struct cell *t, int type, struct tmcb_params *ps)
 	siptrace_data_t sto;
 	siptrace_info_t* info;
 	int faked = 0;
+	int parsed_f = 0;
 	struct sip_msg *msg;
 	struct sip_msg *req;
 	struct ip_addr to_ip;
@@ -1607,6 +1608,11 @@ static void trace_onreply_out(struct cell *t, int type, struct tmcb_params *ps)
 	if(msg == NULL || msg == FAKED_REPLY) {
 		msg = t->uas.request;
 		faked = 1;
+		/* check if from header has been already parsed.
+		 * If not we have to parse it in pkg memory and free it at the end.
+		 */
+		if (msg->from && msg->from->parsed == NULL)
+			parsed_f = 1;
 	}
 
 	if(sip_trace_msg_attrs(msg, &sto) < 0) {
@@ -1686,10 +1692,16 @@ static void trace_onreply_out(struct cell *t, int type, struct tmcb_params *ps)
 
 	if (info->uriState == STRACE_RAW_URI) {
 		LM_BUG("uriState must be either UNUSED or PARSED here! must be a bug! Message won't be traced!\n");
-		return;
+		goto end;
 	}
 
 	sip_trace_store(&sto, info->uriState == STRACE_PARSED_URI ? &info->u.dest_info : NULL, NULL);
+
+end:
+	if (faked && parsed_f) {
+		free_from(msg->from->parsed);
+    msg->from->parsed = NULL;
+	}
 }
 
 static void trace_tm_neg_ack_in(struct cell *t, int type, struct tmcb_params *ps)


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
When tracing a faked reply (like 200 for CANCEL), the sip msg used to retrieve the tracing parameters is the transaction's uas one (uas.request) which might have the from header parsed or not, depending on the routing script actions (by default, if I'm not wrong, it is not parsed). If the header is not parsed, calling get_from in trace_onreply_out function will lead to a memory leak, beacause the header is parsed in pkg memory not freed when the transaction is deleted.