### PR TITLE
[tls] Don't use OpenSSL<1.0.2 fallback on 1.1+

### DIFF
--- a/src/modules/tls/tls_domain.c
+++ b/src/modules/tls/tls_domain.c
@@ -57,8 +57,12 @@ extern EVP_PKEY * tls_engine_private_key(const char* key_id);
  * ECDHE is enabled only on OpenSSL 1.0.0e and later.
  * See http://www.openssl.org/news/secadv_20110906.txt
  * for details.
+ * Also, copied from _ssl.c of Python for correct initialization.
+ * Allow automatic ECDH curve selection (on OpenSSL 1.0.2+), or use
+ * prime256v1 by default.  This is Apache mod_ssl's initialization
+ * policy, so we should be safe. OpenSSL 1.1 has it enabled by default.
  */
-#ifndef OPENSSL_NO_ECDH
+#if !defined(OPENSSL_NO_ECDH) && !defined(OPENSSL_VERSION_1_1)
 static void setup_ecdh(SSL_CTX *ctx)
 {
    EC_KEY *ecdh;
@@ -69,11 +73,15 @@ static void setup_ecdh(SSL_CTX *ctx)
    }
 #endif
 
+#if defined(SSL_CTX_set_ecdh_auto)
+   SSL_CTX_set_ecdh_auto(ctx, 1);
+#else
    ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
    SSL_CTX_set_options(ctx, SSL_OP_SINGLE_ECDH_USE);
    SSL_CTX_set_tmp_ecdh(ctx, ecdh);
 
    EC_KEY_free(ecdh);
+#endif
 }
 #endif
 
@@ -691,7 +699,7 @@ static int set_cipher_list(tls_domain_t* d)
 					tls_domain_str(d), cipher_list);
 			return -1;
 		}
-#ifndef OPENSSL_NO_ECDH
+#if !defined(OPENSSL_NO_ECDH) && !defined(OPENSSL_VERSION_1_1)
                 setup_ecdh(d->ctx[i]);
 #endif
 #ifndef OPENSSL_NO_DH


### PR DESCRIPTION
Addresses #2716. Also see https://bugs.python.org/issue29697.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X ] Tested changes locally
- [ ] Related to issue #2716 

#### Description
For OpenSSL 1.1.x initialization of EC SSL contexts has changed — we shouldn't be using the < 1.0.2 technique on OpenSSL 1.1+. This addresses a corner case where a TLS client(OpenSSL 1.1.1) with P-256 cert would not handshake with a TLS server with a P-521 cert. Adopted from the way that Python `_ssl.c` does initialization. Python, in turn, took this from Apache's `mod_ssl`.
