### PR TITLE
rtpengine: query rtt per call leg

### DIFF
--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -830,7 +830,7 @@ modparam("rtpengine", "mos_min_jitter_pv", "$avp(mos_min_jitter)")
 	<section id="rtpengine.p.mos_min_roundtrip_pv">
 		<title><varname>mos_min_roundtrip_pv</varname> (string)</title>
 		<para>
-			The name of a pseudovariable to hold the packet round-trip time in milliseconds
+			The name of a pseudovariable to hold the packet round-trip time in microseconds
 			at the time the minimum MOS value was encountered;
 		</para>
 		<para>
@@ -952,7 +952,7 @@ modparam("rtpengine", "mos_max_jitter_pv", "$avp(mos_max_jitter)")
 	<section id="rtpengine.p.mos_max_roundtrip_pv">
 		<title><varname>mos_max_roundtrip_pv</varname> (string)</title>
 		<para>
-			The name of a pseudovariable to hold the packet round-trip time in milliseconds
+			The name of a pseudovariable to hold the packet round-trip time in microseconds
 			at the time the maximum MOS value was encountered;
 		</para>
 		<para>
@@ -1236,7 +1236,7 @@ modparam("rtpengine", "mos_min_jitter_A_pv", "$avp(mos_min_jitter_A)")
 	<section id="rtpengine.p.mos_min_roundtrip_A_pv">
 		<title><varname>mos_min_roundtrip_A_pv</varname> (string)</title>
 		<para>
-			The name of a pseudovariable to hold the packet round-trip time in milliseconds
+			The name of a pseudovariable to hold the packet round-trip time in microseconds
 			at the time the minimum MOS value was encountered;
 		</para>
 		<para>
@@ -1261,6 +1261,33 @@ modparam("rtpengine", "mos_min_roundtrip_A_pv", "$avp(mos_min_roundtrip_A)")
 		</example>
 	</section>
 
+	<section id="rtpengine.p.mos_min_roundtrip_leg_A_pv">
+		<title><varname>mos_min_roundtrip_leg_A_pv</varname> (string)</title>
+		<para>
+			The name of a pseudovariable to hold the packet round-trip time of the specific call leg
+			in microseconds at the time the minimum MOS value was encountered;
+		</para>
+		<para>
+			There is no default value.
+		</para>
+		<para>
+			This value is filled in after invoking <quote>rtpengine_delete</quote>,
+			<quote>rtpengine_query</quote>, or <quote>rtpengine_manage</quote> if the
+			command resulted in a deletion of the call (or call branch).
+		</para>
+		<para>
+			Only call legs matching the rtpengine label given in the <quote>mos_A_label_pv</quote>
+			will be used in calculating this statistics value.
+		</para>
+		<example>
+		<title>Set <varname>mos_min_roundtrip_leg_A_pv</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpengine", "mos_min_roundtrip_leg_A_pv", "$avp(mos_min_roundtrip_leg_A)")
+...
+</programlisting>
+		</example>
+	</section>
 
 	<section id="rtpengine.p.mos_max_A_pv">
 		<title><varname>mos_max_A_pv</varname> (string)</title>
@@ -1378,7 +1405,7 @@ modparam("rtpengine", "mos_max_jitter_A_pv", "$avp(mos_max_jitter_A)")
 	<section id="rtpengine.p.mos_max_roundtrip_A_pv">
 		<title><varname>mos_max_roundtrip_A_pv</varname> (string)</title>
 		<para>
-			The name of a pseudovariable to hold the packet round-trip time in milliseconds
+			The name of a pseudovariable to hold the packet round-trip time in microseconds
 			at the time the maximum MOS value was encountered;
 		</para>
 		<para>
@@ -1398,6 +1425,34 @@ modparam("rtpengine", "mos_max_jitter_A_pv", "$avp(mos_max_jitter_A)")
 <programlisting format="linespecific">
 ...
 modparam("rtpengine", "mos_max_roundtrip_A_pv", "$avp(mos_max_roundtrip_A)")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="rtpengine.p.mos_max_roundtrip_leg_A_pv">
