### PR TITLE
statsd: adding support for histograms

### DIFF
--- a/src/modules/statsd/doc/statsd_admin.xml
+++ b/src/modules/statsd/doc/statsd_admin.xml
@@ -114,7 +114,7 @@ failure_route[tryagain] {
                 The statsd server collects gauges under the stats.gauges prefix.
             </para>
             <example>
-                <title><function>statsd_set</function> usage</title>
+                <title><function>statsd_gauge</function> usage</title>
                 <programlisting format="linespecific">
 ...
 route [gauge_method]{
@@ -126,6 +126,29 @@ route [gauge_method]{
             </example>
         </section>
 
+        <section id="statsd.f.statsd_histogram">
+            <title>
+                <function moreinfo="none">statsd_histogram(key, value)</function>
+            </title>
+            <para>
+		    The histograms are a measure of time, but they are calculated at the server side.
+		    As the data exported by the client is the same, this is just an alias for the Timer type.
+            </para>
+            <para>
+                This function can be used in ALL ROUTES.
+            </para>
+            <para>
+                The statsd server collects histograms under the stats.histograms prefix.
+            </para>
+            <example>
+                <title><function>statsd_histogram</function> usage</title>
+                <programlisting format="linespecific">
+...
+    statsd_histogram("latency", 1000);
+...
+                </programlisting>
+            </example>
+        </section>
         <section id="statsd.f.statsd_start">
             <title>
                 <function moreinfo="none">statsd_start(key)</function>

--- a/src/modules/statsd/lib_statsd.c
+++ b/src/modules/statsd/lib_statsd.c
@@ -91,6 +91,12 @@ bool statsd_gauge(char *key, char *value){
    return send_command(command);
 }
 
+bool statsd_histogram(char *key, char *value){
+   char command[254];
+   snprintf(command, sizeof command, "%s:%s|h\n", key, value);
+   return send_command(command);
+}
+
 bool statsd_count(char *key, char *value){
    char* end = 0;
    char command[254];

--- a/src/modules/statsd/lib_statsd.h
+++ b/src/modules/statsd/lib_statsd.h
@@ -12,6 +12,7 @@ bool statsd_connect(void);
 bool send_command(char *command);
 bool statsd_set(char *key, char *value);
 bool statsd_gauge(char *key, char *value);
+bool statsd_histogram(char *key, char *value);
 bool statsd_count(char *key, char *value);
 bool statsd_timing(char *key, int value);
 bool statsd_init(char *ip, char *port);

--- a/src/modules/statsd/statsd.c
+++ b/src/modules/statsd/statsd.c
@@ -34,6 +34,7 @@ MODULE_VERSION
 static int mod_init(void);
 void mod_destroy(void);
 static int func_gauge(struct sip_msg *msg, char *key, char* val);
+static int func_histogram(struct sip_msg *msg, char *key, char* val);
 static int func_set(struct sip_msg *msg, char *key, char* val);
 static int func_time_start(struct sip_msg *msg, char *key);
 static int func_time_end(struct sip_msg *msg, char *key);
@@ -50,6 +51,7 @@ static StatsdParams statsd_params= {};
 
 static cmd_export_t commands[] = {
 	{"statsd_gauge", (cmd_function)func_gauge, 2, 0, 0, ANY_ROUTE},
+	{"statsd_histogram", (cmd_function)func_histogram, 2, 0, 0, ANY_ROUTE},
 	{"statsd_start", (cmd_function)func_time_start, 1, 0, 0, ANY_ROUTE},
 	{"statsd_stop", (cmd_function)func_time_end, 1, 0, 0, ANY_ROUTE},
 	{"statsd_incr", (cmd_function)func_incr, 1, 0, 0, ANY_ROUTE},
@@ -117,9 +119,19 @@ static int func_gauge(struct sip_msg* msg, char* key, char* val)
     return statsd_gauge(key, val);
 }
 
+static int func_histogram(struct sip_msg* msg, char* key, char* val)
+{
+    return statsd_histogram(key, val);
+}
+
 static int ki_statsd_gauge(sip_msg_t* msg, str* key, str* val)
 {
     return statsd_gauge(key->s, val->s);
+}
+
+static int ki_statsd_histogram(sip_msg_t* msg, str* key, str* val)
+{
+    return statsd_histogram(key->s, val->s);
 }
 
 static int func_set(struct sip_msg* msg, char* key, char* val)
@@ -237,6 +249,11 @@ char* get_milliseconds(char *dst){
 static sr_kemi_t sr_kemi_statsd_exports[] = {
 	{ str_init("statsd"), str_init("statsd_gauge"),
 		SR_KEMIP_INT, ki_statsd_gauge,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("statsd"), str_init("statsd_histogram"),
+		SR_KEMIP_INT, ki_statsd_histogram,
 		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},


### PR DESCRIPTION
adding support for histograms

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] New feature (non-breaking change which adds new functionality)

#### Description
```
Histograms

The histograms are also a measure of time, but they are calculated at the server side. As the data exported by the client is the same, this is just an alias for the Timer type.

<metric name>:<value>|h
```