### PR TITLE
core: logging: JSON: add CEE schema support

### DIFF
--- a/src/core/dprint.c
+++ b/src/core/dprint.c
@@ -639,8 +639,8 @@ static void ksr_slog_json_str_escape(str *s_in, str *s_out, int *emode)
 	" \"" NAME ".line\": %d, \"" NAME ".function\": \"%s\", \"" NAME ".callid\": \"%.*s\", \"" NAME ".logprefix\": \"%.*s\"," \
 	" \"%smessage\": \"%.*s\" }%s"
 
-#define KSR_SLOG_JSON_CEEFMT "{\"time\":\"%s.%09luZ\",\"proc!id\":\"%d\",\"proc!tid\":%ju,\"pri\":\"%s\",\"subsys\":\"%s\"," \
-        "\"file!name\":\"%s\",\"file!line\":%d,\"native!function\":\"%s\",\"msg\":\"%s\"," \
+#define KSR_SLOG_JSON_CEEFMT "{\"time\":\"%s.%09luZ\",\"proc\":{\"id\":\"%d\",\"tid\":%ju},\"pri\":\"%s\",\"subsys\":\"%s\"," \
+        "\"file\":{\"name\":\"%s\",\"line\":%d},\"native\":{\"function\":\"%s\"},\"msg\":\"%s\"," \
         "\"pname\":\"%s\",\"appname\":\"%s\",\"hostname\":\"%s\"}%s"
 
 void ksr_slog_json(ksr_logdata_t *kld, const char *format, ...)

--- a/src/core/dprint.h
+++ b/src/core/dprint.h
@@ -138,6 +138,7 @@ extern int my_pid(void);
 extern int log_stderr;
 
 extern int log_color;
+extern int log_cee;
 extern char *log_prefix_fmt;
 extern str *log_prefix_val;
 extern int log_prefix_mode;
@@ -172,6 +173,7 @@ void set_module_debug_facility_cb(get_module_debug_facility_f f);
 #define is_printable(level) (get_debug_level(LOG_MNAME, LOG_MNAME_LEN)>=(level))
 extern struct log_level_info log_level_info[];
 extern char *log_name;
+extern char *log_fqdn;
 
 #ifndef NO_SIG_DEBUG
 /** @brief protection against "simultaneous" printing from signal handlers */
@@ -189,6 +191,7 @@ void dprint_color_update(int level, char f, char b);
 void dprint_init_colors(void);
 void dprint_term_color(char f, char b, str *obuf);
 
+void log_init(void);
 void log_prefix_init(void);
 
 #define LOGV_PREFIX_STR ((log_prefix_val)?log_prefix_val->s:"")

--- a/src/main.c
+++ b/src/main.c
@@ -342,9 +342,11 @@ int dont_fork = 0;
 int dont_daemonize = 0;
 int log_stderr = 0;
 int log_color = 0;
+int log_cee = 0;
 /* set custom app name for syslog printing */
 char *log_name = 0;
 char *log_prefix_fmt = 0;
+char *log_fqdn = 0;
 pid_t creator_pid = (pid_t) -1;
 int config_check = 0;
 /* check if reply first via host==us */
@@ -2039,7 +2041,7 @@ int main(int argc, char** argv)
 	sr_cfgenv_init();
 	daemon_status_init();
 
-	dprint_init_colors();
+	log_init();
 
 	/* command line options */
 	options=  ":f:cm:M:dVIhEeb:l:L:n:vKrRDTN:W:w:t:u:g:P:G:SQ:O:a:A:x:X:Y:";


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2797 (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
See the feature request in #2797 

I've provided similar implementation in reSIProcate binaries, Kurento and GStreamer pull requests so they can all share the identical CEE schema.

Tested like this:

```
make

src/kamailio -f ./misc/examples/ims/pcscf/kamailio.cfg --log-engine=json:U -D -dddd -E
```

I copied one of the JSON log lines to a file and parsed it like this to check it is valid JSON:

```
python -m json.tool /tmp/kamailio.json 
{
    "appname": "kamailio",
    "file!line": 97,
    "file!name": "core/mem/pkg.c",
    "hostname": "ws.example.org",
    "msg": "destroying memory manager: q_malloc\n",
    "native!function": "pkg_destroy_manager",
    "pname": "kamailio",
    "pri": "DEBUG",
    "proc!id": "16264",
    "proc!tid": 140525261209856,
    "subsys": "core",
    "time": "2021-08-16T19:04:43.641230480Z"
}
```