+		<title><varname>mos_max_roundtrip_leg_A_pv</varname> (string)</title>
+		<para>
+			The name of a pseudovariable to hold the packet round-trip time of the specific
+			call leg in microseconds at the time the maximum MOS value was encountered;
+		</para>
+		<para>
+			There is no default value.
+		</para>
+		<para>
+			This value is filled in after invoking <quote>rtpengine_delete</quote>,
+			<quote>rtpengine_query</quote>, or <quote>rtpengine_manage</quote> if the
+			command resulted in a deletion of the call (or call branch).
+		</para>
+		<para>
+			Only call legs matching the rtpengine label given in the <quote>mos_A_label_pv</quote>
+			will be used in calculating this statistics value.
+		</para>
+		<example>
+		<title>Set <varname>mos_max_roundtrip_leg_A_pv</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpengine", "mos_max_roundtrip_leg_A_pv", "$avp(mos_max_roundtrip_leg_A)")
 ...
 </programlisting>
 		</example>
@@ -1493,8 +1548,7 @@ modparam("rtpengine", "mos_average_jitter_A_pv", "$avp(mos_average_jitter_A)")
 		<title><varname>mos_average_roundtrip_A_pv</varname> (string)</title>
 		<para>
 			The name of a pseudovariable to hold the average (median) packet round-trip
-			time in milliseconds
-			present throughout the call.
+			time in microseconds present throughout the call.
 		</para>
 		<para>
 			There is no default value.
@@ -1513,6 +1567,34 @@ modparam("rtpengine", "mos_average_jitter_A_pv", "$avp(mos_average_jitter_A)")
 <programlisting format="linespecific">
 ...
 modparam("rtpengine", "mos_average_roundtrip_A_pv", "$avp(mos_average_roundtrip_A)")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="rtpengine.p.mos_average_roundtrip_leg_A_pv">
+		<title><varname>mos_average_roundtrip_leg_A_pv</varname> (string)</title>
+		<para>
+			The name of a pseudovariable to hold the average (median) packet round-trip
+			time of the specific call leg in microseconds present throughout the call.
+		</para>
+		<para>
+			There is no default value.
+		</para>
+		<para>
+			This value is filled in after invoking <quote>rtpengine_delete</quote>,
+			<quote>rtpengine_query</quote>, or <quote>rtpengine_manage</quote> if the
+			command resulted in a deletion of the call (or call branch).
+		</para>
+		<para>
+			Only call legs matching the rtpengine label given in the <quote>mos_A_label_pv</quote>
+			will be used in calculating this statistics value.
+		</para>
+		<example>
+		<title>Set <varname>mos_average_roundtrip_leg_A_pv</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpengine", "mos_average_roundtrip_leg_A_pv", "$avp(mos_average_roundtrip_leg_A)")
 ...
 </programlisting>
 		</example>
@@ -1686,7 +1768,7 @@ modparam("rtpengine", "mos_min_jitter_B_pv", "$avp(mos_min_jitter_B)")
 	<section id="rtpengine.p.mos_min_roundtrip_B_pv">
 		<title><varname>mos_min_roundtrip_B_pv</varname> (string)</title>
 		<para>
-			The name of a pseudovariable to hold the packet round-trip time in milliseconds
+			The name of a pseudovariable to hold the packet round-trip time in microseconds
 			at the time the minimum MOS value was encountered;
 		</para>
 		<para>
@@ -1706,6 +1788,34 @@ modparam("rtpengine", "mos_min_jitter_B_pv", "$avp(mos_min_jitter_B)")
 <programlisting format="linespecific">
 ...
 modparam("rtpengine", "mos_min_roundtrip_B_pv", "$avp(mos_min_roundtrip_B)")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="rtpengine.p.mos_min_roundtrip_leg_B_pv">
