### PR TITLE
keepalive: custom pinging interval per destination

### DIFF
--- a/src/modules/drouting/drouting.c
+++ b/src/modules/drouting/drouting.c
@@ -223,7 +223,7 @@ static int dr_update_keepalive(pgw_t *addrs)
 	for(cur = addrs; cur != NULL; cur = cur->next) {
 		LM_DBG("uri: %.*s\n", cur->ip.len, cur->ip.s);
 		keepalive_api.add_destination(
-				&cur->ip, &owner, 0, dr_keepalive_statechanged, cur);
+				&cur->ip, &owner, 0, 0, dr_keepalive_statechanged, cur);
 	}
 
 	return 0;

--- a/src/modules/keepalive/api.h
+++ b/src/modules/keepalive/api.h
@@ -38,7 +38,7 @@ typedef int ka_state;
 #define KA_STATE_DOWN 2
 
 typedef int (*ka_add_dest_f)(str *uri, str *owner, int flags,
-		ka_statechanged_f callback, void *user_attr);
+        int ping_interval, ka_statechanged_f callback, void *user_attr);
 typedef ka_state (*ka_dest_state_f)(str *uri);
 typedef int (*ka_del_destination_f)(str *uri, str *owner);
 typedef int (*ka_find_destination_f)(str *uri, str *owner,ka_dest_t **target,ka_dest_t **head);

--- a/src/modules/keepalive/doc/keepalive.xml
+++ b/src/modules/keepalive/doc/keepalive.xml
@@ -46,6 +46,5 @@
     
     <xi:include href="keepalive_admin.xml"/>
     <xi:include href="keepalive_devel.xml"/>
-    
-    
+
 </book>

--- a/src/modules/keepalive/doc/keepalive_devel.xml
+++ b/src/modules/keepalive/doc/keepalive_devel.xml
@@ -30,7 +30,7 @@
 
 	<section id="dev-add_destination">
 		<title>
-		<function moreinfo="none">add_destination(uri, owner, flags, [callback, [user_attr]])</function>
+		<function moreinfo="none">add_destination(uri, owner, flags, ping_interval, [callback, [user_attr]])</function>
 		</title>
 		<para>
 			This function registers a new destination to monitor. 
@@ -61,6 +61,11 @@
 		<listitem>
 			<para>
 				<emphasis>flags (integer)</emphasis> - destination flags (<emphasis>unused for now, use 0 value</emphasis>)
+			</para>
+		</listitem>
+		<listitem>
+			<para>
+				<emphasis>ping_interval (integer)</emphasis> - Pinging <emphasis>interval</emphasis> in seconds for this destination
 			</para>
 		</listitem>
 		<listitem>
