### PR TITLE
xhttp_prom: added prom_counter_dec function

### DIFF
--- a/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
+++ b/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
@@ -407,6 +407,43 @@ kamailio_cnt01 {method="push", IP="192.168.0.1"} 0 1234567890
 		</programlisting>
 			</example>
 		</section>
+		<section id="xhttp_prom.f.prom_counter_dec">
+			<title>
+				<function moreinfo="none">prom_counter_dec(name, number, l0, l1, l2)</function>
+			</title>
+			<para>Get a counter identified by its name and labels and deccrease its value by a
+				number. If counter does not exist it creates the counter, initializes it to zero. If
+				after decrement resulted value lower then 0, then function return error</para>
+			<para>Name is mandatory, number is mandatory. Number has to be positive or zero
+				(integer). l0, l1, l2 are values of labels and are optional.</para>
+			<para>name value and number of labels have to match a previous counter definition with
+				prom_counter.</para>
+			<para>This function accepts pseudovariables on its parameters.</para>
+			<para>Available via KEMI framework as <emphasis>counter_dec_l0</emphasis>,
+					<emphasis>counter_dec_l1</emphasis>, <emphasis>counter_dec_l2</emphasis> and
+					<emphasis>counter_dec_l3</emphasis>.</para>
+			<example>
+				<title><function>prom_counter_dec</function> usage</title>
+				<programlisting format="linespecific">
+...
+# Definition of cnt01 counter with no labels.
+modparam("xhttp_prom", "prom_counter", "name=cnt01;");
+...
+# Decrement 10 from value of cnt01 counter (with no labels) If counter does not exist it gets created.
+prom_counter_dec("cnt01", "10");
+...
+
+# Definition of cnt02 counter with two labels method and IP
+modparam("xhttp_prom", "prom_counter", "name=cnt02; label=method:IP;");
+...
+# Decrement 15 from value of cnt02 counter with labels method and IP. It creates the counter if it does not exist.
+prom_counter_dec("cnt02", "15", "push", "192.168.0.1");
+# When listed the metric it will show a line like this:
+kamailio_cnt02 {method="push", IP="192.168.0.1"} 15 1234567890
+...
+		</programlisting>
+			</example>
+		</section>
 		<section id="xhttp_prom.f.prom_counter_inc">
 			<title>
 				<function moreinfo="none">prom_counter_inc(name, number, l0, l1, l2)</function>

--- a/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
+++ b/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding='ISO-8859-1'?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
 "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
 
 <!-- Include general documentation entities -->

--- a/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
+++ b/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
@@ -11,161 +11,130 @@
 
 <chapter>
 
-  <title>&adminguide;</title>
-  
-  <section>
-	<title>Overview</title>
-	<para>
-	  This module generates suitable metrics for a Prometheus monitoring platform.
-	</para>
-	<para>
-	  It answers Prometheus pull requests (HTTP requests to /metrics URL).
-	</para>
-	<para>
-	  The module generates metrics based on &kamailio; statistics, and also the user
-	  can create his own metrics (currently counters, gauges and histograms).
-	</para>
-	<para>
-	  The xHTTP_PROM module uses the xHTTP module to handle HTTP requests.
-	  Read the documentation of the xHTTP module for more details.
-	</para>
-	<para>
-	  NOTE: This module is based on xHTTP_RPC one.
-	</para>
-	<para>
-	  <emphasis>IMPORTANT</emphasis>: This module uses private memory to generate HTTP
-	  responses, and shared memory to store all the metrics.
-	  Remember to increase size of private and shared memory if you use a huge amount
-	  of metrics.
-	</para>
-	<para>
-	  Prometheus URLs:
-	  <itemizedlist>
-		<listitem>
-		  <para><ulink url="https://prometheus.io/">https://prometheus.io/</ulink></para>
-		</listitem>
-		<listitem>
-		  <para><ulink url="https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels">https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels</ulink></para>
-		</listitem>
-		<listitem>
-		  <para><ulink url="https://prometheus.io/docs/instrumenting/exposition_formats/">https://prometheus.io/docs/instrumenting/exposition_formats/</ulink></para>
-		</listitem>
-	  </itemizedlist>
-	</para>
-  </section>
-  <section>
-	<title>Dependencies</title>
+	<title>&adminguide;</title>
+
 	<section>
-	  <title>&kamailio; Modules</title>
-	  <para>
-		The following modules must be loaded before this module:
-		<itemizedlist>
-		  <listitem>
-			<para>
-			  <emphasis>xhttp</emphasis> -- xHTTP.
-			</para>
-		  </listitem>
-		</itemizedlist>
-	  </para>
+		<title>Overview</title>
+		<para>This module generates suitable metrics for a Prometheus monitoring platform.</para>
+		<para>It answers Prometheus pull requests (HTTP requests to /metrics URL).</para>
+		<para>The module generates metrics based on &kamailio; statistics, and also the user can
+			create his own metrics (currently counters, gauges and histograms).</para>
+		<para>The xHTTP_PROM module uses the xHTTP module to handle HTTP requests. Read the
+			documentation of the xHTTP module for more details.</para>
+		<para>NOTE: This module is based on xHTTP_RPC one.</para>
+		<para>
+			<emphasis>IMPORTANT</emphasis>: This module uses private memory to generate HTTP
+			responses, and shared memory to store all the metrics. Remember to increase size of
+			private and shared memory if you use a huge amount of metrics.</para>
+		<para>Prometheus URLs: <itemizedlist>
+				<listitem>
+					<para><ulink url="https://prometheus.io/">https://prometheus.io/</ulink></para>
+				</listitem>
+				<listitem>
+					<para><ulink
+							url="https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels"
+							>https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels</ulink></para>
+				</listitem>
+				<listitem>
+					<para><ulink url="https://prometheus.io/docs/instrumenting/exposition_formats/"
+							>https://prometheus.io/docs/instrumenting/exposition_formats/</ulink></para>
+				</listitem>
+			</itemizedlist>
+		</para>
 	</section>
 	<section>
-	  <title>External Libraries or Applications</title>
-	  <para>
-		The following libraries or applications must be installed before running
-		&kamailio; with this module loaded:
-		<itemizedlist>
-		  <listitem>
-			<para>
-			  <emphasis>None</emphasis>
+		<title>Dependencies</title>
+		<section>
+			<title>&kamailio; Modules</title>
+			<para>The following modules must be loaded before this module: <itemizedlist>
+					<listitem>
+						<para>
+							<emphasis>xhttp</emphasis> -- xHTTP.</para>
+					</listitem>
+				</itemizedlist>
 			</para>
-		  </listitem>
-		</itemizedlist>
-	  </para>
+		</section>
+		<section>
+			<title>External Libraries or Applications</title>
+			<para>The following libraries or applications must be installed before running
+				&kamailio; with this module loaded: <itemizedlist>
+					<listitem>
+						<para>
+							<emphasis>None</emphasis>
+						</para>
+					</listitem>
+				</itemizedlist>
+			</para>
+		</section>
 	</section>
-  </section>
-  <section>
-	<title>Parameters</title>
-	<section id="xhttp_prom.p.xhttp_prom_buf_size">
-	  <title><varname>xhttp_prom_buf_size</varname> (integer)</title>
-	  <para>
-		Specifies the maximum length of the buffer (in bytes) used
-		to write the metric reply information in order to
-		build the HTML response.
-	  </para>
-	  <para>
-		<emphasis>
-		  Default value is 0 (auto set to 1/3 of the size of the configured pkg mem).
-		</emphasis>
-	  </para>
-	  <example>
-		<title>Set <varname>xhttp_prom_buf_size</varname> parameter</title>
-		<programlisting format="linespecific">
+	<section>
+		<title>Parameters</title>
+		<section id="xhttp_prom.p.xhttp_prom_buf_size">
+			<title><varname>xhttp_prom_buf_size</varname> (integer)</title>
+			<para>Specifies the maximum length of the buffer (in bytes) used to write the metric
+				reply information in order to build the HTML response.</para>
+			<para>
+				<emphasis> Default value is 0 (auto set to 1/3 of the size of the configured pkg
+					mem). </emphasis>
+			</para>
+			<example>
+				<title>Set <varname>xhttp_prom_buf_size</varname> parameter</title>
+				<programlisting format="linespecific">
 ...
 modparam("xhttp_prom", "xhttp_prom_buf_size", 1024)
 ...
 		</programlisting>
-	  </example>
-	</section>
-	<section id="xhttp_prom.p.xhttp_prom_timeout">
-	  <title><varname>xhttp_prom_timeout</varname> (integer)</title>
-	  <para>
-		Specifies a timeout in minutes. A metric not used during this timeout is
-		automatically deleted. Listing metrics does not count as using them.
-	  </para>
-	  <para>
-		<emphasis>If set to 0 timeout is disabled.</emphasis>
- 		Negative values are not allowed.
-	  </para>
-	  <para>
-		<emphasis>
-		  Default value is 60 minutes.
-		</emphasis>
-	  </para>
-	  <example>
-		<title>Set <varname>xhttp_prom_timeout</varname> parameter</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.p.xhttp_prom_timeout">
+			<title><varname>xhttp_prom_timeout</varname> (integer)</title>
+			<para>Specifies a timeout in minutes. A metric not used during this timeout is
+				automatically deleted. Listing metrics does not count as using them.</para>
+			<para>
+				<emphasis>If set to 0 timeout is disabled.</emphasis> Negative values are not
+				allowed.</para>
+			<para>
+				<emphasis> Default value is 60 minutes. </emphasis>
+			</para>
+			<example>
+				<title>Set <varname>xhttp_prom_timeout</varname> parameter</title>
+				<programlisting format="linespecific">
 ...
 # Set timeout to 10 hours		  
 modparam("xhttp_prom", "xhttp_prom_timeout", 600)
 ...
 		</programlisting>
