### PR TITLE
cplc and pua_dialoginfo enhancement

### DIFF
--- a/src/modules/cplc/cpl_db.c
+++ b/src/modules/cplc/cpl_db.c
@@ -53,7 +53,7 @@ int cpl_db_bind(const str* db_url, const str *db_table)
 	/* CPL module uses all database functions */
 	if (!DB_CAPABILITY(cpl_dbf, DB_CAP_ALL)) {
 		LM_CRIT("Database modules does not "
-		    "provide all functions needed by cpl-c module\n");
+		    "provide all functions needed by cplc module\n");
 		return -1;
 	}
 

--- a/src/modules/cplc/cpl_env.h
+++ b/src/modules/cplc/cpl_env.h
@@ -37,6 +37,8 @@ struct cpl_enviroment {
 	char  *log_dir;         /* dir where the user log should be dumped */
 	int    proxy_recurse;   /* numbers of proxy redirection accepted */
 	int    proxy_route;     /* script route to be run before proxy */
+	int    redirect_route;  /* script route to be run before redirect */
+	int    ignore3xx;       /* deactivate 3xx responses handling */
 	int    case_sensitive;  /* is user part case sensitive ? */
 	str    realm_prefix;    /* domain prefix to be ignored */
 	int    cmd_pipe[2];     /* communication pipe with aux. process */

--- a/src/modules/cplc/cpl_loader.c
+++ b/src/modules/cplc/cpl_loader.c
@@ -243,6 +243,13 @@ static void cpl_rpc_load(rpc_t* rpc, void* ctx)
 		rpc->fault(ctx, 500, "Failed saving CPL");
 		goto done;
 	}
+	else
+	{
+		if (rpc->rpl_printf(ctx, "CPL Enabled") < 0) {
+			rpc->fault(ctx, 500, "Server error");
+			goto done;
+		}
+	}
 
 done:
 	if (enc_log.s)
@@ -276,6 +283,13 @@ static void cpl_rpc_remove(rpc_t* rpc, void* ctx)
 	if (rmv_from_db( &uri.user, cpl_env.use_domain?&uri.host:0)!=1) {
 		rpc->fault(ctx, 500, "Remove failed");
 		return;
+	}
+	else
+	{
+		if (rpc->rpl_printf(ctx, "CPL Disabled") < 0) {
+			rpc->fault(ctx, 500, "Server error");
+			return;
+		}
 	}
 }
 

--- a/src/modules/cplc/cpl_proxy.h
+++ b/src/modules/cplc/cpl_proxy.h
@@ -179,6 +179,11 @@ static void reply_callback( struct cell* t, int type, struct tmcb_params* ps)
 		return;
 	}
 
+	if ( (1 == cpl_env.ignore3xx) && (ps->code)/100==3) {
+		//do not handle 3XX response
+		goto exit;
+	}
+
 	/* if it's a redirect-> do I have to added to the location set ? */
 	if (intr->proxy.recurse && (ps->code)/100==3) {
 		LM_DBG("recurse level %d processing..\n",intr->proxy.recurse);

--- a/src/modules/cplc/cpl_run.c
+++ b/src/modules/cplc/cpl_run.c
@@ -710,6 +710,12 @@ static inline char *run_redirect( struct cpl_interpreter *intr )
 		intr->flags |= CPL_IS_STATEFUL;
 	}
 
