### PR TITLE
http_client: http_client_request to include default clientcert, clien…

### DIFF
--- a/src/modules/http_client/functions.c
+++ b/src/modules/http_client/functions.c
@@ -673,6 +673,18 @@ int http_client_request(
 			query_params.http_proxy_port = default_http_proxy_port;
 		}
 	}
+	if(default_tls_clientcert.s != NULL && default_tls_clientcert.len > 0) {
+		query_params.clientcert = default_tls_clientcert.s;
+	}
+	if(default_tls_clientkey.s != NULL && default_tls_clientkey.len > 0) {
+		query_params.clientkey = default_tls_clientkey.s;
+	}
+	if(default_tls_cacert != NULL) {
+		query_params.cacert = default_tls_cacert;
+	}
+	if(default_cipher_suite_list.s != NULL && default_cipher_suite_list.len) {
+		query_params.ciphersuites = default_cipher_suite_list.s;
+	}
 
 	res = curL_request_url(_m, _met, _url, _dst, &query_params);
 


### PR DESCRIPTION
- the lost module uses http_client API functions and in the course of NG112
  client certificates are used for authentication when querying LIS or ECRF,
  the fix allows these to be read out via http_client module parameters.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

To use client certificates for authentication when sending HTTP requests via the http_client
API function `http_client_request`, the auth. specific module parameters (default values) are not
passed to curl. The fix allows these to be read out via http_client module parameters to
set proper curl config parameters. Maybe it's a new feature rather than a fix.
