### PR TITLE
keepalive: ignore delete_counter if it is set to 0

### DIFF
--- a/src/modules/keepalive/doc/keepalive_admin.xml
+++ b/src/modules/keepalive/doc/keepalive_admin.xml
@@ -96,7 +96,7 @@ modparam("keepalive", "destination", "sip.provider.com")
 			<section>
 				<title><varname>delete_counter</varname>(int)</title>
 				<para>
-					Unsuccesful attemps  increase delete_counter . After passing it , keepalive module doesn't try to send options requests.
+					Unsuccesful attemps increase delete_counter. After passing it, keepalive module doesn't try to send options requests. Ignored if it's set to 0.
 				</para>
 				<para>
 				<emphasis>

--- a/src/modules/keepalive/keepalive_core.c
+++ b/src/modules/keepalive/keepalive_core.c
@@ -67,15 +67,14 @@ void ka_check_timer(unsigned int ticks, void *param)
 			ka_dest = ka_dest->next) {
 		LM_DBG("ka_check_timer dest:%.*s\n", ka_dest->uri.len, ka_dest->uri.s);
 
+		if(ka_counter_del > 0 && ka_dest->counter > ka_counter_del) {
+			continue;
+		}
+
 		/* Send ping using TM-Module.
 		 * int request(str* m, str* ruri, str* to, str* from, str* h,
 		 *		str* b, str *oburi,
 		 *		transaction_cb cb, void* cbp); */
-
-		if(ka_dest->counter>ka_counter_del){
-			continue;
-		}
-
 		set_uac_req(&uac_r, &ka_ping_method, 0, 0, 0, TMCB_LOCAL_COMPLETED,
 				ka_options_callback, (void *)ka_dest);
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Recently a new parameter `delete_counter` was added. There is no way to ignore it, (just set a really big number could serve as a workaround).
This is a small change to ignore it if `delete_counter` if is set to 0. 