### PR TITLE
sl: disabled SREV_NET_DATA_SENT for HTTP responses

### DIFF
--- a/src/core/receive.h
+++ b/src/core/receive.h
@@ -32,6 +32,7 @@
 #include "ip_addr.h"
 
 int receive_msg(char* buf, unsigned int len, struct receive_info *ri);
+int sip_check_fline(char *buf, unsigned int len);
 unsigned int inc_msg_no(void);
 void ksr_msg_env_reset(void);
 

--- a/src/modules/sl/sl_funcs.c
+++ b/src/modules/sl/sl_funcs.c
@@ -210,7 +210,11 @@ int sl_reply_helper(struct sip_msg *msg, int code, char *reason, str *tag)
 	dst.comp=msg->via1->comp_no;
 #endif
 	dst.send_flags=msg->rpl_send_flags;
-	ret = msg_send(&dst, buf.s, buf.len);
+	if(sip_check_fline(buf.s, buf.len) == 0)
+		ret = msg_send_buffer(&dst, buf.s, buf.len, 0);
+	else
+		ret = msg_send_buffer(&dst, buf.s, buf.len, 1);
+
 	mhomed=backup_mhomed;
 
 	keng = sr_kemi_eng_get();


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
HTTP request do not trigger `SREV_NET_DATA_RECV` (please check [`receive_msg`](https://github.com/kamailio/kamailio/blob/0e806316b84be8388dad670e964e54011000b4a4/src/core/receive.c#L321))

This PR adds the same behavior for HTTP responces.