-	  </example>
-	</section>
-	<section id="xhttp_prom.p.xhttp_prom_stats">
-	  <title><varname>xhttp_prom_stats</varname> (str)</title>
-	  <para>
-		Specifies which internal statistics from &kamailio; to show.
-		
-		Possible values:
-		<itemizedlist>
-		  <listitem>
-			<para><emphasis>all</emphasis> - Show whole &kamailio; statistics</para>
-		  </listitem>
-		  <listitem>
-			<para><emphasis>group_name:</emphasis> - Show all statistics for a group</para>
-		  </listitem>
-		  <listitem>
-			<para><emphasis>statistic_name</emphasis> - Show a specific statistic.
-			It automatically finds the group.</para>
-		  </listitem>
-		</itemizedlist>
-	  </para>
-	  <para>
-		<emphasis>
-		  Default value is "", meaning do not display any &kamailio; statistics.
-		</emphasis>
-	  </para>
-	  <para>
-		<emphasis>
-		  IMPORTANT: &kamailio; internal statistics are parsed to convert - into _, so they
-		  accomplish with Prometheus guidelines for metric names.
-		  <ulink url="https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels">https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels</ulink>
-		</emphasis>
-		User generated statistics and label names are not parsed.
-	  </para>
-	  <example>
-		<title>Set <varname>xhttp_prom_stats</varname> parameter</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.p.xhttp_prom_stats">
+			<title><varname>xhttp_prom_stats</varname> (str)</title>
+			<para>Specifies which internal statistics from &kamailio; to show. Possible values: <itemizedlist>
+					<listitem>
+						<para><emphasis>all</emphasis> - Show whole &kamailio; statistics</para>
+					</listitem>
+					<listitem>
+						<para><emphasis>group_name:</emphasis> - Show all statistics for a
+							group</para>
+					</listitem>
+					<listitem>
+						<para><emphasis>statistic_name</emphasis> - Show a specific statistic. It
+							automatically finds the group.</para>
+					</listitem>
+				</itemizedlist>
+			</para>
+			<para>
+				<emphasis> Default value is "", meaning do not display any &kamailio; statistics.
+				</emphasis>
+			</para>
+			<para>
+				<emphasis> IMPORTANT: &kamailio; internal statistics are parsed to convert - into _,
+					so they accomplish with Prometheus guidelines for metric names. <ulink
+						url="https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels"
+						>https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels</ulink>
+				</emphasis> User generated statistics and label names are not parsed.</para>
+			<example>
+				<title>Set <varname>xhttp_prom_stats</varname> parameter</title>
+				<programlisting format="linespecific">
 ...
 # show all kamailio statistics.
 modparam("xhttp_prom", "xhttp_prom_stats", "all")
@@ -180,24 +149,19 @@ modparam("xhttp_prom", "xhttp_prom_stats", "200_replies")
 modparam("xhttp_prom", "xhttp_prom_stats", "")
 ...
 		</programlisting>
-	  </example>
-	</section>
-	<section id="xhttp_prom.p.xhttp_prom_beginning">
-	  <title><varname>xhttp_prom_beginning</varname> (str)</title>
-	  <para>
-		Specifies beginning of string the metrics are build with.
-	  </para>
-	  <para>
-		<emphasis>It defaults to "kamailio_"</emphasis>, so if not specified every
-		metric will start with "kamailio_".
-	  </para>
-	  <para>
-		Void string "" is also allowed, meaning no prefix string for every metric
-		name.
-	  </para>
-	  <example>
-		<title>Set <varname>xhttp_prom_beginning</varname> parameter</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.p.xhttp_prom_beginning">
+			<title><varname>xhttp_prom_beginning</varname> (str)</title>
+			<para>Specifies beginning of string the metrics are build with.</para>
+			<para>
+				<emphasis>It defaults to "kamailio_"</emphasis>, so if not specified every metric
+				will start with "kamailio_".</para>
+			<para>Void string "" is also allowed, meaning no prefix string for every metric
+				name.</para>
+			<example>
+				<title>Set <varname>xhttp_prom_beginning</varname> parameter</title>
+				<programlisting format="linespecific">
 ...
 # All metrics will start with "my_metric_".
 modparam("xhttp_prom", "xhttp_prom_beginning", "my_metric_")
@@ -206,49 +170,42 @@ modparam("xhttp_prom", "xhttp_prom_beginning", "my_metric_")
 modparam("xhttp_prom", "xhttp_prom_beginning", "");
 ...
 		</programlisting>
-	  </example>
-	</section>
-	<section id="xhttp_prom.p.prom_counter">
-	  <title><varname>prom_counter</varname> (str)</title>
-	  <para>
-		Create a counter metric.
-	  </para>
-	  <para>
-		This function declares a counter but the actual counter is only created
-		when using it (by adding to or resetting it)
-	  </para>
-	  <para>
-		It takes a list of attribute=value separated by semicolon, the attributes can
-		be name and label.
-	  </para>
-	  <itemizedlist>
-		<listitem>
-		  <para>
-			<emphasis>name</emphasis> - name of the counter. This attribute is mandatory.
-			It is used to generate the metric name. Each name is unique, no metric shall
-			repeat a name.
-		  </para>
-		</listitem>
-		<listitem>
-		  <para>
-			<emphasis>label</emphasis> - names of labels in the counter. Optional.
-			Only one label parameter at most allowed in counters.
-			Each label name is separated by <emphasis>:</emphasis> without spaces.
-			At most only three label names allowed in each label parameter.
-			<example><title><varname>prom_counter</varname> label example</title>
-			<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.p.prom_counter">
+			<title><varname>prom_counter</varname> (str)</title>
+			<para>Create a counter metric.</para>
+			<para>This function declares a counter but the actual counter is only created when using
+				it (by adding to or resetting it)</para>
+			<para>It takes a list of attribute=value separated by semicolon, the attributes can be
+				name and label.</para>
+			<itemizedlist>
+				<listitem>
+					<para>
+						<emphasis>name</emphasis> - name of the counter. This attribute is
+						mandatory. It is used to generate the metric name. Each name is unique, no
+						metric shall repeat a name.</para>
+				</listitem>
+				<listitem>
+					<para>
+						<emphasis>label</emphasis> - names of labels in the counter. Optional. Only
+						one label parameter at most allowed in counters. Each label name is
+						separated by <emphasis>:</emphasis> without spaces. At most only three label
+						names allowed in each label parameter. <example>
+							<title><varname>prom_counter</varname> label example</title>
+							<programlisting format="linespecific">
 # Create two labels called method and handler
 label = method:handler
 This would generate  {method="whatever", handler="whatever2"} when building
 the metric.
 			</programlisting>
-			</example>
-		  </para>
-		</listitem>
-	  </itemizedlist>
-	  <example>
-		<title>Set <varname>prom_counter</varname> parameter</title>
-		<programlisting format="linespecific">
+						</example>
+					</para>
+				</listitem>
+			</itemizedlist>
+			<example>
+				<title>Set <varname>prom_counter</varname> parameter</title>
+				<programlisting format="linespecific">
 ...
 		  
 # Create cnt_first counter with no labels.
@@ -266,49 +223,42 @@ using it by prom_counter_inc or prom_counter_reset functions.
 
 ...
 		</programlisting>
-	  </example>
-	</section>
-	<section id="xhttp_prom.p.prom_gauge">
-	  <title><varname>prom_gauge</varname> (str)</title>
-	  <para>
-		Create a gauge metric.
-	  </para>
-	  <para>
-		This function declares the gauge but the actual gauge is only created
-		when using it (by setting or resetting it)
-	  </para>
-	  <para>
-		It takes a list of attribute=value separated by semicolon, the attributes can
-		be name and value.
-	  </para>
-	  <itemizedlist>
-		<listitem>
-		  <para>
-			<emphasis>name</emphasis> - name of the gauge. This attribute is mandatory.
-			It is used to generate the metric name. Each name is unique, no metric shall
-			repeat a name.
-		  </para>
-		</listitem>
-		<listitem>
-		  <para>
-			<emphasis>label</emphasis> - names of labels in the gauge. Optional.
-			Only one label parameter at most allowed in gauges.
-			Each label name is separated by <emphasis>:</emphasis> without spaces.
-			At most only three label names allowed inside each label parameter.
-			<example><title><varname>prom_gauge</varname> label example</title>
-			<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.p.prom_gauge">
+			<title><varname>prom_gauge</varname> (str)</title>
+			<para>Create a gauge metric.</para>
+			<para>This function declares the gauge but the actual gauge is only created when using
+				it (by setting or resetting it)</para>
+			<para>It takes a list of attribute=value separated by semicolon, the attributes can be
+				name and value.</para>
+			<itemizedlist>
+				<listitem>
+					<para>
+						<emphasis>name</emphasis> - name of the gauge. This attribute is mandatory.
+						It is used to generate the metric name. Each name is unique, no metric shall
+						repeat a name.</para>
+				</listitem>
+				<listitem>
+					<para>
+						<emphasis>label</emphasis> - names of labels in the gauge. Optional. Only
+						one label parameter at most allowed in gauges. Each label name is separated
+						by <emphasis>:</emphasis> without spaces. At most only three label names
+						allowed inside each label parameter. <example>
+							<title><varname>prom_gauge</varname> label example</title>
+							<programlisting format="linespecific">
 # Create two labels called method and handler
 label = method:handler
 This would generate  {method="whatever", handler="whatever2"} when building
 the metric.
 			</programlisting>
-			</example>
-		  </para>
-		</listitem>
-	  </itemizedlist>
-	  <example>
-		<title>Set <varname>prom_gauge</varname> parameter</title>
-		<programlisting format="linespecific">
+						</example>
+					</para>
+				</listitem>
+			</itemizedlist>
+			<example>
+				<title>Set <varname>prom_gauge</varname> parameter</title>
+				<programlisting format="linespecific">
 ...
 
 # Create gg_first gauge with no labels
@@ -323,67 +273,54 @@ modparam("xhttp_prom", "prom_gauge", "name=gg_third; label=method:handler;");
 
 ...
 		</programlisting>
-	  </example>
-	</section>
-	<section id="xhttp_prom.p.prom_histogram">
-	  <title><varname>prom_histogram</varname> (str)</title>
-	  <para>
-		Create a histogram metric.
-	  </para>
-	  <para>
-		This function declares a histogram but the actual histogram is only created
-		when observing it.
-	  </para>
-	  <para>
-		It takes a list of attribute=value separated by semicolon, the attributes can
-		be name, label and buckets.
-	  </para>
-	  <itemizedlist>
-		<listitem>
-		  <para>
-			<emphasis>name</emphasis> - name of the histogram. This attribute is mandatory.
-			It is used to generate the metric name. Each name is unique, no metric shall
-			repeat a name.
-		  </para>
-		</listitem>
-		<listitem>
-		  <para>
-			<emphasis>label</emphasis> - names of labels in the histogram. Optional.
-			Only one label parameter at most allowed in histograms.
-			Each label name is separated by <emphasis>:</emphasis> without spaces.
-			At most only three label names allowed in each label parameter.
-			<example><title><varname>prom_histogram</varname> label example</title>
-			<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.p.prom_histogram">
+			<title><varname>prom_histogram</varname> (str)</title>
+			<para>Create a histogram metric.</para>
+			<para>This function declares a histogram but the actual histogram is only created when
+				observing it.</para>
+			<para>It takes a list of attribute=value separated by semicolon, the attributes can be
+				name, label and buckets.</para>
+			<itemizedlist>
+				<listitem>
+					<para>
+						<emphasis>name</emphasis> - name of the histogram. This attribute is
+						mandatory. It is used to generate the metric name. Each name is unique, no
+						metric shall repeat a name.</para>
+				</listitem>
+				<listitem>
+					<para>
+						<emphasis>label</emphasis> - names of labels in the histogram. Optional.
+						Only one label parameter at most allowed in histograms. Each label name is
+						separated by <emphasis>:</emphasis> without spaces. At most only three label
+						names allowed in each label parameter. <example>
+							<title><varname>prom_histogram</varname> label example</title>
+							<programlisting format="linespecific">
 # Create two labels called method and handler
 label = method:handler
 This would generate  {method="whatever", handler="whatever2"} when building
 the metric.
 			</programlisting>
