### PR TITLE
core: use third array element when generating totag suffix

### DIFF
--- a/src/core/tags.h
+++ b/src/core/tags.h
@@ -51,17 +51,18 @@ static inline void calc_crc_suffix( struct sip_msg *msg, char *tag_suffix)
 	suffix_source[0]=msg->via1->host;
 	suffix_source[1]=msg->via1->port_str;
 	if (msg->via1->branch) {
-		suffix_source[2]=msg->via1->branch->value;
+		suffix_source[ss_nr++]=msg->via1->branch->value;
 	} else {
 		suffix_source[2].s = NULL;
 		suffix_source[2].len = 0;
 	}
 	crcitt_string_array( tag_suffix, suffix_source, ss_nr );
 
+	ss_nr=2;
 	suffix_source[0]=msg->via1->port_str;
 	suffix_source[1]=msg->via1->host;
 	if (msg->callid) {
-		suffix_source[2]=msg->callid->body;
+		suffix_source[ss_nr++]=msg->callid->body;
 	} else {
 		suffix_source[2].s = NULL;
 		suffix_source[2].len = 0;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Since totag suffix generation was updated in 5.3 to increase randomness, the third element of the array in both parts - via1 branch and call-id - have never been included. The result is that for any given host/port the generated totag is always the same, causing issues with some UAs - specifically relating to presence subscriptions in the cases identified.