### PR TITLE
Rfc3264 on session

### DIFF
--- a/src/core/parser/sdp/sdp.c
+++ b/src/core/parser/sdp/sdp.c
@@ -453,6 +453,18 @@ static int parse_sdp_session(str *sdp_body, int session_num, str *cnt_disp, sdp_
 		extract_bwidth(&tmpstr1, &session->bw_type, &session->bw_width);
 	}
 
+	/* Find sendrecv_mode between session begin and first media.
+	 * parse session attributes to check is_on_hold for a= for all medias. */
+	a1p = find_first_sdp_line(o1p, m1p, 'a', NULL);
+	while (a1p) {
+		tmpstr1.s = a1p;
+		tmpstr1.len = m1p - a1p;
+		if (extract_sendrecv_mode(&tmpstr1, &session->sendrecv_mode, &session->is_on_hold) == 0) {
+			break;
+		}
+		a1p = find_next_sdp_line(a1p, m1p, 'a', NULL);
+	}
+
 	/* Have session. Iterate media descriptions in session */
 	m2p = m1p;
 	stream_num = 0;

--- a/src/core/parser/sdp/sdp.h
+++ b/src/core/parser/sdp/sdp.h
@@ -111,6 +111,8 @@ typedef struct sdp_session_cell {
 				AS - application specific */
 	str bw_width;     /**< The <bandwidth> is interpreted as kilobits per second by default */
 	int streams_num;  /**< number of streams inside a session */
+	str sendrecv_mode;
+	int is_on_hold; /**< flag indicating if this session is on hold */
 	struct sdp_stream_cell*  streams;
 } sdp_session_cell_t;
 

--- a/src/modules/textops/textops.c
+++ b/src/modules/textops/textops.c
@@ -4517,8 +4517,15 @@ static int ki_is_audio_on_hold(sip_msg_t *msg)
 				if(!sdp_stream) break;
 				if(sdp_stream->media.len==AUDIO_STR_LEN &&
 					strncmp(sdp_stream->media.s,AUDIO_STR,AUDIO_STR_LEN)==0 &&
+					sdp_stream->sendrecv_mode.len &&
 					sdp_stream->is_on_hold)
 					return sdp_stream->is_on_hold;
+				if(sdp_stream->media.len==AUDIO_STR_LEN &&
+					strncmp(sdp_stream->media.s,AUDIO_STR,AUDIO_STR_LEN)==0 &&
+					!sdp_stream->sendrecv_mode.len &&
+					sdp_session->sendrecv_mode.len &&
+					sdp_session->is_on_hold)
+					return sdp_session->is_on_hold;
 				sdp_stream_num++;
 			}
 			sdp_session_num++;


### PR DESCRIPTION

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
some user agents send a=sendonly as a session attribute and is_audio_on_hold() returns false when it should return true.

#### Changes
- changed sdp_session_cell struct in sdp.h to add sendrecv_mode and is_on_hold
- changed parse_sdp_session in sdp.c to iterate session attributes and call extract_sendrecv_mode for assigment to session
- changed ki_is_audio_on_hold in textops.c to look for session sendrecv_mode if its not set in media



