### PR TITLE
cnxcc: remove duplicated entries with a same CID value

### DIFF
--- a/src/modules/cnxcc/cnxcc_mod.c
+++ b/src/modules/cnxcc/cnxcc_mod.c
@@ -1578,6 +1578,7 @@ static int ki_set_max_credit(sip_msg_t *msg, str *sclient, str *scredit,
 {
 	credit_data_t *credit_data = NULL;
 	call_t *call = NULL;
+	hash_tables_t *hts = NULL;
 
 	double credit = 0, connect_cost = 0, cost_per_second = 0;
 
@@ -1617,6 +1618,12 @@ static int ki_set_max_credit(sip_msg_t *msg, str *sclient, str *scredit,
 	if(cost_per_second <= 0) {
 		LM_ERR("cost_per_second value must be > 0: %f\n", cost_per_second);
 		return -1;
+	}
+
+	if(try_get_call_entry(&msg->callid->body, &call, &hts) == 0) {
+		LM_ERR("call-id[%.*s] already present\n",
+		msg->callid->body.len, msg->callid->body.s);
+		return -2;
 	}
 
 	LM_DBG("Setting up new call for client [%.*s], max-credit[%f], "
@@ -1796,6 +1803,7 @@ static int ki_set_max_channels(sip_msg_t *msg, str *sclient, int max_chan)
 {
 	credit_data_t *credit_data = NULL;
 	call_t *call = NULL;
+	hash_tables_t *hts = NULL;
 
 	if(parse_headers(msg, HDR_CALLID_F, 0) != 0) {
 		LM_ERR("Error parsing Call-ID");
@@ -1824,6 +1832,12 @@ static int ki_set_max_channels(sip_msg_t *msg, str *sclient, int max_chan)
 		LM_ERR("[%.*s]: client ID cannot be null\n", msg->callid->body.len,
 				msg->callid->body.s);
 		return -1;
+	}
+
+	if(try_get_call_entry(&msg->callid->body, &call, &hts) == 0) {
+		LM_ERR("call-id[%.*s] already present\n",
+		msg->callid->body.len, msg->callid->body.s);
+		return -2;
 	}
 
 	LM_DBG("Setting up new call for client [%.*s], max-chan[%d], "
@@ -1882,6 +1896,7 @@ static int ki_set_max_time(sip_msg_t *msg, str *sclient, int max_secs)
 {
 	credit_data_t *credit_data = NULL;
 	call_t *call = NULL;
+	hash_tables_t *hts = NULL;
 
 	if(parse_headers(msg, HDR_CALLID_F, 0) != 0) {
 		LM_ERR("Error parsing Call-ID");
@@ -1911,6 +1926,12 @@ static int ki_set_max_time(sip_msg_t *msg, str *sclient, int max_secs)
 		LM_ERR("[%.*s]: client ID cannot be null\n", msg->callid->body.len,
 				msg->callid->body.s);
 		return -1;
+	}
+
+	if(try_get_call_entry(&msg->callid->body, &call, &hts) == 0) {
+		LM_ERR("call-id[%.*s] already present\n",
+		msg->callid->body.len, msg->callid->body.s);
+		return -2;
 	}
 
 	LM_DBG("Setting up new call for client [%.*s], max-secs[%d], "

--- a/src/modules/cnxcc/cnxcc_mod.c
+++ b/src/modules/cnxcc/cnxcc_mod.c
@@ -1623,7 +1623,7 @@ static int ki_set_max_credit(sip_msg_t *msg, str *sclient, str *scredit,
 	if(try_get_call_entry(&msg->callid->body, &call, &hts) == 0) {
 		LM_ERR("call-id[%.*s] already present\n",
 		msg->callid->body.len, msg->callid->body.s);
-		return -2;
+		return -4;
 	}
 
 	LM_DBG("Setting up new call for client [%.*s], max-credit[%f], "
@@ -1837,7 +1837,7 @@ static int ki_set_max_channels(sip_msg_t *msg, str *sclient, int max_chan)
 	if(try_get_call_entry(&msg->callid->body, &call, &hts) == 0) {
 		LM_ERR("call-id[%.*s] already present\n",
 		msg->callid->body.len, msg->callid->body.s);
-		return -2;
+		return -4;
 	}
 
 	LM_DBG("Setting up new call for client [%.*s], max-chan[%d], "
@@ -1931,7 +1931,7 @@ static int ki_set_max_time(sip_msg_t *msg, str *sclient, int max_secs)
 	if(try_get_call_entry(&msg->callid->body, &call, &hts) == 0) {
 		LM_ERR("call-id[%.*s] already present\n",
 		msg->callid->body.len, msg->callid->body.s);
-		return -2;
+		return -4;
 	}
 
 	LM_DBG("Setting up new call for client [%.*s], max-secs[%d], "

--- a/src/modules/cnxcc/doc/cnxcc.xml
+++ b/src/modules/cnxcc/doc/cnxcc.xml
@@ -23,15 +23,6 @@
 	    <email>carlos.ruizdiaz@gmail.com</email>
 	</address>
 	</author>
-        <editor>
-        <firstname>Jose Luis</firstname>
-        <surname>Verdeguer</surname>
-        <email>verdeguer@zoonsuite.com</email>
-        <affiliation><orgname>Zoon Suite</orgname></affiliation>
-        <address>
-                <email>verdeguer@zoonsuite.com</email>
-        </address>
-        </editor>
     </authorgroup>
     <copyright>
 	<year>2013</year>
@@ -40,10 +31,6 @@
     <copyright>
 	<year>2014</year>
 	<holder>Carlos Ruiz Díaz, carlos@latamvoices.com</holder>
-    </copyright>
-    <copyright>
-	<year>2018</year>
-	<holder>Jose Luis Verdeguer</holder>
     </copyright>
 
     </bookinfo>

--- a/src/modules/cnxcc/doc/cnxcc_admin.xml
+++ b/src/modules/cnxcc/doc/cnxcc_admin.xml
@@ -177,7 +177,7 @@ modparam("cnxcc", "credit_check_period", 1)
 
 					<listitem>
 						<para>
-							<emphasis>-2 - failed, credit value is less than initial pulse value</emphasis>
+							<emphasis>-4 - call-id already present for this client</emphasis>
 						</para>
 					</listitem>
 
@@ -342,6 +342,12 @@ if (!cnxcc_update_max_time("$var(client)", "$var(update_time)")) {
 						<para>
 							<emphasis>-3 - failed, number of calls established
 								is more than the limit you specified</emphasis>
+						</para>
+					</listitem>
+
+					<listitem>
+						<para>
+							<emphasis>-4 - call-id already present for this client</emphasis>
 						</para>
 					</listitem>
 
@@ -555,8 +561,8 @@ route[CNXCC]
 		case -1:
 			xerr("Error setting up credit control");
 			sl_send_reply("503", "Internal Server Error");
-		case -2:
-			xwarn("$ci already exists for client $var(client)");
+		case -4:
+			xwarn("$ci already present for client $var(client)");
 	};
 }
 

--- a/src/modules/cnxcc/doc/cnxcc_admin.xml
+++ b/src/modules/cnxcc/doc/cnxcc_admin.xml
@@ -549,7 +549,7 @@ route[CNXCC]
 			"$var(connect_cost)",
 			"$var(cost_per_sec)",
 			"$var(i_pulse)",
-			"$var(f_pulse)"));
+			"$var(f_pulse)");
 
 	switch ($?) {
 		case -1:

--- a/src/modules/cnxcc/doc/cnxcc_admin.xml
+++ b/src/modules/cnxcc/doc/cnxcc_admin.xml
@@ -543,14 +543,21 @@ route[CNXCC]
 	$var(i_pulse)             = 30;
 	$var(f_pulse)             = 6;
 
-	if (!cnxcc_set_max_credit("$var(client)",
+
+	cnxcc_set_max_credit("$var(client)",
 			"$var(credit)",
 			"$var(connect_cost)",
 			"$var(cost_per_sec)",
 			"$var(i_pulse)",
 			"$var(f_pulse)")) {
-		xlog("Error setting up credit control");
-	}
+
+	switch ($?) {
+		case -1:
+			xerr("Error setting up credit control");
+			sl_send_reply("503", "Internal Server Error");
+		case -2:
+			xwarn("$ci already exists for client $var(client)");
+	};
 }
 
 event_route[cnxcc:call-shutdown]

--- a/src/modules/cnxcc/doc/cnxcc_admin.xml
+++ b/src/modules/cnxcc/doc/cnxcc_admin.xml
@@ -549,7 +549,7 @@ route[CNXCC]
 			"$var(connect_cost)",
 			"$var(cost_per_sec)",
 			"$var(i_pulse)",
-			"$var(f_pulse)")) {
+			"$var(f_pulse)"));
 
 	switch ($?) {
 		case -1:


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ x] Commit message has the format required by CONTRIBUTING guide
- [ x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ x] Each component has a single commit (if not, squash them into one commit)
- [ x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x ] PR should be backported to stable branches
- [x ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
When cnxcc receives a message wih a registered CID (for example in a re-INVITE) it saves as a new call and this is a problem:
- cnxcc store 2 times the same call and it discounts credit for both
- when the call is finished, cnxcc only remove one record and the other continues discounting credit. 
- when credit is finished (of an non active call), all active calls are killed

An example:
```
kamcmd> cnxcc.check_client test
id:0,confirmed:no,local_consumed_amount:0.004800,global_consumed_amount:3.126200,local_max_amount:30.000000,global_max_amount:30.000000,call_id:41211f7e0a65b41c4ca7181b18db0f1e@185.47.15.56:5080,start_timestamp:0,inip:1,finp:1,connect:0.000000,cps:0.004800;
id:1,confirmed:no,local_consumed_amount:0.004800,global_consumed_amount:3.126200,local_max_amount:30.000000,global_max_amount:30.000000,call_id:41211f7e0a65b41c4ca7181b18db0f1e@185.47.15.56:5080,start_timestamp:0,inip:1,finp:1,connect:0.000000,cps:0.004800;
id:2,confirmed:no,local_consumed_amount:0.000200,global_consumed_amount:3.126200,local_max_amount:30.000000,global_max_amount:30.000000,call_id:5e911ab1452cf1a3165af5262b519977@185.47.15.56:5080,start_timestamp:0,inip:1,finp:1,connect:0.000000,cps:0.000200;
id:3,confirmed:no,local_consumed_amount:0.000200,global_consumed_amount:3.126200,local_max_amount:30.000000,global_max_amount:30.000000,call_id:5e911ab1452cf1a3165af5262b519977@185.47.15.56:5080,start_timestamp:0,inip:1,finp:1,connect:0.000000,cps:0.000200;
id:4,confirmed:no,local_consumed_amount:0.000800,global_consumed_amount:3.126200,local_max_amount:30.000000,global_max_amount:30.000000,call_id:0f44fbc63883e52d72c9f52f49253476@185.47.15.56:5080,start_timestamp:0,inip:1,finp:1,connect:0.000000,cps:0.000800;
```
- id 0 and id 1 are the same call that has been inserted twice.
- id 2 and id 3 are the same call that has been inserted twice.
- id 4 is a finished call that has not been removed from the stack and continues discounting credit.
