### PR TITLE
nathelper: fix_nated_sdp added support for a=rtcp param RFC3605

### DIFF
--- a/src/modules/nathelper/doc/nathelper_admin.xml
+++ b/src/modules/nathelper/doc/nathelper_admin.xml
@@ -562,7 +562,7 @@ if (search("User-Agent: Cisco ATA.*") {fix_nated_contact();};
 				<listitem>
 					<para><emphasis>0x02</emphasis> - rewrite media
 					&ip; address (c=) with source address of the message
-					or the provided IP address (the provide IP address take
+					or the provided IP address. (a=rtpc) param will be rewritten if exists. (the provided IP address take
 					precedence over the source address).</para>
 				</listitem>
 				<listitem>
@@ -572,7 +572,7 @@ if (search("User-Agent: Cisco ATA.*") {fix_nated_contact();};
 				<listitem>
 					<para><emphasis>0x08</emphasis> - rewrite IP from
 					origin description (o=) with source address of the message
-					or the provided IP address (the provide IP address take
+					or the provided IP address. (a=rtpc) param will be rewritten if exists. (the provided IP address take
 					precedence over the source address).</para>
 				</listitem>
 			</itemizedlist>
@@ -582,7 +582,7 @@ if (search("User-Agent: Cisco ATA.*") {fix_nated_contact();};
 			If not specified, the received signalling IP will be used. The
 			parameter allows pseudo-variables usage. NOTE: For the IP to be
 			used, you need to use 0x02 or 0x08 flags, otherwise it will have
-			no effect.
+			no effect. Must be IPv4 address family. 
 			</para>
 			</listitem>
 		</itemizedlist>


### PR DESCRIPTION
- GH #2459


#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2459 

#### Description
fix_nated_sdp() function with flags 0x02 and 0x08 and an IP address as argument (or without one) does modify the media line and the connection line. In addition it will modify IP address in "a=rtcp" parameter (rfc3605) in case if there is one. If a=rtcp param is not found the function doesn't return -1, but prints a DBG message and continues to execute (changing c= or o= lines)  