### PR TITLE
core: added xavu_serialize_fields function

### DIFF
--- a/src/core/xavp.c
+++ b/src/core/xavp.c
@@ -1030,14 +1030,21 @@ int xavp_set_child_sval(str *rname, str *cname, str *sval)
 }
 
 /**
- * internal function to serialize fields of an xavp (from any of the lists: XAVP, XAUV, or XAVI).
+ * serialize the values in subfields of an xavp in name=value; format
+ * - rname - name of the root list xavp
+ * - obuf - buffer were to write the output
+ * - olen - the size of obuf
+ * return: 0 - not found; -1 - error; >0 - length of output
  */
-int xavx_serialize_fields(sr_xavp_t *ravp, char *obuf, int olen)
+
+int xavp_serialize_fields(str *rname, char *obuf, int olen)
 {
+	sr_xavp_t *ravp = NULL;
 	sr_xavp_t *avp = NULL;
 	str ostr;
 	int rlen;
 
+	ravp = xavp_get(rname, NULL);
 	if(ravp==NULL || ravp->val.type!=SR_XTYPE_XAVP) {
 		/* not found or not holding subfields */
 		return 0;
@@ -1085,18 +1092,6 @@ int xavx_serialize_fields(sr_xavp_t *ravp, char *obuf, int olen)
 		avp = avp->next;
 	}
 	return rlen;
-}
-
-/**
- * serialize the values in subfields of an xavp in name=value; format
- * - rname - name of the root list xavp
- * - obuf - buffer were to write the output
- * - olen - the size of obuf
- * return: 0 - not found; -1 - error; >0 - length of output
- */
-int xavp_serialize_fields(str *rname, char *obuf, int olen)
-{
-	return xavx_serialize_fields(xavp_get(rname, NULL), obuf, olen);
 }
 
 /**
@@ -1460,9 +1455,60 @@ sr_xavp_t *xavu_set_child_sval(str *rname, str *cname, str *sval)
  */
 int xavu_serialize_fields(str *rname, char *obuf, int olen)
 {
-	return xavx_serialize_fields(xavu_get(rname, NULL), obuf, olen);
-}
+	sr_xavp_t *ravu = NULL;
+	sr_xavp_t *avu = NULL;
+	str ostr;
+	int rlen;
 
+	ravu = xavu_get(rname, NULL);
+	if(ravu==NULL || ravu->val.type!=SR_XTYPE_XAVP) {
+		/* not found or not holding subfields */
+		return 0;
+	}
+
+	rlen = 0;
+	ostr.s = obuf;
+	avu = ravu->val.v.xavp;
+	while(avu) {
+		switch(avu->val.type) {
+			case SR_XTYPE_INT:
+				LM_DBG("     XAVP int value: %d\n", avu->val.v.i);
+				ostr.len = snprintf(ostr.s, olen-rlen, "%.*s=%u;",
+						avu->name.len, avu->name.s, (unsigned int)avu->val.v.i);
+				if(ostr.len<=0 || ostr.len>=olen-rlen) {
+					LM_ERR("failed to serialize int value (%d/%d\n",
+							ostr.len, olen-rlen);
+					return -1;
+				}
+			break;
+			case SR_XTYPE_STR:
+				LM_DBG("     XAVP str value: %s\n", avu->val.v.s.s);
+				if(avu->val.v.s.len == 0) {
+					ostr.len = snprintf(ostr.s, olen-rlen, "%.*s;",
+						avu->name.len, avu->name.s);
+				} else {
+					ostr.len = snprintf(ostr.s, olen-rlen, "%.*s=%.*s;",
+						avu->name.len, avu->name.s,
+						avu->val.v.s.len, avu->val.v.s.s);
+				}
+				if(ostr.len<=0 || ostr.len>=olen-rlen) {
+					LM_ERR("failed to serialize int value (%d/%d\n",
+							ostr.len, olen-rlen);
+					return -1;
+				}
+			break;
+			default:
+				LM_DBG("skipping value type: %d\n", avu->val.type);
+				ostr.len = 0;
+		}
+		if(ostr.len>0) {
+			ostr.s += ostr.len;
+			rlen += ostr.len;
+		}
+		avu = avu->next;
+	}
+	return rlen;
+}
 
 /**
  *
@@ -2390,5 +2436,57 @@ int xavi_set_child_sval(str *rname, str *cname, str *sval)
  */
 int xavi_serialize_fields(str *rname, char *obuf, int olen)
 {
-	return xavx_serialize_fields(xavi_get(rname, NULL), obuf, olen);
+	sr_xavp_t *ravi = NULL;
+	sr_xavp_t *avi = NULL;
+	str ostr;
+	int rlen;
+
+	ravi = xavi_get(rname, NULL);
+	if(ravi==NULL || ravi->val.type!=SR_XTYPE_XAVP) {
+		/* not found or not holding subfields */
+		return 0;
+	}
+
+	rlen = 0;
+	ostr.s = obuf;
+	avi = ravi->val.v.xavp;
+	while(avi) {
+		switch(avi->val.type) {
+			case SR_XTYPE_INT:
+				LM_DBG("     XAVP int value: %d\n", avi->val.v.i);
+				ostr.len = snprintf(ostr.s, olen-rlen, "%.*s=%u;",
+						avi->name.len, avi->name.s, (unsigned int)avi->val.v.i);
+				if(ostr.len<=0 || ostr.len>=olen-rlen) {
+					LM_ERR("failed to serialize int value (%d/%d\n",
+							ostr.len, olen-rlen);
+					return -1;
+				}
+			break;
+			case SR_XTYPE_STR:
+				LM_DBG("     XAVP str value: %s\n", avi->val.v.s.s);
+				if(avi->val.v.s.len == 0) {
+					ostr.len = snprintf(ostr.s, olen-rlen, "%.*s;",
+						avi->name.len, avi->name.s);
+				} else {
+					ostr.len = snprintf(ostr.s, olen-rlen, "%.*s=%.*s;",
+						avi->name.len, avi->name.s,
+						avi->val.v.s.len, avi->val.v.s.s);
+				}
+				if(ostr.len<=0 || ostr.len>=olen-rlen) {
+					LM_ERR("failed to serialize int value (%d/%d\n",
+							ostr.len, olen-rlen);
+					return -1;
+				}
+			break;
+			default:
+				LM_DBG("skipping value type: %d\n", avi->val.type);
+				ostr.len = 0;
+		}
+		if(ostr.len>0) {
+			ostr.s += ostr.len;
+			rlen += ostr.len;
+		}
+		avi = avi->next;
+	}
+	return rlen;
 }

