### PR TITLE
Fix ip parsing in ipops

### DIFF
--- a/src/modules/ipops/ipops_mod.c
+++ b/src/modules/ipops/ipops_mod.c
@@ -1104,12 +1104,12 @@ static inline ip_addr_t *strtoipX(str *ips)
 	if(ips->s[0] == '[' || memchr(ips->s, ':', ips->len)!=NULL)
 	{
 		/* IPv6 */
-		if(str2ip6buf(ips, &ipb) < 0) {
+		if(str2ip6buf(ips, &ipb) == 0) {
 			return &ipb;
 		}
 	} else {
 		/* IPv4 */
-		if (str2ipbuf(ips, &ipb)<0) {
+		if (str2ipbuf(ips, &ipb)==0) {
 			return &ipb;
 		}
 	}


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2645

#### Description
For #2645, a patch was pushed in 47b45b60a037808a675f7d52dd5b2ee80bfe0868, but this code does not correctly check the return value of `str2ip6buf` and `str2ipbuf`.

As described in the comments on both methods, they return zero *for success*.

This MR should be backported to 5.4 as well.