@@ -133,7 +138,7 @@ void my_callback(str uri, int state, void *user_attr) {
 str dest  = str_init("sip:192.168.10.21:5060");
 str owner = str_init("mymodule");
 
-if (ka_api.add_destination(dest, owner, 0, my_callback, NULL) != 0) {
+if (ka_api.add_destination(dest, owner, 0, 60, my_callback, NULL) != 0) {
     LM_ERR("can't add destination\n");
     goto error;
 }

--- a/src/modules/keepalive/keepalive.h
+++ b/src/modules/keepalive/keepalive.h
@@ -38,6 +38,8 @@
 #define KA_PROBING_DST 8  /*!< checking destination */
 #define KA_STATES_ALL 15  /*!< all bits for the states of destination */
 
+extern int ka_ping_interval;
+
 #define ds_skip_dst(flags) ((flags) & (KA_INACTIVE_DST | KA_DISABLED_DST))
 
 #define KA_PROBE_NONE 0
@@ -64,6 +66,7 @@ typedef struct _ka_dest
 	struct ip_addr ip_address; /*!< IP-Address of the entry */
 	unsigned short int port;   /*!< Port of the URI */
 	unsigned short int proto;  /*!< Protocol of the URI */
+	struct timer_ln *timer;
 	struct _ka_dest *next;
 } ka_dest_t;
 
@@ -76,8 +79,10 @@ typedef struct _ka_destinations_list
 extern ka_destinations_list_t *ka_destinations_list;
 extern int ka_counter_del;
 
-int ka_add_dest(str *uri, str *owner, int flags, ka_statechanged_f callback,
-		void *user_attr);
+ticks_t ka_check_timer(ticks_t ticks, struct timer_ln* tl, void* param);
+
+int ka_add_dest(str *uri, str *owner, int flags, int ping_interval,
+        ka_statechanged_f callback, void *user_attr);
 int ka_destination_state(str *uri);
 int ka_str_copy(str *src, str *dest, char *prefix);
 int free_destination(ka_dest_t *dest) ;

--- a/src/modules/keepalive/keepalive_mod.c
+++ b/src/modules/keepalive/keepalive_mod.c
@@ -51,7 +51,6 @@ static void mod_destroy(void);
 static int ka_mod_add_destination(modparam_t type, void *val);
 int ka_init_rpc(void);
 int ka_alloc_destinations_list();
-extern void ka_check_timer(unsigned int ticks, void *param);
 static int w_cmd_is_alive(struct sip_msg *msg, char *str1, char *str2);
 static int fixup_add_destination(void** param, int param_no);
 static int w_add_destination(sip_msg_t *msg, char *uri, char *owner);
@@ -125,11 +124,6 @@ static int mod_init(void)
 	if(ka_alloc_destinations_list() < 0)
 		return -1;
 
-	if(register_timer(ka_check_timer, NULL, ka_ping_interval) < 0) {
-		LM_ERR("failed registering timer\n");
-		return -1;
-	}
-
 	return 0;
 }
 
@@ -186,7 +180,7 @@ static int w_add_destination(sip_msg_t *msg, char *uri, char *owner)
 		return -1;
 	}
 
-	return ka_add_dest(&suri, &sowner, 0, 0, 0);
+	return ka_add_dest(&suri, &sowner, 0, ka_ping_interval, 0, 0);
 }
 
 /*!
@@ -197,7 +191,7 @@ static int ki_add_destination(sip_msg_t *msg, str *uri, str *owner)
 	if(ka_alloc_destinations_list() < 0)
 		return -1;
 
-	return ka_add_dest(uri, owner, 0, 0, 0);
+	return ka_add_dest(uri, owner, 0, ka_ping_interval, 0, 0);
 }
 
 /*!
@@ -247,7 +241,7 @@ static int ka_mod_add_destination(modparam_t type, void *val)
 	str owner = str_init("_params");
 	LM_DBG("adding destination %.*s\n", dest.len, dest.s);
 
-	return ka_add_dest(&dest, &owner, 0, 0, 0);
+	return ka_add_dest(&dest, &owner, 0, ka_ping_interval, 0, 0);
 }
 
 /*

--- a/src/modules/keepalive/keepalive_rpc.c
+++ b/src/modules/keepalive/keepalive_rpc.c
@@ -122,7 +122,7 @@ static void keepalive_rpc_add(rpc_t *rpc, void *ctx)
 		return;
 	}
 
-	if(ka_add_dest(&sip_adress,&table_name,0,0,0) < 0 ){
+	if(ka_add_dest(&sip_adress,&table_name,0,ka_ping_interval,0,0) < 0 ){
 		LM_ERR("couldn't add data to list \n"  );
 		rpc->fault(ctx, 500, "couldn't add data to list");
 		return;


### PR DESCRIPTION
- This functionality it's just available when using api.h bindings. For exported functions current value ka_ping_interval is used.
- Modified add_destination function to provide this new parameter.
- Now we have one timer per destination, instead of multiple, so we don't need to iterate over all destinations. Timers are cleaned when destinations are removed.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

With this code, you can have a different pinging timeout for each destination, instead of the fixed (default 30 seconds) one. 
This change is compatible (not breaking) with .cfg or kemi invocations, but it's breaking developers api. 