### PR TITLE
ndb_redis: Fix leaks from PV parsing

### DIFF
--- a/src/modules/ndb_redis/ndb_redis_mod.c
+++ b/src/modules/ndb_redis/ndb_redis_mod.c
@@ -795,10 +795,7 @@ error_key:
 	return -1;
 }
 
-/**
- *
- */
-static int pv_get_redisc(struct sip_msg *msg,  pv_param_t *param,
+static int pv_get_redisc_result(struct sip_msg *msg,  pv_param_t *param,
 		pv_value_t *res)
 {
 	redisc_pv_t *rpv;
@@ -904,6 +901,25 @@ static int pv_get_redisc(struct sip_msg *msg,  pv_param_t *param,
 			/* We do nothing. */
 			return pv_get_null(msg, param, res);
 	}
+}
+
+static int pv_get_redisc(struct sip_msg *msg, pv_param_t *param,
+		pv_value_t *res)
+{
+	redisc_pv_t *rpv = (redisc_pv_t*)param->pvn.u.dname;
+	gparam_t *gparam;
+	int result = pv_get_redisc_result(msg, param, res);
+	/* Clean-up allocations made while parsing */
+	for (gparam = rpv->pos; gparam != &rpv->pos[MAXIMUM_NESTED_KEYS]; ++gparam)
+	{
+		if (gparam->type != GPARAM_TYPE_PVS) continue;
+		pkg_free(gparam->v.pvs);
+		gparam->type = GPARAM_TYPE_INT;
+		gparam->v.i = -1;
+	}
+	pkg_free(rpv);
+	param->pvn.u.dname = NULL;
+	return result;
 }
 
 /**


### PR DESCRIPTION
- Add missing pkg_free for the dynamic PV name created during PV parsing
- Add missing pkg_free for any GPARAM_TYPE_PVS created during PV parsing

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

We are using NDB_REDIS in anger, fetching data from changing hash structures. We very quickly found that we were running out of package memory from using NDB_REDIS. Enabling Kamailio's own memory debug logging quickly revealed that every query of a `$redis(...)` PV caused a package memory leak.

In order to handle structured data returned from Redis commands, the NDB_REDIS module creates dynamic PVs that vary depending on the nature of the data being fetched from the reply. In order to return such dynamic PVs, it has a custom parser that allocates a dynamic PV structure as well as potentially multiple nested parameter structures. These are never freed.

It appears that the allocated structures are only used within the subsequent handler to fetch the data. Therefore, to resolve the leak, the allocated structures are freed after the data for the PV in question has been fetched.