### PR TITLE
Fix 2 issues that prevent auto_bind_ipv6 from happening on my setup

### DIFF
--- a/src/core/socket_info.c
+++ b/src/core/socket_info.c
@@ -1085,7 +1085,7 @@ static int get_flags(int family){
 	int nll = 0;
     int nl_sock = -1;
 
-	fill_nl_req(req, RTM_GETLINK, AF_INET);
+	fill_nl_req(req, RTM_GETLINK, family);
 
 	if((nl_sock = nl_bound_sock()) < 0) return -1;
 


### PR DESCRIPTION
#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Without the first commit, on my setup - which has lots of interfaces with lots of addresses - auto_bind_ipv6 will make kamailio stuck on startup. It actually happens in get_flags, where data sent back from kernel can't fit into 8K anymore.

Second commit is fixing obvious typo while we're at it.