### PR TITLE
core: ut - fixed str_casesearch()

### DIFF
--- a/src/core/ut.c
+++ b/src/core/ut.c
@@ -353,7 +353,7 @@ char *stre_search_strz(char *vstart, char *vend, char *needlez)
 char *str_casesearch(str *text, str *needle)
 {
 	int i,j;
-	for(i=0;i<text->len-needle->len;i++) {
+	for(i=0;i<=text->len-needle->len;i++) {
 		for(j=0;j<needle->len;j++) {
 			if ( !((text->s[i+j]==needle->s[j]) ||
 					( isalpha((int)text->s[i+j])
@@ -363,7 +363,7 @@ char *str_casesearch(str *text, str *needle)
 		if (j==needle->len)
 			return text->s+i;
 	}
-	return 0;
+	return NULL;
 }
 
 /**


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX

#### Description
There's an regression after 42228552b72267786561704f120e3da3aac5fd89 

`pike.so` was affected by the commit. RPC `pike.top` and `pike.list` commands didn't work.

`str_casesearch()` had returned NULL while text and needle were equal.


