### PR TITLE
core: allow empty matches

### DIFF
--- a/src/core/data_lump.c
+++ b/src/core/data_lump.c
@@ -299,7 +299,7 @@ struct lump* del_lump(struct sip_msg* msg, int offset, int len,
 		return 0;
 	}
 	if (len==0){
-		LM_WARN("0 len (offset=%d)\n", offset);
+		LM_DBG("0 len (offset=%d)\n", offset);
 	}
 
 	tmp=pkg_malloc(sizeof(struct lump));

--- a/src/core/re.c
+++ b/src/core/re.c
@@ -440,10 +440,6 @@ struct replace_lst* subst_run(struct subst_expr* se, const char* input,
 				LM_ERR("Unknown offset?\n");
 				goto error;
 			}
-			if (pmatch[0].rm_so==pmatch[0].rm_eo) {
-				LM_ERR("Matched string is empty, invalid regexp?\n");
-				goto error;
-			}
 			*crt=pkg_malloc(sizeof(struct replace_lst));
 			if (*crt==0){
 				PKG_MEM_ERROR;


### PR DESCRIPTION
Anchors like ^ and $ match beginning resp. ending of strings but their
matches are zero length, which is ok.
The anchors can be used to pre-/append a prefix/suffix via e.g.
subst_hf("X-My-Header", "/^/prefix /", "a");
subst_hf("X-My-Header", "/$/ suffix/", "a");

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
