### PR TITLE
tm: Add callid_cseq_matching param

### DIFF
--- a/src/modules/tm/config.c
+++ b/src/modules/tm/config.c
@@ -47,6 +47,7 @@ struct cfg_group_tm	default_tm_cfg = {
 	1,	/* ruri_matching */
 	1,	/* via1_matching */
 	0,	/* callid_matching */
+	0,	/* callid_cseq_matching */
 	FR_TIME_OUT,	/* fr_timeout */
 	INV_FR_TIME_OUT,	/* fr_inv_timeout */
 	INV_FR_TIME_OUT_NEXT, /* fr_inv_timeout_next */
@@ -115,6 +116,8 @@ cfg_def_t	tm_cfg_def[] = {
 		"perform first Via header check in transaction matching"},
 	{"callid_matching",	CFG_VAR_INT | CFG_ATOMIC,	0, 0, 0, 0,
 		"perform callid check in transaction matching"},
+	{"callid_cseq_matching",CFG_VAR_INT | CFG_ATOMIC,	0, 0, 0, 0,
+		"perform callid+cseq instead of md5 in transaction matching"},
 	{"fr_timer",		CFG_VAR_INT | CFG_ATOMIC,	0, 0, timer_fixup, 0,
 		"timer which hits if no final reply for a request "
 		"or ACK for a negative INVITE reply arrives "

--- a/src/modules/tm/config.h
+++ b/src/modules/tm/config.h
@@ -99,6 +99,7 @@ struct cfg_group_tm {
 	int	ruri_matching;
 	int	via1_matching;
 	int	callid_matching;
+	int	callid_cseq_matching;
 	unsigned int	fr_timeout;
 	unsigned int	fr_inv_timeout;
 	unsigned int    fr_inv_timeout_next;

--- a/src/modules/tm/doc/params.xml
+++ b/src/modules/tm/doc/params.xml
@@ -997,6 +997,29 @@ modparam("tm", "callid_matching", 1)
 	</example>
 	</section>
 
+	<section id="tm.p.callid_cseq_matching">
+		<title><varname>callid_cseq_matching</varname> (int)</title>
+		<para>
+			If set to something other than 0, will do transaction matching 
+			using callid and cseq header values instead of via branch md5 value.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>callid_cseq_matching</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("tm", "callid_cseq_matching", 0)
+...
+
+kamcmd cfg.set_now_int tm callid_cseq_matching 1
+		</programlisting>
+		</example>
+	</section>
+
 	<section id="tm.p.pass_provisional_replies">
 	<title><varname>pass_provisional_replies</varname> (integer)</title>
 	<para>

--- a/src/modules/tm/tm.c
+++ b/src/modules/tm/tm.c
@@ -432,6 +432,7 @@ static param_export_t params[]={
 	{"ruri_matching",       PARAM_INT, &default_tm_cfg.ruri_matching         },
 	{"via1_matching",       PARAM_INT, &default_tm_cfg.via1_matching         },
 	{"callid_matching",     PARAM_INT, &default_tm_cfg.callid_matching       },
+	{"callid_cseq_matching",PARAM_INT, &default_tm_cfg.callid_cseq_matching  },
 	{"fr_timer",            PARAM_INT, &default_tm_cfg.fr_timeout            },
 	{"fr_inv_timer",        PARAM_INT, &default_tm_cfg.fr_inv_timeout        },
 	{"wt_timer",            PARAM_INT, &default_tm_cfg.wait_timeout          },


### PR DESCRIPTION
Enable transaction matching using callid and cseq values
instead of via md5 value.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Hello,

We had an issue with kamailio that the generated tm p_cell->md5 was not sent out in Via "branch=" parameter. Instead, other value was sent. Thus when comparing the replies Via "branch=" md5 value back to p_cell->md5, the transactions mismatched and dialogs were not setup. This happened for the most of the transactions/dialogs.

We could not really figure out why the above was happening. Because this was an isolated system, we decided to do this workaround using callid and cseq matching for transactions, and it helped. Now most of the dialogs are setup.

Let me know what you think, if other had this problem and if this PR helps.

Thank you,
Stefan 