### PR TITLE
tm: restore xavps & flags after rebuilding message

### DIFF
--- a/src/modules/tm/uac.c
+++ b/src/modules/tm/uac.c
@@ -300,10 +300,6 @@ static inline int t_run_local_req(
 	set_route_type( backup_route_type );
 	p_onsend=0;
 
-	/* restore original environment */
-	tm_xdata_swap(new_cell, &backup_xd, 1);
-	setsflagsval(sflag_bk);
-
 	if (unlikely(ra_ctx.run_flags&DROP_R_F)) {
 		LM_DBG("tm:local-request dropped msg. to %.*s\n",
 				lreq.dst_uri.len, lreq.dst_uri.s);
@@ -372,6 +368,10 @@ normal_update:
 	}
 
 clean:
+	/* restore original environment */
+	tm_xdata_swap(new_cell, &backup_xd, 1);
+	setsflagsval(sflag_bk);
+
 	/* clean local msg structure */
 	if (unlikely(lreq.new_uri.s))
 	{


### PR DESCRIPTION

#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
setting via xavp in tm:local-request has no effect

```
xavp_via_params = "via"

event_route[tm:local-request]
{
    $xavp(via=>xi) = "something"
    via_add_xavp_params("1");
}

reply_route {
    $var(vd) = $sel(via.params["xi"]);
    xlog("L_INFO", "$ci|log|core|reply $rm this should be true => ('$var(vd)' == 'something')\n");
}

```

#### Changes
changed t_run_local_req and moved restore xavps & flags to the end, after the messages changes are applied.