-			</example>
-		  </para>
-		</listitem>
-		<listitem>
-		  <para>
-			<emphasis>buckets</emphasis> - specifies upper bounds for buckets in the
-			histogram. This attribute is optional.
-		  </para>
-		  <para>
-			Bucket values are separated by ":". Each value has to be a number.
-		  </para>
-		  <para>
-			"+Inf" upper bucket is always automatically included.
-		  </para>
-		  <para>At least one bucket value is needed (other than +Inf).</para>
-		  <para>Every bucket value has to increase in the list.</para>
-		  <para>
-			If no buckets specified, default bucket list is set to these values:
-		  </para>
-		  <para>[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]</para>
-		</listitem>
-	  </itemizedlist>
-	  <example>
-		<title>Set <varname>prom_histogram</varname> parameter</title>
-		<programlisting format="linespecific">
+						</example>
+					</para>
+				</listitem>
+				<listitem>
+					<para>
+						<emphasis>buckets</emphasis> - specifies upper bounds for buckets in the
+						histogram. This attribute is optional.</para>
+					<para>Bucket values are separated by ":". Each value has to be a number.</para>
+					<para>"+Inf" upper bucket is always automatically included.</para>
+					<para>At least one bucket value is needed (other than +Inf).</para>
+					<para>Every bucket value has to increase in the list.</para>
+					<para>If no buckets specified, default bucket list is set to these
+						values:</para>
+					<para>[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]</para>
+				</listitem>
+			</itemizedlist>
+			<example>
+				<title>Set <varname>prom_histogram</varname> parameter</title>
+				<programlisting format="linespecific">
 ...
 		  
 # Create my_histo histogram with no labels and default buckets.
@@ -403,34 +340,28 @@ using it by prom_histogram_observe function.
 
 ...
 		</programlisting>
-	  </example>
+			</example>
+		</section>
 	</section>
-  </section>
-  <section>
-	<title>Functions</title>
-	<section id="xhttp_prom.f.prom_counter_reset">
-	  <title>
-		<function moreinfo="none">prom_counter_reset(name, l0, l1, l2)</function>
-	  </title>
-	  <para>
-		Get a counter based on its name and labels and reset its value to 0.
-		Name parameter is mandatory. Values of labels are optional (from none up to three).
-		Name in prom_counter_reset has to match same name in prom_counter parameter.
-		Number of labels in prom_counter_reset has to match number of labels in prom_counter parameter.
-		First time a counter is used with this reset function the counter is created if it does not exist already.
-	  </para>
-	  <para>
-		This function accepts pseudovariables on its parameters.
-	  </para>
-	  <para>
-		Available via KEMI framework as <emphasis>counter_reset_l0</emphasis>,
-		<emphasis>counter_reset_l1</emphasis>,
-		<emphasis>counter_reset_l2</emphasis> and
-		<emphasis>counter_reset_l3</emphasis>.
-	  </para>
-	  <example>
-		<title><function>prom_counter_reset</function> usage</title>
-		<programlisting format="linespecific">
+	<section>
+		<title>Functions</title>
+		<section id="xhttp_prom.f.prom_counter_reset">
+			<title>
+				<function moreinfo="none">prom_counter_reset(name, l0, l1, l2)</function>
+			</title>
+			<para>Get a counter based on its name and labels and reset its value to 0. Name
+				parameter is mandatory. Values of labels are optional (from none up to three). Name
+				in prom_counter_reset has to match same name in prom_counter parameter. Number of
+				labels in prom_counter_reset has to match number of labels in prom_counter
+				parameter. First time a counter is used with this reset function the counter is
+				created if it does not exist already.</para>
+			<para>This function accepts pseudovariables on its parameters.</para>
+			<para>Available via KEMI framework as <emphasis>counter_reset_l0</emphasis>,
+					<emphasis>counter_reset_l1</emphasis>, <emphasis>counter_reset_l2</emphasis> and
+					<emphasis>counter_reset_l3</emphasis>.</para>
+			<example>
+				<title><function>prom_counter_reset</function> usage</title>
+				<programlisting format="linespecific">
 ...
 # Definition of counter with prom_counter with labels method and IP
 modparam("xhttp_prom", "prom_counter", "name=cnt01; label=method:IP;");
@@ -443,31 +374,25 @@ prom_counter_reset("cnt01", "push", "192.168.0.1");
 kamailio_cnt01 {method="push", IP="192.168.0.1"} 0 1234567890
 ...
 		</programlisting>
-	  </example>
-	</section>
-	<section id="xhttp_prom.f.prom_gauge_reset">
-	  <title>
-		<function moreinfo="none">prom_gauge_reset(name, l0, l1, l2)</function>
-	  </title>
-	  <para>
-		Get a gauge based on its name and labels and reset its value to 0.
-		Name parameter is mandatory. Values of labels are optional (from none up to three).
-		Name in prom_gauge_reset has to match same name in prom_gauge parameter.
-		Number of labels in prom_gauge_reset has to match number of labels in prom_gauge parameter.
-		First time a gauge is used with this reset function the gauge is created if it does not exist already.
-	  </para>
-	  <para>
-		This function accepts pseudovariables on its parameters.
-	  </para>
-	  <para>
-		Available via KEMI framework as <emphasis>gauge_reset_l0</emphasis>,
-		<emphasis>gauge_reset_l1</emphasis>,
-		<emphasis>gauge_reset_l2</emphasis> and
-		<emphasis>gauge_reset_l3</emphasis>.
-	  </para>
-	  <example>
-		<title><function>prom_gauge_reset</function> usage</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.f.prom_gauge_reset">
+			<title>
+				<function moreinfo="none">prom_gauge_reset(name, l0, l1, l2)</function>
+			</title>
+			<para>Get a gauge based on its name and labels and reset its value to 0. Name parameter
+				is mandatory. Values of labels are optional (from none up to three). Name in
+				prom_gauge_reset has to match same name in prom_gauge parameter. Number of labels in
+				prom_gauge_reset has to match number of labels in prom_gauge parameter. First time a
+				gauge is used with this reset function the gauge is created if it does not exist
+				already.</para>
+			<para>This function accepts pseudovariables on its parameters.</para>
+			<para>Available via KEMI framework as <emphasis>gauge_reset_l0</emphasis>,
+					<emphasis>gauge_reset_l1</emphasis>, <emphasis>gauge_reset_l2</emphasis> and
+					<emphasis>gauge_reset_l3</emphasis>.</para>
+			<example>
+				<title><function>prom_gauge_reset</function> usage</title>
+				<programlisting format="linespecific">
 ...
 # Definition of gauge with prom_gauge with labels method and IP
 modparam("xhttp_prom", "prom_gauge", "name=cnt01; label=method:IP;");
@@ -480,36 +405,26 @@ prom_gauge_reset("cnt01", "push", "192.168.0.1");
 kamailio_cnt01 {method="push", IP="192.168.0.1"} 0 1234567890
 ...
 		</programlisting>
-	  </example>
-	</section>
-	<section id="xhttp_prom.f.prom_counter_inc">
-	  <title>
-		<function moreinfo="none">prom_counter_inc(name, number, l0, l1, l2)</function>
-	  </title>
-	  <para>
-		Get a counter identified by its name and labels and increase its value by a number.
-		If counter does not exist it creates the counter, initializes it to zero and adds the number.
-	  </para>
-	  <para>
-		Name is mandatory, number is mandatory.
-		Number has to be positive or zero (integer).
-		l0, l1, l2 are values of labels and are optional.
-	  </para>
-	  <para>
-		name value and number of labels have to match a previous counter definition with prom_counter.
-	  </para>
-	  <para>
-		This function accepts pseudovariables on its parameters.
-	  </para>
-	  <para>
-		Available via KEMI framework as <emphasis>counter_inc_l0</emphasis>,
-		<emphasis>counter_inc_l1</emphasis>,
-		<emphasis>counter_inc_l2</emphasis> and
-		<emphasis>counter_inc_l3</emphasis>.
-	  </para>
-	  <example>
-		<title><function>prom_counter_inc</function> usage</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.f.prom_counter_inc">
+			<title>
+				<function moreinfo="none">prom_counter_inc(name, number, l0, l1, l2)</function>
+			</title>
+			<para>Get a counter identified by its name and labels and increase its value by a
+				number. If counter does not exist it creates the counter, initializes it to zero and
+				adds the number.</para>
+			<para>Name is mandatory, number is mandatory. Number has to be positive or zero
+				(integer). l0, l1, l2 are values of labels and are optional.</para>
+			<para>name value and number of labels have to match a previous counter definition with
+				prom_counter.</para>
+			<para>This function accepts pseudovariables on its parameters.</para>
+			<para>Available via KEMI framework as <emphasis>counter_inc_l0</emphasis>,
+					<emphasis>counter_inc_l1</emphasis>, <emphasis>counter_inc_l2</emphasis> and
+					<emphasis>counter_inc_l3</emphasis>.</para>
+			<example>
+				<title><function>prom_counter_inc</function> usage</title>
+				<programlisting format="linespecific">
 ...
 # Definition of cnt01 counter with no labels.
 modparam("xhttp_prom", "prom_counter", "name=cnt01;");
@@ -527,36 +442,25 @@ prom_counter_inc("cnt02", "15", "push", "192.168.0.1");
 kamailio_cnt02 {method="push", IP="192.168.0.1"} 15 1234567890
 ...
 		</programlisting>
-	  </example>
-	</section>
-	<section id="xhttp_prom.f.prom_gauge_set">
-	  <title>
-		<function moreinfo="none">prom_gauge_set(name, number, l0, l1, l2)</function>
-	  </title>
-	  <para>
-		Get a gauge identified by its name and labels and set its value to a number.
-		If gauge does not exist it creates the gauge and assigns the value to it.
-	  </para>
-	  <para>
-		Name is mandatory, number is mandatory.
-		Number is a string that will be parsed as a float.
-		l0, l1, l2 are values of labels and are optional.
-	  </para>
-	  <para>
-		name value and number of labels have to match a previous gauge definition with prom_gauge.
-	  </para>
-	  <para>
-		This function accepts pseudovariables on its parameters.
-	  </para>
-	  <para>
-		Available via KEMI framework as <emphasis>gauge_set_l0</emphasis>,
-		<emphasis>gauge_set_l1</emphasis>,
-		<emphasis>gauge_set_l2</emphasis> and
-		<emphasis>gauge_set_l3</emphasis>.
-	  </para>
-	  <example>
-		<title><function>prom_gauge_set</function> usage</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.f.prom_gauge_set">
+			<title>
+				<function moreinfo="none">prom_gauge_set(name, number, l0, l1, l2)</function>
+			</title>
+			<para>Get a gauge identified by its name and labels and set its value to a number. If
+				gauge does not exist it creates the gauge and assigns the value to it.</para>
+			<para>Name is mandatory, number is mandatory. Number is a string that will be parsed as
+				a float. l0, l1, l2 are values of labels and are optional.</para>
+			<para>name value and number of labels have to match a previous gauge definition with
+				prom_gauge.</para>
+			<para>This function accepts pseudovariables on its parameters.</para>
+			<para>Available via KEMI framework as <emphasis>gauge_set_l0</emphasis>,
+					<emphasis>gauge_set_l1</emphasis>, <emphasis>gauge_set_l2</emphasis> and
+					<emphasis>gauge_set_l3</emphasis>.</para>
+			<example>
+				<title><function>prom_gauge_set</function> usage</title>
+				<programlisting format="linespecific">
 ...
 # Definition of gg01 gauge with no labels.
 modparam("xhttp_prom", "prom_gauge", "name=gg01;");