+	/* run what redirect route is set */
+	if (cpl_env.redirect_route) {
+		/* do not alter route type - it might be REQUEST or FAILURE */
+		run_top_route( main_rt.rlist[cpl_env.redirect_route], intr->msg, 0);
+	}
+
 	/* add the lump to the reply */
 	lump = add_lump_rpl( intr->msg, lump_str.s , lump_str.len , LUMP_RPL_HDR);
 	if(!lump) {

--- a/src/modules/cplc/cpl_switches.h
+++ b/src/modules/cplc/cpl_switches.h
@@ -817,6 +817,8 @@ static inline char *run_time_switch( struct cpl_interpreter *intr )
 				/* restore the orig TZ */
 				if ( flags&(1<<7) )
 					set_TZ(cpl_env.orig_tz.s);
+				/* reset flags */
+				flags &= (1<<7);
 				/* free structs that I don't need any more */
 				ac_tm_free( &att );
 				tmrec_free( &trt );

--- a/src/modules/cplc/cplc.c
+++ b/src/modules/cplc/cplc.c
@@ -64,12 +64,14 @@ static char *dtd_file      = 0;  /* name of the DTD file for CPL parser */
 static char *lookup_domain = 0;
 static str  timer_avp      = STR_NULL;  /* name of variable timer AVP */
 static str  proxy_route    = STR_NULL;
-
+static str  redirect_route = STR_NULL;
 
 struct cpl_enviroment    cpl_env = {
 		0, /* no cpl logging */
 		0, /* recurse proxy level is 0 */
 		0, /* no script route to be run before proxy */
+		0, /* no script route to be run before redirect */
+		0, /* by default handle 3xx responses */
 		0, /* user part is not case sensitive */
 		{0,0},   /* no domain prefix to be ignored */
 		{-1,-1}, /* communication pipe to aux_process */
@@ -125,6 +127,8 @@ static param_export_t params[] = {
 	{"cpl_dtd_file",   PARAM_STRING, &dtd_file                          },
 	{"proxy_recurse",  INT_PARAM, &cpl_env.proxy_recurse             },
 	{"proxy_route",    PARAM_STR, &proxy_route                     },
+	{"redirect_route", PARAM_STR, &redirect_route               },
+	{"ignore3xx",  INT_PARAM, &cpl_env.ignore3xx             },
 	{"log_dir",        PARAM_STRING, &cpl_env.log_dir                   },
 	{"case_sensitive", INT_PARAM, &cpl_env.case_sensitive            },
 	{"realm_prefix",   PARAM_STR, &cpl_env.realm_prefix            },
@@ -226,6 +230,14 @@ static int cpl_init(void)
 		cpl_env.proxy_route=route_lookup(&main_rt, proxy_route.s);
 		if (cpl_env.proxy_route==-1) {
 			LM_CRIT("route <%s> defined in proxy_route does not exist\n",proxy_route.s);
+			goto error;
+		}
+	}
+
+	if (redirect_route.len>0) {
+		cpl_env.redirect_route=route_lookup(&main_rt, redirect_route.s);
+		if (cpl_env.redirect_route==-1) {
+			LM_CRIT("route <%s> defined in redirect_route does not exist\n",redirect_route.s);
 			goto error;
 		}
 	}

--- a/src/modules/cplc/doc/cplc.xml
+++ b/src/modules/cplc/doc/cplc.xml
@@ -28,10 +28,19 @@
 				<email>bogdan@voice-system.ro</email>
 			</address>
 		</editor>
+		<editor>
+			<firstname>Frederic</firstname>
+			<surname>Gaisnon</surname>
+			<email>frederic.gaisnon@gmail.com</email>
+		</editor>
 	</authorgroup>
 	<copyright>
 		<year>2003</year>
 		<holder>&fhg;</holder>
+	</copyright>
+	<copyright>
+		<year>2021</year>
+		<holder>MomentTech</holder>
 	</copyright>
 	</bookinfo>
 	<toc></toc>

--- a/src/modules/cplc/doc/cplc_admin.xml
+++ b/src/modules/cplc/doc/cplc_admin.xml
@@ -17,7 +17,7 @@
 
 	<section>
 		<title>Overview</title>
-		<para>cpl-c modules implements a CPL (Call Processing Language)
+		<para>cplc modules implements a CPL (Call Processing Language)
 		interpreter. Support for uploading/downloading/removing scripts via
 		SIP REGISTER method is present.
 		</para>
@@ -106,7 +106,7 @@
 				<title>Set <varname>db_url</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","db_url","&exampledb;")
+modparam("cplc","db_url","&exampledb;")
 ...
 </programlisting>
 			</example>
@@ -117,7 +117,7 @@ modparam("cpl-c","db_url","&exampledb;")
 				Indicates the name of the table that store the CPL scripts.
 				This table must be locate into the database specified by
 				<quote>db_url</quote> parameter. For more about the format of the CPL
-				table please see the modules/cpl-c/init.mysql file.
+				table please see the modules/cplc/init.mysql file.
 			</para>
 			<para>
 			<emphasis>
@@ -128,7 +128,7 @@ modparam("cpl-c","db_url","&exampledb;")
 				<title>Set <varname>db_table</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","cpl_table","cpl")
+modparam("cplc","cpl_table","cpl")
 ...
 </programlisting>
 			</example>
@@ -147,7 +147,7 @@ modparam("cpl-c","cpl_table","cpl")
 				<title>Set <varname>username_column</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","username_column","username")
+modparam("cplc","username_column","username")
 ...
 </programlisting>
 			</example>
@@ -166,7 +166,7 @@ modparam("cpl-c","username_column","username")
 				<title>Set <varname>domain_column</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","domain_column","domain")
+modparam("cplc","domain_column","domain")
 ...
 </programlisting>
 			</example>
@@ -186,7 +186,7 @@ modparam("cpl-c","domain_column","domain")
 				<title>Set <varname>cpl_xml_column</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","cpl_xml_column","cpl_xml")
+modparam("cplc","cpl_xml_column","cpl_xml")
 ...
 </programlisting>
 			</example>
@@ -206,7 +206,7 @@ modparam("cpl-c","cpl_xml_column","cpl_xml")
 				<title>Set <varname>cpl_bin_column</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","cpl_bin_column","cpl_bin")
+modparam("cplc","cpl_bin_column","cpl_bin")
 ...
 </programlisting>
 			</example>
@@ -228,7 +228,7 @@ modparam("cpl-c","cpl_bin_column","cpl_bin")
 				<title>Set <varname>cpl_dtd_file</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","cpl_dtd_file","/etc/kamailio/cpl-06.dtd")
+modparam("cplc","cpl_dtd_file","/etc/kamailio/cpl-06.dtd")
 ...
 </programlisting>
 			</example>
@@ -250,7 +250,7 @@ modparam("cpl-c","cpl_dtd_file","/etc/kamailio/cpl-06.dtd")
 				<title>Set <varname>log_dir</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","log_dir","/var/log/kamailio/cpl")
+modparam("cplc","log_dir","/var/log/kamailio/cpl")
 ...
 </programlisting>
 			</example>
@@ -274,7 +274,7 @@ modparam("cpl-c","log_dir","/var/log/kamailio/cpl")
 				<title>Set <varname>proxy_recurse</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","proxy_recurse",2)
+modparam("cplc","proxy_recurse",2)
 ...
 </programlisting>
 			</example>
@@ -283,6 +283,7 @@ modparam("cpl-c","proxy_recurse",2)
 			<title><varname>proxy_route</varname> (string)</title>
 			<para>
 				Before doing proxy (forward), a script route can be executed.
+                                This parameter indicates the name of the route called.
 				All modifications made by that route will be reflected only for
 				the current branch.
 			</para>
@@ -295,7 +296,7 @@ modparam("cpl-c","proxy_recurse",2)
 				<title>Set <varname>proxy_route</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","proxy_route","1")
+modparam("cplc","proxy_route","CPL_PROXY")
 ...
 </programlisting>
 			</example>
@@ -316,7 +317,7 @@ modparam("cpl-c","proxy_route","1")
 				<title>Set <varname>case_sensitive</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","case_sensitive",1)
+modparam("cplc","case_sensitive",1)
 ...
 </programlisting>
 			</example>
@@ -336,7 +337,7 @@ modparam("cpl-c","case_sensitive",1)
 				<title>Set <varname>realm_prefix</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","realm_prefix","sip.")
+modparam("cplc","realm_prefix","sip.")
 ...
 </programlisting>
 			</example>
@@ -361,7 +362,7 @@ modparam("cpl-c","realm_prefix","sip.")
 				<title>Set <varname>timer_avp</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","timer_avp","$avp(i:14)")
+modparam("cplc","timer_avp","$avp(i:14)")
 ...
 </programlisting>
 			</example>
@@ -386,7 +387,7 @@ modparam("cpl-c","timer_avp","$avp(i:14)")
 				<title>Set <varname>lookup_domain</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","lookup_domain","location")
+modparam("cplc","lookup_domain","location")
 ...
 </programlisting>
 			</example>
@@ -409,7 +410,7 @@ modparam("cpl-c","lookup_domain","location")
 					parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","lookup_append_branches",1)
+modparam("cplc","lookup_append_branches",1)
 ...
 </programlisting>
 			</example>
@@ -430,10 +431,53 @@ modparam("cpl-c","lookup_append_branches",1)
 				<title>Set <varname>use_domain</varname> parameter</title>
 				<programlisting format="linespecific">
 ...
-modparam("cpl-c","use_domain",1)
+modparam("cplc","use_domain",1)
 ...
 </programlisting>
-			</example>
+                        </example>
+                </section>
+                <section id="cplc.p.redirect_route">
+                        <title><varname>redirect_route</varname> (string)</title>
+                        <para>
+                                Before doing redirect (deflection), a script route can be executed.
+                                This parameter indicates the name of the route called.
+                                All modifications made by that route will be reflected only for
+                                the current branch.
+                        </para>
+                        <para>
+                                <emphasis>
+                                        Default value of this parameter is NULL (none).
+                                </emphasis>
+                        </para>
+                        <example>
+                                <title>Set <varname>redirect_route</varname> parameter</title>
+                                <programlisting format="linespecific">
+...
+modparam("cplc","redirect_route", "CPL_REDIRECT")
+...
+				</programlisting>
+                        </example>
+                </section>
+
+                </section>
+                <section id="cplc.p.ignore3xx">
+                        <title><varname>ignore3xx</varname> (integer)</title>
+                        <para>
+                                Indicates if 3xx SIP response must be ignored.
+                        </para>
+                        <para>
+                                <emphasis>
+                                        Default value is <quote>0 (disabled)</quote>.
+                                </emphasis>
+                        </para>
+                        <example>
+                                <title>Set <varname>ignore3xx</varname> parameter</title>
+                                <programlisting format="linespecific">
+...
+modparam("cplc","ignore3xx",1)
+...
+				</programlisting>
+                        </example>
 		</section>
 
 	</section>
@@ -690,7 +734,7 @@ if (method=="REGISTER") {
 		<section>
 			<title>Database setup</title>
 			<para>
-			Before running &kamailio; with cpl-c, you have to setup the database 
+			Before running &kamailio; with cplc, you have to setup the database 
 			table where the module will store the CPL scripts. For that, if
 			the table was not created by the installation script or you choose
 			to install everything by yourself you can use the cpc-create.sql

--- a/src/modules/pua_dialoginfo/doc/pua_dialoginfo.xml
+++ b/src/modules/pua_dialoginfo/doc/pua_dialoginfo.xml
@@ -45,6 +45,11 @@
 		    <email>phil.lavin@synety.com</email>
 		</address>
 	    </editor>
+		<editor>
+			<firstname>Frederic</firstname>
+			<surname>Gaisnon</surname>
+			<email>frederic.gaisnon@gmail.com</email>
+		</editor>
 	</authorgroup>
 	<copyright>
 	    <year>2006</year>
@@ -53,6 +58,10 @@
 	<copyright>
 	    <year>2008</year>
 	    <holder>Klaus Darilion IPCom</holder>
+	</copyright>
+	<copyright>
+		<year>2021</year>
+		<holder>MomentTech</holder>
 	</copyright>
   </bookinfo>
     <toc></toc>

--- a/src/modules/pua_dialoginfo/doc/pua_dialoginfo_admin.xml
+++ b/src/modules/pua_dialoginfo/doc/pua_dialoginfo_admin.xml
@@ -536,7 +536,71 @@ modparam("pua_dialoginfo", "callee_trying", 1)
 </programlisting>
 		</example>
 		</section>
-	</section>
+
+                <section>
+                <title><varname>caller_entity_when_publish_disabled</varname> (int)</title>
+                <para>
+                        Must be a valid sip uri.
+                        If this parameter is set, this uri is used as caller entity in
+                        publish xml body if associated dialog has the flag
+                        disable_caller_publish_flag set.
+                        Note only the flag received on dialog creation is used to activate
+                        this feature.
+                </para>
+                <para>
+                        <emphasis>Default value is <quote>NULL</quote>.</emphasis>
+                </para>
+                <example>
+                        <title>Set <varname>caller_entity_when_publish_disabled</varname> parameter</title>
+                        <programlisting format="linespecific">
+...
+modparam("pua_dialoginfo", "caller_entity_when_publish_disabled", "sip:caller@publish.disabled.com")
+...
+			</programlisting>
+                </example>
+                </section>
+
+                <section>
+                <title><varname>callee_entity_when_publish_disabled</varname> (int)</title>
+                <para>
+                        Must be a valid sip uri.
+                        If this parameter is set, this uri is used as callee entity in
+                        publish xml body if associated dialog has the flag
+                        disable_callee_publish_flag set.
+                        Note only the flag received on dialog creation is used to activate
+                        this feature.
+                </para>
+                <para>
+                        <emphasis>Default value is <quote>NULL</quote>.</emphasis>
+                </para>
+                <example>
+                        <title>Set <varname>callee_entity_when_publish_disabled</varname> parameter</title>
+                        <programlisting format="linespecific">
+...
+modparam("pua_dialoginfo", "callee_entity_when_publish_disabled", "sip:callee@publish.disabled.com")
+...
+			</programlisting>
+                </example>
+                </section>
+
+                <section>
+                <title><varname>publish_dialog_req_within</varname> (int)</title>
+                <para>
+                        If this parameter is set to 1, subsequents requests received in dialog generate
+                        corresponding publish request.
+                </para>
+                <para>
+                        <emphasis>Default value is <quote>1</quote>.</emphasis>
+                </para>
+                <example>
+                        <title>Set <varname>publish_dialog_req_within</varname> parameter</title>
+                        <programlisting format="linespecific">
+...
+modparam("pua_dialoginfo", "publish_dialog_req_within", 0)
+...
+			</programlisting>
+                </example>
+                </section>
 
 	<section>
 	<title>Functions</title>

--- a/src/modules/pua_dialoginfo/pua_dialoginfo.c
+++ b/src/modules/pua_dialoginfo/pua_dialoginfo.c
@@ -63,6 +63,7 @@ MODULE_VERSION
 #define DEF_CALLEE_TRYING 0
 #define DEF_DISABLE_CALLER_PUBLISH_FLAG -1
 #define DEF_DISABLE_CALLEE_PUBLISH_FLAG -1
+#define DEF_PUBLISH_DIALOG_REQ_WITHIN 1
 
 /* define PUA_DIALOGINFO_DEBUG to activate more verbose
  * logging and dialog info callback debugging
@@ -80,6 +81,8 @@ int_str pubruri_callee_avp_name;
 
 static str caller_dlg_var = {0, 0}; /* pubruri_caller */
 static str callee_dlg_var = {0, 0}; /* pubruri_callee */
+static str caller_entity_when_publish_disabled = {0, 0}; /* pubruri_caller */
+static str callee_entity_when_publish_disabled = {0, 0}; /* pubruri_callee */
 
 /* Module parameter variables */
 int include_callid         = DEF_INCLUDE_CALLID;
@@ -95,7 +98,7 @@ int disable_caller_publish_flag = DEF_DISABLE_CALLER_PUBLISH_FLAG;
 int disable_callee_publish_flag = DEF_DISABLE_CALLEE_PUBLISH_FLAG;
 char * pubruri_caller_avp  = DEF_PUBRURI_CALLER_AVP;
 char * pubruri_callee_avp  = DEF_PUBRURI_CALLEE_AVP;
-
+int publish_dialog_req_within = DEF_PUBLISH_DIALOG_REQ_WITHIN;
 
 send_publish_t pua_send_publish;
 /** module functions */
@@ -123,6 +126,9 @@ static param_export_t params[]={
 	{"callee_trying",       INT_PARAM, &callee_trying },
 	{"disable_caller_publish_flag",   INT_PARAM, &disable_caller_publish_flag },
 	{"disable_callee_publish_flag",   INT_PARAM, &disable_callee_publish_flag },
+	{"caller_entity_when_publish_disabled",  PARAM_STR, &caller_entity_when_publish_disabled },
+	{"callee_entity_when_publish_disabled",  PARAM_STR, &callee_entity_when_publish_disabled },
+	{"publish_dialog_req_within",      INT_PARAM, &publish_dialog_req_within },
 	{0, 0, 0 }
 };
 
@@ -249,6 +255,7 @@ __dialog_sendpublish(struct dlg_cell *dlg, int type, struct dlg_cb_params *_para
 {
 	str tag = {0,0};
 	str uri = {0,0};
+	str identity_local = {0,0};
 	str target = {0,0};
 	struct dlginfo_cell *dlginfo = NULL;
 
@@ -266,25 +273,33 @@ __dialog_sendpublish(struct dlg_cell *dlg, int type, struct dlg_cb_params *_para
 		uri = dlginfo->to_uri;
 	}
 
+	if (dlginfo->disable_caller_publish) {
+		identity_local=caller_entity_when_publish_disabled;
+	} else {
+		identity_local=dlginfo->from_uri;
+	}
+
+	if (dlginfo->disable_callee_publish) {
+		uri=callee_entity_when_publish_disabled;
+	}
+
 	switch (type) {
 		case DLGCB_FAILED:
 		case DLGCB_TERMINATED:
 		case DLGCB_EXPIRED:
 			LM_DBG("dialog over, from=%.*s\n", dlginfo->from_uri.len,
 					dlginfo->from_uri.s);
-			if (disable_caller_publish_flag == -1 || !(request
-						&& (request->flags & (1<<disable_caller_publish_flag))))
-			{
+			if ((!dlginfo->disable_caller_publish) && (disable_caller_publish_flag == -1 || !(request
+						&& (request->flags & (1<<disable_caller_publish_flag))))) {
 				dialog_publish_multi("terminated", dlginfo->pubruris_caller,
-						&(dlginfo->from_uri), &uri, &(dlginfo->callid), 1,
+						&identity_local, &uri, &(dlginfo->callid), 1,
 						10, 0, 0, &(dlginfo->from_contact),
 						&target, send_publish_flag==-1?1:0);
 			}
-			if (disable_callee_publish_flag == -1 || !(request
-						&& (request->flags & (1<<disable_callee_publish_flag))))
-			{
+			if ((!dlginfo->disable_callee_publish) && (disable_callee_publish_flag == -1 || !(request
+						&& (request->flags & (1<<disable_callee_publish_flag))))) {
 				dialog_publish_multi("terminated", dlginfo->pubruris_callee,
-						&uri, &(dlginfo->from_uri), &(dlginfo->callid), 0,
+						&uri, &identity_local, &(dlginfo->callid), 0,
 						10, 0, 0, &target, &(dlginfo->from_contact),
 						send_publish_flag==-1?1:0);
 			}
@@ -294,19 +309,17 @@ __dialog_sendpublish(struct dlg_cell *dlg, int type, struct dlg_cb_params *_para
 		case DLGCB_CONFIRMED_NA:
 			LM_DBG("dialog confirmed, from=%.*s\n", dlginfo->from_uri.len,
 					dlginfo->from_uri.s);
-			if (disable_caller_publish_flag == -1 || !(request
-						&& (request->flags & (1<<disable_caller_publish_flag))))
-			{
+			if ((!dlginfo->disable_caller_publish) && (disable_caller_publish_flag == -1 || !(request
+						&& (request->flags & (1<<disable_caller_publish_flag))))) {
 				dialog_publish_multi("confirmed", dlginfo->pubruris_caller,
-						&(dlginfo->from_uri), &uri, &(dlginfo->callid), 1,
+						&identity_local, &uri, &(dlginfo->callid), 1,
 						dlginfo->lifetime, 0, 0, &(dlginfo->from_contact), &target,
 						send_publish_flag==-1?1:0);
 			}
-			if (disable_callee_publish_flag == -1 || !(request
-						&& (request->flags & (1<<disable_callee_publish_flag))))
-			{
+			if ((!dlginfo->disable_callee_publish) && (disable_callee_publish_flag == -1 || !(request
+						&& (request->flags & (1<<disable_callee_publish_flag))))) {
 				dialog_publish_multi("confirmed", dlginfo->pubruris_callee, &uri,
-						&(dlginfo->from_uri), &(dlginfo->callid), 0,
+						&identity_local, &(dlginfo->callid), 0,
 						dlginfo->lifetime, 0, 0, &target, &(dlginfo->from_contact),
 						send_publish_flag==-1?1:0);
 			}
@@ -342,54 +355,51 @@ __dialog_sendpublish(struct dlg_cell *dlg, int type, struct dlg_cb_params *_para
 						tag.len = 0;
 					}
 				}
-				if (disable_caller_publish_flag == -1 || !(request
-							&& (request->flags & (1<<disable_caller_publish_flag))))
-				{
+				if ((!dlginfo->disable_caller_publish) && (disable_caller_publish_flag == -1 || !(request
+							&& (request->flags & (1<<disable_caller_publish_flag))))) {
 					if (caller_confirmed) {
 						dialog_publish_multi("confirmed", dlginfo->pubruris_caller,
-								&(dlginfo->from_uri), &uri, &(dlginfo->callid), 1,
+								&identity_local, &uri, &(dlginfo->callid), 1,
 								dlginfo->lifetime, &(dlginfo->from_tag), &tag,
 								&(dlginfo->from_contact), &target,
 								send_publish_flag==-1?1:0);
 					} else {
 						dialog_publish_multi("early", dlginfo->pubruris_caller,
-								&(dlginfo->from_uri), &uri, &(dlginfo->callid), 1,
+								&identity_local, &uri, &(dlginfo->callid), 1,
 								dlginfo->lifetime, &(dlginfo->from_tag), &tag,
 								&(dlginfo->from_contact), &target,
 								send_publish_flag==-1?1:0);
 					}
 				}
-				if (disable_callee_publish_flag == -1 || !(request &&
-							(request->flags & (1<<disable_callee_publish_flag))))
-				{
+				if ((!dlginfo->disable_callee_publish) && (disable_callee_publish_flag == -1 || !(request
+							&& (request->flags & (1<<disable_callee_publish_flag))))) {
 					dialog_publish_multi("early", dlginfo->pubruris_callee, &uri,
-							&(dlginfo->from_uri), &(dlginfo->callid), 0,
+							&identity_local, &(dlginfo->callid), 0,
 							dlginfo->lifetime, &tag, &(dlginfo->from_tag), &target,
 							&(dlginfo->from_contact), send_publish_flag==-1?1:0);
 				}
 
 			} else {
-				if (disable_caller_publish_flag == -1 || !(request &&
-							(request->flags & (1<<disable_caller_publish_flag))))
-				{
+				if ((!dlginfo->disable_caller_publish) && (disable_caller_publish_flag == -1 || !(request
+					&& (request->flags & (1<<disable_caller_publish_flag))))) {
 					if (caller_confirmed) {
 						dialog_publish_multi("confirmed", dlginfo->pubruris_caller,
-								&(dlginfo->from_uri), &uri, &(dlginfo->callid), 1,
+								&identity_local, &uri, &(dlginfo->callid), 1,
 								dlginfo->lifetime, 0, 0, &(dlginfo->from_contact),
 								&target, send_publish_flag==-1?1:0);
 
 					} else {
 						dialog_publish_multi("early", dlginfo->pubruris_caller,
-								&(dlginfo->from_uri), &uri, &(dlginfo->callid), 1,
+								&identity_local, &uri, &(dlginfo->callid), 1,
 								dlginfo->lifetime, 0, 0, &(dlginfo->from_contact),
 								&target, send_publish_flag==-1?1:0);
 					}
 				}
-				if (disable_callee_publish_flag == -1 || !(request
-							&& (request->flags & (1<<disable_callee_publish_flag))))
+                                if ((!dlginfo->disable_callee_publish) && (disable_callee_publish_flag == -1 || !(request
+                                                && (request->flags & (1<<disable_callee_publish_flag)))))
 				{
 					dialog_publish_multi("early", dlginfo->pubruris_callee, &uri,
-							&(dlginfo->from_uri), &(dlginfo->callid), 0,
+							&identity_local, &(dlginfo->callid), 0,
 							dlginfo->lifetime, 0, 0, &target,
 							&(dlginfo->from_contact), send_publish_flag==-1?1:0);
 				}
@@ -398,19 +408,17 @@ __dialog_sendpublish(struct dlg_cell *dlg, int type, struct dlg_cb_params *_para
 		default:
 			LM_ERR("unhandled dialog callback type %d received, from=%.*s\n",
 					type, dlginfo->from_uri.len, dlginfo->from_uri.s);
-			if (disable_caller_publish_flag == -1 || !(request &&
-						(request->flags & (1<<disable_caller_publish_flag))))
-			{
+			if ((!dlginfo->disable_caller_publish) && (disable_caller_publish_flag == -1 || !(request
+					&& (request->flags & (1<<disable_caller_publish_flag))))) {
 				dialog_publish_multi("terminated", dlginfo->pubruris_caller,
-						&(dlginfo->from_uri), &uri, &(dlginfo->callid), 1,
+						&identity_local, &uri, &(dlginfo->callid), 1,
 						10, 0, 0, &(dlginfo->from_contact), &target,
 						send_publish_flag==-1?1:0);
 			}
-			if (disable_callee_publish_flag == -1 || !(request &&
-						(request->flags & (1<<disable_callee_publish_flag))))
-			{
+			if ((!dlginfo->disable_callee_publish) && (disable_callee_publish_flag == -1 || !(request
+					&& (request->flags & (1<<disable_callee_publish_flag))))) {
 				dialog_publish_multi("terminated", dlginfo->pubruris_callee, &uri,
-						&(dlginfo->from_uri), &(dlginfo->callid), 0,
+						&identity_local, &(dlginfo->callid), 0,
 						10, 0, 0, &target, &(dlginfo->from_contact),
 						send_publish_flag==-1?1:0);
 			}
@@ -466,7 +474,7 @@ struct str_list* get_str_list(unsigned short avp_flags, int_str avp_name) {
 
 }
 
-struct dlginfo_cell* get_dialog_data(struct dlg_cell *dlg, int type)
+struct dlginfo_cell* get_dialog_data(struct dlg_cell *dlg, int type, int disable_caller_publish, int disable_callee_publish)
 {
 	struct dlginfo_cell *dlginfo;
 	int len;
@@ -490,6 +498,8 @@ struct dlginfo_cell* get_dialog_data(struct dlg_cell *dlg, int type)
 
 	/* copy from dlg structure to dlginfo structure */
 	dlginfo->lifetime     = override_lifetime ? override_lifetime : dlg->lifetime;
+	dlginfo->disable_caller_publish     = disable_caller_publish;
+	dlginfo->disable_callee_publish     = disable_callee_publish;
 	dlginfo->from_uri.s   = (char*)dlginfo + sizeof(struct dlginfo_cell);
 	dlginfo->from_uri.len = dlg->from_uri.len;
 	dlginfo->to_uri.s     = dlginfo->from_uri.s + dlg->from_uri.len;
@@ -591,14 +601,25 @@ struct dlginfo_cell* get_dialog_data(struct dlg_cell *dlg, int type)
 	}
 
 	/* register dialog callbacks which triggers sending PUBLISH */
-	if (dlg_api.register_dlgcb(dlg,
+        if (publish_dialog_req_within) {
+		if (dlg_api.register_dlgcb(dlg,
 				DLGCB_FAILED| DLGCB_CONFIRMED_NA | DLGCB_TERMINATED
 				| DLGCB_EXPIRED | DLGCB_REQ_WITHIN | DLGCB_EARLY,
 				__dialog_sendpublish, dlginfo, free_dlginfo_cell) != 0) {
-		LM_ERR("cannot register callback for interesting dialog types\n");
-		free_dlginfo_cell(dlginfo);
-		return NULL;
-	}
+			LM_ERR("cannot register callback for interesting dialog types\n");
+			free_dlginfo_cell(dlginfo);
+			return NULL;
+		}
+        } else {
+		if (dlg_api.register_dlgcb(dlg,
+				DLGCB_FAILED| DLGCB_CONFIRMED_NA | DLGCB_TERMINATED
+				| DLGCB_EXPIRED | DLGCB_EARLY,
+				__dialog_sendpublish, dlginfo, free_dlginfo_cell) != 0) {
+			LM_ERR("cannot register callback for interesting dialog types\n");
+			free_dlginfo_cell(dlginfo);
+			return NULL;
+		}
+        }
 
 #ifdef PUA_DIALOGINFO_DEBUG
 	/* dialog callback testing (registered last to be executed frist) */
@@ -622,6 +643,10 @@ __dialog_created(struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
 {
 	struct sip_msg *request = _params->req;
 	struct dlginfo_cell *dlginfo;
+	str identity_remote = {0,0};
+	str identity_local = {0,0};
+	int disable_caller_publish = 0;
+	int disable_callee_publish = 0;
 
 	if (request==NULL || request->REQ_METHOD != METHOD_INVITE)
 		return;
@@ -632,26 +657,46 @@ __dialog_created(struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
 	LM_DBG("new INVITE dialog created: from=%.*s\n",
 			dlg->from_uri.len, dlg->from_uri.s);
 
-	dlginfo=get_dialog_data(dlg, type);
+	if (disable_caller_publish_flag != -1 && caller_entity_when_publish_disabled.len > 0 &&
+			(request && (request->flags & (1<<disable_caller_publish_flag)))) {
+		disable_caller_publish = 1;
+	}
+
+	if (disable_callee_publish_flag != -1 && callee_entity_when_publish_disabled.len > 0 &&
+			(request && (request->flags & (1<<disable_callee_publish_flag)))) {
+		disable_callee_publish=1;
+	}
+
+        dlginfo=get_dialog_data(dlg, type, disable_caller_publish, disable_callee_publish);
 	if(dlginfo==NULL)
 		return;
 
-	if (disable_caller_publish_flag == -1 || !(request && (request->flags
-					& (1<<disable_caller_publish_flag))))
-	{
+	if (disable_caller_publish) {
+		identity_local=caller_entity_when_publish_disabled;
+	} else {
+		identity_local=dlginfo->from_uri;
+	}
+
+	if (disable_callee_publish) {
+		identity_remote=callee_entity_when_publish_disabled;
+	} else {
+		identity_remote=(include_req_uri)?dlg->req_uri:dlg->to_uri;
+	}
+
+	if ((!disable_caller_publish) && (disable_caller_publish_flag == -1 || !(request
+		&& (request->flags & (1<<disable_caller_publish_flag))))) {
 		dialog_publish_multi("Trying", dlginfo->pubruris_caller,
-				&(dlg->from_uri),
-				(include_req_uri)?&(dlg->req_uri):&(dlg->to_uri),
+				&identity_local,
+				&identity_remote,
 				&(dlg->callid), 1, dlginfo->lifetime,
 				0, 0, 0, 0, (send_publish_flag==-1)?1:0);
 	}
 
-	if (callee_trying && (disable_callee_publish_flag == -1 || !(request
-					&& (request->flags & (1<<disable_callee_publish_flag)))))
-	{
+	if (callee_trying && ((!disable_callee_publish) && (disable_callee_publish_flag == -1 || !(request
+			&& (request->flags & (1<<disable_callee_publish_flag)))))) {
 		dialog_publish_multi("Trying", dlginfo->pubruris_callee,
-				(include_req_uri)?&(dlg->req_uri):&(dlg->to_uri),
-				&(dlg->from_uri),
+				&identity_remote,
+				&identity_local,
 				&(dlg->callid), 0, dlginfo->lifetime,
 				0, 0, 0, 0, (send_publish_flag==-1)?1:0);
 	}
@@ -665,7 +710,7 @@ __dialog_loaded(struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
 	LM_DBG("INVITE dialog loaded: from=%.*s\n",
 			dlg->from_uri.len, dlg->from_uri.s);
 
-	dlginfo=get_dialog_data(dlg, type);
+	dlginfo=get_dialog_data(dlg, type, 0, 0);
 	if(dlginfo!=NULL) {
 		LM_DBG("dialog info initialized (from=%.*s)\n",
 				dlg->from_uri.len, dlg->from_uri.s);
@@ -683,6 +728,7 @@ static int mod_init(void)
 
 	str s;
 	pv_spec_t avp_spec;
+        struct sip_uri ruri_uri;
 
 	if(caller_dlg_var.len<=0) {
 		LM_WARN("pubruri_caller_dlg_var is not set"
@@ -692,6 +738,28 @@ static int mod_init(void)
 	if(callee_dlg_var.len<=0) {
 		LM_WARN("pubruri_callee_dlg_var is not set"
 				" - restore on restart disabled\n");
+	}
+
+	if((caller_entity_when_publish_disabled.len > 0) && (disable_caller_publish_flag == -1)) {
+		LM_WARN("caller_entity_when_publish_disabled is set but disable_caller_publish_flag is not defined"
+			" - caller_entity_when_publish_disabled cannot be used \n");
+	}
+
+	if((callee_entity_when_publish_disabled.len > 0) && (disable_callee_publish_flag == -1)) {
+		LM_WARN("callee_entity_when_publish_disabled is set but disable_callee_publish_flag is not defined"
+			" - callee_entity_when_publish_disabled cannot be used \n");
+	}
+
+	if ((caller_entity_when_publish_disabled.len > 0) &&
+		(parse_uri(caller_entity_when_publish_disabled.s, caller_entity_when_publish_disabled.len, &ruri_uri) < 0)) {
+		LM_ERR("caller_entity_when_publish_disabled is not a valid SIP uri\n");
+		return -1;
+	}
+
+	if ((callee_entity_when_publish_disabled.len > 0) &&
+		(parse_uri(callee_entity_when_publish_disabled.s, callee_entity_when_publish_disabled.len, &ruri_uri) < 0)) {
+		LM_ERR("callee_entity_when_publish_disabled is not a valid SIP uri\n");
+		return -1;
 	}
 
 	bind_pua= (bind_pua_t)find_export("bind_pua", 1,0);

--- a/src/modules/pua_dialoginfo/pua_dialoginfo.h
+++ b/src/modules/pua_dialoginfo/pua_dialoginfo.h
@@ -45,6 +45,9 @@ struct dlginfo_cell {
 	struct str_list* pubruris_caller;
 	struct str_list* pubruris_callee;
 	unsigned int lifetime;
+        /*dialog module does not always resend all flags, so we use flags set on first request*/
+        int disable_caller_publish;
+        int disable_callee_publish;
 };
 
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x ] Commit message has the format required by CONTRIBUTING guide
- [x ] Commits are split per component (core, individual modules, libs, utils, ...)
- [x ] Each component has a single commit (if not, squash them into one commit)
- [x ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x ] Small bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
cplc: add a configuration route before redirected call (key: redirect_route)
same behaviour as proxy_route
cplc: deactivate 3XX responses handling (key: ignore3xx)
cplc: time based cpl did not work if several are set
cplc: add return result to kamcmd commands
cplc: documentation update (new keys, new module name, proxy_route modification)

pua_dialoginfo: disable publish notifications for subsequent requests (key: publish_dialog_req_within)
Generally all these PUBLISH generated are not usefull.

pua_dialoginfo: add new key to really deactivate caller or callee notification when the deactivated party was supervised (key: caller_entity_when_publish_disabled key: callee_entity_when_publish_disabled)
If Alice calls Bob with Alice and Bob already supervised by watchers and disable_caller_publish_flag set, PUBLISH generated for Bob will generate NOTIFY for Alice's watchers and Bob's watchers instead of just Bob's watchers.
Note that dlginfo_cell structure is updated because flag set for disabling party (disable_caller_publish_flag or disable_callee_publish_flag ) are not always present in subsequent request received by pua_dialoginfo module. So flag set on initial request are stored and used during the dialog.