### PR TITLE
dmq_usrloc: add new parameter `usrloc_delete` to disable synchronizing delete actions

### DIFF
--- a/src/modules/dmq_usrloc/dmq_usrloc.c
+++ b/src/modules/dmq_usrloc/dmq_usrloc.c
@@ -42,6 +42,7 @@ int _dmq_usrloc_batch_msg_contacts = 1;
 int _dmq_usrloc_batch_msg_size = 60000;
 int _dmq_usrloc_batch_usleep = 0;
 str _dmq_usrloc_domain = str_init("location");
+int _dmq_usrloc_delete = 1;
 
 usrloc_api_t dmq_ul;
 
@@ -56,6 +57,7 @@ static param_export_t params[] = {
 	{"batch_size",   INT_PARAM, &_dmq_usrloc_batch_size},
 	{"batch_usleep", INT_PARAM, &_dmq_usrloc_batch_usleep},
 	{"usrloc_domain", PARAM_STR, &_dmq_usrloc_domain},
+	{"usrloc_delete", INT_PARAM, &_dmq_usrloc_delete},
 	{0, 0, 0}
 };
 

--- a/src/modules/dmq_usrloc/doc/dmq_usrloc.xml
+++ b/src/modules/dmq_usrloc/doc/dmq_usrloc.xml
@@ -55,6 +55,22 @@
 	<copyright>
 	    <year>2017</year>
 	</copyright>
+	<authorgroup>
+	    <editor>
+		<firstname>Emmanuel</firstname>
+		<surname>Schmidbauer</surname>
+		<affiliation><orgname>TextNow Inc.</orgname></affiliation>
+		<email>emmanuel.schmidbauer@textnow.com</email>
+		<address>
+		<otheraddr>
+		<ulink></ulink>
+		</otheraddr>
+		</address>
+	    </editor>
+	</authorgroup>
+	<copyright>
+	    <year>2020</year>
+	</copyright>
     </bookinfo>
     <toc></toc>
     

--- a/src/modules/dmq_usrloc/doc/dmq_usrloc_admin.xml
+++ b/src/modules/dmq_usrloc/doc/dmq_usrloc_admin.xml
@@ -282,7 +282,25 @@ modparam("dmq_usrloc", "replicate_socket_info", 0)
 </programlisting>
 	</example>
 	</section>
+	<section id="usrloc_dmq.p.usrloc_delete">
+		<title><varname>usrloc_delete</varname> (int)</title>
+		<para>
+			Enable (1) or disable (0) synchronizing usrloc delete actions. Disabling delete actions can be useful when user location data is ephemeral.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 1.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>usrloc_domain</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dmq_usrloc", "usrloc_delete", 0)
+...
+</programlisting>
+		</example>
+	</section>
 	</section>
 
 </chapter>
-

--- a/src/modules/dmq_usrloc/usrloc_sync.c
+++ b/src/modules/dmq_usrloc/usrloc_sync.c
@@ -58,6 +58,7 @@ extern int _dmq_usrloc_batch_msg_size;
 extern int _dmq_usrloc_batch_size;
 extern int _dmq_usrloc_batch_usleep;
 extern str _dmq_usrloc_domain;
+extern int _dmq_usrloc_delete;
 
 static int add_contact(str aor, ucontact_info_t* ci)
 {
@@ -815,7 +816,9 @@ void dmq_ul_cb_contact(ucontact_t* ptr, int type, void* param)
 				usrloc_dmq_send_contact(ptr, aor, DMQ_UPDATE, 0);
 				break;
 			case UL_CONTACT_DELETE:
-				usrloc_dmq_send_contact(ptr, aor, DMQ_RM, 0);
+				if (_dmq_usrloc_delete >= 1) {
+					usrloc_dmq_send_contact(ptr, aor, DMQ_RM, 0);
+				}
 				break;
 			case UL_CONTACT_EXPIRE:
 				//usrloc_dmq_send_contact(ptr, aor, DMQ_UPDATE);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
in high volume systems with ephemeral user location data (e.g. very low expiration times on user location records), the user location delete action can cause a high amount of DMQ traffic when UAs unregister. This new parameter allows the user location `delete` action to be disabled from being shared across DMQ nodes which helps reduce DMQ traffic on systems with high register/unregister rates and low expiration times.