### PR TITLE
pua_dialoginfo: Add display attributes to identity tags.

### DIFF
--- a/src/modules/pua_dialoginfo/dialog_publish.c
+++ b/src/modules/pua_dialoginfo/dialog_publish.c
@@ -188,6 +188,8 @@ str* build_dialoginfo(char *state, str *entity, str *peer, str *callid,
 			LM_ERR("while adding child\n");
 			goto error;
 		}
+		/* Testing(POC) - Add a display attribute to the remote/identity tag */
+		xmlNewProp(tag_node, BAD_CAST "display", BAD_CAST "RemoteCallerName");	
 		tag_node = xmlNewChild(remote_node, NULL, BAD_CAST "target", NULL);
 		if( tag_node ==NULL)
 		{
@@ -229,6 +231,8 @@ str* build_dialoginfo(char *state, str *entity, str *peer, str *callid,
 			LM_ERR("while adding child\n");
 			goto error;
 		}
+		/* Testing(POC) - Add a display attribute to the local/identity tag */
+		xmlNewProp(tag_node, BAD_CAST "display", BAD_CAST "localCallerName");
 		if (localtarget && localtarget->s) {
 			memcpy(buf, localtarget->s, localtarget->len);
 			buf[localtarget->len]= '\0';


### PR DESCRIPTION
pua_dialoginfo: Add display attributes to identity tags.

- This is an example of how "display" attributes could be added to identity tags in the PUBLISH message XML body.
- This is not a working solution, the strings("RemoteCallerName" & "LocalCallerName") are "hard coded". I could not figure out how to get the caller/callee information from the SIP message.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #2615

#### Description
This is not a working solution. Opening the PR as requested by @miconda in issue #2615. I just added a couple lines to test how adding a "display" attribute to the identity tags would look like. This allows the phone to update it's display with relevant caller/callee information. I "hard coded" the values to verify that this works. However, I could not figure out how to get the display name from the SIP message(I'm not experienced with C). 

It seems that the "local" identity should have it's display name set to the name in the From header. And, the remote identity should have its display name set to the user part of the URI in the "To" header. 

