### PR TITLE
support subscribe dialog (topos + topos_redis)

### DIFF
--- a/src/modules/htable/htable.c
+++ b/src/modules/htable/htable.c
@@ -484,7 +484,7 @@ static int ht_rm_items(sip_msg_t* msg, str* hname, str* op, str *val,
 		case 2:
 			if(strncmp(op->s, "re", 2)==0) {
 				isval.s = *val;
-				if (ht_dmq_replicate_action(HT_DMQ_RM_CELL_RE, &ht->name, NULL,
+				if ((ht->dmqreplicate > 0) && ht_dmq_replicate_action(HT_DMQ_RM_CELL_RE, &ht->name, NULL,
 							AVP_VAL_STR, &isval, mkey)!=0) {
 					LM_ERR("dmq relication failed (op %d)\n", mkey);
 				}
@@ -494,7 +494,7 @@ static int ht_rm_items(sip_msg_t* msg, str* hname, str* op, str *val,
 				return 1;
 			} else if(strncmp(op->s, "sw", 2)==0) {
 				isval.s = *val;
-				if (ht_dmq_replicate_action(HT_DMQ_RM_CELL_SW, &ht->name, NULL,
+				if ((ht->dmqreplicate > 0) &&ht_dmq_replicate_action(HT_DMQ_RM_CELL_SW, &ht->name, NULL,
 							AVP_VAL_STR, &isval, mkey)!=0) {
 					LM_ERR("dmq relication failed (op %d)\n", mkey);
 				}

--- a/src/modules/topos/doc/topos.xml
+++ b/src/modules/topos/doc/topos.xml
@@ -23,11 +23,20 @@
 		<surname>Mierla</surname>
 		<email>miconda@gmail.com</email>
 	    </editor>
+            <editor>
+                <firstname>Frederic</firstname>
+                <surname>Gaisnon</surname>
+                <email>frederic.gaisnon@gmail.com</email>
+            </editor>
 	</authorgroup>
 	<copyright>
 	    <year>2016</year>
 	    <holder>&fhg;</holder>
 	</copyright>
+        <copyright>
+            <year>2021</year>
+            <holder>MomentTech</holder>
+        </copyright>
     </bookinfo>
     <toc></toc>
     

--- a/src/modules/topos/doc/topos_admin.xml
+++ b/src/modules/topos/doc/topos_admin.xml
@@ -30,8 +30,8 @@
 		a dialog -- record_route() must be used for them as well, the
 		headers are not going to be in the messages sent to the network, they
 		are needed to know local addresses used to communicate with each side.
-		At this moment it is not designed to work for presence (SUBSCRIBE-based)
-		dialogs. The REGISTER and PUBLISH requests are skipped from processing
+                This module is designed to work for presence (SUBSCRIBE-based) dialogs too.
+		The REGISTER and PUBLISH requests are skipped from processing
 		by this module, expected to be terminated on a local SIP server.
 	</para>
 	</section>
@@ -199,6 +199,9 @@ modparam("topos", "branch_expire", 300)
 			after the initial call setup on re-INVITEs or other in-dialog
 			messages. So set a large enough value (according your longest call
 			duration) to prevent problems in re-writing messages.
+			This key is only relevant for INVITE dialog. 
+                        SUBSCRIBE dialog records lifetime are based on value set in expires
+                        header. Moreover each re-SUBSCRIBEs update the dialog timestamp.
 		</para>
 		<para>
 		<emphasis>

--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -905,6 +905,11 @@ int tps_request_received(sip_msg_t *msg, int dialog)
 				goto error;
 			}
 		}
+		if((get_cseq(msg)->method_id)&(METHOD_SUBSCRIBE)) {
+			if(tps_storage_update_dialog(msg, &mtsd, &stsd, TPS_DBU_CONTACT|TPS_DBU_TIME)<0) {
+				goto error;
+			}
+		}
 	}
 	return 0;
 

--- a/src/modules/topos/tps_storage.h
+++ b/src/modules/topos/tps_storage.h
@@ -41,6 +41,7 @@
 #define TPS_DBU_RPLATTRS	(1<<1)
 #define TPS_DBU_ARR		(1<<2)
 #define TPS_DBU_BRR		(1<<3)
+#define TPS_DBU_TIME		(1<<4)
 #define TPS_DBU_ALL		(0xffffffff)
 
 #define TPS_DATA_SIZE	8192
@@ -79,6 +80,7 @@ typedef struct tps_data {
 	int32_t iflags;
 	int32_t direction;
 	uint32_t s_method_id;
+	int32_t expires;
 } tps_data_t;
 
 int tps_storage_dialog_find(sip_msg_t *msg, tps_data_t *td);

--- a/src/modules/topos_redis/doc/topos_redis.xml
+++ b/src/modules/topos_redis/doc/topos_redis.xml
@@ -23,6 +23,11 @@
 		<surname>Mierla</surname>
 		<email>miconda@gmail.com</email>
 	    </editor>
+	    <editor>
+		<firstname>Frederic</firstname>
+		<surname>Gaisnon</surname>
+		<email>frederic.gaisnon@gmail.com</email>
+	    </editor>
 	</authorgroup>
 	<copyright>
 	    <year>2017</year>
@@ -31,6 +36,10 @@
 	<copyright>
 	    <year>2017</year>
 	    <holder>flowroute.com</holder>
+	</copyright>
+	<copyright>
+	    <year>2021</year>
+	    <holder>MomentTech</holder>
 	</copyright>
     </bookinfo>
     <toc></toc>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x ] Commit message has the format required by CONTRIBUTING guide
- [x ] Commits are split per component (core, individual modules, libs, utils, ...)
- [x ] Each component has a single commit (if not, squash them into one commit)
- [x ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x ] Small bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
topos_redis: support SUBSCRIBE dialog
topos: SUBSCRIBE dialog
topos: documentation for SUBSCRIBE dialog
topos: add description for dialog_expire key

Add support for dialog subscribe when using topos.
When a Subscribe is received, a Subscribe dialog is created. Dialog TTL is set according to expire received in SIP request.
At each resubscribe the TTL is refresh according to expires set in SIP request.
Notify (in-dialog) with header event set are supposed to be inside a Subscribe dialog.

bugfix:
topos: when contact mode is set to 1, contact uri created is malformed if received contact has no user part
In this case we have a sip uri like : sip:@host

htable: ht_dmq_replicate_action was always called on ht_rm_items even if dmq was not activated
