### PR TITLE
Update uac-create.sql to reflect UACREG_TABLE_VERSION in uac_reg.h

### DIFF
--- a/utils/kamctl/db_sqlite/uac-create.sql
+++ b/utils/kamctl/db_sqlite/uac-create.sql
@@ -18,5 +18,5 @@ CREATE TABLE uacreg (
     CONSTRAINT uacreg_l_uuid_idx UNIQUE (l_uuid)
 );
 
-INSERT INTO version (table_name, table_version) values ('uacreg','4');
+INSERT INTO version (table_name, table_version) values ('uacreg','5');
 

--- a/utils/kamctl/mysql/uac-create.sql
+++ b/utils/kamctl/mysql/uac-create.sql
@@ -18,5 +18,5 @@ CREATE TABLE `uacreg` (
     CONSTRAINT l_uuid_idx UNIQUE (`l_uuid`)
 );
 
-INSERT INTO version (table_name, table_version) values ('uacreg','4');
+INSERT INTO version (table_name, table_version) values ('uacreg','5');
 

--- a/utils/kamctl/oracle/uac-create.sql
+++ b/utils/kamctl/oracle/uac-create.sql
@@ -26,5 +26,5 @@ END uacreg_tr;
 /
 BEGIN map2users('uacreg'); END;
 /
-INSERT INTO version (table_name, table_version) values ('uacreg','4');
+INSERT INTO version (table_name, table_version) values ('uacreg','5');
 

--- a/utils/kamctl/postgres/uac-create.sql
+++ b/utils/kamctl/postgres/uac-create.sql
@@ -18,5 +18,5 @@ CREATE TABLE uacreg (
     CONSTRAINT uacreg_l_uuid_idx UNIQUE (l_uuid)
 );
 
-INSERT INTO version (table_name, table_version) values ('uacreg','4');
+INSERT INTO version (table_name, table_version) values ('uacreg','5');
 


### PR DESCRIPTION
Table version needs to be updated updated in uac-create.sql, to match uac_reg.h version 5. Version 5 reflects the addition of the contact_addr column.