### PR TITLE
registrar: added new parameter sock_addr

### DIFF
--- a/src/modules/registrar/doc/registrar_admin.xml
+++ b/src/modules/registrar/doc/registrar_admin.xml
@@ -535,31 +535,6 @@ modparam("registrar", "sock_hdr_name", "Sock-Info")
 		</example>
 	</section>
 
-	<section id="registrar.p.sock_addr">
-		<title><varname>sock_addr</varname> (string)</title>
-		<para>
-		This parameters can be used to override value written into socket field when contact is saved.
-		The value should be given in the following format: proto:IP:port. 
-		</para>
-		<para>
-		It could be usefull when kamailio is installed behind NAT and it is necessary to store its public IP 
-		instead socket on which the register request was received.
-		</para>
-		<para>
-		<emphasis>
-			Default value is NULL.
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>sock_addr</varname> parameter</title>
-		<programlisting format="linespecific">
-...
-modparam("registrar", "sock_addr", "udp:104.215.148.63:5060")
-...
-		</programlisting>
-		</example>
-	</section>
-
 	<section id="registrar.p.method_filtering">
 		<title><varname>method_filtering</varname> (integer)</title>
 		<para>

--- a/src/modules/registrar/doc/registrar_admin.xml
+++ b/src/modules/registrar/doc/registrar_admin.xml
@@ -535,6 +535,31 @@ modparam("registrar", "sock_hdr_name", "Sock-Info")
 		</example>
 	</section>
 
+	<section id="registrar.p.use_advertised_address">
+		<title><varname>use_advertised_address</varname> (integer)</title>
+		<para>
+		This parameter can be used to override value written into socket field when contact is saved.
+		If set to 1, advertised address will be written instead local listen socket.
+		</para>
+		<para>
+		This could be useful when kamailio is installed behind NAT and it is necessary to store its public IP 
+		instead socket on which the register request was received.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0 (disabled).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>use_advertised_address</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("registrar", "use_advertised_address", 1)
+...
+		</programlisting>
+		</example>
+	</section>
+
 	<section id="registrar.p.method_filtering">
 		<title><varname>method_filtering</varname> (integer)</title>
 		<para>

--- a/src/modules/registrar/doc/registrar_admin.xml
+++ b/src/modules/registrar/doc/registrar_admin.xml
@@ -535,6 +535,31 @@ modparam("registrar", "sock_hdr_name", "Sock-Info")
 		</example>
 	</section>
 
+	<section id="registrar.p.sock_addr">
+		<title><varname>sock_addr</varname> (string)</title>
+		<para>
+		This parameters can be used to override value written into socket field when contact is saved.
+		The value should be given in the following format: proto:IP:port. 
+		</para>
+		<para>
+		It could be usefull when kamailio is installed behind NAT and it is necessary to store its public IP 
+		instead socket on which the register request was received.
+		</para>
+		<para>
+		<emphasis>
+			Default value is NULL.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>sock_addr</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("registrar", "sock_addr", "udp:104.215.148.63:5060")
+...
+		</programlisting>
+		</example>
+	</section>
+
 	<section id="registrar.p.method_filtering">
 		<title><varname>method_filtering</varname> (integer)</title>
 		<para>

--- a/src/modules/registrar/registrar.c
+++ b/src/modules/registrar/registrar.c
@@ -131,6 +131,7 @@ int reg_use_domain = 0;
 
 int sock_flag = -1;
 str sock_hdr_name = {0,0};
+str sock_addr = {0,0};
 
 /* where to go for event route ("usrloc:contact-expired") */
 int reg_expire_event_rt = -1; /* default disabled */
@@ -249,6 +250,7 @@ static param_export_t params[] = {
 	{"lookup_filter_mode", INT_PARAM, &reg_lookup_filter_mode			},
 	{"min_expires_mode",   PARAM_INT, &reg_min_expires_mode				},
 	{"use_expired_contacts",  INT_PARAM, &default_registrar_cfg.use_expired_contacts	 },
+	{"sock_addr",          PARAM_STR, &sock_addr                        },
 	{0, 0, 0}
 };
 

--- a/src/modules/registrar/registrar.c
+++ b/src/modules/registrar/registrar.c
@@ -132,6 +132,8 @@ int reg_use_domain = 0;
 int sock_flag = -1;
 str sock_hdr_name = {0,0};
 
