### PR TITLE
lost: removed not used namespace

### DIFF
--- a/src/modules/lost/utilities.c
+++ b/src/modules/lost/utilities.c
@@ -955,12 +955,15 @@ https://tools.ietf.org/html/rfc5222
 	/* set properties */
 	xmlNewProp(ptrFindService, BAD_CAST "xmlns",
 			BAD_CAST "urn:ietf:params:xml:ns:lost1");
-	xmlNewProp(ptrFindService, BAD_CAST "xmlns:p2",
-			BAD_CAST "http://www.opengis.net/gml");
 	xmlNewProp(ptrFindService, BAD_CAST "serviceBoundary",
 			(loc->boundary == 1) ? BAD_CAST "value" : BAD_CAST "reference");
 	xmlNewProp(ptrFindService, BAD_CAST "recursive",
 			(loc->recursive == 1) ? BAD_CAST "true" : BAD_CAST "false");
+	if(loc->xpath == NULL) {
+		xmlNewProp(ptrFindService, BAD_CAST "xmlns:p2",
+				BAD_CAST "http://www.opengis.net/gml");
+	}
+
 	/* location - element */
 	ptrLocation = xmlNewChild(ptrFindService, NULL, BAD_CAST "location", NULL);
 	xmlNewProp(ptrLocation, BAD_CAST "id", BAD_CAST loc->identity);


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Caller LIS server may use namepace prefix `gml` or any other.
When created LOST request, then `location-info` payload created from `pidf-lo` and `p2` prefix namespace not used.

I suggest make some code cleanup and remove not used strings.