### PR TITLE
rtpengine: rtpengine_allow_op return node logic

### DIFF
--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -259,8 +259,9 @@ modparam("rtpengine", "rtpengine_tout_ms", 2000)
 	<section id="rtpengine.p.rtpengine_allow_op">
 		<title><varname>rtpengine_allow_op</varname> (integer)</title>
 		<para>
-		Enable this setting to allow finishing the current sessions while denying new sessions for the
-		<emphasis>manually deactivated nodes </emphasis> via kamctl command i.e. "disabled(permanent)" nodes.
+		Enable this setting to allow finishing the current sessions while denying new sessions for deactivated nodes.
+		</para>
+		<para>Nodes can be <emphasis>manually deactivated </emphasis> via kamctl command i.e. "disabled(permanent)" nodes.
 		Probably the manually deactivated machine is still running(did not crash).
 		</para>
 		<para>
@@ -277,6 +278,18 @@ modparam("rtpengine", "rtpengine_tout_ms", 2000)
 		<para>
 		<emphasis>
 		Default value is <quote>0</quote> to keep the current behaviour.
+		</emphasis>
+		</para>
+		<para>
+		<emphasis>
+		If value set to <quote>1</quote> it will send commands to all disabled nodes for the
+		existing call.
+		</emphasis>
+		</para>
+		<para>
+		<emphasis>
+		If value set to <quote>2</quote> it will send commands only to manually disabled
+		nodes. (Not when timeout is disabled or node broken)
 		</emphasis>
 		</para>
 		<example>

--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -3347,8 +3347,10 @@ select_rtpp_node(str callid, str viabranch, int do_test, struct rtpp_node **quer
 		} else {
 			LM_DBG("node=%.*s for calllen=%d callid=%.*s is disabled, either broke or timeout disabled! Return it\n",
 				node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
+			if (rtpengine_allow_op == 1) {
+				return node;
+			}
 		}
-		/*return node;*/
 	}
 
 	return NULL;

--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -3343,11 +3343,12 @@ select_rtpp_node(str callid, str viabranch, int do_test, struct rtpp_node **quer
 		if (node->rn_recheck_ticks == RTPENGINE_MAX_RECHECK_TICKS) {
 			LM_DBG("node=%.*s for calllen=%d callid=%.*s is disabled(permanent) (probably still UP)! Return it\n",
 				node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
+			return node;
 		} else {
 			LM_DBG("node=%.*s for calllen=%d callid=%.*s is disabled, either broke or timeout disabled! Return it\n",
 				node->rn_url.len, node->rn_url.s, callid.len, callid.len, callid.s);
 		}
-		return node;
+		/*return node;*/
 	}
 
 	return NULL;


### PR DESCRIPTION
When using rtpengine_allow_op param, return node for ongoing calls only if rtpengine is manually disabled.
 
When a rtpengine instance is disabled, rtpengine_allow_op will allow the indialog requests to be processed through that rtpengine. 
But it's not desirable to return the node when the rtpengine has unexpectedly crashed or has any undesired issues, because the rtp commands attempted cause congestion problem in the kamailio.
So with this patch we only return the node if the rtpengine has been manually disabled and it's still supposed to be working.


<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
