### PR TITLE
pv: fixed error "pv_get_method(): no CSEQ header"

### DIFF
--- a/src/modules/pv/pv_core.c
+++ b/src/modules/pv/pv_core.c
@@ -147,6 +147,9 @@ int pv_get_method(struct sip_msg *msg, pv_param_t *param,
 				(int)msg->first_line.u.request.method_value);
 	}
 
+	if (IS_HTTP_REPLY(msg))
+		return pv_get_null(msg, param, res);
+
 	if(msg->cseq==NULL && ((parse_headers(msg, HDR_CSEQ_F, 0)==-1) ||
 				(msg->cseq==NULL)))
 	{


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
pv: fixed error "pv_get_method(): no CSEQ header"
when sent HTTP request like
```
HTTP/1.1 200 OK
Sia: SIP/2.0/TCP 8.8.8.8:39813
Content-Type: application/json
Server: kamailio
Content-Length: 49

{"data":{"status-code":200,"reason-phrase":"OK"}}
```