@@ -574,37 +478,28 @@ prom_gauge_set("gg02", "2.8", "push", "192.168.0.1");
 kamailio_gg02 {method="push", IP="192.168.0.1"} 2.8 1234567890
 ...
 		</programlisting>
-	  </example>
-	</section>
-	<section id="xhttp_prom.f.prom_histogram_observe">
-	  <title>
-		<function moreinfo="none">prom_histogram_observe(name, number, l0, l1, l2)</function>
-	  </title>
-	  <para>
-		Get a histogram identified by its name and labels and observe a value in it.
-		If histogram does not exist it creates the histogram and accumulate the value in its
-		buckets, counter and sum.
-	  </para>
-	  <para>
-		Name is mandatory, number is mandatory.
-		Number is a string that will be parsed as a float.
-		l0, l1, l2 are values of labels and are optional.
-	  </para>
-	  <para>
-		name value and number of labels have to match a previous histogram definition with prom_histogram.
-	  </para>
-	  <para>
-		This function accepts pseudovariables on its parameters.
-	  </para>
-	  <para>
-		Available via KEMI framework as <emphasis>histogram_observe_l0</emphasis>,
-		<emphasis>histogram_observe_l1</emphasis>,
-		<emphasis>histogram_observe_l2</emphasis> and
-		<emphasis>histogram_observe_l3</emphasis>.
-	  </para>
-	  <example>
-		<title><function>prom_histogram_observe</function> usage</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.f.prom_histogram_observe">
+			<title>
+				<function moreinfo="none">prom_histogram_observe(name, number, l0, l1,
+					l2)</function>
+			</title>
+			<para>Get a histogram identified by its name and labels and observe a value in it. If
+				histogram does not exist it creates the histogram and accumulate the value in its
+				buckets, counter and sum.</para>
+			<para>Name is mandatory, number is mandatory. Number is a string that will be parsed as
+				a float. l0, l1, l2 are values of labels and are optional.</para>
+			<para>name value and number of labels have to match a previous histogram definition with
+				prom_histogram.</para>
+			<para>This function accepts pseudovariables on its parameters.</para>
+			<para>Available via KEMI framework as <emphasis>histogram_observe_l0</emphasis>,
+					<emphasis>histogram_observe_l1</emphasis>,
+					<emphasis>histogram_observe_l2</emphasis> and
+					<emphasis>histogram_observe_l3</emphasis>.</para>
+			<example>
+				<title><function>prom_histogram_observe</function> usage</title>
+				<programlisting format="linespecific">
 ...
 # Definition of hist01 histogram with no labels and default buckets.
 modparam("xhttp_prom", "prom_histogram", "name=hist01;");
@@ -628,21 +523,18 @@ hist02_count{method="push", IP="192.168.0.1"} 1 1592574659768
 
 ...
 		</programlisting>
-	  </example>
-	</section>
-	<section id="xhttp_prom.f.prom_dispatch">
-	  <title>
-		<function moreinfo="none">prom_dispatch()</function>
-	  </title>
-	  <para>
-		Handle the HTTP request and generate a response.
-	  </para>
-	  <para>
-		Available via KEMI framework as <emphasis>xhttp_prom.dispatch</emphasis>
-	  </para>
-	  <example>
-		<title><function>prom_dispatch</function> usage</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.f.prom_dispatch">
+			<title>
+				<function moreinfo="none">prom_dispatch()</function>
+			</title>
+			<para>Handle the HTTP request and generate a response.</para>
+			<para>Available via KEMI framework as <emphasis>xhttp_prom.dispatch</emphasis>
+			</para>
+			<example>
+				<title><function>prom_dispatch</function> usage</title>
+				<programlisting format="linespecific">
 ...
 # Needed to use SIP frames as HTTP ones.
 tcp_accept_no_cl=yes
@@ -665,11 +557,11 @@ event_route[xhttp:request] {
 }
 ...
 		</programlisting>
-	  </example>
-	  <example>
-		<title><function>prom_dispatch</function> usage (more complete)</title>
-		<para>Another example with counters and gauge:</para>
-		<programlisting format="linespecific">
+			</example>
+			<example>
+				<title><function>prom_dispatch</function> usage (more complete)</title>
+				<para>Another example with counters and gauge:</para>
+				<programlisting format="linespecific">
 ...
 # Needed to use SIP frames as HTTP ones.
 tcp_accept_no_cl=yes
@@ -737,23 +629,20 @@ kamailio_sl_sent_replies 15 1554839325427
 kamailio_sl_xxx_replies 0 1554839325461
 ...
 		</programlisting>
-	  </example>
-	</section>
-	<section id="xhttp_prom.f.prom_check_uri">
-	  <title>
-		<function moreinfo="none">prom_check_uri()</function>
-	  </title>
-	  <para>
-		Check if path of HTTP URL equals /metrics. This avoids us to check hu variable
-		from xHTTP module.
-	  </para>
-	  <para>NOTE: Remember not to block /metrics URL in xHTTP module</para>
-	  <para>
-		Available via KEMI framework as <emphasis>xhttp_prom.check_uri</emphasis>
-	  </para>
-	  <example>
-		<title><function>prom_check_uri</function> usage</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.f.prom_check_uri">
+			<title>
+				<function moreinfo="none">prom_check_uri()</function>
+			</title>
+			<para>Check if path of HTTP URL equals /metrics. This avoids us to check hu variable
+				from xHTTP module.</para>
+			<para>NOTE: Remember not to block /metrics URL in xHTTP module</para>
+			<para>Available via KEMI framework as <emphasis>xhttp_prom.check_uri</emphasis>
+			</para>
+			<example>
+				<title><function>prom_check_uri</function> usage</title>
+				<programlisting format="linespecific">
 ...
 # Needed to use SIP frames as HTTP ones.
 tcp_accept_no_cl=yes
@@ -775,155 +664,186 @@ event_route[xhttp:request] {
 }
 ...
 		</programlisting>
-	  </example>
+			</example>
+		</section>
 	</section>
-  </section>
-  <section>
-	<title><acronym>RPC</acronym> Commands</title>
-	<section  id="xhttp_prom.rpc.counter_reset">
-	  <title><function moreinfo="none">xhttp_prom.counter_reset</function></title>
-	  <para>
-		Set a counter to zero.
-	  </para>
-      <para>
-        Name: <emphasis>xhttp_prom.counter_reset</emphasis>
-      </para>
-      <para>Parameters:</para>
-	  <itemizedlist>
-		<listitem><para><emphasis>name</emphasis>: name of the counter (mandatory)</para></listitem>
-		<listitem><para><emphasis>l0</emphasis>: value of the first label (optional)</para></listitem>
-		<listitem><para><emphasis>l1</emphasis>: value of second label (optional)</para></listitem>
-		<listitem><para><emphasis>l2</emphasis>: value of the third label (optional)</para></listitem>
-	  </itemizedlist>
-	  <example>
-		<title><function>xhttp_prom.counter_reset</function> usage</title>
-		<programlisting format="linespecific">
+	<section>
+		<title><acronym>RPC</acronym> Commands</title>
+		<section id="xhttp_prom.rpc.counter_reset">
+			<title><function moreinfo="none">xhttp_prom.counter_reset</function></title>
+			<para>Set a counter to zero.</para>
+			<para>Name: <emphasis>xhttp_prom.counter_reset</emphasis>
+			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+				<listitem>
+					<para><emphasis>name</emphasis>: name of the counter (mandatory)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l0</emphasis>: value of the first label (optional)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l1</emphasis>: value of second label (optional)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l2</emphasis>: value of the third label (optional)</para>
+				</listitem>
+			</itemizedlist>
+			<example>
+				<title><function>xhttp_prom.counter_reset</function> usage</title>
+				<programlisting format="linespecific">
 		  ...
 		  &kamcmd; xhttp_prom.counter_reset "cnt01" "push" "192.168.0.1"
 		  ...
 		</programlisting>
-	  </example>
-    </section>
-	<section  id="xhttp_prom.rpc.counter_inc">
-	  <title><function moreinfo="none">xhttp_prom.counter_inc</function></title>
-	  <para>
-		Add a number to a counter based on its name and labels.
-	  </para>
-      <para>
-        Name: <emphasis>xhttp_prom.counter_inc</emphasis>
-      </para>
-      <para>Parameters:</para>
-	  <itemizedlist>
-		<listitem><para><emphasis>name</emphasis>: name of the counter (mandatory)</para></listitem>
-		<listitem><para><emphasis>number</emphasis>: integer to add to counter value. Negative values not allowed.</para></listitem>
-		<listitem><para><emphasis>l0</emphasis>: value of the first label (optional)</para></listitem>
-		<listitem><para><emphasis>l1</emphasis>: value of second label (optional)</para></listitem>
-		<listitem><para><emphasis>l2</emphasis>: value of the third label (optional)</para></listitem>
-	  </itemizedlist>
-	  <example>
-		<title><function>xhttp_prom.counter_inc</function> usage</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.rpc.counter_inc">
+			<title><function moreinfo="none">xhttp_prom.counter_inc</function></title>
+			<para>Add a number to a counter based on its name and labels.</para>
+			<para>Name: <emphasis>xhttp_prom.counter_inc</emphasis>
+			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+				<listitem>
+					<para><emphasis>name</emphasis>: name of the counter (mandatory)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>number</emphasis>: integer to add to counter value. Negative
+						values not allowed.</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l0</emphasis>: value of the first label (optional)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l1</emphasis>: value of second label (optional)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l2</emphasis>: value of the third label (optional)</para>
+				</listitem>
+			</itemizedlist>
+			<example>
+				<title><function>xhttp_prom.counter_inc</function> usage</title>
+				<programlisting format="linespecific">
 		  ...
 		  &kamcmd; xhttp_prom.counter_inc "cnt01" 15 "push" "192.168.0.1"
 		  ...
 		</programlisting>
