### PR TITLE
keepalive: early start of OPTIONS checking

### DIFF
--- a/src/modules/keepalive/keepalive.h
+++ b/src/modules/keepalive/keepalive.h
@@ -48,6 +48,8 @@ extern int ka_ping_interval;
 #define KA_PROBE_INACTIVE 2
 #define KA_PROBE_ONLYFLAGGED 3
 
+#define KA_FIRST_TRY_DELAY 500 /* First OPTIONS send is done 500 millis after adding the destination */
+
 typedef void (*ka_statechanged_f)(str *uri, int state, void *user_attr);
 typedef void (*ka_response_f)(
 		str *uri, struct tmcb_params *ps, void *user_attr);
@@ -62,6 +64,7 @@ typedef struct _ka_dest
 	int state;
 	time_t last_checked, last_up, last_down;
 	int counter;	// counts unreachable attemps
+	ticks_t ping_interval;  /*!< Actual interval between OPTIONS  */
 
 	void *user_attr;
 	ka_statechanged_f statechanged_clb;
@@ -70,7 +73,7 @@ typedef struct _ka_dest
 	struct ip_addr ip_address; /*!< IP-Address of the entry */
 	unsigned short int port;   /*!< Port of the URI */
 	unsigned short int proto;  /*!< Protocol of the URI */
-	struct timer_ln *timer;
+	struct timer_ln *timer;    /*!< Timer firing the OPTIONS test */
 	struct _ka_dest *next;
 } ka_dest_t;
 

--- a/src/modules/keepalive/keepalive_api.c
+++ b/src/modules/keepalive/keepalive_api.c
@@ -107,6 +107,7 @@ int ka_add_dest(str *uri, str *owner, int flags, int ping_interval,
 	dest->statechanged_clb = statechanged_clb;
 	dest->response_clb = response_clb;
 	dest->user_attr = user_attr;
+	dest->ping_interval = MS_TO_TICKS((ping_interval == 0 ? ka_ping_interval : ping_interval) * 1000) ;
 
     dest->timer = timer_alloc();
 	if (dest->timer == NULL) {
@@ -116,8 +117,7 @@ int ka_add_dest(str *uri, str *owner, int flags, int ping_interval,
 
 	timer_init(dest->timer, ka_check_timer, dest, 0);
 
-    int actual_ping_interval =  ping_interval == 0 ? ka_ping_interval : ping_interval;
-	if(timer_add(dest->timer, MS_TO_TICKS(actual_ping_interval * 1000)) < 0){
+	if(timer_add(dest->timer, MS_TO_TICKS(KA_FIRST_TRY_DELAY)) < 0){
 		LM_ERR("failed to start timer\n");
 		goto err;
 	}

--- a/src/modules/keepalive/keepalive_core.c
+++ b/src/modules/keepalive/keepalive_core.c
@@ -82,7 +82,7 @@ ticks_t ka_check_timer(ticks_t ticks, struct timer_ln* tl, void* param)
 
     ka_dest->last_checked = time(NULL);
 
-	return (ticks_t)(-1); /* periodical */
+	return ka_dest->ping_interval; /* periodical, but based on dest->ping_interval, not on initial_timeout */
 }
 
 /*! \brief


### PR DESCRIPTION
- Current code takes some time to start checking (ping_interval). So, if someone sets a really high ping_interval it takes a while to get destination status. This change fires the first OPTIONS check just 3 seconds (fixed) after the destination is added. The checks would be done with the pace defined in ping_interval.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Current code takes some time to start checking (ping_interval). So, if someone sets a really high ping_interval it takes a while to get destination status. This change fires the first OPTIONS check just 3 seconds (fixed) after the destination is added. The checks would be done with the pace defined in ping_interval.