### PR TITLE
dispatcher: add an attribute to preset the latency estimator

### DIFF
--- a/src/modules/dispatcher/dispatch.h
+++ b/src/modules/dispatcher/dispatch.h
@@ -204,6 +204,8 @@ typedef struct _ds_latency_stats {
 	uint32_t timeout;
 } ds_latency_stats_t;
 
+void latency_stats_init(ds_latency_stats_t *latency_stats, int latency, int count);
+
 typedef struct _ds_dest {
 	str uri;          /*!< address/uri */
 	int flags;        /*!< flags */

--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -709,6 +709,7 @@ modparam("dispatcher", "ds_probing_mode", 1)
 		<title><varname>ds_ping_latency_stats</varname> (int)</title>
 		<para>
 		Enable latency measurement when pinging nodes
+		The estimator can be initialized at startup and reload using the attribute latency.
 		</para>
 
 		<itemizedlist>
@@ -735,6 +736,9 @@ DEST: {
 	URI: sip:1.2.3.4
 	FLAGS: AX
 	PRIORITY: 9
+	ATTRS: {
+		BODY: latency=24
+	}
 	LATENCY: {
 		AVG: 24.250000 # weighted moving average for the last few weeks
 		STD: 1.035000  # standard deviation of AVG
@@ -2125,6 +2129,9 @@ kamctl rpc dispatcher.hash 4 bob server.com
 						<listitem>
 							<para>'obproxy' - SIP URI of outbound proxy to be used when sending
 								pings. It overwrites the general ds_outbound_proxy parameter.</para>
+						</listitem>
+						<listitem>
+							<para>'latency' - latency_stats initialization in ms.</para>
 						</listitem>
 					</itemizedlist>
 		</para>


### PR DESCRIPTION


<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Type Of Change
- [x] New feature (non-breaking change which adds new functionality)

#### Description
Add a configuration setting to preset latency estimator in dispatcher