### PR TITLE
pike: fixed regression

### DIFF
--- a/src/modules/pike/ip_tree.c
+++ b/src/modules/pike/ip_tree.c
@@ -301,10 +301,6 @@ pike_ip_node_t* mark_node(unsigned char *ip,int ip_len,
 		}
 	}
 
-	if(node==NULL) {
-		return NULL;
-	}
-
 	LM_DBG("only first %d were matched!\n",byte_pos);
 	*flag = 0;
 	*father = 0;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
There's an regression in 5.5 on `pike.so`. After c9dc0336a33a0ecfe776975be7fbfab8f3c91b48 the module has stopped to work. `mark_node()` had returned a NULL on every IP-address.
