### PR TITLE
Fix in parsing IPv6 address:port

### DIFF
--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -1022,7 +1022,14 @@ int add_rtpengine_socks(struct rtpp_set *rtpp_list, char *rtpengine,
 
 		/* Check the rn_address is 'hostname:port' */
 		/* Check the rn_address port is valid */
-		p1 = strchr(pnode->rn_address, ':');
+		if(pnode->rn_umode == 6) {
+                        p1 = strstr(pnode->rn_address, "]:");
+                        if(p1 != NULL) {
+                                p1++;
+                        }
+                } else {
+                        p1 = strchr(pnode->rn_address, ':');
+                }
 		if (p1 != NULL) {
 			p1++;
 		}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->
This patch fix wrong parsing the pair of IPv6 addr:port in rtpengine module, when loading node information from database.
<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
