### PR TITLE
acc: add to-tag for locally generated replies

### DIFF
--- a/src/modules/acc/acc.c
+++ b/src/modules/acc/acc.c
@@ -123,6 +123,13 @@ int core2strar(struct sip_msg *req, str *c_vals, int *i_vals, char *t_vals)
 		t_vals[2] = TYPE_NULL;
 	}
 
+	LM_DBG("default - totag[%.*s]\n", c_vals[2].len, c_vals[2].s);
+	if (c_vals[2].len == 0 && acc_env.to_tag.s && acc_env.to_tag.len > 0) {
+		LM_DBG("extra [%p] totag[%.*s]\n", acc_env.to_tag.s, acc_env.to_tag.len, acc_env.to_tag.s);
+		c_vals[2].len = acc_env.to_tag.len;
+		c_vals[2].s = acc_env.to_tag.s;
+	}
+
 	/* Callid */
 	if (req->callid && req->callid->body.len) {
 		c_vals[3] = req->callid->body;

--- a/src/modules/acc/acc_api.h
+++ b/src/modules/acc/acc_api.h
@@ -54,6 +54,7 @@ typedef struct acc_enviroment {
 	str code_s;
 	str reason;
 	struct hdr_field *to;
+	str to_tag; /*!< locally generated to-tag */
 	str text;
 	time_t ts;
 	struct timeval tv;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
When doing t_reply/send_reply stateful, the ACC module will not add the to-tag to the ACC events.
This patch will fix this and ensure that we get the to-tag that was locally generated used in the reply.

example :

```
modparam("acc", "acc_prepare_always", 1)
modparam("acc_json", "acc_missed_flag", 6)

failure_route[test] {
    setflag(6); // MISSED_ACC, the failure will be recorded by ACC
    t_flush_flags(); // This will set the flags in the newly created transaction
    t_reply("500", "Service Unavailable");
}
```
This does generate an ACC event, however the to-tag is not populated, my guess this is because the TM callback is done before the to-tag is generated.

This patch will populate the to-tag immediately.

