### PR TITLE
tls: fix OpenSSL engine in child processes

### DIFF
--- a/src/modules/tls/doc/hsm_howto.xml
+++ b/src/modules/tls/doc/hsm_howto.xml
@@ -22,17 +22,17 @@
 		</para>
 		<para>
 		<programlisting>
-AWS CloudHSM Example
+Thales Luna Example
 --------------------
 
 ...
-# Example for AWS CloudHSM (SafeNet Luna)
+# Example for Thales Luna
 modparam("tls", "engine", "gem")
-modparam("tls", "engine_config", "/usr/local/etc/kamailio/luna.conf")
-modparam("tls", "engine_algorithms", "ALL)
+modparam("tls", "engine_config", "/usr/local/etc/kamailio/thales.cnf")
+modparam("tls", "engine_algorithms", "EC")
 ...
 
-/usr/local/etc/kamailio/luna.cnf is a OpenSSL config format file used to
+/usr/local/etc/kamailio/thales.cnf is a OpenSSL config format file used to
 bootstrap the engine, e.g., pass the PIN.
 
 ...
@@ -43,11 +43,12 @@ kamailio = openssl_init
 engines = engine_section
 
 [ engine_section ]
-# gem is the name of the SafeNet Luna OpenSSL engine
+# gem is the name of the Thales Luna OpenSSL engine
 gem = gem_section
 
 [ gem_section ]
-# from SafeNet documentation
+# from Thales documentation
+dynamic_path = /usr/lib64/engines-1.1/gem.so
 ENGINE_INIT = 0:20:21:password=1234-ABCD-5678-EFGH
 ...
 


### PR DESCRIPTION
tls_init.c calls OPENSSL_init_ssl(); this initializes the
global engine linked-list and this cannot be reset in the child.

To avoid linked-list corruption we manually instantiate
the engine object required for loading private keys instead of
relying on CONF_modules_load_file().

Updates to doc/.

Addresses #2839

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #2839

#### Description
The call to `OPENSSL_init_ssl()` in `tls_init.c` results in the creation of the engine linked-list in the parent.

This affects per-child engine private keys as there is no api to reinitialize the engine linked-list in the child.

This PR removes the call to `CONF_modules_load_file()` which causes linked-list corruption and replaces
the initialization of engine private keys in the child with with other api calls which do not manipulate global
objects.