+		<title><varname>mos_min_roundtrip_leg_B_pv</varname> (string)</title>
+		<para>
+			The name of a pseudovariable to hold the packet round-trip time of the specific call leg
+			in microseconds at the time the minimum MOS value was encountered;
+		</para>
+		<para>
+			There is no default value.
+		</para>
+		<para>
+			This value is filled in after invoking <quote>rtpengine_delete</quote>,
+			<quote>rtpengine_query</quote>, or <quote>rtpengine_manage</quote> if the
+			command resulted in a deletion of the call (or call branch).
+		</para>
+		<para>
+			Only call legs matching the rtpengine label given in the <quote>mos_B_label_pv</quote>
+			will be used in calculating this statistics value.
+		</para>
+		<example>
+		<title>Set <varname>mos_min_roundtrip_leg_B_pv</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpengine", "mos_min_roundtrip_leg_B_pv", "$avp(mos_min_roundtrip_leg_B)")
 ...
 </programlisting>
 		</example>
@@ -1828,7 +1938,7 @@ modparam("rtpengine", "mos_max_jitter_B_pv", "$avp(mos_max_jitter_B)")
 	<section id="rtpengine.p.mos_max_roundtrip_B_pv">
 		<title><varname>mos_max_roundtrip_B_pv</varname> (string)</title>
 		<para>
-			The name of a pseudovariable to hold the packet round-trip time in milliseconds
+			The name of a pseudovariable to hold the packet round-trip time in microseconds
 			at the time the maximum MOS value was encountered;
 		</para>
 		<para>
@@ -1848,6 +1958,34 @@ modparam("rtpengine", "mos_max_jitter_B_pv", "$avp(mos_max_jitter_B)")
 <programlisting format="linespecific">
 ...
 modparam("rtpengine", "mos_max_roundtrip_B_pv", "$avp(mos_max_roundtrip_B)")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="rtpengine.p.mos_max_roundtrip_leg_B_pv">
+		<title><varname>mos_max_roundtrip_leg_B_pv</varname> (string)</title>
+		<para>
+			The name of a pseudovariable to hold the packet round-trip time of the specific
+			call leg in microseconds at the time the maximum MOS value was encountered;
+		</para>
+		<para>
+			There is no default value.
+		</para>
+		<para>
+			This value is filled in after invoking <quote>rtpengine_delete</quote>,
+			<quote>rtpengine_query</quote>, or <quote>rtpengine_manage</quote> if the
+			command resulted in a deletion of the call (or call branch).
+		</para>
+		<para>
+			Only call legs matching the rtpengine label given in the <quote>mos_A_label_pv</quote>
+			will be used in calculating this statistics value.
+		</para>
+		<example>
+		<title>Set <varname>mos_max_roundtrip_leg_B_pv</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpengine", "mos_max_roundtrip_leg_B_pv", "$avp(mos_max_roundtrip_leg_B)")
 ...
 </programlisting>
 		</example>
@@ -1943,8 +2081,7 @@ modparam("rtpengine", "mos_average_jitter_B_pv", "$avp(mos_average_jitter_B)")
 		<title><varname>mos_average_roundtrip_B_pv</varname> (string)</title>
 		<para>
 			The name of a pseudovariable to hold the average (median) packet round-trip
-			time in milliseconds
-			present throughout the call.
+			time in microseconds present throughout the call.
 		</para>
 		<para>
 			There is no default value.
@@ -1963,6 +2100,34 @@ modparam("rtpengine", "mos_average_jitter_B_pv", "$avp(mos_average_jitter_B)")
 <programlisting format="linespecific">
 ...
 modparam("rtpengine", "mos_average_roundtrip_B_pv", "$avp(mos_average_roundtrip_B)")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="rtpengine.p.mos_average_roundtrip_leg_B_pv">
+		<title><varname>mos_average_roundtrip_leg_B_pv</varname> (string)</title>
+		<para>
+			The name of a pseudovariable to hold the average (median) packet round-trip
+			time of the specific call leg in microseconds present throughout the call.
+		</para>
+		<para>
+			There is no default value.
+		</para>
+		<para>
+			This value is filled in after invoking <quote>rtpengine_delete</quote>,
+			<quote>rtpengine_query</quote>, or <quote>rtpengine_manage</quote> if the
+			command resulted in a deletion of the call (or call branch).
+		</para>
+		<para>
+			Only call legs matching the rtpengine label given in the <quote>mos_B_label_pv</quote>
+			will be used in calculating this statistics value.
+		</para>
+		<example>
+		<title>Set <varname>mos_average_roundtrip_leg_B_pv</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpengine", "mos_average_roundtrip_leg_B_pv", "$avp(mos_average_roundtrip_leg_B)")
 ...
 </programlisting>
 		</example>