--- a/src/core/xavp.h
+++ b/src/core/xavp.h
@@ -107,6 +107,7 @@ sr_xavp_t *xavp_clone_level_nodata_with_new_name(sr_xavp_t *xold, str *dst_name)
 sr_xavp_t* xavp_get_child(str *rname, str *cname);
 sr_xavp_t* xavp_get_child_with_ival(str *rname, str *cname);
 sr_xavp_t* xavp_get_child_with_sval(str *rname, str *cname);
+int xavx_serialize_fields(sr_xavp_t *ravp, char *obuf, int olen);
 int xavp_serialize_fields(str *rname, char *obuf, int olen);
 
 int xavp_set_child_ival(str *rname, str *cname, int ival);
@@ -131,6 +132,7 @@ sr_xavp_t *xavu_set_sval(str *rname, str *sval);
 sr_xavp_t *xavu_set_child_xval(str *rname, str *cname, sr_xval_t *xval);
 sr_xavp_t *xavu_set_child_ival(str *rname, str *cname, int ival);
 sr_xavp_t *xavu_set_child_sval(str *rname, str *cname, str *sval);
+int xavu_serialize_fields(str *rname, char *obuf, int olen);
 
 /** xavi api */
 int xavi_init_head(void);

--- a/src/core/xavp.h
+++ b/src/core/xavp.h
@@ -107,7 +107,6 @@ sr_xavp_t *xavp_clone_level_nodata_with_new_name(sr_xavp_t *xold, str *dst_name)
 sr_xavp_t* xavp_get_child(str *rname, str *cname);
 sr_xavp_t* xavp_get_child_with_ival(str *rname, str *cname);
 sr_xavp_t* xavp_get_child_with_sval(str *rname, str *cname);
-int xavx_serialize_fields(sr_xavp_t *ravp, char *obuf, int olen);
 int xavp_serialize_fields(str *rname, char *obuf, int olen);
 
 int xavp_set_child_ival(str *rname, str *cname, int ival);


### PR DESCRIPTION
Also added a function called by the three "*_serialize_fields" to reduce code duplication.

The interface is not modified.

#### Type Of Change
- [x] New feature (non-breaking change which adds new functionality)

#### Checklist:
- [x] Tested changes locally

#### Description
Small pull request that adds a function "xavu_serialize_fields" (with same interface as "xavp_serialize_fields" and "xavi_serialize_fields"), and an internal helper function to reduce code duplication.

