### PR TITLE
evapi: added KEMI function for evapi_async_unicast

### DIFF
--- a/src/modules/evapi/evapi_mod.c
+++ b/src/modules/evapi/evapi_mod.c
@@ -733,7 +733,7 @@ static int ki_evapi_async_relay_unicast(sip_msg_t *msg, str *sdata, str *stag)
         {
                 LM_ERR("failed to suspend request processing\n");
                 return -1;
-        }
+	}
 
 	LM_DBG("transaction suspended [%u:%u]\n", tindex, tlabel);
 
@@ -750,9 +750,9 @@ static int ki_evapi_async_relay_unicast(sip_msg_t *msg, str *sdata, str *stag)
 
         if(evapi_relay_unicast(sdata, stag)<0) {
                 LM_ERR("failed to relay event: [[%.*s]] to [%.*s] \n",
-                                sdata->len, sdata->s, stag->len, stag->s);
-                return -2;
-        }
+				sdata->len, sdata->s, stag->len, stag->s);
+		return -2;
+	}
 	return 1;
 }
 
@@ -819,11 +819,11 @@ static sr_kemi_t sr_kemi_evapi_exports[] = {
 		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
                         SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
-        { str_init("evapi"), str_init("async_relay_unicast"),
-                SR_KEMIP_INT, ki_evapi_async_relay_unicast,
-                { SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
-                        SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
-        },
+	{ str_init("evapi"), str_init("async_relay_unicast"),
+		SR_KEMIP_INT, ki_evapi_async_relay_unicast,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
 	{ {0, 0}, {0, 0}, 0, NULL, { 0, 0, 0, 0, 0, 0 } }
 };
 /* clang-format on */

--- a/src/modules/evapi/evapi_mod.c
+++ b/src/modules/evapi/evapi_mod.c
@@ -705,51 +705,51 @@ static int ki_evapi_async_relay(sip_msg_t *msg, str *sdata)
 
 static int ki_evapi_async_relay_unicast(sip_msg_t *msg, str *sdata, str *stag)
 {
-        unsigned int tindex;
-        unsigned int tlabel;
-        tm_cell_t *t = 0;
+	unsigned int tindex;
+	unsigned int tlabel;
+	tm_cell_t *t = 0;
 
-        if(tmb.t_suspend==NULL) {
-                LM_ERR("evapi async relay is disabled - tm module not loaded\n");
-                return -1;
-        }
+	if(tmb.t_suspend==NULL) {
+		LM_ERR("evapi async relay is disabled - tm module not loaded\n");
+		return -1;
+	}
 
-        t = tmb.t_gett();
-        if (t==NULL || t==T_UNDEFINED)
-        {
-                if(tmb.t_newtran(msg)<0)
-                {
-                        LM_ERR("cannot create the transaction\n");
-                        return -1;
-                }
-                t = tmb.t_gett();
-                if (t==NULL || t==T_UNDEFINED)
-                {
-                        LM_ERR("cannot lookup the transaction\n");
-                        return -1;
-                }
-        }
-        if(tmb.t_suspend(msg, &tindex, &tlabel)<0)
-        {
-                LM_ERR("failed to suspend request processing\n");
-                return -1;
+	t = tmb.t_gett();
+	if (t==NULL || t==T_UNDEFINED)
+	{
+		if(tmb.t_newtran(msg)<0)
+		{
+			LM_ERR("cannot create the transaction\n");
+			return -1;
+		}
+		t = tmb.t_gett();
+		if (t==NULL || t==T_UNDEFINED)
+		{
+			LM_ERR("cannot lookup the transaction\n");
+			return -1;
+		}
+	}
+	if(tmb.t_suspend(msg, &tindex, &tlabel)<0)
+	{
+		LM_ERR("failed to suspend request processing\n");
+		return -1;
 	}
 
 	LM_DBG("transaction suspended [%u:%u]\n", tindex, tlabel);
 
 
-        if(sdata->s==NULL || sdata->len == 0) {
-                LM_ERR("invalid data parameter\n");
-                return -1;
-        }
+	if(sdata->s==NULL || sdata->len == 0) {
+		LM_ERR("invalid data parameter\n");
+		return -1;
+	}
 
-        if(stag->s==NULL || stag->len == 0) {
-                LM_ERR("invalid tag parameter\n");
-                return -1;
-        }
+	if(stag->s==NULL || stag->len == 0) {
+		LM_ERR("invalid tag parameter\n");
+		return -1;
+	}
 
-        if(evapi_relay_unicast(sdata, stag)<0) {
-                LM_ERR("failed to relay event: [[%.*s]] to [%.*s] \n",
+	if(evapi_relay_unicast(sdata, stag)<0) {
+		LM_ERR("failed to relay event: [[%.*s]] to [%.*s] \n",
 				sdata->len, sdata->s, stag->len, stag->s);
 		return -2;
 	}

--- a/src/modules/evapi/evapi_mod.c
+++ b/src/modules/evapi/evapi_mod.c
@@ -703,7 +703,7 @@ static int ki_evapi_async_relay(sip_msg_t *msg, str *sdata)
 	return 1;
 }
 
-static int ki_evapi_async_relay_unicast(sip_msg_t *msg, str *sdata, str *stag)
+static int ki_evapi_async_unicast(sip_msg_t *msg, str *sdata, str *stag)
 {
 	unsigned int tindex;
 	unsigned int tlabel;
@@ -819,8 +819,8 @@ static sr_kemi_t sr_kemi_evapi_exports[] = {
 		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
                         SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
-	{ str_init("evapi"), str_init("async_relay_unicast"),
-		SR_KEMIP_INT, ki_evapi_async_relay_unicast,
+	{ str_init("evapi"), str_init("async_unicast"),
+		SR_KEMIP_INT, ki_evapi_async_unicast,
 		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
added KEMI function for evapi_async_unicast for evapi module
