### PR TITLE
nathelper: add optional set_contact_alias([trim]) parameter

### DIFF
--- a/src/core/dset.c
+++ b/src/core/dset.c
@@ -1029,6 +1029,91 @@ int uri_restore_rcv_alias(str *uri, str *nuri, str *suri)
 	return 0;
 }
 
+
+/**
+ * trim alias parameter from uri
+ * - nuri->s must point to a buffer of nuri->len size
+ */
+int uri_trim_rcv_alias(str *uri, str *nuri)
+{
+	char *p;
+	str skip;
+	str ip, port;
+	int proto;
+
+	if(uri == NULL || nuri == NULL) {
+		LM_ERR("invalid parameter value\n");
+		return -1;
+	}
+
+	/* sip:x;alias=1.1.1.1~0~0 */
+	if(uri->len < 23) {
+		/* no alias possible */
+		return 0;
+	}
+	p = uri->s + uri->len - 18;
+	skip.s = 0;
+	while(p > uri->s + 5) {
+		if(strncmp(p, ";alias=", 7) == 0) {
+			skip.s = p;
+			break;
+		}
+		p--;
+	}
+	if(skip.s == 0) {
+		/* alias parameter not found */
+		return 0;
+	}
+	p += 7;
+	ip.s = p;
+	p = (char *)memchr(ip.s, '~', (size_t)(uri->s + uri->len - ip.s));
+	if(p == NULL) {
+		/* proper alias parameter not found */
+		return 0;
+	}
+	ip.len = p - ip.s;
+	p++;
+	if(p >= uri->s + uri->len) {
+		/* proper alias parameter not found */
+		return 0;
+	}
+	port.s = p;
+	p = (char *)memchr(port.s, '~', (size_t)(uri->s + uri->len - port.s));
+	if(p == NULL) {
+		/* proper alias parameter not found */
+		return 0;
+	}
+	port.len = p - port.s;
+	p++;
+	if(p >= uri->s + uri->len) {
+		/* proper alias parameter not found */
+		return 0;
+	}
+	proto = (int)(*p - '0');
+	p++;
+
+	if(p != uri->s + uri->len && *p != ';') {
+		/* proper alias parameter not found */
+		return 0;
+	}
+	skip.len = (int)(p - skip.s);
+	if(nuri->len <= uri->len - skip.len) {
+		LM_ERR("uri buffer too small\n");
+		return -1;
+	}
+
+	p = nuri->s;
+	memcpy(p, uri->s, (size_t)(skip.s - uri->s));
+	p += skip.s - uri->s;
+	memcpy(p, skip.s + skip.len,
+			(size_t)(uri->s + uri->len - skip.s - skip.len));
+	p += uri->s + uri->len - skip.s - skip.len;
+	nuri->len = p - nuri->s;
+
+	LM_DBG("decoded <%.*s> => [%.*s]\n", uri->len, uri->s, nuri->len, nuri->s);
+	return 1;
+}
+
 /* address of record (aor) management */
 
 /* address of record considered case sensitive

--- a/src/core/dset.h
+++ b/src/core/dset.h
@@ -284,6 +284,7 @@ int setbflagsval(unsigned int branch, flag_t val);
 
 int uri_add_rcv_alias(sip_msg_t *msg, str *uri, str *nuri);
 int uri_restore_rcv_alias(str *uri, str *nuri, str *suri);
+int uri_trim_rcv_alias(str *uri, str *nuri);
 
 int init_dst_set(void);
 

--- a/src/modules/nathelper/doc/nathelper_admin.xml
+++ b/src/modules/nathelper/doc/nathelper_admin.xml
@@ -842,7 +842,7 @@ if(is_rfc1918("$rd")) {
 
 	<section id="nathelper.set_contact_alias">
 		<title>
-		<function moreinfo="none">set_contact_alias()</function>
+		<function moreinfo="none">set_contact_alias([trim])</function>
 		</title>
 		<para>
 		Adds an <quote>;alias=ip~port~transport</quote> parameter to the
@@ -850,6 +850,16 @@ if(is_rfc1918("$rd")) {
 		The new contact URI is immediately visible to other modules in the
 		way the <function>fix_nated_contact()</function> does it.
 		</para>
+		<para>Meaning of parameters:</para>
+		<itemizedlist>
+			<listitem>
+				<para>
+					<emphasis>trim</emphasis> - by default, set_contact_alias() will not detect and trim an
+					already existing alias parameter. If this optional parameter is set to "1", set_contact_alias()
+					will trim the existing alias before adding a new one.
+				</para>
+			</listitem>
+		</itemizedlist>
 		<para>
 		This function can be used from
 		REQUEST_ROUTE, ONREPLY_ROUTE, BRANCH_ROUTE, and FAILURE_ROUTE.


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2308 

#### Description
add support for trimming an already existing alias parameter when calling `set_contact_alias()`
