### PR TITLE
dialog: dlg_cell, always check for a to-tag match

### DIFF
--- a/src/modules/dialog/dlg_hash.c
+++ b/src/modules/dialog/dlg_hash.c
@@ -865,6 +865,7 @@ static inline struct dlg_cell* internal_get_dlg(unsigned int h_entry,
 						unsigned int *dir, int mode)
 {
 	struct dlg_cell *dlg;
+	struct dlg_cell *dlg_no_totag=NULL;
 	struct dlg_entry *d_entry;
 
 	d_entry = &(d_table->entries[h_entry]);
@@ -876,13 +877,24 @@ static inline struct dlg_cell* internal_get_dlg(unsigned int h_entry,
 		if (match_dialog( dlg, callid, ftag, ttag, dir)==1) {
 			ref_dlg_unsafe(dlg, 1);
 			if(likely(mode==0)) dlg_unlock( d_table, d_entry);
-			LM_DBG("dialog callid='%.*s' found on entry %u, dir=%d\n",
-				callid->len, callid->s,h_entry,*dir);
+
+			/* If to-tag is empty continue to search in case another dialog is found with a matching to-tag. */
+			if (dlg->tag[1].len == 0) {
+				dlg_no_totag=dlg;
+				LM_DBG("dialog callid='%.*s' found on entry %u, dir=%d\n",
+					callid->len, callid->s,h_entry,*dir);
+				continue;
+			}
+			LM_DBG("dialog callid='%.*s' found on entry %u, dir=%d to-tag='%.*s'\n",
+				callid->len, callid->s,h_entry,*dir, dlg->tag[1].len, dlg->tag[1].s);
+
 			return dlg;
 		}
 	}
 
 	if(likely(mode==0)) dlg_unlock( d_table, d_entry);
+	if (dlg_no_totag) return dlg_no_totag;
+
 	LM_DBG("no dialog callid='%.*s' found\n", callid->len, callid->s);
 	return 0;
 }


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)


#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Based on the email thread :
```
[SR-Users] Dialog - timeout for dlg with CallID
```
Several users are facing unexpected dialog disconnection caused by no-ack timer.

Using a modified version of the dialog module to improve debug-ability 
https://github.com/kamailio/kamailio/pull/2483

I was able to confirm at least one problem and after looking at the trace, it seems like dialog mismatch with a serial forking scenario :

- log line 3 is telling us that a NO-ACK disconnection should be triggered
- log line 1-2 is telling us what happened when the ACK was received in dlg_onroute(), oddly enough state 5 was old and new, could it be a mismatch/confusio with the previous dialog, looking in this direction ...
```
1: 2020-09-25T16:30:16.896: dialog [dlg_handlers.c:1273]: extra_ack_debug_info(): [ACK][1] state not changed >>> call-id[562419_125824138_2072238224] to-tag[<sip:+14019991904@anon.com>;tag=gK02b68836]
2: 2020-09-25T16:30:16.896: dialog [dlg_handlers.c:1440]: dlg_onroute(): [ACK] state not changed old[5]new[5]
...
3: 2020-09-25T16:32:22.674: dialog [dlg_hash.c:247]: dlg_clean_run(): dialog disconnection no-ACK call-id[562419_125824138_2072238224][1601051416]<[1601051542 - 60]
```

After looking at the pcap trace, call-id 562419_125824138_2072238224 was involved in serial forking :

call attempt1
```
X >> INVITE >> Y   // no to-tag  
X << 100
...
X << 408           // to-tag=594d50c3218065a60bb91fd47a70fbc1-59edef02 (locally generated)
X >> ACK           // to-tag=594d50c3218065a60bb91fd47a70fbc1-59edef02
```
call attempt2
```
X >> INVITE >> Z   // no to-tag
X << 100
X << 200    << Z   // to-tag=gK02b68836
X >> ACK    >> Z   // to-tag=gK02b68836 (Should be state old[3]new[4], I wonder how it could possibly be state old[5]new[5])
```


I did look at several occurrences and there is always a locally generated 408/to-tag before, seems like I have a good lead to investigate further.