### PR TITLE
core websocket close event

### DIFF
--- a/src/core/events.c
+++ b/src/core/events.c
@@ -189,6 +189,15 @@ int sr_event_register_cb(int type, sr_event_cb_f f)
 				}
 				if(i==SREV_CB_LIST_SIZE) return -1;
 			break;
+		case SREV_TCP_WS_CLOSE:
+				for(i=0; i<SREV_CB_LIST_SIZE; i++) {
+					if(_sr_events_list.tcp_ws_close[i]==0) {
+						_sr_events_list.tcp_ws_close[i] = f;
+						break;
+					}
+				}
+				if(i==SREV_CB_LIST_SIZE) return -1;
+			break;
 		default:
 			return -1;
 	}
@@ -335,6 +344,15 @@ int sr_event_exec(int type, sr_event_param_t *evp)
 						ret |= _sr_events_list.sip_reply_out[i](evp);
 					}
 				} else return 1;
+		case SREV_TCP_WS_CLOSE:
+				if(unlikely(_sr_events_list.tcp_ws_close[0]!=0))
+				{
+					ret = 0;
+					for(i=0; i<SREV_CB_LIST_SIZE
+							&& _sr_events_list.tcp_ws_close[i]; i++) {
+						ret = _sr_events_list.tcp_ws_close[i](evp);
+					}
+				} else return 1;
 		default:
 			return -1;
 	}
@@ -378,6 +396,8 @@ int sr_event_enabled(int type)
 				return (_sr_events_list.net_data_send!=0)?1:0;
 		case SREV_SIP_REPLY_OUT:
 				return (_sr_events_list.sip_reply_out[0]!=0)?1:0;
+		case SREV_TCP_WS_CLOSE:
+				return (_sr_events_list.tcp_ws_close[0]!=0)?1:0;
 	}
 	return 0;
 }

--- a/src/core/events.h
+++ b/src/core/events.h
@@ -38,6 +38,7 @@
 #define SREV_NET_DATA_RECV		14
 #define SREV_NET_DATA_SEND		15
 #define SREV_SIP_REPLY_OUT		16
+#define SREV_TCP_WS_CLOSE		17
 
 #define SREV_CB_LIST_SIZE	8
 
@@ -71,6 +72,7 @@ typedef struct sr_event_cb {
 	sr_event_cb_f net_data_recv;
 	sr_event_cb_f net_data_send;
 	sr_event_cb_f sip_reply_out[SREV_CB_LIST_SIZE];
+	sr_event_cb_f tcp_ws_close[SREV_CB_LIST_SIZE];
 } sr_event_cb_t;
 
 void sr_event_cb_init(void);


### PR DESCRIPTION

#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
allow kamailio modules to be notified when a websocket is closed without depending on script callbacks.
this allows for multiple independent modules to subscribe to new core event `SREV_TCP_WS_CLOSE`