### PR TITLE
core: don't close tcp connection for dropped non sip messages

### DIFF
--- a/src/core/receive.c
+++ b/src/core/receive.c
@@ -300,7 +300,7 @@ int receive_msg(char *buf, unsigned int len, receive_info_t *rcv_info)
 			LM_DBG("attempt of nonsip message processing failed\n");
 		} else if(ret == NONSIP_MSG_DROP) {
 			LM_DBG("nonsip message processing completed\n");
-			goto error02;
+			goto end;
 		}
 	}
 	if(errsipmsg==1) {


### PR DESCRIPTION

#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [X] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
when handling non sip messages in a module thru the callback, if we return `NONSIP_MSG_DROP` the tcp/websocket connection is closed. this was observed when receiving non sip messages with websocket module.
