### PR TITLE
core: add sip_parser_log core variable

### DIFF
--- a/src/core/cfg.lex
+++ b/src/core/cfg.lex
@@ -363,6 +363,7 @@ MEMSAFETY	"mem_safety"
 MEMJOIN		"mem_join"
 MEMSTATUSMODE		"mem_status_mode"
 CORELOG		"corelog"|"core_log"
+SIP_PARSER_LOG "sip_parser_log"
 SIP_WARNING sip_warning
 SERVER_SIGNATURE server_signature
 SERVER_HEADER server_header
@@ -810,6 +811,7 @@ IMPORTFILE      "import_file"
 <INITIAL>{MEMSAFETY}	{ count(); yylval.strval=yytext; return MEMSAFETY; }
 <INITIAL>{MEMJOIN}	{ count(); yylval.strval=yytext; return MEMJOIN; }
 <INITIAL>{MEMSTATUSMODE}	{ count(); yylval.strval=yytext; return MEMSTATUSMODE; }
+<INITIAL>{SIP_PARSER_LOG}  { count(); yylval.strval=yytext; return SIP_PARSER_LOG; }
 <INITIAL>{CORELOG}	{ count(); yylval.strval=yytext; return CORELOG; }
 <INITIAL>{SIP_WARNING}	{ count(); yylval.strval=yytext; return SIP_WARNING; }
 <INITIAL>{USER}		{ count(); yylval.strval=yytext; return USER; }

--- a/src/core/cfg.y
+++ b/src/core/cfg.y
@@ -388,6 +388,7 @@ extern char *default_routename;
 %token MEMSAFETY
 %token MEMJOIN
 %token MEMSTATUSMODE
+%token SIP_PARSER_LOG
 %token CORELOG
 %token SIP_WARNING
 %token SERVER_SIGNATURE
@@ -943,6 +944,8 @@ assign_stm:
 	| MEMJOIN EQUAL error { yyerror("int value expected"); }
 	| MEMSTATUSMODE EQUAL intno { default_core_cfg.mem_status_mode=$3; }
 	| MEMSTATUSMODE EQUAL error { yyerror("int value expected"); }
+	| SIP_PARSER_LOG EQUAL intno { default_core_cfg.sip_parser_log=$3; }
+	| SIP_PARSER_LOG EQUAL error { yyerror("int value expected"); }
 	| CORELOG EQUAL intno { default_core_cfg.corelog=$3; }
 	| CORELOG EQUAL error { yyerror("int value expected"); }
 	| SIP_WARNING EQUAL NUMBER { sip_warning=$3; }

--- a/src/core/cfg_core.c
+++ b/src/core/cfg_core.c
@@ -115,6 +115,7 @@ struct cfg_group_core default_core_cfg = {
 	1, /*!< mem_safety - 0 disabled; 1 enabled */
 	1, /*!< mem_join - 1 enabled */
 	0, /*!< mem_status_mode - 0 only free fragments, 1 all fragements */
+	L_ERR, /*!< sip msg parser error log level*/
 	L_ERR, /*!< corelog */
 	L_DBG, /*!< latency cfg log */
 	L_ERR, /*!< latency log */
@@ -318,6 +319,8 @@ cfg_def_t core_cfg_def[] = {
 		"join free memory fragments"},
 	{"mem_status_mode",		CFG_VAR_INT|CFG_ATOMIC,	0, 0, 0, 0,
 		"print status for free or all memory fragments"},
+	{"sip_parser_log",		CFG_VAR_INT|CFG_ATOMIC,	0, 0, 0, 0,
+		"log level for sip msg parser error messages"},
 	{"corelog",		CFG_VAR_INT|CFG_ATOMIC,	0, 0, 0, 0,
 		"log level for non-critical core error messages"},
 	{"latency_cfg_log",		CFG_VAR_INT|CFG_ATOMIC,	0, 0, 0, 0,

--- a/src/core/cfg_core.h
+++ b/src/core/cfg_core.h
@@ -103,6 +103,7 @@ struct cfg_group_core {
 	int mem_safety; /*!< memory safety control option */
 	int mem_join; /*!< memory free fragments join option */
 	int mem_status_mode; /*!< memory status printed for free/all fragments */
+	int sip_parser_log; /*!< sip msg parser error log level*/
 	int corelog; /*!< log level for non-critcal core error messages */
 	int latency_cfg_log; /*!< log level for printing latency of routing blocks */
 	int latency_log; /*!< log level for latency limits messages */

--- a/src/core/parser/msg_parser.c
+++ b/src/core/parser/msg_parser.c
@@ -677,7 +677,7 @@ int parse_msg(char* const buf, const unsigned int len, struct sip_msg* const msg
 
 error:
 	/* more debugging, msg->orig is/should be null terminated*/
-	LOG(cfg_get(core, core_cfg, corelog), "ERROR: parse_msg: message=<%.*s>\n",
+	LOG(cfg_get(core, core_cfg, sip_parser_log), "ERROR: parse_msg: message=<%.*s>\n",
 			(int)msg->len, ZSW(msg->buf));
 	return -1;
 }

--- a/src/core/parser/parse_fline.c
+++ b/src/core/parser/parse_fline.c
@@ -268,7 +268,7 @@ error:
 	}
 error1:
 	fl->type=SIP_INVALID;
-	LOG(cfg_get(core, core_cfg, corelog), "parse_first_line: bad message (offset: %d)\n", offset);
+	LOG(cfg_get(core, core_cfg, sip_parser_log), "parse_first_line: bad message (offset: %d)\n", offset);
 	/* skip  line */
 	nl=eat_line(buffer,len);
 	return nl;

--- a/src/core/receive.c
+++ b/src/core/receive.c
@@ -304,7 +304,7 @@ int receive_msg(char *buf, unsigned int len, receive_info_t *rcv_info)
 		}
 	}
 	if(errsipmsg==1) {
-		LOG(cfg_get(core, core_cfg, corelog),
+		LOG(cfg_get(core, core_cfg, sip_parser_log),
 				"core parsing of SIP message failed (%s:%d/%d)\n",
 				ip_addr2a(&msg->rcv.src_ip), (int)msg->rcv.src_port,
 				(int)msg->rcv.proto);


### PR DESCRIPTION
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
when handling non sip messages, parser errors are logged at core level which defaults to ERR.
since this may induce in error sysops or log scanners, sometimes the core level is set to debug just to omit these
messages from log, which is not good since other messages are omitted too.
this commit adds a new core variable to set the log level for message parsing errors.
this way, we can explicitly set the log level for message parsing while leaving the core level at ERR.

