### PR TITLE
pua: update_version_puadb() use pres_id to select record

### DIFF
--- a/src/modules/pua/pua_db.c
+++ b/src/modules/pua/pua_db.c
@@ -1485,8 +1485,8 @@ int update_contact_puadb(ua_pres_t *pres, str *contact)
 int update_version_puadb(ua_pres_t *pres)
 
 {
-	db_key_t q_cols[3], db_cols[1];
-	db_val_t q_vals[3], db_vals[1];
+	db_key_t q_cols[1], db_cols[1];
+	db_val_t q_vals[1], db_vals[1];
 	int n_query_cols= 0, n_update_cols=0;
 
 	if (pres==NULL)
@@ -1496,22 +1496,10 @@ int update_version_puadb(ua_pres_t *pres)
 	}
 
 	/* cols and values used for search query */
-	q_cols[n_query_cols] = &str_call_id_col;
+	q_cols[n_query_cols] = &str_pres_id_col;
 	q_vals[n_query_cols].type = DB1_STR;
 	q_vals[n_query_cols].nul = 0;
-	q_vals[n_query_cols].val.str_val = pres->call_id;
-	n_query_cols++;
-
-	q_cols[n_query_cols] = &str_to_tag_col;
-	q_vals[n_query_cols].type = DB1_STR;
-	q_vals[n_query_cols].nul = 0;
-	q_vals[n_query_cols].val.str_val = pres->to_tag;
-	n_query_cols++;
-
-	q_cols[n_query_cols] = &str_from_tag_col;
-	q_vals[n_query_cols].type = DB1_STR;
-	q_vals[n_query_cols].nul = 0;
-	q_vals[n_query_cols].val.str_val = pres->from_tag;
+	q_vals[n_query_cols].val.str_val = pres->id;
 	n_query_cols++;
 
 	/* we overwrite contact even if not changed */


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2414

#### Description
* only relevant when db_mode is PUA_DB_ONLY
* call_id/to_tag/from_tag values can be "", for instance with
  DIALOG_PUBLISH.* records. Then **ALL** records get version
  field update
* update_vesion_puadb() is called from send_publish() and pres->id
  value is valid after a call to get_record_puadb()

