### PR TITLE
kazoo : fix routing of reply events

### DIFF
--- a/src/modules/kazoo/kz_amqp.c
+++ b/src/modules/kazoo/kz_amqp.c
@@ -2498,24 +2498,24 @@ void kz_amqp_fire_connection_event(char *event, char* host, char* zone)
 
 void kz_amqp_cb_ok(kz_amqp_cmd_ptr cmd)
 {
-	int n = route_lookup(&main_rt, cmd->cb_route);
+	int n = route_lookup(&onreply_rt, cmd->cb_route);
 	if(n==-1) {
 		/* route block not found in the configuration file */
 		return;
 	}
-	struct action *a = main_rt.rlist[n];
+	struct action *a = onreply_rt.rlist[n];
 	tmb.t_continue(cmd->t_hash, cmd->t_label, a);
 	ksr_msg_env_reset();
 }
 
 void kz_amqp_cb_error(kz_amqp_cmd_ptr cmd)
 {
-	int n = route_lookup(&main_rt, cmd->err_route);
+	int n = route_lookup(&failure_rt, cmd->err_route);
 	if(n==-1) {
 		/* route block not found in the configuration file */
 		return;
 	}
-	struct action *a = main_rt.rlist[n];
+	struct action *a = failure_rt.rlist[n];
 	tmb.t_continue(cmd->t_hash, cmd->t_label, a);
 	ksr_msg_env_reset();
 }


### PR DESCRIPTION
success events should be routed to onreply_route[]
failure events should be routed to failure_route[]

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Kazoo cfg files use onreply_route[]  and failure_route[] to handle the replies from AMQP and the module was sending the replies to the main route and therefore the scripts were not receiving the responses 