### PR TITLE
p_usrloc: reworking mdb_availability_control

### DIFF
--- a/src/modules/p_usrloc/p_usrloc_mod.c
+++ b/src/modules/p_usrloc/p_usrloc_mod.c
@@ -185,7 +185,7 @@ str default_db_type   = str_init(DEFAULT_DB_TYPE);
 str domain_db         = str_init(DEFAULT_DOMAIN_DB);
 int default_dbt       = 0;
 int expire            = 0;
-db_shared_param_t *write_on_master_db_shared;
+int *mdb_w_available;
 
 /*! \brief
  * Exported functions
@@ -311,13 +311,6 @@ static int mod_init(void)
 	}
 #endif
 
-	if((write_on_master_db_shared = shm_malloc(sizeof(db_shared_param_t))) == NULL) {
-		LM_ERR("couldn't allocate shared memory.\n");
-		return -1;
-	} else {
-		write_on_master_db_shared->val = db_master_write;
-	}
-
 	if(ul_hash_size<=1)
 		ul_hash_size = 512;
 	else
@@ -406,14 +399,18 @@ static int mod_init(void)
 		LM_ERR("could not init database watch environment.\n");
 		return -1;
 	}
-	if (lock_init(&write_on_master_db_shared->lock)==0){
-		LM_ERR("could not initialise lock\n");
+
+	if((mdb_w_available = shm_malloc(sizeof(int))) == NULL) {
+		LM_ERR("couldn't allocate shared memory. \n");
+		return -1;
 	}
-	if(write_on_master_db_shared->val){
+	if (db_master_write) {
 		/* register extra dummy timer to be created in init_db_check() */
 		register_dummy_timers(1);
+		if (mdb_availability_control) {
+			check_master_db();
+		}
 	}
-        check_master_db(db_master_write);
 	return 0;
 }
 
@@ -422,7 +419,7 @@ static int child_init(int _rank)
 {
 	if(_rank==PROC_INIT) {
 		if(init_db_check() < 0){
-				LM_ERR("could not initialise database check.\n");
+			LM_ERR("could not initialise database check.\n");
 			return -1;
 		}
 		return 0;

--- a/src/modules/p_usrloc/p_usrloc_mod.h
+++ b/src/modules/p_usrloc/p_usrloc_mod.h
@@ -123,11 +123,7 @@ extern int connection_expires;
 extern int alg_location;
 
 extern int  max_loc_nr;
-typedef struct db_shared_param {
-	int val;
-	gen_lock_t lock;
-} db_shared_param_t;
-extern db_shared_param_t *write_on_master_db_shared;
+extern int * mdb_w_available;
 extern int mdb_availability_control;
 
 #endif /* UL_MOD_H */

--- a/src/modules/p_usrloc/ul_db_watch.c
+++ b/src/modules/p_usrloc/ul_db_watch.c
@@ -97,8 +97,8 @@ void check_dbs(unsigned int ticks, void *param){
 	int found;
 	int i;
 
-	if(mdb_availability_control) {
-		check_master_db(db_master_write);
+	if (db_master_write && mdb_availability_control) {
+		check_master_db();
 	}
 	if(!list_lock){
 		return;
@@ -152,20 +152,19 @@ void check_dbs(unsigned int ticks, void *param){
 	lock_release(list_lock);
 }
 
-void check_master_db(int dbm_write_default) {
+void check_master_db() {
 	if(mdb.write.dbh){
 		mdb.write.dbf.close(mdb.write.dbh);
 		mdb.write.dbh = NULL;
 	}
 
-	lock_get(&write_on_master_db_shared->lock);
 	if((mdb.write.dbh  = mdb.write.dbf.init(mdb.write.url)) == NULL) {
-		write_on_master_db_shared->val = 0;
-		LM_WARN("Master db is unavailable.\n");
+		LM_INFO("Master db is unavailable.\n");
+		*mdb_w_available = 0;
 	} else {
-		write_on_master_db_shared->val = dbm_write_default;
+		LM_INFO("Master db is available.\n");
+		*mdb_w_available = 1;
 	}
-	lock_release(&write_on_master_db_shared->lock);
 }
 
 int ul_register_watch_db(int id){

--- a/src/modules/p_usrloc/ul_db_watch.h
+++ b/src/modules/p_usrloc/ul_db_watch.h
@@ -35,6 +35,6 @@ int ul_register_watch_db(int id);
 
 int ul_unregister_watch_db(int id);
 
-void check_master_db(int dbm_write_default);
+void check_master_db();
 
 #endif


### PR DESCRIPTION
- simplify general implementation
- avoid deadlock due to a process trying to acquire same lock twice

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
On a timer, checking the availability of the master db used for writing and setting a status variable accordingly. In case the mdb_availability_control option is set, this status variable is consulted with no synchronization by each process when trying to do a write to the master db. As error mitigation, in case the per process handle associated with master db is NULL, p_usrlock recreates it. In case the per process handle is not NULL, Kamailio will try to recreate a broken connection by itself.