### PR TITLE
core: do not return connection if port does not match

### DIFF
--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1575,7 +1575,7 @@ struct tcp_connection* _tcpconn_find(int id, struct ip_addr* ip, int port,
 	int is_local_ip_any;
 	
 #ifdef EXTRA_DEBUG
-	LM_DBG("%d  port %d\n", id, port);
+	LM_DBG("id=%d  port=%d\n", id, port);
 	if (ip) print_ip("tcpconn_find: ip ", ip, "\n");
 #endif
 	if (likely(id)){
@@ -1586,8 +1586,13 @@ struct tcp_connection* _tcpconn_find(int id, struct ip_addr* ip, int port,
 			print_ip("ip=", &c->rcv.src_ip, "\n");
 #endif
 			if ((id==c->id)&&(c->state!=S_CONN_BAD)) {
-				LM_DBG("found connection by id: %d\n", id);
-				return c;
+				if(!port || port == c->rcv.src_port) {
+					LM_DBG("found connection by id: %d\n", id);
+					return c;
+				}
+				else {
+					LM_DBG("ignoring id %d (port=%d, c->rcv.src_port=%d\n", c->id, port ,c->rcv.src_port);
+				}
 			}
 		}
 	}else if (likely(ip)){


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
If kamailio is behind a NAT only return connection if port matches. We observed this issue on an instance after ~10h of operation.
