### PR TITLE
rr: all "record_route_...()" functions consider custom user AVP

### DIFF
--- a/src/modules/rr/record.c
+++ b/src/modules/rr/record.c
@@ -527,9 +527,12 @@ int record_route_preset(struct sip_msg* _m, str* _data)
 	}
 
 	if (add_username) {
-		if (get_username(_m, &user) < 0) {
-			LM_ERR("failed to extract username\n");
-			return -1;
+		/* check if there is a custom user set */
+		if (get_custom_user(_m, &user) < 0) {
+			if (get_username(_m, &user) < 0) {
+				LM_ERR("failed to extract username\n");
+				return -1;
+			}
 		}
 	} else if (use_ob == 1) {
 		if (rr_obb.encode_flow_token(&user, &_m->rcv) != 0) {
@@ -814,9 +817,12 @@ int record_route_advertised_address(struct sip_msg* _m, str* _data)
 	user.s = 0;
 
 	if (add_username) {
-		if (get_username(_m, &user) < 0) {
-			LM_ERR("failed to extract username\n");
-			return -1;
+		/* check if there is a custom user set */
+		if (get_custom_user(_m, &user) < 0) {
+			if (get_username(_m, &user) < 0) {
+				LM_ERR("failed to extract username\n");
+				return -1;
+			}
 		}
 	} else if (use_ob == 1) {
 		if (rr_obb.encode_flow_token(&user, &_m->rcv) != 0) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally, testet against local branch of 5.1.6
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Until this fix, only the function record_route() considered the
value of the custom user AVP (if present). The functions
record_route_preset() and record_route_advertised_address(),
on the other hand, ignored the value of the custom user AVP,
even if it was presnt.
Now all three functions, record_route(), record_route_preset()
and record_route_advertised_address(), consider the value of the
custom user VP, if it is present.