### PR TITLE
sl: Fix 3xx stats RPC marshalling

### DIFF
--- a/src/modules/sl/sl_stats.c
+++ b/src/modules/sl/sl_stats.c
@@ -73,7 +73,7 @@ static void rpc_stats(rpc_t* rpc, void* c)
 			"202", total.err[RT_202],
 			"2xx", total.err[RT_2xx]);
 
-	rpc->struct_add(st, "ddd",
+	rpc->struct_add(st, "dddd",
 			"300", total.err[RT_300],
 			"301", total.err[RT_301],
 			"302", total.err[RT_302],


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

The struct_add() method was getting 4 values but only 3 "d".