### PR TITLE
rtpengine : add node fallback if node ran out of ports

### DIFF
--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -294,6 +294,9 @@ static pv_spec_t *media_duration_pvar = NULL;
 #define RTPENGINE_SESS_LIMIT_MSG "Parallel session limit reached"
 #define RTPENGINE_SESS_LIMIT_MSG_LEN (sizeof(RTPENGINE_SESS_LIMIT_MSG)-1)
 
+#define RTPENGINE_SESS_OUT_OF_PORTS_MSG "Ran out of ports"
+#define RTPENGINE_SESS_OUT_OF_PORTS_MSG_LEN (sizeof(RTPENGINE_SESS_OUT_OF_PORTS_MSG)-1)
+
 char* force_send_ip_str="";
 int force_send_ip_af = AF_UNSPEC;
 
@@ -2632,6 +2635,13 @@ select_node:
 				LM_WARN("proxy %.*s: %.*s", node->rn_url.len, node->rn_url.s , error.len, error.s);
 				goto select_node;
 			}
+			if ((RTPENGINE_SESS_OUT_OF_PORTS_MSG_LEN == error.len) &&
+				(strncmp(error.s, RTPENGINE_SESS_OUT_OF_PORTS_MSG, RTPENGINE_SESS_OUT_OF_PORTS_MSG_LEN) == 0))
+			{
+				LM_WARN("proxy %.*s: %.*s", node->rn_url.len, node->rn_url.s , error.len, error.s);
+				goto select_node;
+			}
+
 			LM_ERR("proxy replied with error: %.*s\n", error.len, error.s);
 		}
 		goto error;


### PR DESCRIPTION
When rtpengine answers with error-reason 'Ran out of ports' adopt the same behavor that when node answers 'Parallel session limit reached'

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x ] Commit message has the format required by CONTRIBUTING guide
- [x ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ x] Each component has a single commit (if not, squash them into one commit)
- [ x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Backport of the 'sessions limit' behavor for the 'Ran out of ports' error-reason.