+int sock_advertise_enabled = 0;
+
 /* where to go for event route ("usrloc:contact-expired") */
 int reg_expire_event_rt = -1; /* default disabled */
 str reg_event_callback = STR_NULL;
@@ -249,6 +251,7 @@ static param_export_t params[] = {
 	{"lookup_filter_mode", INT_PARAM, &reg_lookup_filter_mode			},
 	{"min_expires_mode",   PARAM_INT, &reg_min_expires_mode				},
 	{"use_expired_contacts",  INT_PARAM, &default_registrar_cfg.use_expired_contacts	 },
+	{"use_advertised_address", PARAM_INT, &sock_advertise_enabled		},
 	{0, 0, 0}
 };
 

--- a/src/modules/registrar/registrar.c
+++ b/src/modules/registrar/registrar.c
@@ -131,7 +131,6 @@ int reg_use_domain = 0;
 
 int sock_flag = -1;
 str sock_hdr_name = {0,0};
-str sock_addr = {0,0};
 
 /* where to go for event route ("usrloc:contact-expired") */
 int reg_expire_event_rt = -1; /* default disabled */
@@ -250,7 +249,6 @@ static param_export_t params[] = {
 	{"lookup_filter_mode", INT_PARAM, &reg_lookup_filter_mode			},
 	{"min_expires_mode",   PARAM_INT, &reg_min_expires_mode				},
 	{"use_expired_contacts",  INT_PARAM, &default_registrar_cfg.use_expired_contacts	 },
-	{"sock_addr",          PARAM_STR, &sock_addr                        },
 	{0, 0, 0}
 };
 

--- a/src/modules/registrar/registrar.h
+++ b/src/modules/registrar/registrar.h
@@ -99,7 +99,6 @@ extern int reg_flow_timer;
 
 extern str sock_hdr_name;
 extern int sock_flag;
-extern str sock_addr;
 
 extern str reg_xavp_cfg;
 extern str reg_xavp_rcd;

--- a/src/modules/registrar/registrar.h
+++ b/src/modules/registrar/registrar.h
@@ -99,6 +99,7 @@ extern int reg_flow_timer;
 
 extern str sock_hdr_name;
 extern int sock_flag;
+extern str sock_addr;
 
 extern str reg_xavp_cfg;
 extern str reg_xavp_rcd;

--- a/src/modules/registrar/registrar.h
+++ b/src/modules/registrar/registrar.h
@@ -99,6 +99,7 @@ extern int reg_flow_timer;
 
 extern str sock_hdr_name;
 extern int sock_flag;
+extern int sock_advertise_enabled;
 
 extern str reg_xavp_cfg;
 extern str reg_xavp_rcd;

--- a/src/modules/registrar/save.c
+++ b/src/modules/registrar/save.c
@@ -253,14 +253,14 @@ static inline ucontact_info_t* pack_ci( struct sip_msg* _m, contact_t* _c,
 		}
 
 		/* set received socket */
