### PR TITLE
Keepalive/response callback

### DIFF
--- a/src/modules/drouting/drouting.c
+++ b/src/modules/drouting/drouting.c
@@ -223,7 +223,7 @@ static int dr_update_keepalive(pgw_t *addrs)
 	for(cur = addrs; cur != NULL; cur = cur->next) {
 		LM_DBG("uri: %.*s\n", cur->ip.len, cur->ip.s);
 		keepalive_api.add_destination(
-				&cur->ip, &owner, 0, 0, dr_keepalive_statechanged, cur);
+				&cur->ip, &owner, 0, 0, dr_keepalive_statechanged, 0, cur);
 	}
 
 	return 0;

--- a/src/modules/keepalive/api.h
+++ b/src/modules/keepalive/api.h
@@ -38,7 +38,8 @@ typedef int ka_state;
 #define KA_STATE_DOWN 2
 
 typedef int (*ka_add_dest_f)(str *uri, str *owner, int flags,
-        int ping_interval, ka_statechanged_f callback, void *user_attr);
+        int ping_interval, ka_statechanged_f statechanged_clb, ka_response_f response_clb,
+        void *user_attr);
 typedef ka_state (*ka_dest_state_f)(str *uri);
 typedef int (*ka_del_destination_f)(str *uri, str *owner);
 typedef int (*ka_find_destination_f)(str *uri, str *owner,ka_dest_t **target,ka_dest_t **head);

--- a/src/modules/keepalive/doc/keepalive.xml
+++ b/src/modules/keepalive/doc/keepalive.xml
@@ -47,4 +47,5 @@
     <xi:include href="keepalive_admin.xml"/>
     <xi:include href="keepalive_devel.xml"/>
 
+
 </book>

--- a/src/modules/keepalive/doc/keepalive_devel.xml
+++ b/src/modules/keepalive/doc/keepalive_devel.xml
@@ -30,7 +30,7 @@
 
 	<section id="dev-add_destination">
 		<title>
-		<function moreinfo="none">add_destination(uri, owner, flags, ping_interval, [callback, [user_attr]])</function>
+		<function moreinfo="none">add_destination(uri, owner, flags, ping_interval, [statechanged_clb, response_clb, [user_attr]])</function>
 		</title>
 		<para>
 			This function registers a new destination to monitor. 
@@ -70,7 +70,7 @@
 		</listitem>
 		<listitem>
 			<para>
-				<emphasis>callback (ka_statechanged_f, optional)</emphasis> - callback function, executed on destination's state change.
+				<emphasis>statechanged_clb (ka_statechanged_f, optional)</emphasis> - callback function, executed on destination's state change.
 			</para>
 			<para>
 				The callback function is of type <code>void (*ka_statechanged_f)(str *uri, int state, void *user_attr);</code>. Use <emphasis>NULL</emphasis> to set no callback.
@@ -92,7 +92,18 @@
 		</listitem>
 		<listitem>
 			<para>
-				<emphasis>user_attr (void * pointer, optional)</emphasis> - If callback function is setup, this parameter will be forwarded to it, as last parameter. Use <emphasis>NULL</emphasis> to set no user_attr parameter.
+				<emphasis>response_clb (ka_response_f, optional)</emphasis> - callback function, executed on destination's response provided.
+			</para>
+			<para>
+				The callback function is of type <code> void (*ka_response_f)(str *uri, struct tmcb_params *ps, void *user_attr);</code>. Use <emphasis>NULL</emphasis> to set no callback.
+			</para>
+			<para>
+				ps is a pack structure with all params passed to callback function. Defined in t_hooks.h
+			</para>
+		</listitem>
+		<listitem>
+			<para>
+				<emphasis>user_attr (void * pointer, optional)</emphasis> - If any callback function is setup, this parameter will be forwarded to it (or both callbacks in both are defined), as last parameter. Use <emphasis>NULL</emphasis> to set no user_attr parameter.
 			</para>
 		</listitem>
 		</itemizedlist>
@@ -128,17 +139,18 @@ if (bind_keepalive( &amp;ka_api ) != 0) {
 }
 ...
 ...
