### PR TITLE
core: fixup sip_msg_apply_changes

### DIFF
--- a/src/core/msg_translator.c
+++ b/src/core/msg_translator.c
@@ -3267,6 +3267,7 @@ int build_sip_msg_from_buf(struct sip_msg *msg, char *buf, int len,
 int sip_msg_update_buffer(sip_msg_t *msg, str *obuf)
 {
 	sip_msg_t tmp;
+	int res;
 
 	if(obuf==NULL || obuf->s==NULL || obuf->len<=0) {
 		LM_ERR("invalid buffer parameter\n");
@@ -3326,6 +3327,13 @@ int sip_msg_update_buffer(sip_msg_t *msg, str *obuf)
 		LM_ERR("parsing new sip message failed [[%.*s]]\n", msg->len, msg->buf);
 		/* exit config execution - sip_msg_t structure is no longer
 		 * valid/safe for config */
+		return 0;
+	}
+
+	//parse all the headers again
+	res = parse_headers(msg, HDR_EOH_F, 0);
+	if (res == -1) {
+		LM_ERR("Error while parsing headers (%d)\n", res);
 		return 0;
 	}
 


### PR DESCRIPTION
- adds header parser to fill headers in msg structure. msg gets copied
but many of the headers don't when msg_apply_changes is called.
- reported in #2803

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2803 

#### Description

adds header parser to fill headers in msg structure. msg gets copied
but many of the headers don't get filled when msg_apply_changes is called. This can cause segmentation fault by calling null pointers.