### PR TITLE
tm: enhance fr/retr timers logging

### DIFF
--- a/src/modules/tm/t_lookup.c
+++ b/src/modules/tm/t_lookup.c
@@ -1818,6 +1818,9 @@ int t_set_fr(struct sip_msg* msg, unsigned int fr_inv_to, unsigned int fr_to)
 		set_msgid_val(user_fr_inv_timeout, msg->id, int, (int)fr_inv);
 		set_msgid_val(user_fr_timeout, msg->id, int, (int)fr);
 	}else{
+#ifdef TIMER_DEBUG
+		LM_DBG("changing default FR timeout values: (\"fr_inv_timeout\": %d, \"fr_timeout\": %d)\n", fr_inv, fr);
+#endif
 		change_fr(t, fr_inv, fr); /* change running uac timers */
 	}
 	return 1;
@@ -1880,6 +1883,9 @@ int t_set_retr(struct sip_msg* msg, unsigned int t1_ms, unsigned int t2_ms)
 		set_msgid_val(user_rt_t1_timeout_ms, msg->id, int, (int)t1_ms);
 		set_msgid_val(user_rt_t2_timeout_ms, msg->id, int, (int)t2_ms);
 	}else{
+#ifdef TIMER_DEBUG
+		LM_DBG("changing default RETR timeout values to: (\"retr_t1_interval\": %d, \"retr_t2_interval\": %d)\n", t1_ms, t2_ms);
+#endif
 		change_retr(t, 1, t1_ms, t2_ms); /* change running uac timers */
 	}
 	return 1;

--- a/src/modules/tm/t_reply.c
+++ b/src/modules/tm/t_reply.c
@@ -2718,6 +2718,9 @@ int reply_received( struct sip_msg  *p_msg )
 				( (last_uac_status<msg_status) &&
 					((msg_status>=180) || (last_uac_status==0)) )
 			) ) { /* provisional now */
+#ifdef TIMER_DEBUG
+		LM_DBG("updating FR/RETR timers, \"fr_inv_timeout\": %d\n", t->fr_inv_timeout);
+#endif
 		restart_rb_fr(& uac->request, t->fr_inv_timeout);
 		uac->request.flags|=F_RB_FR_INV; /* mark fr_inv */
 	} /* provisional replies */

--- a/src/modules/tm/t_suspend.c
+++ b/src/modules/tm/t_suspend.c
@@ -486,6 +486,9 @@ int t_continue_helper(unsigned int hash_index, unsigned int label,
 			( (last_uac_status<msg_status) &&
 			((msg_status>=180) || (last_uac_status==0)) )
 		) ) { /* provisional now */
+#ifdef TIMER_DEBUG
+			LM_DBG("updating FR/RETR timers, \"fr_inv_timeout\": %d\n", t->fr_inv_timeout);
+#endif
 			restart_rb_fr(& t->uac[branch].request, t->fr_inv_timeout);
 			t->uac[branch].request.flags|=F_RB_FR_INV; /* mark fr_inv */
 		}

--- a/src/modules/tm/timer.c
+++ b/src/modules/tm/timer.c
@@ -510,6 +510,13 @@ ticks_t retr_buf_handler(ticks_t ticks, struct timer_ln *tl, void *p)
 							  a little race risk, but
 							  nothing bad would happen */
 		rbuf->flags |= F_RB_TIMEOUT;
+#ifdef TIMER_DEBUG
+		if (rbuf->flags & F_RB_FR_INV) {
+			LM_DBG("reached the \"fr_inv_timeout\"\n");
+		} else {
+			LM_DBG("reached the \"fr_timeout\"\n");
+		}
+#endif
 		/* WARNING:  the next line depends on taking care not to start the
 		 *           wait timer before finishing with t (if this is not
 		 *           guaranteed then comment the timer_allow_del() line) */

--- a/src/modules/tm/timer.h
+++ b/src/modules/tm/timer.h
@@ -168,6 +168,10 @@ inline static int _set_fr_retr(struct retr_buf *rb, unsigned retr_ms)
 	ticks_t retr_ticks;
 	int ret;
 
+#ifdef TIMER_DEBUG
+	LM_DBG("starting FR/RETR timers\n");
+#endif
+
 	ticks = get_ticks_raw();
 	timeout = rb->my_T->fr_timeout;
 	eol = rb->my_T->end_of_life;


### PR DESCRIPTION
- Mention when FR timeout is reached, and which of FR timers expired
- Log when starting FR/RETR timers
- log when changing default timeouts to user-set values
- log when resetting fr/retr timers on provisional replies

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
The main reason for these changes is that we haven't found any possibility to distinguish which of `fr` timeouts expires. The rest of the logs are also helpful, but secondary. 
As they all are under `ifdef TIMEOUT_DEBUG` I hope it is not a big deal.