### PR TITLE
auth_radius, misc_radius: Adds VENDOR() definition if the freeradius-client.h does not contain one

### DIFF
--- a/src/modules/misc_radius/radius.h
+++ b/src/modules/misc_radius/radius.h
@@ -42,6 +42,9 @@
 #else
 #include <freeradius-client.h>
 #define DEFAULT_RADIUSCLIENT_CONF ""
+#ifndef VENDOR
+#define VENDOR(x) (((x) >> 16) & 0xffff)
+#endif
 #endif
 
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [X] Related to issue #2496 

#### Description
<!-- Describe your changes in detail -->

freeradius-client removed the `VENDOR()` definition after commit https://github.com/FreeRADIUS/freeradius-client/commit/50d78bb53f4f341aa708e196b8955cacbae59669, since a new way was added in the library to separate vendor attributes. Currently `(((x) >> 8) & 0xffffff)` to determine vendor id works but is considered old-style. This PR adds the `VENDOR()` definition back if the freeradius-client library we are linking against is after 50d78b.
