### PR TITLE
uac: fixing REGISTER to use custom socket after 401/407

### DIFF
--- a/src/modules/uac/uac_reg.c
+++ b/src/modules/uac/uac_reg.c
@@ -1011,6 +1011,20 @@ void uac_reg_tm_callback( struct cell *t, int type, struct tmcb_params *ps)
 		uac_r.cb  = uac_reg_tm_callback;
 		/* Callback parameter */
 		uac_r.cbp = (void*)uuid;
+
+		if(ri->socket.s != NULL && ri->socket.len > 0) {
+                        /* custom socket */
+                        LM_DBG("using custom socket %.*s to send request\n",
+                                ri->socket.len, ri->socket.s);
+                        uac_r.ssock = &ri->socket;
+                } else {
+                        /* default socket */
+                        if(uac_default_socket.s != NULL && uac_default_socket.len > 0) {
+                                LM_DBG("using configured default_socket to send request\n");
+                                uac_r.ssock = &uac_default_socket;
+                        }
+                }
+
 		ret = uac_tmb.t_request_within(&uac_r);
 
 		if(ret<0) {


### PR DESCRIPTION
- After receiving 401/407 uac does not use configured custom socket,
  second register send from first available address.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
uac module does not use configured custom socket when send second REGISTER after receiving 401/407,
so packet send via first suitable socket in config with wrong source address, some carriers drops this packets
because they have configured ACLs.

