### PR TITLE
mohqueue: use t_newtran() if transaction does not exist

### DIFF
--- a/src/modules/mohqueue/mohq_funcs.c
+++ b/src/modules/mohqueue/mohq_funcs.c
@@ -185,6 +185,7 @@ void ack_msg (sip_msg_t *pmsg, call_lst *pcall)
 char *pfncname = "ack_msg: ";
 struct cell *ptrans;
 tm_api_t *ptm = pmod_data->ptm;
+tm_cell_t *t = 0;
 if (pcall->call_state != CLSTA_INVITED)
   {
   /**********
@@ -215,7 +216,22 @@ if (ptm->t_lookup_ident (&ptrans, pcall->call_hash, pcall->call_label) < 0)
   }
 else
   {
-  if (ptm->t_release (pcall->call_pmsg) < 0)
+  t = ptm->t_gett();
+  if (t==NULL || t==T_UNDEFINED)
+    {
+      if (ptm->t_newtran(pmsg)<0)
+        {
+          LM_ERR("cannot create the transaction\n");
+          return;
+        }
+      t = ptm->t_gett();
+      if (t==NULL || t==T_UNDEFINED)
+        {
+          LM_ERR("cannot lookup the transaction\n");
+          return;
+        }
+    }
+  if (ptm->t_release_transaction(t) < 0)
     {
     LM_ERR ("%sRelease transaction failed for call (%s)!\n",
       pfncname, pcall->call_from);


### PR DESCRIPTION
#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [ ] Tested changes locally
- [x] Related to issue #2370 

#### Description
make sure transaction exists with `t_newtran()` and use `t_release_transaction()` instead of `t_release()`
