### PR TITLE
http_async_client: add curl_follow_redirect parameter

### DIFF
--- a/src/modules/http_async_client/doc/http_async_client_admin.xml
+++ b/src/modules/http_async_client/doc/http_async_client_admin.xml
@@ -201,6 +201,26 @@ modparam("http_async_client", "curl_verbose", 1)
 		</example>
 	</section>
 	<section>
+		<title><varname>curl_follow_redirect</varname> (integer)</title>
+        <para>
+		    If defined to a non-zero value, will tell curl to follow HTTP 3xx redirects.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0 (disabled).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>curl_follow_redirect</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("http_async_client", "curl_follow_redirect", 1)
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section>
 		<title><varname>memory_manager</varname> (string)</title>
         <para>
 			Choose the memory manager used by curl:

--- a/src/modules/http_async_client/http_async_client_mod.c
+++ b/src/modules/http_async_client/http_async_client_mod.c
@@ -74,6 +74,7 @@ int tls_version = 0; // Use default SSL version in HTTPS requests (see curl/curl
 int tls_verify_host = 1; // By default verify host in HTTPS requests
 int tls_verify_peer = 1; // By default verify peer in HTTPS requests
 int curl_verbose = 0;
+int curl_follow_redirect = 0;
 char* tls_client_cert = NULL; // client SSL certificate path, defaults to NULL
 char* tls_client_key = NULL; // client SSL certificate key path, defaults to NULL
 char* tls_ca_path = NULL; // certificate authority dir path, defaults to NULL
@@ -150,6 +151,7 @@ static param_export_t params[]={
 	{"tls_verify_host",		INT_PARAM,		&tls_verify_host},
 	{"tls_verify_peer",		INT_PARAM,		&tls_verify_peer},
 	{"curl_verbose",		INT_PARAM,		&curl_verbose},
+	{"curl_follow_redirect",	INT_PARAM,		&curl_follow_redirect},
 	{"tls_client_cert",		PARAM_STRING,	&tls_client_cert},
 	{"tls_client_key",		PARAM_STRING,	&tls_client_key},
 	{"tls_ca_path",			PARAM_STRING,	&tls_ca_path},

--- a/src/modules/http_async_client/http_multi.c
+++ b/src/modules/http_async_client/http_multi.c
@@ -462,6 +462,9 @@ int new_request(str *query, http_m_params_t *query_params, http_multi_cbe_t cb, 
 		curl_easy_setopt(cell->easy, CURLOPT_VERBOSE, 1L);
 		curl_easy_setopt(cell->easy, CURLOPT_DEBUGFUNCTION, debug_cb);
 	}
+	if (curl_follow_redirect) {
+                curl_easy_setopt(cell->easy, CURLOPT_FOLLOWLOCATION, 1L);
+	}
 	curl_easy_setopt(cell->easy, CURLOPT_ERRORBUFFER, cell->error);
 	curl_easy_setopt(cell->easy, CURLOPT_PRIVATE, cell);
 	curl_easy_setopt(cell->easy, CURLOPT_SSL_VERIFYPEER, cell->params.tls_verify_peer);

--- a/src/modules/http_async_client/http_multi.h
+++ b/src/modules/http_async_client/http_multi.h
@@ -58,6 +58,7 @@ extern stat_var *errors;
 extern stat_var *timeouts;
 extern int tls_version;
 extern int curl_verbose;
+extern int curl_follow_redirect;
 
 void set_curl_mem_callbacks(void);
 int init_http_multi();


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

add curl_follow_redirect module parameter to http_async_client to set CURLOPT_FOLLOWLOCATION during libcurl init, allowing libcurl to follow 3xx HTTP redirect responses.