### PR TITLE
keepalive: added uuid to ka_dest structure to avoid passing the whole struct to tm

### DIFF
--- a/src/modules/keepalive/keepalive.h
+++ b/src/modules/keepalive/keepalive.h
@@ -31,6 +31,8 @@
 #include <time.h>
 #include "../../core/sr_module.h"
 #include "../../core/locking.h"
+#include "../../core/str.h"
+#include "../../core/utils/sruid.h"
 #include "../tm/tm_load.h"
 
 #define KA_INACTIVE_DST 1 /*!< inactive destination */
@@ -60,6 +62,7 @@ typedef struct _ka_dest
 	str uri;
 	str owner; // name of destination "owner"
 			   // (module asking to monitor this destination
+	str  uuid; // Universal id for this record
 	int flags;
 	int state;
 	time_t last_checked, last_up, last_down;
@@ -85,6 +88,7 @@ typedef struct _ka_destinations_list
 
 extern ka_destinations_list_t *ka_destinations_list;
 extern int ka_counter_del;
+extern sruid_t ka_sruid;
 
 ticks_t ka_check_timer(ticks_t ticks, struct timer_ln* tl, void* param);
 
@@ -96,6 +100,7 @@ int ka_str_copy(str *src, str *dest, char *prefix);
 int free_destination(ka_dest_t *dest) ;
 int ka_del_destination(str *uri, str *owner) ;
 int ka_find_destination(str *uri, str *owner, ka_dest_t **target ,ka_dest_t **head);
+int ka_find_destination_by_uuid(str uuid, ka_dest_t **target, ka_dest_t **head);
 int ka_lock_destination_list();
 int ka_unlock_destination_list();
 #endif

--- a/src/modules/keepalive/keepalive_mod.c
+++ b/src/modules/keepalive/keepalive_mod.c
@@ -61,6 +61,7 @@ extern struct tm_binds tmb;
 
 int ka_ping_interval = 30;
 ka_destinations_list_t *ka_destinations_list = NULL;
+sruid_t ka_sruid;
 str ka_ping_from = str_init("sip:keepalive@kamailio.org");
 int ka_counter_del = 5;
 
@@ -123,6 +124,10 @@ static int mod_init(void)
 
 	if(ka_alloc_destinations_list() < 0)
 		return -1;
+
+	if(sruid_init(&ka_sruid, '-', "ka", SRUID_INC) < 0) {
+		return -1;
+	}
 
 	return 0;
 }


### PR DESCRIPTION

- This avoids a race condition that may happen processing tm_request callbacl
- Allows to identify uniquely a ka_dest record

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2448 

#### Description
<!-- Describe your changes in detail -->
Check issue