### PR TITLE
nathelper: fix_nated_sdp added ignoring RFC3605-param if omitted

### DIFF
--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -1609,13 +1609,12 @@ static int is_rfc1918_f(struct sip_msg *msg, char *str1, char *str2)
 #define AOLDMEDPRT_LEN (sizeof(AOLDMEDPRT) - 1)
 
 
-/* replace ip addresses in SDP and return umber of replacements */
+/* replace ip addresses in SDP and return number of replacements */
 static inline int replace_sdp_ip(
 		struct sip_msg *msg, str *org_body, char *line, str *ip, int linelen)
 {
 	str body1, oldip, newip;
 	str body = *org_body;
-	unsigned hasreplaced = 0;
 	int pf, pf1 = 0;
 	str body2;
 	char *bodylimit = body.s + body.len;
@@ -1631,10 +1630,11 @@ static inline int replace_sdp_ip(
 	}
 	body1 = body;
 	for(;;) {
-		if(nh_extract_mediaip(&body1, &oldip, &pf, line, linelen) == -1)
+		ret = nh_extract_mediaip(&body1, &oldip, &pf, line, linelen);
+		if(ret == 0)
 			break;
-		if(pf != AF_INET) {
-			LM_ERR("not an IPv4 address in '%s' SDP\n", line);
+		if(ret == -1) {
+			LM_ERR("can't extract '%s' IP from the SDP\n", line);
 			return -1;
 		}
 		if(!pf1)
@@ -1652,12 +1652,7 @@ static inline int replace_sdp_ip(
 			return -1;
 		}
 		count += ret;
-		hasreplaced = 1;
 		body1 = body2;
-	}
-	if(!hasreplaced) {
-		LM_ERR("can't extract '%s' IP from the SDP\n", line);
-		return -1;
 	}
 
 	return count;
@@ -1739,9 +1734,8 @@ static int ki_fix_nated_sdp_ip(sip_msg_t *msg, int level, str *ip)
 		/* Iterate all a=rtcp and replace ips in them. rfc3605 */
 		ret = replace_sdp_ip(msg, &body, "a=rtcp", (ip && ip->len>0) ? ip : 0, 6);
 		if(ret == -1)
-			LM_DBG("a=rtcp parameter does not exist. nothing to do.\n");
-		else 
-			count += ret;
+			return -1;
+		count += ret;
 
 		if(level & FIX_MEDIP) {
 			/* Iterate all c= and replace ips in them. */
@@ -1800,7 +1794,7 @@ static int nh_extract_mediaip(str *body, str *mediaip, int *pf, char *line,
 		cp = cp1 + linelen;
 	}
 	if(cp1 == NULL)
-		return -1;
+		return 0;
 
 	mediaip->s = cp1 + linelen;
 	mediaip->len =


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in doc/ subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2459

#### Description
There's a small regression after #2497.

If SDP didn't have an "a=rtcp" header (RFC1889 behavior), Kamailio had thrown an Error `can't extract 'a=rtcp' IP from the SDP` on every INVITE. After the PR Kamailio does not flood into log.

Please take into account IPv6 address parser after the commit.
