### PR TITLE
core: PV_IDX_NONE to point that pv had no index

### DIFF
--- a/src/core/pvapi.c
+++ b/src/core/pvapi.c
@@ -857,6 +857,7 @@ char* pv_parse_spec2(str *in, pv_spec_p e, int silent)
 	tr = 0;
 	pvstate = 0;
 	memset(e, 0, sizeof(pv_spec_t));
+	e->pvp.pvi.type = PV_IDX_NONE;
 	p = in->s;
 	p++;
 	if(*p==PV_LNBRACKET)
@@ -1366,6 +1367,12 @@ int pv_get_spec_index(struct sip_msg* msg, pv_param_p ip, int *idx, int *flags)
 	}
 	if(ip->pvi.type == PV_IDX_INT)
 	{
+		*idx = ip->pvi.u.ival;
+		return 0;
+	}
+	if(ip->pvi.type == PV_IDX_NONE)
+	{
+		*flags = PV_IDX_NONE;
 		*idx = ip->pvi.u.ival;
 		return 0;
 	}

--- a/src/core/pvar.h
+++ b/src/core/pvar.h
@@ -61,6 +61,7 @@
 #define PV_IDX_PVAR	1
 #define PV_IDX_ALL	2
 #define PV_IDX_ITR	3
+#define PV_IDX_NONE 4
 
 /*! if PV name is dynamic, integer, or str */
 #define pv_has_dname(pv) ((pv)->pvp.pvn.type==PV_NAME_PVAR)

--- a/src/modules/pv/pv_core.c
+++ b/src/modules/pv/pv_core.c
@@ -1806,7 +1806,7 @@ int pv_get_avp(struct sip_msg *msg,  pv_param_t *param, pv_value_t *res)
 	if ((avp=search_first_avp(name_type, avp_name, &avp_value, &state))==0)
 		return pv_get_null(msg, param, res);
 	res->flags = PV_VAL_STR;
-	if(idxf==0 && idx==0)
+	if(idx==0 && (idxf==PV_IDX_INT || idxf==PV_IDX_NONE))
 	{
 		if(avp->flags & AVP_VAL_STR)
 		{
@@ -1964,7 +1964,7 @@ int pv_get_hdr(struct sip_msg *msg,  pv_param_t *param, pv_value_t *res)
 
 	/* get the value */
 	res->flags = PV_VAL_STR;
-	if(idxf==0 && idx==0)
+	if(idx==0 && (idxf==PV_IDX_INT || idxf==PV_IDX_NONE))
 	{
 		res->rs  = hf->body;
 		return 0;


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally

#### Description
<!-- Describe your changes in detail -->
if index is 0 there were no way to know if the index was there

$x_hdr(A) = "value" needs to append a value
$(x_hdr(A)[0]) = "value" needs to set the value

pv_parse_spec(str *s, pv_spec_p p) was always setting p->pvp.pvi.type
to 0 == PV_IDX_INT