### PR TITLE
ndb_redis: redis_cmd() check reply type to detect command errors

### DIFF
--- a/src/modules/ndb_redis/redis_client.c
+++ b/src/modules/ndb_redis/redis_client.c
@@ -950,6 +950,14 @@ int redisc_exec(str *srv, str *res, str *cmd, ...)
 			goto error_exec;
 		}
 	}
+
+	LM_DBG("rpl->rplRedis->type:%d\n", rpl->rplRedis->type);
+	if(rpl->rplRedis->type == REDIS_REPLY_ERROR) {
+		LM_ERR("Redis error:%.*s\n",
+			(int)rpl->rplRedis->len, rpl->rplRedis->str);
+		goto error_exec;
+	}
+
 	if (check_cluster_reply(rpl->rplRedis, &rsrv)) {
 		LM_DBG("rsrv->ctxRedis = %p\n", rsrv->ctxRedis);
 		if(rsrv->ctxRedis==NULL)
@@ -983,6 +991,13 @@ int redisc_exec(str *srv, str *res, str *cmd, ...)
 				STR_ZTOV(cmd->s[cmd->len], c);
 				goto error_exec;
 			}
+		}
+
+		LM_DBG("rpl->rplRedis->type:%d\n", rpl->rplRedis->type);
+		if(rpl->rplRedis->type == REDIS_REPLY_ERROR) {
+			LM_ERR("Redis error:%.*s\n",
+				(int)rpl->rplRedis->len, rpl->rplRedis->str);
+			goto error_exec;
 		}
 	}
 	STR_ZTOV(cmd->s[cmd->len], c);


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2300

#### Description

from https://github.com/redis/hiredis#using-replies

> The standard replies that redisCommand are of the type redisReply. The type field in the redisReply should be used to test what kind of reply was received:
> 
> - REDIS_REPLY_STATUS:
>   The command replied with a status reply. The status string can be accessed using reply->str. The length of this string can be accessed using reply->len.
> 
>  - REDIS_REPLY_ERROR:
>     The command replied with an error. The error string can be accessed identical to REDIS_REPLY_STATUS.

adding checks for the reply type to detect command errors