### PR TITLE
 cplc: permanent contact not skipped by lookup anymore

### DIFF
--- a/src/modules/cplc/cpl_run.c
+++ b/src/modules/cplc/cpl_run.c
@@ -283,7 +283,7 @@ static inline char *run_lookup( struct cpl_interpreter *intr )
 		} else {
 			contact = r->contacts;
 			/* skip expired contacts */
-			while ((contact) && (contact->expires <= tc))
+			while ((contact) && (contact->expires > 0) && (contact->expires <= tc))
 				contact = contact->next;
 			/* any contacts left? */
 			if (contact) {


### PR DESCRIPTION
- a permanently registered contact has an "expires" value of 0 in usrloc
  when processing lookup, cplc module checks that contacts are not expired by
  checking that the "expires" value of the contact is not lower than current
  time
  as a consequence, permanently registered contact are alsways skipped and
  never targeted

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
when an address-of-record has a permanent contact set, and when a cpl is set, the lookup function of the cplc module skips the permanent contact and no branch to this contact is created. When no cpl is set, usrloc lookup will create the expected branch. So there is a different behavior depending on the presence of a cpl.
the proposed fix will correct this behavior : the cplc module will create a branch to the permanent contact during lookup