### PR TITLE
core: fix to xavp_rm_internal (#2604)

### DIFF
--- a/src/core/xavp.c
+++ b/src/core/xavp.c
@@ -454,6 +454,8 @@ static int xavp_rm_internal(str *name, sr_xavp_t **head, int idx)
 				if(idx>=0)
 					return 1;
 				count++;
+			} else {
+				prv = foo;
 			}
 			n++;
 		} else {
@@ -1914,6 +1916,8 @@ static int xavi_rm_internal(str *name, sr_xavp_t **head, int idx)
 				if(idx>=0)
 					return 1;
 				count++;
+			} else {
+				prv = foo;
 			}
 			n++;
 		} else {


### PR DESCRIPTION
This fixes the following issue:
https://github.com/kamailio/kamailio/issues/2604

When called to remove a specific index from a given xavp, function xavp_rm_by_index removes the index (as expected) but also all others before it.

E.g :
If called with idx = 1, it removes indexes 0 and 1.
Likewise if invoked with idx = 2 => the first 3 elements are removed.

This bug is located in function xavp_rm_internal. An assignment was missing when looping over the xavp list.
Same for xavi_rm_internal.