### PR TITLE
Enable CentOS 7 to build with OpenSSL 1.1.1 package from EPEL

### DIFF
--- a/pkg/kamailio/obs/kamailio.spec
+++ b/pkg/kamailio/obs/kamailio.spec
@@ -172,6 +172,11 @@
 %define _rundir %{_localstatedir}/run
 %endif
 
+# build with openssl 1.1.1 on RHEL 7 based dists
+%if 0%{?rhel} == 7
+%bcond_with openssl11
+%endif
+
 # redefine buggy openSUSE Leap _sharedstatedir macro. More info at https://bugzilla.redhat.com/show_bug.cgi?id=183370
 %if 0%{?suse_version} == 1315
 %define _sharedstatedir /var/lib
@@ -279,8 +284,13 @@ Account transaction information in a JSON dictionary.
 %package    auth-ephemeral
 Summary:    Functions for authentication using ephemeral credentials
 Group:      %{PKGGROUP}
+%if 0%{?rhel} == 7 && %{with openssl11}
+Requires:   openssl11, kamailio = %ver
+BuildRequires:  openssl11-devel
+%else
 Requires:   openssl, kamailio = %ver
 BuildRequires:  openssl-devel
+%endif
 
 %description    auth-ephemeral
 Functions for authentication using ephemeral credentials.
@@ -365,8 +375,13 @@ Requires:   openssl
 BuildRequires:  openssl-devel
 %endif
 %if 0%{?rhel} == 7
+%if %{with openssl11}
+Requires:   openssl11-libs
+BuildRequires:  openssl11-devel
+%else
 Requires:   openssl-libs
 BuildRequires:  openssl-devel
+%endif
 %endif
 %if 0%{?fedora}
 Requires:   openssl-libs
@@ -673,8 +688,13 @@ MySQL database connectivity for Kamailio.
 %package    outbound
 Summary:    Outbound (RFC 5626) support for Kamailio
 Group:      %{PKGGROUP}
+%if 0%{?rhel} == 7 && %{with openssl11}
+Requires:   openssl11, kamailio = %ver
+BuildRequires:  openssl11-devel
+%else
 Requires:   openssl, kamailio = %ver
 BuildRequires:  openssl-devel
+%endif
 
 %description    outbound
 RFC 5626, "Managing Client-Initiated Connections in the Session Initiation
@@ -952,8 +972,13 @@ SQLite database connectivity for Kamailio.
 %package    tls
 Summary:    TLS transport for Kamailio
 Group:      %{PKGGROUP}
+%if 0%{?rhel} == 7 && %{with openssl11}
+Requires:   openssl11, kamailio = %ver
+BuildRequires:  openssl11-devel
+%else
 Requires:   openssl, kamailio = %ver
 BuildRequires:  openssl-devel
+%endif
 
 %description    tls
 TLS transport for Kamailio.
@@ -1008,8 +1033,13 @@ Non-SIP utitility functions for Kamailio.
 %package    websocket
 Summary:    WebSocket transport for Kamailio
 Group:      %{PKGGROUP}
+%if 0%{?rhel} == 7 && %{with openssl11}
+Requires:   libunistring, openssl11, kamailio = %ver
+BuildRequires:  libunistring-devel, openssl11-devel
+%else
 Requires:   libunistring, openssl, kamailio = %ver
 BuildRequires:  libunistring-devel, openssl-devel
+%endif
 
 %description    websocket
 WebSocket transport for Kamailio.
@@ -1106,6 +1136,9 @@ make cfg prefix=/usr \
 make
 make every-module skip_modules="app_mono db_cassandra db_oracle iptrtpproxy \
     jabber ndb_cassandra osp" \
+%if %{with openssl11}
+    SSL_BUILDER="pkg-config libssl11" \
+%endif
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel} == 8
     FREERADIUS=1 \
 %endif
@@ -1201,6 +1234,9 @@ rm -rf %{buildroot}
 make install
 make install-modules-all skip_modules="app_mono db_cassandra db_oracle \
     iptrtpproxy jabber osp" \
+%if %{with openssl11}
+    SSL_BUILDER="pkg-config libssl11" \
+%endif
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel} == 8
     FREERADIUS=1 \
 %endif


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
EPEL  now includes a openssl11 package for CentOS 7. This feature is for users who want to build kamailio-tls with OpenSSL 1.1.1 instead of OpenSSL 1.0.2.

It is implemented as a `--with=openssl11` conditional (the default is off), so should not affect/change the regular CentOS 7 builds as distributed by kamailio.org.

This is for adventurous users on CentOS 7 willing to maintain their own OpenSSL 1.1.1-enabled TLS package. EPEL dependencies( openssl11-libs, openssl11-devel) are required at runtime and for build.
