### PR TITLE
dialog: access dialog table by reference for dmq_send_all_dlgs

### DIFF
--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -646,22 +646,22 @@ error:
 
 int dmq_send_all_dlgs(dmq_node_t* dmq_node) {
 	int index;
-	dlg_entry_t entry;
+	dlg_entry_t *entry;
 	dlg_cell_t *dlg;
 
 	LM_DBG("sending all dialogs \n");
 
 	for(index = 0; index< d_table->size; index++){
 		/* lock the whole entry */
-		entry = (d_table->entries)[index];
-		dlg_lock( d_table, &entry);
+		entry = &(d_table->entries)[index];
+		dlg_lock( d_table, entry);
 
-		for(dlg = entry.first; dlg != NULL; dlg = dlg->next){
+		for(dlg = entry->first; dlg != NULL; dlg = dlg->next){
 			dlg->dflags |= DLG_FLAG_CHANGED_PROF;
 			dlg_dmq_replicate_action(DLG_DMQ_UPDATE, dlg, 0, dmq_node);
 		}
 
-		dlg_unlock( d_table, &entry);
+		dlg_unlock( d_table, entry);
 	}
 
 	return 0;


### PR DESCRIPTION
- Access to the d_table entries should be done by reference so there is
no risk of race conditions to get and release the lock

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2547

#### Description
<!-- Describe your changes in detail -->
It was seen the access to the d_table was not being made by reference on the function dmq_send_all_dlgs. It was then leading to race conditions where the same entry could have its lock changed elsewhere and then a dead lock would occur. By checking the code in other places where the d_table is used, everywhere it is accessed by reference, this function was the only one not following this logic.
Changes were done to have "entry" as a reference to d_table and not a copy.