-		if (_m->rcv.bind_address && _m->rcv.bind_address->useinfo.sock_str.len > 0) {
-		    memset(&si, 0, sizeof(struct socket_info));
-		    si.sock_str = _m->rcv.bind_address->useinfo.sock_str;
-		    ci.sock = &si;
-		} else if (_m->flags&sock_flag) {
+		if (_m->flags&sock_flag) {
 			ci.sock = get_sock_val(_m);
 			if (ci.sock==0)
 				ci.sock = _m->rcv.bind_address;
+		} else if (sock_advertise_enabled && _m->rcv.bind_address && _m->rcv.bind_address->useinfo.sock_str.len > 0) {
+		    memset(&si, 0, sizeof(struct socket_info));
+		    si.sock_str = _m->rcv.bind_address->useinfo.sock_str;
+		    ci.sock = &si;
 		} else {
 			ci.sock = _m->rcv.bind_address;
 		}

--- a/src/modules/registrar/save.c
+++ b/src/modules/registrar/save.c
@@ -230,6 +230,7 @@ static inline ucontact_info_t* pack_ci( struct sip_msg* _m, contact_t* _c,
 	static unsigned int allowed, allow_parsed;
 	static struct sip_msg *m = 0;
 	int_str val;
+	struct socket_info *si = 0;
 
 	if (_m!=0) {
 		memset( &ci, 0, sizeof(ucontact_info_t));
@@ -252,7 +253,18 @@ static inline ucontact_info_t* pack_ci( struct sip_msg* _m, contact_t* _c,
 		}
 
 		/* set received socket */
-		if (_m->flags&sock_flag) {
+		if (sock_addr.len>0) {
+			si = (struct socket_info *)pkg_malloc(sizeof(struct socket_info));
+			if(si == 0) {
+				LOG(L_ERR, "ERROR: pack_ci: memory allocation error\n");
+				rerrno = R_PARSE;
+				goto error;
+			}
+
+			memset(si, 0, sizeof(struct socket_info));
+			si->sock_str = sock_addr;
+			ci.sock = si;
+		} else if (_m->flags&sock_flag) {
 			ci.sock = get_sock_val(_m);
 			if (ci.sock==0)
 				ci.sock = _m->rcv.bind_address;
@@ -412,6 +424,11 @@ static inline ucontact_info_t* pack_ci( struct sip_msg* _m, contact_t* _c,
 
 	return &ci;
 error:
+
+	if (si) {
+		pkg_free(si);
+	}
+
 	return 0;
 }
 
@@ -559,6 +576,11 @@ static inline int insert_contacts(struct sip_msg* _m, udomain_t* _d, str* _a, in
 	} else { /* No contacts found */
 		build_contact(_m, NULL, &u->host);
 	}
+	
+	if (sock_addr.len>0 && ci && ci->sock) {
+		pkg_free(ci->sock);
+	}
+	
 
 #ifdef USE_TCP
 	if ( tcp_check && e_max>0 ) {
@@ -572,6 +594,12 @@ static inline int insert_contacts(struct sip_msg* _m, udomain_t* _d, str* _a, in
 error:
 	if (r)
 		ul.delete_urecord(_d, _a, r);
+
+	if (sock_addr.len>0 && ci && ci->sock) {
+		pkg_free(ci->sock);
+	}
+	
+
 	return -1;
 }
 
@@ -814,8 +842,17 @@ static inline int update_contacts(struct sip_msg* _m, urecord_t* _r, int _mode, 
 	}
 #endif
 
+	if (sock_addr.len>0 && ci && ci->sock) {
+		pkg_free(ci->sock);
+	}
+
 	return rc;
 error:
+
+	if (sock_addr.len>0 && ci && ci->sock) {
+		pkg_free(ci->sock);
+	}
+	
 	return -1;
 }
 

--- a/src/modules/registrar/save.c
+++ b/src/modules/registrar/save.c
@@ -253,7 +253,7 @@ static inline ucontact_info_t* pack_ci( struct sip_msg* _m, contact_t* _c,
 		}
 
 		/* set received socket */
-		if (_m->rcv.bind_address->useinfo.sock_str.len > 0) {
+		if (_m->rcv.bind_address && _m->rcv.bind_address->useinfo.sock_str.len > 0) {
 		    memset(&si, 0, sizeof(struct socket_info));
 		    si.sock_str = _m->rcv.bind_address->useinfo.sock_str;
 		    ci.sock = &si;

--- a/src/modules/registrar/save.c
+++ b/src/modules/registrar/save.c
@@ -253,9 +253,9 @@ static inline ucontact_info_t* pack_ci( struct sip_msg* _m, contact_t* _c,
 		}
 
 		/* set received socket */
-		if (sock_addr.len>0) {
+		if (_m->rcv.bind_address->useinfo.sock_str.len > 0) {
 		    memset(&si, 0, sizeof(struct socket_info));
-		    si.sock_str = sock_addr;
+		    si.sock_str = _m->rcv.bind_address->useinfo.sock_str;
 		    ci.sock = &si;
 		} else if (_m->flags&sock_flag) {
 			ci.sock = get_sock_val(_m);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This feature was made half year ago. We would like to have inside location record address of the host where kamailio is installed. However when we installed it behind NAT we got private address in this field. 
This feature introduces possibility to set a socket string which will be written into location record. It could be public address instead address on which the register request was received. The default value is NULL and it works as usual. The feature was installed on our production servers in April and since that time it works well. I would like to propose this feature to others, because it could be useful.