### PR TITLE
core: fixed route hash table cleanup

### DIFF
--- a/src/core/route.c
+++ b/src/core/route.c
@@ -91,8 +91,11 @@ inline static void destroy_rlist(struct route_list* rt)
 		rt->entries=0;
 	}
 	if (rt->names.table){
-		clist_foreach_safe(rt->names.table, e, tmp, next){
-			pkg_free(e);
+		int i;
+		for(i = 0; i < RT_HASH_SIZE; i++) {
+			clist_foreach_safe(&rt->names.table[i], e, tmp, next) {
+				pkg_free(e);
+			}
 		}
 		pkg_free(rt->names.table);
 		rt->names.table=0;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2892

#### Description
When Kamailio goes to shutdown then routing hash table cleaned properly.