### PR TITLE
core: logging: JSON: CEE: add the @cee prefix in Syslog messages

### DIFF
--- a/src/core/dprint.c
+++ b/src/core/dprint.c
@@ -652,6 +652,10 @@ static void ksr_slog_json_str_escape(str *s_in, str *s_out, int *emode)
         "\"file\":{\"name\":\"%s\",\"line\":%d},\"native\":{\"function\":\"%s\"},\"msg\":\"%s\"," \
         "\"pname\":\"%s\",\"appname\":\"%s\",\"hostname\":\"%s\"}%s"
 
+#define KSR_SLOG_SYSLOG_JSON_CEEFMT "@cee: " KSR_SLOG_JSON_CEEFMT
+
+#define KSR_SLOG_STDERR_JSON_CEEFMT KSR_SLOG_JSON_CEEFMT
+
 void ksr_slog_json(ksr_logdata_t *kld, const char *format, ...)
 {
 	va_list arglist;
@@ -718,7 +722,7 @@ void ksr_slog_json(ksr_logdata_t *kld, const char *format, ...)
 	strftime (iso8601buf, ISO8601_BUF_SIZE, "%FT%T", &_tm);
 	if (unlikely(log_stderr)) {
 		if (unlikely(log_cee)) {
-			fprintf(stderr, KSR_SLOG_JSON_CEEFMT,
+			fprintf(stderr, KSR_SLOG_STDERR_JSON_CEEFMT,
 			iso8601buf, _tp.tv_nsec, my_pid(),
 #ifdef HAVE_PTHREAD
                         (uintmax_t)pthread_self(),
@@ -739,7 +743,7 @@ void ksr_slog_json(ksr_logdata_t *kld, const char *format, ...)
 		}
 	} else {
 		if (unlikely(log_cee)) {
-			_km_log_func(kld->v_facility, KSR_SLOG_JSON_CEEFMT,
+			_km_log_func(kld->v_facility, KSR_SLOG_SYSLOG_JSON_CEEFMT,
 			iso8601buf, _tp.tv_nsec, my_pid(),
 #ifdef HAVE_PTHREAD
                         pthread_self(),


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
The JSON CEE output from ```stderr``` is OK

When the messages are sent through Syslog, they need this extra prefix ```@cee:``` before the JSON string

Tested with ```rsyslog-omelasticsearch``` and [OpenSearch Dashboard (replacement for Kibana)](https://opensearch.org/)

```
module(load="mmjsonparse")

# we handle LOG_LOCAL5 only, use the same setting in the application config
local5.* :mmjsonparse:

template(name="isJSON" type="list") {
  property(name="$!all-json")
}

module(load="omelasticsearch")
local5.* action(type="omelasticsearch"
           template="isJSON"
           server="some-server"
           serverport="9200"
           searchIndex="log"
           searchType="_doc/"
           uid="admin"
           pwd="admin")
```