--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -149,6 +149,7 @@ struct minmax_mos_stats {
 	str packetloss_param;
 	str jitter_param;
 	str roundtrip_param;
+	str roundtrip_leg_param;
 	str samples_param;
 
 	pv_elem_t *mos_pv;
@@ -156,6 +157,7 @@ struct minmax_mos_stats {
 	pv_elem_t *packetloss_pv;
 	pv_elem_t *jitter_pv;
 	pv_elem_t *roundtrip_pv;
+	pv_elem_t *roundtrip_leg_pv;
 	pv_elem_t *samples_pv;
 };
 struct minmax_mos_label_stats {
@@ -174,6 +176,7 @@ struct minmax_stats_vals {
 	long long packetloss;
 	long long jitter;
 	long long roundtrip;
+	long long roundtrip_leg;
 	long long samples;
 	long long avg_samples; /* our own running count to average the averages */
 };
@@ -463,15 +466,18 @@ static param_export_t params[] = {
 	{"mos_min_packetloss_pv",     PARAM_STR, &global_mos_stats.min.packetloss_param      },
 	{"mos_min_jitter_pv",         PARAM_STR, &global_mos_stats.min.jitter_param          },
 	{"mos_min_roundtrip_pv",      PARAM_STR, &global_mos_stats.min.roundtrip_param       },
+	{"mos_min_roundtrip_leg_pv",  PARAM_STR, &global_mos_stats.min.roundtrip_leg_param   },
 	{"mos_max_pv",                PARAM_STR, &global_mos_stats.max.mos_param             },
 	{"mos_max_at_pv",             PARAM_STR, &global_mos_stats.max.at_param              },
 	{"mos_max_packetloss_pv",     PARAM_STR, &global_mos_stats.max.packetloss_param      },
 	{"mos_max_jitter_pv",         PARAM_STR, &global_mos_stats.max.jitter_param          },
 	{"mos_max_roundtrip_pv",      PARAM_STR, &global_mos_stats.max.roundtrip_param       },
+	{"mos_max_roundtrip_leg_pv",  PARAM_STR, &global_mos_stats.max.roundtrip_leg_param   },
 	{"mos_average_pv",            PARAM_STR, &global_mos_stats.average.mos_param         },
 	{"mos_average_packetloss_pv", PARAM_STR, &global_mos_stats.average.packetloss_param  },
 	{"mos_average_jitter_pv",     PARAM_STR, &global_mos_stats.average.jitter_param      },
 	{"mos_average_roundtrip_pv",  PARAM_STR, &global_mos_stats.average.roundtrip_param   },
+	{"mos_average_roundtrip_leg_pv", PARAM_STR, &global_mos_stats.average.roundtrip_leg_param },
 	{"mos_average_samples_pv",    PARAM_STR, &global_mos_stats.average.samples_param     },
 
 	/* designated side A */
@@ -481,15 +487,18 @@ static param_export_t params[] = {
 	{"mos_min_packetloss_A_pv",     PARAM_STR, &side_A_mos_stats.min.packetloss_param      },
 	{"mos_min_jitter_A_pv",         PARAM_STR, &side_A_mos_stats.min.jitter_param          },
 	{"mos_min_roundtrip_A_pv",      PARAM_STR, &side_A_mos_stats.min.roundtrip_param       },
+	{"mos_min_roundtrip_leg_A_pv",  PARAM_STR, &side_A_mos_stats.min.roundtrip_leg_param   },
 	{"mos_max_A_pv",                PARAM_STR, &side_A_mos_stats.max.mos_param             },
 	{"mos_max_at_A_pv",             PARAM_STR, &side_A_mos_stats.max.at_param              },
 	{"mos_max_packetloss_A_pv",     PARAM_STR, &side_A_mos_stats.max.packetloss_param      },
 	{"mos_max_jitter_A_pv",         PARAM_STR, &side_A_mos_stats.max.jitter_param          },
 	{"mos_max_roundtrip_A_pv",      PARAM_STR, &side_A_mos_stats.max.roundtrip_param       },
+	{"mos_max_roundtrip_leg_A_pv",  PARAM_STR, &side_A_mos_stats.max.roundtrip_leg_param   },
 	{"mos_average_A_pv",            PARAM_STR, &side_A_mos_stats.average.mos_param         },
 	{"mos_average_packetloss_A_pv", PARAM_STR, &side_A_mos_stats.average.packetloss_param  },
 	{"mos_average_jitter_A_pv",     PARAM_STR, &side_A_mos_stats.average.jitter_param      },
 	{"mos_average_roundtrip_A_pv",  PARAM_STR, &side_A_mos_stats.average.roundtrip_param   },
+	{"mos_average_roundtrip_leg_A_pv",  PARAM_STR, &side_A_mos_stats.average.roundtrip_leg_param },
 	{"mos_average_samples_A_pv",    PARAM_STR, &side_A_mos_stats.average.samples_param     },
 
 	/* designated side B */
@@ -499,15 +508,18 @@ static param_export_t params[] = {
 	{"mos_min_packetloss_B_pv",     PARAM_STR, &side_B_mos_stats.min.packetloss_param      },
 	{"mos_min_jitter_B_pv",         PARAM_STR, &side_B_mos_stats.min.jitter_param          },
 	{"mos_min_roundtrip_B_pv",      PARAM_STR, &side_B_mos_stats.min.roundtrip_param       },
+	{"mos_min_roundtrip_B_pv",      PARAM_STR, &side_B_mos_stats.min.roundtrip_param       },
 	{"mos_max_B_pv",                PARAM_STR, &side_B_mos_stats.max.mos_param             },
 	{"mos_max_at_B_pv",             PARAM_STR, &side_B_mos_stats.max.at_param              },
 	{"mos_max_packetloss_B_pv",     PARAM_STR, &side_B_mos_stats.max.packetloss_param      },
 	{"mos_max_jitter_B_pv",         PARAM_STR, &side_B_mos_stats.max.jitter_param          },
 	{"mos_max_roundtrip_B_pv",      PARAM_STR, &side_B_mos_stats.max.roundtrip_param       },
+	{"mos_max_roundtrip_leg_B_pv",  PARAM_STR, &side_B_mos_stats.max.roundtrip_leg_param   },
 	{"mos_average_B_pv",            PARAM_STR, &side_B_mos_stats.average.mos_param         },
 	{"mos_average_packetloss_B_pv", PARAM_STR, &side_B_mos_stats.average.packetloss_param  },
 	{"mos_average_jitter_B_pv",     PARAM_STR, &side_B_mos_stats.average.jitter_param      },
 	{"mos_average_roundtrip_B_pv",  PARAM_STR, &side_B_mos_stats.average.roundtrip_param   },
+	{"mos_average_roundtrip_leg_B_pv",  PARAM_STR, &side_B_mos_stats.average.roundtrip_leg_param },
 	{"mos_average_samples_B_pv",    PARAM_STR, &side_B_mos_stats.average.samples_param     },
 
 	{0, 0, 0}
@@ -1925,6 +1937,8 @@ static int minmax_pv_parse(struct minmax_mos_stats *s, int *got_any) {
 		return -1;
 	if (pv_parse_var(&s->roundtrip_param, &s->roundtrip_pv, got_any))
 		return -1;
+	if (pv_parse_var(&s->roundtrip_leg_param, &s->roundtrip_leg_pv, got_any))
+		return -1;
 	if (pv_parse_var(&s->samples_param, &s->samples_pv, got_any))
 		return -1;
 	return 0;
@@ -3272,6 +3286,7 @@ static void avp_print_mos(struct minmax_mos_stats *s, struct minmax_stats_vals *
 	avp_print_int(s->packetloss_pv, vals->packetloss / vals->avg_samples, msg);
 	avp_print_int(s->jitter_pv, vals->jitter / vals->avg_samples, msg);
 	avp_print_int(s->roundtrip_pv, vals->roundtrip / vals->avg_samples, msg);
+	avp_print_int(s->roundtrip_leg_pv, vals->roundtrip_leg / vals->avg_samples, msg);
 	avp_print_int(s->samples_pv, vals->samples / vals->avg_samples, msg);
 }
 
@@ -3287,6 +3302,7 @@ static int decode_mos_vals_dict(struct minmax_stats_vals *vals, bencode_item_t *
 	vals->packetloss = bencode_dictionary_get_integer(mos_ent, "packet loss", -1);
 	vals->jitter = bencode_dictionary_get_integer(mos_ent, "jitter", -1);
 	vals->roundtrip = bencode_dictionary_get_integer(mos_ent, "round-trip time", -1);
+	vals->roundtrip_leg = bencode_dictionary_get_integer(mos_ent, "round-trip time leg", -1);
 	vals->samples = bencode_dictionary_get_integer(mos_ent, "samples", -1);
 	vals->avg_samples = 1;
 
@@ -3416,6 +3432,7 @@ ssrc_ok:
 			average_vals.packetloss += vals_decoded.packetloss;
 			average_vals.jitter += vals_decoded.jitter;
 			average_vals.roundtrip += vals_decoded.roundtrip;
+			average_vals.roundtrip_leg += vals_decoded.roundtrip_leg;
 			average_vals.samples += vals_decoded.samples;
 		}
 


### PR DESCRIPTION
#### Type Of Change
- [x] New feature (non-breaking change which adds new functionality)

#### Checklist:
- [x] Tested changes locally

#### Description
This modification is to provide access to the new exposed metrics.

RTPengine is now keeping track of RTT per call leg
https://github.com/sipwise/rtpengine/pull/1116


I also corrected the documentation as the RTT was always in microseconds not milliseconds.|


```
Kamailio config :

modparam("rtpengine", "mos_B_label_pv", "$avp(mos_B_label)")
modparam("rtpengine", "mos_max_roundtrip_B_pv", "$avp(mos_max_roundtrip_B)");
modparam("rtpengine", "mos_average_roundtrip_B_pv", "$avp(mos_average_roundtrip_B)");
modparam("rtpengine", "mos_average_roundtrip_leg_B_pv", "$avp(mos_average_roundtrip_leg_B)");

modparam("rtpengine", "mos_A_label_pv", "$avp(mos_A_label)")
modparam("rtpengine", "mos_max_roundtrip_A_pv", "$avp(mos_max_roundtrip_A)");
modparam("rtpengine", "mos_average_roundtrip_A_pv", "$avp(mos_average_roundtrip_A)");
modparam("rtpengine", "mos_average_roundtrip_leg_A_pv", "$avp(mos_average_roundtrip_leg_A)");

modparam("rtpengine", "mos_min_pv", "$avp(mos_min)")
modparam("rtpengine", "mos_max_roundtrip_pv", "$avp(mos_max_roundtrip)");
modparam("rtpengine", "mos_average_roundtrip_pv", "$avp(mos_average_roundtrip)");
modparam("rtpengine", "mos_average_roundtrip_leg_pv", "$avp(mos_average_roundtrip_leg)");

route[QOS] {
	$avp(mos_A_label) = "legA";	
	$avp(mos_B_label) = "legB";	
	rtpengine_query();
	xinfo("[QOS][Caller]rtt[$avp(mos_average_roundtrip_A)us]rtt_leg[$avp(mos_average_roundtrip_leg_A)]\n");
	xinfo("[QOS][Callee]rtt[$avp(mos_average_roundtrip_B)us]rtt_leg[$avp(mos_average_roundtrip_leg_B)]\n");
	xinfo("[QOS][Average]rtt[$avp(mos_average_roundtrip)us]rtt_leg[$avp(mos_average_roundtrip_leg)]\n");
}
```
