### PR TITLE
acc: new skip_cdr modparam to prevent cdr generation

### DIFF
--- a/src/modules/acc/acc_cdr.c
+++ b/src/modules/acc/acc_cdr.c
@@ -392,6 +392,16 @@ static int write_cdr( struct dlg_cell* dialog,
 		return -1;
 	}
 
+	/* Skip cdr if cdr_skip dlg_var exists */
+	if (cdr_skip.len > 0) {
+		str* nocdr_val = 0;
+		nocdr_val = dlgb.get_dlg_var( dialog, &cdr_skip);
+		if ( nocdr_val ){
+			LM_DBG( "cdr_skip dlg_var set, skip cdr!");
+			return 0;
+		}
+	}
+
 	ret = log_write_cdr(dialog, message);
 	ret |= db_write_cdr(dialog, message);
 	return ret;

--- a/src/modules/acc/acc_mod.c
+++ b/src/modules/acc/acc_mod.c
@@ -121,6 +121,7 @@ int cdr_start_on_confirmed = 0;
 int cdr_expired_dlg_enable = 0;
 static char* cdr_facility_str = 0;
 static char* cdr_log_extra_str = 0;
+str cdr_skip = {NULL, 0};
 
 str cdr_start_str = str_init("start_time");
 str cdr_end_str = str_init("end_time");
@@ -206,6 +207,7 @@ static param_export_t params[] = {
 	{"log_extra",            PARAM_STRING, &log_extra_str        },
 	/* cdr specific */
 	{"cdr_enable",           INT_PARAM, &cdr_enable                 },
+	{"cdr_skip",             PARAM_STR, &cdr_skip                   },
 	{"cdr_log_enable",         INT_PARAM, &cdr_log_enable           },
 	{"cdr_start_on_confirmed", INT_PARAM, &cdr_start_on_confirmed   },
 	{"cdr_facility",         PARAM_STRING, &cdr_facility_str           },

--- a/src/modules/acc/acc_mod.h
+++ b/src/modules/acc/acc_mod.h
@@ -53,6 +53,7 @@ extern int cdr_extra_nullable;
 extern int cdr_start_on_confirmed;
 extern int cdr_log_facility;
 extern int cdr_expired_dlg_enable;
+extern str cdr_skip;
 
 extern int db_flag;
 extern int db_missed_flag;

--- a/src/modules/acc/doc/acc_admin.xml
+++ b/src/modules/acc/doc/acc_admin.xml
@@ -1037,6 +1037,23 @@ modparam("acc", "cdr_enable", 1)
 </programlisting>
 		</example>
 	</section>
+	<section id="acc.p.cdr_skip">
+		<title><varname>cdr_skip</varname> (string)</title>
+		<para>
+		Skip cdr generation for dialogs with this dlg_var set.
+		</para>
+		<para>
+		Default value is NULL.
+		</para>
+		<example>
+		<title>cdr_skip example</title>
+		<programlisting format="linespecific">
+...
+modparam("acc", "cdr_skip", "nocdr")
+...
+</programlisting>
+		</example>
+	</section>
 	<section id="acc.p.cdr_expired_dlg_enable">
 		<title><varname>cdr_expired_dlg_enable</varname> (integer)</title>
 		<para>


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2348 

#### Description

This PR allows excluding certain calls from CDRs in Kamailio route logic:

-  adds a new modparam called _cdr_skip_ to **acc** module

- dialogs ended with chosen dlg_var set (no matter the value) won't generate a CDR even though _cdr_enable_ modparam is set.

  - both database and log CDR will be prevented.