-/* callback function */
-void my_callback(str uri, int state, void *user_attr) {
-
+/* callback function (on state changed) */
+void my_state_changed_clb(str uri, int state, void *user_attr) {
 	printf("%.*s new state is: %d\n", uri.len, uri.str, state)
 }
 
-/* register a new destination */
-str dest  = str_init("sip:192.168.10.21:5060");
-str owner = str_init("mymodule");
+/* callback function (on each response received) */
+void my_response_clb(str *uri, struct tmcb_params *ps, void *user_attr) {
+	printf("response [%d] from %.*s\n", ps->code, uri.len, uri.str)
+}
 
-if (ka_api.add_destination(dest, owner, 0, 60, my_callback, NULL) != 0) {
+if (ka_api.add_destination(dest, owner, 0, 60, my_state_changed_clb,
+				my_response_clb, NULL) != 0) {
     LM_ERR("can't add destination\n");
     goto error;
 }

--- a/src/modules/keepalive/keepalive.h
+++ b/src/modules/keepalive/keepalive.h
@@ -31,6 +31,7 @@
 #include <time.h>
 #include "../../core/sr_module.h"
 #include "../../core/locking.h"
+#include "../tm/tm_load.h"
 
 #define KA_INACTIVE_DST 1 /*!< inactive destination */
 #define KA_TRYING_DST 2   /*!< temporary trying destination */
@@ -48,6 +49,8 @@ extern int ka_ping_interval;
 #define KA_PROBE_ONLYFLAGGED 3
 
 typedef void (*ka_statechanged_f)(str *uri, int state, void *user_attr);
+typedef void (*ka_response_f)(
+		str *uri, struct tmcb_params *ps, void *user_attr);
 
 
 typedef struct _ka_dest
@@ -62,6 +65,7 @@ typedef struct _ka_dest
 
 	void *user_attr;
 	ka_statechanged_f statechanged_clb;
+	ka_response_f response_clb;
 	struct socket_info *sock;
 	struct ip_addr ip_address; /*!< IP-Address of the entry */
 	unsigned short int port;   /*!< Port of the URI */
@@ -82,7 +86,8 @@ extern int ka_counter_del;
 ticks_t ka_check_timer(ticks_t ticks, struct timer_ln* tl, void* param);
 
 int ka_add_dest(str *uri, str *owner, int flags, int ping_interval,
-        ka_statechanged_f callback, void *user_attr);
+        ka_statechanged_f statechanged_clb, ka_response_f response_clb,
+        void *user_attr);
 int ka_destination_state(str *uri);
 int ka_str_copy(str *src, str *dest, char *prefix);
 int free_destination(ka_dest_t *dest) ;

--- a/src/modules/keepalive/keepalive_api.c
+++ b/src/modules/keepalive/keepalive_api.c
@@ -63,7 +63,7 @@ int bind_keepalive(keepalive_api_t *api)
  * Add a new destination in keepalive pool
  */
 int ka_add_dest(str *uri, str *owner, int flags, int ping_interval,
-    ka_statechanged_f callback, void *user_attr)
+    ka_statechanged_f statechanged_clb, ka_response_f response_clb, void *user_attr)
 {
 	struct sip_uri _uri;
 	ka_dest_t *dest=0,*hollow=0;
@@ -104,7 +104,8 @@ int ka_add_dest(str *uri, str *owner, int flags, int ping_interval,
 		goto err;
 
 	dest->flags = flags;
-	dest->statechanged_clb = callback;
+	dest->statechanged_clb = statechanged_clb;
+	dest->response_clb = response_clb;
 	dest->user_attr = user_attr;
 
     dest->timer = timer_alloc();

--- a/src/modules/keepalive/keepalive_core.c
+++ b/src/modules/keepalive/keepalive_core.c
@@ -129,6 +129,9 @@ static void ka_options_callback(
 
 		ka_dest->state = state;
 	}
+	if(ka_dest->response_clb != NULL) {
+		ka_dest->response_clb(&ka_dest->uri, ps, ka_dest->user_attr);
+	}
 }
 
 /*

--- a/src/modules/keepalive/keepalive_mod.c
+++ b/src/modules/keepalive/keepalive_mod.c
@@ -180,7 +180,7 @@ static int w_add_destination(sip_msg_t *msg, char *uri, char *owner)
 		return -1;
 	}
 
-	return ka_add_dest(&suri, &sowner, 0, ka_ping_interval, 0, 0);
+	return ka_add_dest(&suri, &sowner, 0, ka_ping_interval, 0, 0, 0);
 }
 
 /*!
@@ -191,7 +191,7 @@ static int ki_add_destination(sip_msg_t *msg, str *uri, str *owner)
 	if(ka_alloc_destinations_list() < 0)
 		return -1;
 
-	return ka_add_dest(uri, owner, 0, ka_ping_interval, 0, 0);
+	return ka_add_dest(uri, owner, 0, ka_ping_interval, 0, 0, 0);
 }
 
 /*!
@@ -241,7 +241,7 @@ static int ka_mod_add_destination(modparam_t type, void *val)
 	str owner = str_init("_params");
 	LM_DBG("adding destination %.*s\n", dest.len, dest.s);
 
-	return ka_add_dest(&dest, &owner, 0, ka_ping_interval, 0, 0);
+	return ka_add_dest(&dest, &owner, 0, ka_ping_interval, 0, 0, 0);
 }
 
 /*

--- a/src/modules/keepalive/keepalive_rpc.c
+++ b/src/modules/keepalive/keepalive_rpc.c
@@ -122,7 +122,7 @@ static void keepalive_rpc_add(rpc_t *rpc, void *ctx)
 		return;
 	}
 
-	if(ka_add_dest(&sip_adress,&table_name,0,ka_ping_interval,0,0) < 0 ){
+	if(ka_add_dest(&sip_adress,&table_name,0,ka_ping_interval,0,0,0) < 0 ){
 		LM_ERR("couldn't add data to list \n"  );
 		rpc->fault(ctx, 500, "couldn't add data to list");
 		return;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This change allows you to set a new callback for keepalive that will be executed each time it receives a response for an OPTIONS message.
This change is compatible (not breaking) with .cfg or kemi invocations, but it's breaking developers api.