-	  </example>
-    </section>
-	<section  id="xhttp_prom.rpc.gauge_reset">
-	  <title><function moreinfo="none">xhttp_prom.gauge_reset</function></title>
-	  <para>
-		Set gauge value to zero. Select gauge based on its name and labels.
-	  </para>
-      <para>
-        Name: <emphasis>xhttp_prom.gauge_reset</emphasis>
-      </para>
-      <para>Parameters:</para>
-	  <itemizedlist>
-		<listitem><para><emphasis>name</emphasis>: name of the gauge (mandatory)</para></listitem>
-		<listitem><para><emphasis>l0</emphasis>: value of the first label (optional)</para></listitem>
-		<listitem><para><emphasis>l1</emphasis>: value of second label (optional)</para></listitem>
-		<listitem><para><emphasis>l2</emphasis>: value of the third label (optional)</para></listitem>
-	  </itemizedlist>
-	  <example>
-		<title><function>xhttp_prom.gauge_reset</function> usage</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.rpc.gauge_reset">
+			<title><function moreinfo="none">xhttp_prom.gauge_reset</function></title>
+			<para>Set gauge value to zero. Select gauge based on its name and labels.</para>
+			<para>Name: <emphasis>xhttp_prom.gauge_reset</emphasis>
+			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+				<listitem>
+					<para><emphasis>name</emphasis>: name of the gauge (mandatory)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l0</emphasis>: value of the first label (optional)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l1</emphasis>: value of second label (optional)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l2</emphasis>: value of the third label (optional)</para>
+				</listitem>
+			</itemizedlist>
+			<example>
+				<title><function>xhttp_prom.gauge_reset</function> usage</title>
+				<programlisting format="linespecific">
 		  ...
 		  &kamcmd; xhttp_prom.gauge_reset "gg01" "push" "192.168.0.1"
 		  ...
 		</programlisting>
-	  </example>
-    </section>
-	<section  id="xhttp_prom.rpc.gauge_set">
-	  <title><function moreinfo="none">xhttp_prom.gauge_set</function></title>
-	  <para>
-		Set a gauge to a number. Select the gauge by its name and labels.
-	  </para>
-      <para>
-        Name: <emphasis>xhttp_prom.gauge_set</emphasis>
-      </para>
-      <para>Parameters:</para>
-	  <itemizedlist>
-				<listitem><para><emphasis>name</emphasis>: name of the gauge (mandatory)</para></listitem>
-		<listitem><para><emphasis>number</emphasis>: float value to set the gauge to (mandatory)</para></listitem>
-		<listitem><para><emphasis>l0</emphasis>: value of the first label (optional)</para></listitem>
-		<listitem><para><emphasis>l1</emphasis>: value of second label (optional)</para></listitem>
-		<listitem><para><emphasis>l2</emphasis>: value of the third label (optional)</para></listitem>
-	  </itemizedlist>
-	  <example>
-		<title><function>xhttp_prom.gauge_set</function> usage</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.rpc.gauge_set">
+			<title><function moreinfo="none">xhttp_prom.gauge_set</function></title>
+			<para>Set a gauge to a number. Select the gauge by its name and labels.</para>
+			<para>Name: <emphasis>xhttp_prom.gauge_set</emphasis>
+			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+				<listitem>
+					<para><emphasis>name</emphasis>: name of the gauge (mandatory)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>number</emphasis>: float value to set the gauge to
+						(mandatory)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l0</emphasis>: value of the first label (optional)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l1</emphasis>: value of second label (optional)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l2</emphasis>: value of the third label (optional)</para>
+				</listitem>
+			</itemizedlist>
+			<example>
+				<title><function>xhttp_prom.gauge_set</function> usage</title>
+				<programlisting format="linespecific">
 		  ...
 		  &kamcmd; xhttp_prom.gauge_set "gg01" -- -5.2
 		  ...
 		</programlisting>
-	  </example>
-    </section>
-	<section  id="xhttp_prom.rpc.histogram_observe">
-	  <title><function moreinfo="none">xhttp_prom.histogram_observe</function></title>
-	  <para>
-		Observe a number in a histogram. Select the histogram by its name and labels.
-	  </para>
-      <para>
-        Name: <emphasis>xhttp_prom.histogram_observe</emphasis>
-      </para>
-      <para>Parameters:</para>
-	  <itemizedlist>
-		<listitem><para><emphasis>name</emphasis>: name of the histogram (mandatory)</para></listitem>
-		<listitem><para><emphasis>number</emphasis>: float value to observe in the histogram (mandatory)</para></listitem>
-		<listitem><para><emphasis>l0</emphasis>: value of the first label (optional)</para></listitem>
-		<listitem><para><emphasis>l1</emphasis>: value of second label (optional)</para></listitem>
-		<listitem><para><emphasis>l2</emphasis>: value of the third label (optional)</para></listitem>
-	  </itemizedlist>
-	  <example>
-		<title><function>xhttp_prom.histogram_observe</function> usage</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.rpc.histogram_observe">
+			<title><function moreinfo="none">xhttp_prom.histogram_observe</function></title>
+			<para>Observe a number in a histogram. Select the histogram by its name and
+				labels.</para>
+			<para>Name: <emphasis>xhttp_prom.histogram_observe</emphasis>
+			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+				<listitem>
+					<para><emphasis>name</emphasis>: name of the histogram (mandatory)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>number</emphasis>: float value to observe in the histogram
+						(mandatory)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l0</emphasis>: value of the first label (optional)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l1</emphasis>: value of second label (optional)</para>
+				</listitem>
+				<listitem>
+					<para><emphasis>l2</emphasis>: value of the third label (optional)</para>
+				</listitem>
+			</itemizedlist>
+			<example>
+				<title><function>xhttp_prom.histogram_observe</function> usage</title>
+				<programlisting format="linespecific">
 		  ...
 		  &kamcmd; xhttp_prom.histogram_observe "hist01" -- -5.2
 		  ...
 		</programlisting>
-	  </example>
-    </section>
-	<section  id="xhttp_prom.rpc.metric_list_print">
-	  <title><function moreinfo="none">xhttp_prom.metric_list_print</function></title>
-	  <para>
-		List of all user defined metrics.
-	  </para>
-      <para>
-        Name: <emphasis>xhttp_prom.metric_list_print</emphasis>
-      </para>
-      <para>Parameters:<emphasis>none</emphasis></para>
-	  <para>
-		<emphasis>NOTE:</emphasis>: If you list a lot of metrics you may need to increase
-		buffer size of your RPC transport layer.
-	  </para>
-	  <example>
-		<title><function>xhttp_prom.metric_list_print</function> usage</title>
-		<programlisting format="linespecific">
+			</example>
+		</section>
+		<section id="xhttp_prom.rpc.metric_list_print">
+			<title><function moreinfo="none">xhttp_prom.metric_list_print</function></title>
+			<para>List of all user defined metrics.</para>
+			<para>Name: <emphasis>xhttp_prom.metric_list_print</emphasis>
+			</para>
+			<para>Parameters:<emphasis>none</emphasis></para>
+			<para>
+				<emphasis>NOTE:</emphasis>: If you list a lot of metrics you may need to increase
+				buffer size of your RPC transport layer.</para>
+			<example>
+				<title><function>xhttp_prom.metric_list_print</function> usage</title>
+				<programlisting format="linespecific">
 		  ...
 		  &kamcmd; xhttp_prom.metric_list_print
 		  ...
 		</programlisting>
-	  </example>
+			</example>
+		</section>
 	</section>
-  </section>
-</chapter>	
+</chapter>

--- a/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
+++ b/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
@@ -377,8 +377,8 @@ the metric.
 		  <para>Every bucket value has to increase in the list.</para>
 		  <para>
 			If no buckets specified, default bucket list is set to these values:
-			<para>[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]</para>
 		  </para>
+		  <para>[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]</para>
 		</listitem>
 	  </itemizedlist>
 	  <example>

--- a/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
+++ b/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
@@ -42,13 +42,13 @@
 	  Prometheus URLs:
 	  <itemizedlist>
 		<listitem>
-		  <ulink url="https://prometheus.io/">https://prometheus.io/</ulink>
+		  <para><ulink url="https://prometheus.io/">https://prometheus.io/</ulink></para>
 		</listitem>
 		<listitem>
-		  <ulink url="https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels">https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels</ulink>
+		  <para><ulink url="https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels">https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels</ulink></para>
 		</listitem>
 		<listitem>
-		<ulink url="https://prometheus.io/docs/instrumenting/exposition_formats/">https://prometheus.io/docs/instrumenting/exposition_formats/</ulink>
+		  <para><ulink url="https://prometheus.io/docs/instrumenting/exposition_formats/">https://prometheus.io/docs/instrumenting/exposition_formats/</ulink></para>
 		</listitem>
 	  </itemizedlist>
 	</para>

--- a/src/modules/xhttp_prom/prom_metric.c
+++ b/src/modules/xhttp_prom/prom_metric.c
@@ -1133,29 +1133,6 @@ error:
 }
 
 /**
- * @brief Add some positive amount to a counter.
- */
-int prom_counter_inc(str *s_name, int number, str *l1, str *l2, str *l3)
-{
-	lock_get(prom_lock);
-
-	/* Find a lvalue based on its metric name and labels. */
-	prom_lvalue_t *p = NULL;
-	p = prom_metric_lvalue_get(s_name, M_COUNTER, l1, l2, l3);
-	if (!p) {
-		LM_ERR("Cannot find counter: %.*s\n", s_name->len, s_name->s);
-		lock_release(prom_lock);
-		return -1;
-	}
-
-	/* Add to counter value. */
-	p->m.cval += number;
-	
-	lock_release(prom_lock);
-	return 0;
-}
-
-/**
  * @brief Updates a counter.
  */
 int prom_counter_update(str *s_name, operation operation, int number, str *l1, str *l2, str *l3)

--- a/src/modules/xhttp_prom/prom_metric.h
+++ b/src/modules/xhttp_prom/prom_metric.h
@@ -76,11 +76,6 @@ int prom_counter_reset(str *s_name, str *l1, str *l2, str *l3);
 int prom_gauge_reset(str *s_name, str *l1, str *l2, str *l3);
 
 /**
- * @brief Add some positive amount to a counter.
- */
-int prom_counter_inc(str *s_name, int number, str *l1, str *l2, str *l3);
-
-/**
  * @brief Updates a counter.
  */
 int prom_counter_update(str *s_name, operation operation, int number, str *l1, str *l2, str *l3);

--- a/src/modules/xhttp_prom/prom_metric.h
+++ b/src/modules/xhttp_prom/prom_metric.h
@@ -81,6 +81,11 @@ int prom_gauge_reset(str *s_name, str *l1, str *l2, str *l3);
 int prom_counter_inc(str *s_name, int number, str *l1, str *l2, str *l3);
 
 /**
+ * @brief Updates a counter.
+ */
+int prom_counter_update(str *s_name, operation operation, int number, str *l1, str *l2, str *l3);
+
+/**
  * @brief Set a value in a gauge.
  */
 int prom_gauge_set(str *s_name, double number, str *l1, str *l2, str *l3);

--- a/src/modules/xhttp_prom/xhttp_prom.c
+++ b/src/modules/xhttp_prom/xhttp_prom.c
@@ -971,9 +971,9 @@ static int fixup_counter_inc(void** param, int param_no)
 /* } */
 
 /**
- * @brief Add an integer to a counter (No labels).
+ * @brief Updates counter (No labels).
  */
