### PR TITLE
dialog: fix dlg_onroute

### DIFF
--- a/src/modules/dialog/dlg_handlers.c
+++ b/src/modules/dialog/dlg_handlers.c
@@ -1319,13 +1319,21 @@ void dlg_onroute(struct sip_msg* req, str *route_params, void *param)
 
 			dlg = dlg_lookup(h_entry, h_id);
 			if (dlg==0) {
+
+				char *callid_s = "(no-call-id)";
+				int callid_len = 12; 
+				if (req->callid != 0) {
+					callid_s = req->callid->body.s; 
+					callid_len = req->callid->body.len;
+				}
+
 				LM_WARN("unable to find dialog for %.*s "
 					"with route param '%.*s' [%u:%u] "
 					"and call-id '%.*s'\n",
 					req->first_line.u.request.method.len,
 					req->first_line.u.request.method.s,
 					val.len,val.s, h_entry, h_id,
-					req->callid->body.len, req->callid->body.s);
+					callid_len, callid_s);
 				if (seq_match_mode==SEQ_MATCH_STRICT_ID )
 					return;
 			} else {


### PR DESCRIPTION
- adds a default value for when there is no call-id in the req struct.
- reported in #2803

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2803

#### Description
<!-- Describe your changes in detail -->

In some cases the callid field of the msg structure doesn't get initialized. In the case the dlg_onroute function is called with this msg and the dialog is not found a warning message is printed using the LM_WARN macro. This logger is called with a req->callid as argument and when this is null a segmentation fault happens. I added a small default value for this case. 