### PR TITLE
lcr: improve binary search to support a match including src port

### DIFF
--- a/src/modules/lcr/lcr_mod.c
+++ b/src/modules/lcr/lcr_mod.c
@@ -3035,8 +3035,7 @@ static int do_from_gw(struct sip_msg *_m, unsigned int lcr_id,
 
 	/* Store tag and flags and return result */
 	if((res != NULL)
-					&& ((transport == PROTO_NONE) || (res->transport_code == transport))
-					&& ((src_port == 0) || (res->port == src_port))) {
+					&& ((transport == PROTO_NONE) || (res->transport_code == transport))) {
 		LM_DBG("request came from gw\n");
 		if(tag_avp_param) {
 			val.s.s = res->tag;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Improve binary search in the lcr module and add a possibility
to do a matching not only based on an IP address of a GW, but also using a source port.

When a possibility to use 'src_port' parameter in from_gw() and from_any_gw()
was introduced here: 14e6fc80b3d2389567c73c4a2196bf8e6d92d8d2
the bsearch() remained untouched, and hence the matching (iteration through existing GWs)
is now done only based on an IP address.

This leads to the issue, when there are more than one GW with the same IP address in gws table,
and from_gw() and from_any_gw() functions are used with the 'src_port' parameter,
it can happen that a wrong GW is picked out by bsearch() from gws table (lcr_gw) and
a check by from_gw() and from_any_gw() returns False.

Hence the matching based on IP address and source port is required for bsearch(),
when from_gw() and from_any_gw() functions are used with the 'src_port' parameter.

This means backwards compatibility is still present (when one uses functions without 'src_port').