### PR TITLE
xlog: add prefix_mode

### DIFF
--- a/src/modules/xlog/doc/xlog_admin.xml
+++ b/src/modules/xlog/doc/xlog_admin.xml
@@ -168,6 +168,28 @@ modparam("xlog", "prefix", "-xlog: ")
 </programlisting>
 		</example>
 	</section>
+	<section id="xlog.p.varname">
+		<title><varname>prefix_mode</varname> (str)</title>
+		<para>
+		control behaviour of <varname>prefix</varname> value.
+		if mode = 0 then <varname>prefix</varname> is treated as string (current behaviour).
+		if mode = 1 then <varname>prefix</varname> is treated as pv_format specifier and value will be evaluated before output.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>prefix_mode</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("xlog", "prefix", "$cfg(name):$cfg(line)")
+modparam("xlog", "prefix_mode", 1)
+...
+</programlisting>
+		</example>
+	</section>
 	<section id="xlog.p.log_facility">
 		<title><varname>log_facility</varname> (string)</title>
 		<para>


### PR DESCRIPTION
allows pv_format specifier in prefix param

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
add `prefix_mode` param to xlog to optionally interpret `prefix` as a `pv_format` specifier.

`config`: 
```
mod_param("xlog", "prefix", "$_s([$(cfg(file):$cfg(line)] $ci $(cfg(route){s.tolower}) )")
mod_param("xlog", "prefix_mode", 1)
...
xlog("L_INFO", "hello")
...
```
`output:`
<pre><code>
66(307) INFO: <b>[my-file.cfg:5]</b> 62795aa2-9696c27c <b>my_route</b> hello
</code>
</pre>