-static int ki_xhttp_prom_counter_inc_l0(struct sip_msg* msg, str *s_name, int number)
+static int ki_xhttp_prom_counter_update_l0(struct sip_msg* msg, operation operation, str *s_name, int number)
 {
 	if (s_name == NULL || s_name->s == NULL || s_name->len == 0) {
 		LM_ERR("Invalid name string\n");
@@ -986,18 +986,26 @@ static int ki_xhttp_prom_counter_inc_l0(struct sip_msg* msg, str *s_name, int nu
 	}
 
 	if (prom_counter_update(s_name, INCREMENT, number, NULL, NULL, NULL)) {
-		LM_ERR("Cannot add number: %d to counter: %.*s\n", number, s_name->len, s_name->s);
+		LM_ERR("Cannot %s number: %d %s counter: %.*s\n",
+			   operation == INCREMENT? "add" : "decrement",
+			   number,
+			   operation == INCREMENT? "to" : "from",
+			   s_name->len, s_name->s);
 		return -1;
 	}
 
-	LM_DBG("Added %d to counter %.*s\n", number, s_name->len, s_name->s);
+	LM_DBG("%s %d %s counter %.*s\n",
+		   operation == INCREMENT? "Added" : "Decremented",
+		   number,
+		   operation == INCREMENT? "to" : "from",
+		   s_name->len, s_name->s);
 	return 1;
 }
 
 /**
- * @brief Add an integer to a counter (1 label).
+ * @brief Updates counter (1 label).
  */
-static int ki_xhttp_prom_counter_inc_l1(struct sip_msg* msg, str *s_name, int number, str *l1)
+static int ki_xhttp_prom_counter_update_l1(struct sip_msg* msg, operation operation, str *s_name, int number, str *l1)
 {
 	if (s_name == NULL || s_name->s == NULL || s_name->len == 0) {
 		LM_ERR("Invalid name string\n");
@@ -1015,14 +1023,20 @@ static int ki_xhttp_prom_counter_inc_l1(struct sip_msg* msg, str *s_name, int nu
 	}
 
 	if (prom_counter_update(s_name, INCREMENT, number, l1, NULL, NULL)) {
-		LM_ERR("Cannot add number: %d to counter: %.*s (%.*s)\n",
-			   number, s_name->len, s_name->s,
+		LM_ERR("Cannot %s number: %d %s counter: %.*s (%.*s)\n",
+			   operation == INCREMENT? "add" : "decrement",
+			   number,
+			   operation == INCREMENT? "to" : "from",
+			   s_name->len, s_name->s,
 			   l1->len, l1->s
 			);
 		return -1;
 	}
 
-	LM_DBG("Added %d to counter %.*s (%.*s)\n", number,
+	LM_DBG("%s %d %s counter %.*s (%.*s)\n",
+		   operation == INCREMENT? "Added" : "Decremented",
+		   number,
+		   operation == INCREMENT? "to" : "from",
 		   s_name->len, s_name->s,
 		   l1->len, l1->s
 		);
@@ -1031,9 +1045,9 @@ static int ki_xhttp_prom_counter_inc_l1(struct sip_msg* msg, str *s_name, int nu
 }
 
 /**
- * @brief Add an integer to a counter (2 labels).
+ * @brief Updates counter (2 labels).
  */
-static int ki_xhttp_prom_counter_inc_l2(struct sip_msg* msg, str *s_name, int number,
+static int ki_xhttp_prom_counter_update_l2(struct sip_msg* msg, operation operation, str *s_name, int number,
 										str *l1, str *l2)
 {
 	if (s_name == NULL || s_name->s == NULL || s_name->len == 0) {
@@ -1057,15 +1071,21 @@ static int ki_xhttp_prom_counter_inc_l2(struct sip_msg* msg, str *s_name, int nu
 	}
 
 	if (prom_counter_update(s_name, INCREMENT, number, l1, l2, NULL)) {
-		LM_ERR("Cannot add number: %d to counter: %.*s (%.*s, %.*s)\n",
-			   number, s_name->len, s_name->s,
+		LM_ERR("Cannot %s number: %d %s counter: %.*s (%.*s, %.*s)\n",
+			   operation == INCREMENT? "add" : "decrement",
+			   number,
+			   operation == INCREMENT? "to" : "from",
+			   s_name->len, s_name->s,
 			   l1->len, l1->s,
 			   l2->len, l2->s
 			);
 		return -1;
 	}
 
-	LM_DBG("Added %d to counter %.*s (%.*s, %.*s)\n", number,
+	LM_DBG("%s %d %s counter %.*s (%.*s, %.*s)\n",
+		   operation == INCREMENT? "Added" : "Decremented",
+		   number,
+		   operation == INCREMENT? "to" : "from",
 		   s_name->len, s_name->s,
 		   l1->len, l1->s,
 		   l2->len, l2->s
@@ -1075,9 +1095,9 @@ static int ki_xhttp_prom_counter_inc_l2(struct sip_msg* msg, str *s_name, int nu
 }
 
 /**
- * @brief Add an integer to a counter (3 labels).
+ * @brief Updates counter (3 labels).
  */
-static int ki_xhttp_prom_counter_inc_l3(struct sip_msg* msg, str *s_name, int number,
+static int ki_xhttp_prom_counter_update_l3(struct sip_msg* msg, operation operation, str *s_name, int number,
 										str *l1, str *l2, str *l3)
 {
 	if (s_name == NULL || s_name->s == NULL || s_name->len == 0) {
@@ -1105,9 +1125,12 @@ static int ki_xhttp_prom_counter_inc_l3(struct sip_msg* msg, str *s_name, int nu
 		return -1;
 	}
 
-	if (prom_counter_update(s_name, INCREMENT, number, l1, l2, l3)) {
-		LM_ERR("Cannot add number: %d to counter: %.*s (%.*s, %.*s, %.*s)\n",
-			   number, s_name->len, s_name->s,
+	if (prom_counter_update(s_name, operation, number, l1, l2, l3)) {
+		LM_ERR("Cannot %s number: %d %s counter: %.*s (%.*s, %.*s, %.*s)\n",
+			   operation == INCREMENT? "add" : "decrement",
+			   number,
+			   operation == INCREMENT? "to" : "from",
+			   s_name->len, s_name->s,
 			   l1->len, l1->s,
 			   l2->len, l2->s,
 			   l3->len, l3->s
@@ -1115,7 +1138,10 @@ static int ki_xhttp_prom_counter_inc_l3(struct sip_msg* msg, str *s_name, int nu
 		return -1;
 	}
 
-	LM_DBG("Added %d to counter %.*s (%.*s, %.*s, %.*s)\n", number,
+	LM_DBG("%s %d %s counter %.*s (%.*s, %.*s, %.*s)\n",
+		   operation == INCREMENT? "Added" : "Decremented",
+		   number,
+		   operation == INCREMENT? "to" : "from",
 		   s_name->len, s_name->s,
 		   l1->len, l1->s,
 		   l2->len, l2->s,
@@ -1123,6 +1149,74 @@ static int ki_xhttp_prom_counter_inc_l3(struct sip_msg* msg, str *s_name, int nu
 		);
 
 	return 1;
+}
+
+/**
+ * @brief Add an integer to a counter (No labels).
+ */
+static int ki_xhttp_prom_counter_inc_l0(struct sip_msg* msg, str *s_name, int number)
+{
+	return ki_xhttp_prom_counter_update_l0(msg, INCREMENT, s_name, number);
+}
+
+/**
+ * @brief Add an integer to a counter (1 labels).
+ */
+static int ki_xhttp_prom_counter_inc_l1(struct sip_msg* msg, str *s_name, int number, str *l1)
+{
+	return ki_xhttp_prom_counter_update_l1(msg, INCREMENT, s_name, number, l1);
+}
+
+/**
+ * @brief Add an integer to a counter (2 labels).
+ */
+static int ki_xhttp_prom_counter_inc_l2(struct sip_msg* msg, str *s_name, int number,
+										str *l1, str *l2)
+{
+	return ki_xhttp_prom_counter_update_l2(msg, INCREMENT, s_name, number, l1, l2);
+}
+
+/**
+ * @brief Add an integer to a counter (3 labels).
+ */
+static int ki_xhttp_prom_counter_inc_l3(struct sip_msg* msg, str *s_name, int number,
+										str *l1, str *l2, str *l3)
+{
+	return ki_xhttp_prom_counter_update_l3(msg, INCREMENT, s_name, number, l1, l2, l3);
+}
+
+/**
+ * @brief Decrement an integer from a counter (No labels).
+ */
+static int ki_xhttp_prom_counter_dec_l0(struct sip_msg* msg, str *s_name, int number)
+{
+	return ki_xhttp_prom_counter_update_l0(msg, DECREMENT, s_name, number);
+}
+
+/**
+ * @brief Decrement an integer from a counter (1 labels).
+ */
+static int ki_xhttp_prom_counter_dec_l1(struct sip_msg* msg, str *s_name, int number, str *l1)
+{
+	return ki_xhttp_prom_counter_update_l1(msg, DECREMENT, s_name, number, l1);
+}
+
+/**
+ * @brief Decrement an integer from a counter (2 labels).
+ */
+static int ki_xhttp_prom_counter_dec_l2(struct sip_msg* msg, str *s_name, int number,
+										str *l1, str *l2)
+{
+	return ki_xhttp_prom_counter_update_l2(msg, DECREMENT, s_name, number, l1, l2);
+}
+
+/**
+ * @brief Decrement an integer from a counter (3 labels).
+ */
+static int ki_xhttp_prom_counter_dec_l3(struct sip_msg* msg, str *s_name, int number,
+										str *l1, str *l2, str *l3)
+{
+	return ki_xhttp_prom_counter_update_l3(msg, DECREMENT, s_name, number, l1, l2, l3);
 }
 
 /**
@@ -1964,6 +2058,26 @@ static sr_kemi_t sr_kemi_xhttp_prom_exports[] = {
 	},
 	{ str_init("xhttp_prom"), str_init("counter_inc_l3"),
 	    SR_KEMIP_INT, ki_xhttp_prom_counter_inc_l3,
+		{ SR_KEMIP_STR, SR_KEMIP_INT, SR_KEMIP_STR,
+			SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE }
+	},
+	{ str_init("xhttp_prom"), str_init("counter_dec_l0"),
+	    SR_KEMIP_INT, ki_xhttp_prom_counter_dec_l0,
+		{ SR_KEMIP_STR, SR_KEMIP_INT, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("xhttp_prom"), str_init("counter_dec_l1"),
+	    SR_KEMIP_INT, ki_xhttp_prom_counter_dec_l1,
+		{ SR_KEMIP_STR, SR_KEMIP_INT, SR_KEMIP_STR,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("xhttp_prom"), str_init("counter_dec_l2"),
+	    SR_KEMIP_INT, ki_xhttp_prom_counter_dec_l2,
+		{ SR_KEMIP_STR, SR_KEMIP_INT, SR_KEMIP_STR,
+			SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("xhttp_prom"), str_init("counter_dec_l3"),
+	    SR_KEMIP_INT, ki_xhttp_prom_counter_dec_l3,
 		{ SR_KEMIP_STR, SR_KEMIP_INT, SR_KEMIP_STR,
 			SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE }
 	},

--- a/src/modules/xhttp_prom/xhttp_prom.c
+++ b/src/modules/xhttp_prom/xhttp_prom.c
@@ -1114,9 +1114,9 @@ static int ki_xhttp_prom_counter_inc_l3(struct sip_msg* msg, str *s_name, int nu
 }
 
 /**
- * @brief Add an integer to a counter.
+ * @brief Updates a counter.
  */
-static int w_prom_counter_inc(struct sip_msg* msg, char *pname, char* pnumber,
+static int w_prom_counter_operation(struct sip_msg* msg, operation operation, char *pname, char* pnumber,
 							  char *l1, char *l2, char *l3)
 {
 	int number;
@@ -1186,16 +1186,16 @@ static int w_prom_counter_inc(struct sip_msg* msg, char *pname, char* pnumber,
 		l3 = NULL;
 	} /* if l1 != NULL */
 
-	if (prom_counter_inc(&s_name, number,
+	if (prom_counter_update(&s_name, operation, number,
 						   (l1!=NULL)?&l1_str:NULL,
 						   (l2!=NULL)?&l2_str:NULL,
 						   (l3!=NULL)?&l3_str:NULL
 						 )) {
-		LM_ERR("Cannot add number: %d to counter: %.*s\n", number, s_name.len, s_name.s);
+		LM_ERR("Cannot %s number: %d %s counter: %.*s\n", operation == INCREMENT? "add" : "decrement", number, operation == INCREMENT? "to" : "from", s_name.len, s_name.s);
 		return -1;
 	}
 
-	LM_DBG("Added %d to counter %.*s\n", number, s_name.len, s_name.s);
+	LM_DBG("%s %d %s counter %.*s\n", operation == INCREMENT? "Added" : "Decremented", number, operation == INCREMENT? "to" : "from", s_name.len, s_name.s);
 	return 1;
 }
 
@@ -1204,7 +1204,7 @@ static int w_prom_counter_inc(struct sip_msg* msg, char *pname, char* pnumber,
  */
 static int w_prom_counter_inc_l0(struct sip_msg* msg, char *pname, char* pnumber)
 {
-	return w_prom_counter_inc(msg, pname, pnumber, NULL, NULL, NULL);
+	return w_prom_counter_operation(msg, INCREMENT, pname, pnumber, NULL, NULL, NULL);
 }
 
 /**
@@ -1213,7 +1213,7 @@ static int w_prom_counter_inc_l0(struct sip_msg* msg, char *pname, char* pnumber
 static int w_prom_counter_inc_l1(struct sip_msg* msg, char *pname, char* pnumber,
 								 char *l1)
 {
-	return w_prom_counter_inc(msg, pname, pnumber, l1, NULL, NULL);
+	return w_prom_counter_operation(msg, INCREMENT, pname, pnumber, l1, NULL, NULL);
 }
 
 /**
@@ -1222,7 +1222,7 @@ static int w_prom_counter_inc_l1(struct sip_msg* msg, char *pname, char* pnumber
 static int w_prom_counter_inc_l2(struct sip_msg* msg, char *pname, char* pnumber,
 								 char *l1, char *l2)
 {
-	return w_prom_counter_inc(msg, pname, pnumber, l1, l2, NULL);
+	return w_prom_counter_operation(msg, INCREMENT, pname, pnumber, l1, l2, NULL);
 }
 
 /**
@@ -1231,7 +1231,7 @@ static int w_prom_counter_inc_l2(struct sip_msg* msg, char *pname, char* pnumber
 static int w_prom_counter_inc_l3(struct sip_msg* msg, char *pname, char* pnumber,
 								 char *l1, char *l2, char *l3)
 {
-	return w_prom_counter_inc(msg, pname, pnumber, l1, l2, l3);
+	return w_prom_counter_operation(msg, INCREMENT, pname, pnumber, l1, l2, l3);
 }
 
 /**

--- a/src/modules/xhttp_prom/xhttp_prom.c
+++ b/src/modules/xhttp_prom/xhttp_prom.c
@@ -973,7 +973,7 @@ static int ki_xhttp_prom_counter_inc_l0(struct sip_msg* msg, str *s_name, int nu
 		return -1;
 	}
 
-	if (prom_counter_inc(s_name, number, NULL, NULL, NULL)) {
+	if (prom_counter_update(s_name, INCREMENT, number, NULL, NULL, NULL)) {
 		LM_ERR("Cannot add number: %d to counter: %.*s\n", number, s_name->len, s_name->s);
 		return -1;
 	}
@@ -1002,7 +1002,7 @@ static int ki_xhttp_prom_counter_inc_l1(struct sip_msg* msg, str *s_name, int nu
 		return -1;
 	}
 
-	if (prom_counter_inc(s_name, number, l1, NULL, NULL)) {
+	if (prom_counter_update(s_name, INCREMENT, number, l1, NULL, NULL)) {
 		LM_ERR("Cannot add number: %d to counter: %.*s (%.*s)\n",
 			   number, s_name->len, s_name->s,
 			   l1->len, l1->s
@@ -1044,7 +1044,7 @@ static int ki_xhttp_prom_counter_inc_l2(struct sip_msg* msg, str *s_name, int nu
 		return -1;
 	}
 
-	if (prom_counter_inc(s_name, number, l1, l2, NULL)) {
+	if (prom_counter_update(s_name, INCREMENT, number, l1, l2, NULL)) {
 		LM_ERR("Cannot add number: %d to counter: %.*s (%.*s, %.*s)\n",
 			   number, s_name->len, s_name->s,
 			   l1->len, l1->s,
@@ -1093,7 +1093,7 @@ static int ki_xhttp_prom_counter_inc_l3(struct sip_msg* msg, str *s_name, int nu
 		return -1;
 	}
 
-	if (prom_counter_inc(s_name, number, l1, l2, l3)) {
+	if (prom_counter_update(s_name, INCREMENT, number, l1, l2, l3)) {
 		LM_ERR("Cannot add number: %d to counter: %.*s (%.*s, %.*s, %.*s)\n",
 			   number, s_name->len, s_name->s,
 			   l1->len, l1->s,
@@ -2090,7 +2090,7 @@ static void rpc_prom_counter_inc(rpc_t *rpc, void *ct)
 	res = rpc->scan(ct, "*SSS", &l1, &l2, &l3);
 	if (res == 0) {
 		/* No labels */
-		if (prom_counter_inc(&s_name, number, NULL, NULL, NULL)) {
+		if (prom_counter_update(&s_name, INCREMENT, number, NULL, NULL, NULL)) {
 			LM_ERR("Cannot add %d to counter: %.*s\n", number, s_name.len, s_name.s);
 			rpc->fault(ct, 500, "Failed to add %d to counter: %.*s", number,
 					   s_name.len, s_name.s);
@@ -2099,7 +2099,7 @@ static void rpc_prom_counter_inc(rpc_t *rpc, void *ct)
 		LM_DBG("Added %d to counter: (%.*s)\n", number, s_name.len, s_name.s);
 		
 	} else if (res == 1) {
-		if (prom_counter_inc(&s_name, number, &l1, NULL, NULL)) {
+		if (prom_counter_update(&s_name, INCREMENT, number, &l1, NULL, NULL)) {
 			LM_ERR("Cannot add %d to counter: %.*s (%.*s)\n", number, s_name.len, s_name.s,
 				   l1.len, l1.s);
 			rpc->fault(ct, 500, "Failed to add %d to counter: %.*s (%.*s)",
@@ -2111,7 +2111,7 @@ static void rpc_prom_counter_inc(rpc_t *rpc, void *ct)
 			   l1.len, l1.s);
 
 	} else if (res == 2) {
-		if (prom_counter_inc(&s_name, number, &l1, &l2, NULL)) {
+		if (prom_counter_update(&s_name, INCREMENT, number, &l1, &l2, NULL)) {
 			LM_ERR("Cannot add %d to counter: %.*s (%.*s, %.*s)\n", number,
 				   s_name.len, s_name.s,
 				   l1.len, l1.s,
@@ -2128,7 +2128,7 @@ static void rpc_prom_counter_inc(rpc_t *rpc, void *ct)
 			   l2.len, l2.s);
 
 	} else if (res == 3) {
-		if (prom_counter_inc(&s_name, number, &l1, &l2, &l3)) {
+		if (prom_counter_update(&s_name, INCREMENT, number, &l1, &l2, &l3)) {
 			LM_ERR("Cannot add %d to counter: %.*s (%.*s, %.*s, %.*s)\n",
 				   number, s_name.len, s_name.s,
 				   l1.len, l1.s,

--- a/src/modules/xhttp_prom/xhttp_prom.c
+++ b/src/modules/xhttp_prom/xhttp_prom.c
@@ -2108,7 +2108,7 @@ static void rpc_prom_counter_reset(rpc_t *rpc, void *ct)
 	return;
 }
 
-static void rpc_prom_counter_inc(rpc_t *rpc, void *ct)
+static void rpc_prom_counter_update(rpc_t *rpc, void *ct, operation operation)
 {
 	str s_name;
 
@@ -2137,60 +2137,102 @@ static void rpc_prom_counter_inc(rpc_t *rpc, void *ct)
 	res = rpc->scan(ct, "*SSS", &l1, &l2, &l3);
 	if (res == 0) {
 		/* No labels */
-		if (prom_counter_update(&s_name, INCREMENT, number, NULL, NULL, NULL)) {
-			LM_ERR("Cannot add %d to counter: %.*s\n", number, s_name.len, s_name.s);
-			rpc->fault(ct, 500, "Failed to add %d to counter: %.*s", number,
+		if (prom_counter_update(&s_name, operation, number, NULL, NULL, NULL)) {
+			LM_ERR("Cannot %s %d %s counter: %.*s\n",
+				   operation == INCREMENT? "add" : "decrement",
+				   number,
+				   operation == INCREMENT? "to" : "from",
+				   s_name.len, s_name.s);
+			rpc->fault(ct, 500, "Failed to %s %d %s counter: %.*s",
+					   operation == INCREMENT? "add" : "decrement",
+					   number,
+					   operation == INCREMENT? "to" : "from",
 					   s_name.len, s_name.s);
 			return;
 		}
-		LM_DBG("Added %d to counter: (%.*s)\n", number, s_name.len, s_name.s);
+		LM_DBG("%s %d %s counter: (%.*s)\n",
+			   operation == INCREMENT? "Added" : "Decremented",
+			   number,
+			   operation == INCREMENT? "to" : "from",
+			   s_name.len, s_name.s);
 		
 	} else if (res == 1) {
-		if (prom_counter_update(&s_name, INCREMENT, number, &l1, NULL, NULL)) {
-			LM_ERR("Cannot add %d to counter: %.*s (%.*s)\n", number, s_name.len, s_name.s,
+		if (prom_counter_update(&s_name, operation, number, &l1, NULL, NULL)) {
+			LM_ERR("Cannot %s %d %s counter: %.*s (%.*s)\n",
+				   operation == INCREMENT? "add" : "decrement",
+				   number,
+				   operation == INCREMENT? "to" : "from",
+				   s_name.len, s_name.s,
 				   l1.len, l1.s);
-			rpc->fault(ct, 500, "Failed to add %d to counter: %.*s (%.*s)",
-					   number, s_name.len, s_name.s,
+			rpc->fault(ct, 500, "Failed to %s %d %s counter: %.*s (%.*s)",
+					   operation == INCREMENT? "add" : "decrement",
+					   number,
+					   operation == INCREMENT? "to" : "from",
+					   s_name.len, s_name.s,
 					   l1.len, l1.s);
 			return;
 		}
-		LM_DBG("Added %d to counter: %.*s (%.*s)\n", number, s_name.len, s_name.s,
+		LM_DBG("%s %d %s counter: %.*s (%.*s)\n",
+			   operation == INCREMENT? "Added" : "Decremented",
+			   number,
+			   operation == INCREMENT? "to" : "from",
+			   s_name.len, s_name.s,
 			   l1.len, l1.s);
 
 	} else if (res == 2) {
-		if (prom_counter_update(&s_name, INCREMENT, number, &l1, &l2, NULL)) {
-			LM_ERR("Cannot add %d to counter: %.*s (%.*s, %.*s)\n", number,
+		if (prom_counter_update(&s_name, operation, number, &l1, &l2, NULL)) {
+			LM_ERR("Cannot %s %d %s counter: %.*s (%.*s, %.*s)\n",
+				   operation == INCREMENT? "add" : "decrement",
+				   number,
+				   operation == INCREMENT? "to" : "from",
 				   s_name.len, s_name.s,
 				   l1.len, l1.s,
 				   l2.len, l2.s);
-			rpc->fault(ct, 500, "Failed to add %d to counter: %.*s (%.*s, %.*s)",
-					   number, s_name.len, s_name.s,
+			rpc->fault(ct, 500, "Failed to %s %d %s counter: %.*s (%.*s, %.*s)",
+					   operation == INCREMENT? "add" : "decrement",
+					   number,
+					   operation == INCREMENT? "to" : "from",
+					   s_name.len, s_name.s,
 					   l1.len, l1.s,
 					   l2.len, l2.s
 				);
 			return;
 		}
-		LM_DBG("Added %d to counter: %.*s (%.*s, %.*s)\n", number, s_name.len, s_name.s,
+		LM_DBG("%s %d %s counter: %.*s (%.*s, %.*s)\n",
+			   operation == INCREMENT? "Added" : "Decremented",
+			   number,
+			   operation == INCREMENT? "to" : "from",
+			   s_name.len, s_name.s,
 			   l1.len, l1.s,
 			   l2.len, l2.s);
 
 	} else if (res == 3) {
-		if (prom_counter_update(&s_name, INCREMENT, number, &l1, &l2, &l3)) {
-			LM_ERR("Cannot add %d to counter: %.*s (%.*s, %.*s, %.*s)\n",
-				   number, s_name.len, s_name.s,
+		if (prom_counter_update(&s_name, operation, number, &l1, &l2, &l3)) {
+			LM_ERR("Cannot %s %d %s counter: %.*s (%.*s, %.*s, %.*s)\n",
+				   operation == INCREMENT? "add" : "decrement",
+				   number,
+				   operation == INCREMENT? "to" : "from",
+				   s_name.len, s_name.s,
 				   l1.len, l1.s,
 				   l2.len, l2.s,
 				   l3.len, l3.s
 				);
-			rpc->fault(ct, 500, "Failed to add %d to counter: %.*s (%.*s, %.*s, %.*s)",
-					   number, s_name.len, s_name.s,
+			rpc->fault(ct, 500, "Failed to $s %d %s counter: %.*s (%.*s, %.*s, %.*s)",
+					   operation == INCREMENT? "add" : "decrement",
+					   number,
+					   operation == INCREMENT? "to" : "from",
+					   s_name.len, s_name.s,
 					   l1.len, l1.s,
 					   l2.len, l2.s,
 					   l3.len, l3.s
 				);
 			return;
 		}
-		LM_DBG("Added %d to counter: %.*s (%.*s, %.*s, %.*s)\n", number, s_name.len, s_name.s,
+		LM_DBG("%s %d %s counter: %.*s (%.*s, %.*s, %.*s)\n",
+			   operation == INCREMENT? "Added" : "Decremented",
+			   number,
+			   operation == INCREMENT? "to" : "from",
+			   s_name.len, s_name.s,
 			   l1.len, l1.s,
 			   l2.len, l2.s,
 			   l3.len, l3.s
@@ -2203,6 +2245,16 @@ static void rpc_prom_counter_inc(rpc_t *rpc, void *ct)
 	} /* if res == 0 */
 
 	return;
+}
+
+static void rpc_prom_counter_inc(rpc_t *rpc, void *ct)
+{
+    rpc_prom_counter_update(rpc, ct, INCREMENT);
+}
+
+static void rpc_prom_counter_dec(rpc_t *rpc, void *ct)
+{
+    rpc_prom_counter_update(rpc, ct, DECREMENT);
 }
 
 static void rpc_prom_gauge_reset(rpc_t *rpc, void *ct)
@@ -2520,6 +2572,10 @@ static const char* rpc_prom_counter_inc_doc[2] = {
 	0
 };
 
+static const char* rpc_prom_counter_dec_doc[2] = {
+	"Decrement a number (greater or equal to zero) from a counter based on its identifier",
+	0
+};
 static const char* rpc_prom_gauge_reset_doc[2] = {
 	"Reset a gauge based on its identifier",
 	0
@@ -2543,6 +2599,7 @@ static const char* rpc_prom_metric_list_print_doc[2] = {
 static rpc_export_t rpc_cmds[] = {
 	{"xhttp_prom.counter_reset", rpc_prom_counter_reset, rpc_prom_counter_reset_doc, 0},
 	{"xhttp_prom.counter_inc", rpc_prom_counter_inc, rpc_prom_counter_inc_doc, 0},
+	{"xhttp_prom.counter_dec", rpc_prom_counter_dec, rpc_prom_counter_dec_doc, 0},
 	{"xhttp_prom.gauge_reset", rpc_prom_gauge_reset, rpc_prom_gauge_reset_doc, 0},
 	{"xhttp_prom.gauge_set", rpc_prom_gauge_set, rpc_prom_gauge_set_doc, 0},
 	{"xhttp_prom.histogram_observe", rpc_prom_histogram_observe, rpc_prom_histogram_observe_doc, 0},

--- a/src/modules/xhttp_prom/xhttp_prom.c
+++ b/src/modules/xhttp_prom/xhttp_prom.c
@@ -77,6 +77,10 @@ static int w_prom_counter_inc_l0(struct sip_msg* msg, char *pname, char* pnumber
 static int w_prom_counter_inc_l1(struct sip_msg* msg, char *pname, char* pnumber, char *l1);
 static int w_prom_counter_inc_l2(struct sip_msg* msg, char *pname, char* pnumber, char *l1, char *l2);
 static int w_prom_counter_inc_l3(struct sip_msg* msg, char *pname, char* pnumber, char *l1, char *l2, char *l3);
+static int w_prom_counter_dec_l0(struct sip_msg* msg, char *pname, char* pnumber);
+static int w_prom_counter_dec_l1(struct sip_msg* msg, char *pname, char* pnumber, char *l1);
+static int w_prom_counter_dec_l2(struct sip_msg* msg, char *pname, char* pnumber, char *l1, char *l2);
+static int w_prom_counter_dec_l3(struct sip_msg* msg, char *pname, char* pnumber, char *l1, char *l2, char *l3);
 static int w_prom_gauge_set_l0(struct sip_msg* msg, char *pname, char* pnumber);
 static int w_prom_gauge_set_l1(struct sip_msg* msg, char *pname, char* pnumber, char *l1);
 static int w_prom_gauge_set_l2(struct sip_msg* msg, char *pname, char* pnumber, char *l1, char *l2);
@@ -150,6 +154,14 @@ static cmd_export_t cmds[] = {
 	{"prom_counter_inc", (cmd_function)w_prom_counter_inc_l2, 4, fixup_counter_inc,
 	 0, ANY_ROUTE},
 	{"prom_counter_inc", (cmd_function)w_prom_counter_inc_l3, 5, fixup_counter_inc,
+	 0, ANY_ROUTE},
+	{"prom_counter_dec", (cmd_function)w_prom_counter_dec_l0, 2, fixup_counter_inc,
+	 0, ANY_ROUTE},
+	{"prom_counter_dec", (cmd_function)w_prom_counter_dec_l1, 3, fixup_counter_inc,
+	 0, ANY_ROUTE},
+	{"prom_counter_dec", (cmd_function)w_prom_counter_dec_l2, 4, fixup_counter_inc,
+	 0, ANY_ROUTE},
+	{"prom_counter_dec", (cmd_function)w_prom_counter_dec_l3, 5, fixup_counter_inc,
 	 0, ANY_ROUTE},
 	{"prom_gauge_set", (cmd_function)w_prom_gauge_set_l0, 2, fixup_metric_reset,
 	 0, ANY_ROUTE},
@@ -1232,6 +1244,41 @@ static int w_prom_counter_inc_l3(struct sip_msg* msg, char *pname, char* pnumber
 								 char *l1, char *l2, char *l3)
 {
 	return w_prom_counter_operation(msg, INCREMENT, pname, pnumber, l1, l2, l3);
+}
+
+/**
+ * @brief Decrement an integer from a counter (no labels)
+ */
+static int w_prom_counter_dec_l0(struct sip_msg* msg, char *pname, char* pnumber)
+{
+	return w_prom_counter_operation(msg, DECREMENT, pname, pnumber, NULL, NULL, NULL);
+}
+
+/**
+ * @brief Decrement an integer from a counter (1 labels)
+ */
+static int w_prom_counter_dec_l1(struct sip_msg* msg, char *pname, char* pnumber,
+								 char *l1)
+{
+	return w_prom_counter_operation(msg, DECREMENT, pname, pnumber, l1, NULL, NULL);
+}
+
+/**
+ * @brief Decrement an integer from a counter (2 labels)
+ */
+static int w_prom_counter_dec_l2(struct sip_msg* msg, char *pname, char* pnumber,
+								 char *l1, char *l2)
+{
+	return w_prom_counter_operation(msg, DECREMENT, pname, pnumber, l1, l2, NULL);
+}
+
+/**
+ * @brief Decrement an integer from a counter (3 labels)
+ */
+static int w_prom_counter_dec_l3(struct sip_msg* msg, char *pname, char* pnumber,
+								 char *l1, char *l2, char *l3)
+{
+	return w_prom_counter_operation(msg, DECREMENT, pname, pnumber, l1, l2, l3);
 }
 
 /**

--- a/src/modules/xhttp_prom/xhttp_prom.h
+++ b/src/modules/xhttp_prom/xhttp_prom.h
@@ -72,6 +72,15 @@ typedef struct prom_ctx {
 } prom_ctx_t;
 
 /**
+ * @brief The enum for increment and decrement operations
+ *
+ */
+typedef enum operation {
+	INCREMENT,
+	DECREMENT
+} operation;
+
+/**
  * @brief string for beginning of metrics.
  */
 extern str xhttp_prom_beginning;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
I use dialog module and want to export current active calls with custom labels.
I need to decrement the counter value when a call is terminated.
`prom_counter_dec` add this functionality.
