### PR TITLE
nathelper: don't fail if 'a=rtcp' has no IP

### DIFF
--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -1696,7 +1696,7 @@ static inline int replace_sdp_ip(
 		hasreplaced = 1;
 		body1 = body2;
 	}
-	if(!hasreplaced) {
+	if(!hasreplaced && memcmp("a=rtcp", line, 6) != 0) {
 		LM_ERR("can't extract '%s' IP from the SDP\n", line);
 		return -1;
 	}


### PR DESCRIPTION
Examples from RFC3605:
>    m=audio 49170 RTP/AVP 0
>    a=rtcp:53020
>
>    m=audio 49170 RTP/AVP 0
>    a=rtcp:53020 IN IP4 126.16.64.4
>
>    m=audio 49170 RTP/AVP 0
>    a=rtcp:53020 IN IP6 2001:2345:6789:ABCD:EF01:2345:6789:ABCD

fix #2768

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2768 (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

don't fail if there's no IP info if line is 'a=rtcp'