### PR TITLE
rtpengine: ignore mos 0 when selecting min-mos

### DIFF
--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -3588,13 +3588,15 @@ ssrc_ok:
 			continue;
 
 		if (decode_mos_vals_dict(&vals_decoded, ssrc_dict, "average MOS")) {
-			average_vals.avg_samples++;
-			average_vals.mos += vals_decoded.mos;
-			average_vals.packetloss += vals_decoded.packetloss;
-			average_vals.jitter += vals_decoded.jitter;
-			average_vals.roundtrip += vals_decoded.roundtrip;
-			average_vals.roundtrip_leg += vals_decoded.roundtrip_leg;
-			average_vals.samples += vals_decoded.samples;
+			if (vals_decoded.mos > 0) {
+				average_vals.avg_samples++;
+				average_vals.mos += vals_decoded.mos;
+				average_vals.packetloss += vals_decoded.packetloss;
+				average_vals.jitter += vals_decoded.jitter;
+				average_vals.roundtrip += vals_decoded.roundtrip;
+				average_vals.roundtrip_leg += vals_decoded.roundtrip_leg;
+				average_vals.samples += vals_decoded.samples;
+			}
 		}
 
 		if (decode_mos_vals_dict(&vals_decoded, ssrc_dict, "highest MOS")) {
@@ -3602,7 +3604,7 @@ ssrc_ok:
 				max_vals = vals_decoded;
 		}
 		if (decode_mos_vals_dict(&vals_decoded, ssrc_dict, "lowest MOS")) {
-			if (vals_decoded.mos < min_vals.mos)
+			if (vals_decoded.mos > 0 && vals_decoded.mos < min_vals.mos)
 				min_vals = vals_decoded;
 		}
 	}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
since mos 0 is unnitialized this can happen when RTP engine does not have a valid RTT (or missing one leg).

RTP engine MOS is never < 1