### PR TITLE
mqueue: add two new module parameters

### DIFF
--- a/src/modules/mqueue/doc/mqueue_admin.xml
+++ b/src/modules/mqueue/doc/mqueue_admin.xml
@@ -150,6 +150,64 @@ modparam("mqueue", "mqueue", "name=qaz")
 	    </example>
 	</section>
 
+
+	<section id="mqueue.p.mqueue_name">
+	    <title><varname>mqueue_name</varname> (string)</title>
+	    <para>
+		Definition of a memory queue, just by name.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>none</quote>.
+		</emphasis>
+	    </para>
+	    <para>
+		Value must be a string.
+	    </para>
+	    <para>
+		The parameter can be set many times, each holding the definition of one queue.
+
+		The max size of each queue defined this way will be equal to mqueue_size(if mqueue_size configured),
+		or limitless (if mqueue_size not configured).
+	    </para>
+	    <example>
+		<title>Set <varname>mqueue_name</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("mqueue", "mqueue_name", "my_own_queue")
+...
+		</programlisting>
+	    </example>
+	</section>
+
+	<section id="mqueue.p.mqueue_size">
+	    <title><varname>mqueue_size</varname> (int)</title>
+	    <para>
+		Definition of the size of all memory queues defined via "mqueue_name" parameter.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>0</quote>.
+		</emphasis>
+	    </para>
+	    <para>
+		Value must be an int.
+	    </para>
+	    <para>
+		The parameter should be set before defining any "mqueue_name".
+		If not set, the queues defined via "mqueue_name" will be limitless.
+	    </para>
+	    <example>
+		<title>Set <varname>mqueue_size</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("mqueue", "mqueue_size", 1024)
+...
+		</programlisting>
+	    </example>
+	</section>
+
+
 	</section>
 
     <section>

--- a/src/modules/rtimer/doc/rtimer_admin.xml
+++ b/src/modules/rtimer/doc/rtimer_admin.xml
@@ -57,6 +57,25 @@
 	<section>
 	<title>Parameters</title>
 	<section>
+		<title><varname>default_interval</varname> (int)</title>
+		<para>
+			The definition of the default interval of timers (if not present on the "timer" parameter)
+		</para>
+		<para>
+			The parameter can be set multiple times to get different intervals in same configuration file.
+		</para>
+		<example>
+		<title>Set <varname>default_interval</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+# default time interval set to 300 seconds
+modparam("rtimer", "default_interval", 300)
+...
+		</programlisting>
+		</example>
+	</section>
+
+	<section>
 		<title><varname>timer</varname> (str)</title>
 		<para>
 		The definition of a timer. The value of the parameter must have the

--- a/src/modules/rtimer/rtimer_mod.c
+++ b/src/modules/rtimer/rtimer_mod.c
@@ -78,12 +78,15 @@ void stm_timer_exec(unsigned int ticks, int worker, void *param);
 void stm_main_timer_exec(unsigned int ticks, void *param);
 int stm_get_worker(struct sip_msg *msg, pv_param_t *param, pv_value_t *res);
 
+static int default_interval = 120;
+
 static pv_export_t rtimer_pvs[] = {
 	{{"rtimer_worker", (sizeof("rtimer_worker")-1)}, PVT_OTHER, stm_get_worker, 0,	0, 0, 0, 0},
 	{ {0, 0}, 0, 0, 0, 0, 0, 0, 0 }
 };
 
 static param_export_t params[]={
+	{"default_interval",       INT_PARAM, &default_interval},
 	{"timer",             PARAM_STRING|USE_FUNC_PARAM, (void*)stm_t_param},
 	{"exec",              PARAM_STRING|USE_FUNC_PARAM, (void*)stm_e_param},
 	{0,0,0}
@@ -294,7 +297,7 @@ int stm_t_param(modparam_t type, void *val)
 		return -1;
 	}
 	if(tmp.interval==0)
-		tmp.interval = 120;
+		tmp.interval = default_interval;
 
 	nt = (stm_timer_t*)pkg_malloc(sizeof(stm_timer_t));
 	if(nt==0)
@@ -307,6 +310,7 @@ int stm_t_param(modparam_t type, void *val)
 	nt->next = _stm_list;
 	_stm_list = nt;
 	free_params(params_list);
+	LM_INFO("created rtimer name=%.*s interval=%d mode=%d\n", tmp.name.len, tmp.name.s, tmp.interval, tmp.mode);
 	return 0;
 }
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Add 2 new mqueue module parameters to simplify config queue definition.
Add 1 new rtimer module parameter to set default timeout if not present.
Updated docs.