### PR TITLE
domain: fix use after free on domain reload

### DIFF
--- a/src/modules/domain/hash.c
+++ b/src/modules/domain/hash.c
@@ -204,8 +204,9 @@ void hash_table_free(struct domain_list **hash_table)
 			shm_free(ap);
 			ap = next_ap;
 		}
+		next = np->next;
 		shm_free(np);
-		np = np->next;
+		np = next;
 	}
 
 	hash_table[DOM_HASH_SIZE] = NULL;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [*] Commit message has the format required by CONTRIBUTING guide
- [*] Commits are split per component (core, individual modules, libs, utils, ...)
- [*] Each component has a single commit (if not, squash them into one commit)
- [*] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [*] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [*] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

I observed this when glancing over commit https://github.com/kamailio/kamailio/commit/f50177003c21f53564be6349c0bb4935be184e2d
The invalid access is pretty clear, and so is the fix.

Cheers!