### PR TITLE
dispatcher: Log dest sets after variable update

### DIFF
--- a/src/modules/dispatcher/dispatch.c
+++ b/src/modules/dispatcher/dispatch.c
@@ -895,13 +895,13 @@ next_line:
 		goto error;
 	}
 
-	LM_DBG("found [%d] dest sets\n", _ds_list_nr);
-
 	fclose(f);
 	f = NULL;
 	/* Update list - should it be sync'ed? */
 	_ds_list_nr = setn;
 	*crt_idx = *next_idx;
+
+	LM_DBG("found [%d] dest sets\n", _ds_list_nr);
 
 	ds_log_sets();
 	return 0;
@@ -1143,13 +1143,13 @@ int ds_load_db(void)
 		goto err2;
 	}
 
-	LM_DBG("found [%d] dest sets\n", _ds_list_nr);
-
 	ds_dbf.free_result(ds_db_handle, res);
 
 	/* update data - should it be sync'ed? */
 	_ds_list_nr = setn;
 	*crt_idx = *next_idx;
+
+	LM_DBG("found [%d] dest sets\n", _ds_list_nr);
 
 	ds_log_sets();
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

I found that zero servers are being logged, even though they are (ignore the line numbers, the file is slightly modified):
```
 0(15681) DEBUG: dispatcher [dispatch.c:919]: ds_load_list(): found [0] dest sets
 0(15681) DEBUG: dispatcher [dispatch.c:222]: ds_log_dst_cb(): dst>> 1031 sip:127.0.0.1:5182 0 0 (,0,0,0)
 0(15681) DEBUG: dispatcher [dispatch.c:222]: ds_log_dst_cb(): dst>> 1011 sip:127.0.0.1:5180 0 0 (,0,0,0)
 0(15681) DEBUG: dispatcher [dispatch.c:222]: ds_log_dst_cb(): dst>> 1021 sip:127.0.0.1:5181 0 0 (,0,0,0)
```
Therefore, I moved the logging of the dest sets after updating variable and this fixed the error.