### PR TITLE
outbound: add flow_token_secret param

### DIFF
--- a/src/modules/outbound/doc/outbound_admin.xml
+++ b/src/modules/outbound/doc/outbound_admin.xml
@@ -499,6 +499,28 @@ modparam("outbound", "force_no_outbound_flag", 2)
 		</example>
 	</section>
 
+	<section>
+		<title><varname>flow_token_secret</varname> (string)</title>
+		<para>
+			Secret phrase used to calculate the outbound key value
+			used for flow tokens validation.
+			Allows to set persistent outbound key.
+		</para>
+		<para>
+			If not specified, <emphasis>outbound</emphasis> will use randomly generated outbound key
+		</para>
+		<example>
+			<title>
+				Set <varname>flow_token_secret</varname> parameter
+			</title>
+			<programlisting format="linespecific">
+...
+modparam("outbound", "flow_token_secret", "johndoessecretphrase")
+...
+			</programlisting>
+		</example>
+	</section>
+
 	</section>
 
 </chapter>


### PR DESCRIPTION
- calculate ob_key as SHA1(flow_token_secret) if specified
- keep old behavior with randomly generated ob_key if not specified

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Adds ``flow_token_secret``(string) parameter for **outbound** module to give the ability to use persistent ob_key which is used for flow tokens validation.

Useful for cluster configurations with floating IP and ensures successful validation of the previously generated flow tokens after the **kamailio** restart.