### PR TITLE
statsd: remove '\r\n' from xlog messages

### DIFF
--- a/src/modules/statsd/lib_statsd.c
+++ b/src/modules/statsd/lib_statsd.c
@@ -11,124 +11,129 @@
 #include "../../core/sr_module.h"
 #include "lib_statsd.h"
 
-static StatsConnection statsd_connection = {
-    "127.0.0.1",
-    "8125",
-    -1
-};
+static StatsConnection statsd_connection = {"127.0.0.1", "8125", -1};
 
-bool statsd_connect(void){
+bool statsd_connect(void)
+{
 
-    struct addrinfo *serverAddr = NULL;
-    int rc;
+	struct addrinfo *serverAddr = NULL;
+	int rc;
 
-    if (statsd_connection.sock > 0){
-        return true;
-    }
+	if(statsd_connection.sock > 0) {
+		return true;
+	}
 
-    rc = getaddrinfo(
-        statsd_connection.ip, statsd_connection.port,
-        NULL, &serverAddr);
-    if (rc != 0 || serverAddr == NULL)
-    {
-        LM_ERR("Statsd: could not initiate server information (%s)\n",
-            gai_strerror(rc));
-        if(serverAddr) freeaddrinfo(serverAddr);
-        return false;
-    }
+	rc = getaddrinfo(
+			statsd_connection.ip, statsd_connection.port, NULL, &serverAddr);
+	if(rc != 0 || serverAddr == NULL) {
+		LM_ERR("Statsd: could not initiate server information (%s)\n",
+				gai_strerror(rc));
+		if(serverAddr)
+			freeaddrinfo(serverAddr);
+		return false;
+	}
 
-    statsd_connection.sock = socket(serverAddr->ai_family, SOCK_DGRAM, IPPROTO_UDP);
-    if (statsd_connection.sock < 0 ){
-        LM_ERR("Statsd: could not create a socket for statsd connection\n");
-        freeaddrinfo(serverAddr);
-        return false;
-    }
+	statsd_connection.sock =
+			socket(serverAddr->ai_family, SOCK_DGRAM, IPPROTO_UDP);
+	if(statsd_connection.sock < 0) {
+		LM_ERR("Statsd: could not create a socket for statsd connection\n");
+		freeaddrinfo(serverAddr);
+		return false;
+	}
 
-    rc = connect(statsd_connection.sock, serverAddr->ai_addr,
-            serverAddr->ai_addrlen);
-    freeaddrinfo(serverAddr);
-    if (rc < 0){
-        LM_ERR("Statsd: could not initiate a connect to statsd\n");
-        return false;
-    }
-    return true;
+	rc = connect(statsd_connection.sock, serverAddr->ai_addr,
+			serverAddr->ai_addrlen);
+	freeaddrinfo(serverAddr);
+	if(rc < 0) {
+		LM_ERR("Statsd: could not initiate a connect to statsd\n");
+		return false;
+	}
+	return true;
 }
 
-bool send_command(char *command){
-    int send_result;
+bool send_command(char *command)
+{
+	int send_result;
 
-    if (!statsd_connect()){
-        return false;
-    }
+	if(!statsd_connect()) {
+		return false;
+	}
 
-    send_result = send(statsd_connection.sock, command, strlen(command), 0);
-    if ( send_result < 0){
-        LM_ERR("could not send the correct info to statsd (%i| %s)\n",
-            send_result, strerror(errno));
-        return true;
-    }
-    LM_DBG("Sent to statsd (%s)", command);
-    return true;
+	send_result = send(statsd_connection.sock, command, strlen(command), 0);
+	if(send_result < 0) {
+		LM_ERR("could not send the correct info to statsd (%i| %s)\n",
+				send_result, strerror(errno));
+		return true;
+	}
+	LM_DBG("Sent to statsd (%s)", command);
+	return true;
 }
 
-bool statsd_set(char *key, char *value){
-   char* end = 0;
-   char command[254];
-   int val;
-   val = strtol(value, &end, 0);
-   if (*end){
-       LM_ERR("statsd_count could not  use the provide value(%s)\n", value);
-       return false;
-   }
-   snprintf(command, sizeof command, "%s:%i|s\n", key, val);
-   return send_command(command);
+bool statsd_set(char *key, char *value)
+{
+	char *end = 0;
+	char command[254];
+	int val;
+	val = strtol(value, &end, 0);
+	if(*end) {
+		LM_ERR("statsd_count could not  use the provide value(%s)\n", value);
+		return false;
+	}
+	snprintf(command, sizeof command, "%s:%i|s\n", key, val);
+	return send_command(command);
 }
 
 
-bool statsd_gauge(char *key, char *value){
-   char command[254];
-   snprintf(command, sizeof command, "%s:%s|g\n", key, value);
-   return send_command(command);
+bool statsd_gauge(char *key, char *value)
+{
+	char command[254];
+	snprintf(command, sizeof command, "%s:%s|g\n", key, value);
+	return send_command(command);
 }
 
-bool statsd_histogram(char *key, char *value){
-   char command[254];
-   snprintf(command, sizeof command, "%s:%s|h\n", key, value);
-   return send_command(command);
+bool statsd_histogram(char *key, char *value)
+{
+	char command[254];
+	snprintf(command, sizeof command, "%s:%s|h\n", key, value);
+	return send_command(command);
 }
 
-bool statsd_count(char *key, char *value){
-   char* end = 0;
-   char command[254];
-   int val;
+bool statsd_count(char *key, char *value)
+{
+	char *end = 0;
+	char command[254];
+	int val;
 
-   val = strtol(value, &end, 0);
-   if (*end){
-       LM_ERR("statsd_count could not  use the provide value(%s)\n", value);
-       return false;
-   }
-   snprintf(command, sizeof command, "%s:%i|c\n", key, val);
-   return send_command(command);
+	val = strtol(value, &end, 0);
+	if(*end) {
+		LM_ERR("statsd_count could not  use the provide value(%s)\n", value);
+		return false;
+	}
+	snprintf(command, sizeof command, "%s:%i|c\n", key, val);
+	return send_command(command);
 }
 
-bool statsd_timing(char *key, int value){
-   char command[254];
-   snprintf(command, sizeof command, "%s:%i|ms\n", key, value);
-   return send_command(command);
+bool statsd_timing(char *key, int value)
+{
+	char command[254];
+	snprintf(command, sizeof command, "%s:%i|ms\n", key, value);
+	return send_command(command);
 }
 
-bool statsd_init(char *ip, char *port){
+bool statsd_init(char *ip, char *port)
+{
 
-    if (ip != NULL){
-        statsd_connection.ip = ip;
-    }
-    if (port != NULL ){
-       statsd_connection.port = port;
-    }
-    return statsd_connect();
+	if(ip != NULL) {
+		statsd_connection.ip = ip;
+	}
+	if(port != NULL) {
+		statsd_connection.port = port;
+	}
+	return statsd_connect();
 }
 
-bool statsd_destroy(void){
-    statsd_connection.sock = 0;
-    return true;
+bool statsd_destroy(void)
+{
+	statsd_connection.sock = 0;
+	return true;
 }

--- a/src/modules/statsd/lib_statsd.h
+++ b/src/modules/statsd/lib_statsd.h
@@ -2,10 +2,11 @@
 
 #define BUFFER_SIZE 8192
 
-typedef struct StatsConnection{
-    char *ip;
-    char *port;
-    int sock;
+typedef struct StatsConnection
+{
+	char *ip;
+	char *port;
+	int sock;
 } StatsConnection;
 
 bool statsd_connect(void);

--- a/src/modules/statsd/statsd.c
+++ b/src/modules/statsd/statsd.c
@@ -33,22 +33,23 @@ MODULE_VERSION
 
 static int mod_init(void);
 void mod_destroy(void);
-static int func_gauge(struct sip_msg *msg, char *key, char* val);
-static int func_histogram(struct sip_msg *msg, char *key, char* val);
-static int func_set(struct sip_msg *msg, char *key, char* val);
+static int func_gauge(struct sip_msg *msg, char *key, char *val);
+static int func_histogram(struct sip_msg *msg, char *key, char *val);
+static int func_set(struct sip_msg *msg, char *key, char *val);
 static int func_time_start(struct sip_msg *msg, char *key);
 static int func_time_end(struct sip_msg *msg, char *key);
 static int func_incr(struct sip_msg *msg, char *key);
 static int func_decr(struct sip_msg *msg, char *key);
-static char* get_milliseconds(char *dst);
+static char *get_milliseconds(char *dst);
 
-typedef struct StatsdParams{
-    char *ip;
-    char *port;
+typedef struct StatsdParams
+{
+	char *ip;
+	char *port;
 } StatsdParams;
 
-static StatsdParams statsd_params= {};
-
+static StatsdParams statsd_params = {};
+/* clang-format off */
 static cmd_export_t commands[] = {
 	{"statsd_gauge", (cmd_function)func_gauge, 2, 0, 0, ANY_ROUTE},
 	{"statsd_histogram", (cmd_function)func_histogram, 2, 0, 0, ANY_ROUTE},
@@ -78,31 +79,31 @@ struct module_exports exports = {
     0,               // child init function
     mod_destroy      // destroy function
 };
-
+/* clang-format on */
 
 static int mod_init(void)
 {
-    int rc = 0;
-    if(!statsd_params.ip){
-        LM_INFO("Statsd init ip value is null. use default 127.0.0.1\r\n");
-    }else{
-        LM_INFO("Statsd init ip value %s \r\n", statsd_params.ip);
-    }
+	int rc = 0;
+	if(!statsd_params.ip) {
+		LM_INFO("Statsd init ip value is null. use default 127.0.0.1\r\n");
+	} else {
+		LM_INFO("Statsd init ip value %s \r\n", statsd_params.ip);
+	}
 
-    if(!statsd_params.port){
-        LM_INFO("Statsd init port value is null. use default 8125\r\n");
-    } else {
-        LM_INFO("Statsd init port value %s\r\n", statsd_params.port);
-    }
+	if(!statsd_params.port) {
+		LM_INFO("Statsd init port value is null. use default 8125\r\n");
+	} else {
+		LM_INFO("Statsd init port value %s\r\n", statsd_params.port);
+	}
 
-    rc = statsd_init(statsd_params.ip, statsd_params.port);
-    if (rc < 0){
-        LM_ERR("Statsd connection failed (ERROR_CODE: %i) \n",rc);
-        return -1;
-    }else{
-        LM_INFO("Statsd: success connection to statsd server\n");
-    }
-    return 0;
+	rc = statsd_init(statsd_params.ip, statsd_params.port);
+	if(rc < 0) {
+		LM_ERR("Statsd connection failed (ERROR_CODE: %i) \n", rc);
+		return -1;
+	} else {
+		LM_INFO("Statsd: success connection to statsd server\n");
+	}
+	return 0;
 }
 
 /**
@@ -110,136 +111,136 @@ static int mod_init(void)
 */
 void mod_destroy(void)
 {
-    statsd_destroy();
-    return;
+	statsd_destroy();
+	return;
 }
 
-static int func_gauge(struct sip_msg* msg, char* key, char* val)
+static int func_gauge(struct sip_msg *msg, char *key, char *val)
 {
-    return statsd_gauge(key, val);
+	return statsd_gauge(key, val);
 }
 
-static int func_histogram(struct sip_msg* msg, char* key, char* val)
+static int func_histogram(struct sip_msg *msg, char *key, char *val)
 {
-    return statsd_histogram(key, val);
+	return statsd_histogram(key, val);
 }
 
-static int ki_statsd_gauge(sip_msg_t* msg, str* key, str* val)
+static int ki_statsd_gauge(sip_msg_t *msg, str *key, str *val)
 {
-    return statsd_gauge(key->s, val->s);
+	return statsd_gauge(key->s, val->s);
 }
 
-static int ki_statsd_histogram(sip_msg_t* msg, str* key, str* val)
+static int ki_statsd_histogram(sip_msg_t *msg, str *key, str *val)
 {
-    return statsd_histogram(key->s, val->s);
+	return statsd_histogram(key->s, val->s);
 }
 
-static int func_set(struct sip_msg* msg, char* key, char* val)
+static int func_set(struct sip_msg *msg, char *key, char *val)
 {
-    return statsd_set(key, val);
+	return statsd_set(key, val);
 }
 
-static int ki_statsd_set(sip_msg_t* msg, str* key, str* val)
+static int ki_statsd_set(sip_msg_t *msg, str *key, str *val)
 {
-    return statsd_set(key->s, val->s);
+	return statsd_set(key->s, val->s);
 }
 
 static int func_time_start(struct sip_msg *msg, char *key)
 {
-    int_str avp_key, avp_val;
-    char unix_time[24];
-    get_milliseconds(unix_time);
-    avp_key.s.s = key;
-    avp_key.s.len = strlen(avp_key.s.s);
+	int_str avp_key, avp_val;
+	char unix_time[24];
+	get_milliseconds(unix_time);
+	avp_key.s.s = key;
+	avp_key.s.len = strlen(avp_key.s.s);
 
-    avp_val.s.s = unix_time;
-    avp_val.s.len = strlen(avp_val.s.s);
+	avp_val.s.s = unix_time;
+	avp_val.s.len = strlen(avp_val.s.s);
 
-	if (add_avp(AVP_NAME_STR|AVP_VAL_STR, avp_key, avp_val) < 0) {
-        LM_ERR("Statsd: time start failed to create AVP\n");
-        return -1;
-    }
-    return 1;
+	if(add_avp(AVP_NAME_STR | AVP_VAL_STR, avp_key, avp_val) < 0) {
+		LM_ERR("Statsd: time start failed to create AVP\n");
+		return -1;
+	}
+	return 1;
 }
 
 static int ki_statsd_start(sip_msg_t *msg, str *key)
 {
-    return func_time_start(msg, key->s);
+	return func_time_start(msg, key->s);
 }
 
 static int func_time_end(struct sip_msg *msg, char *key)
 {
-    char unix_time[24];
-    char *endptr;
-    long int start_time;
-    int result;
+	char unix_time[24];
+	char *endptr;
+	long int start_time;
+	int result;
 
-    struct search_state st;
+	struct search_state st;
 
-    get_milliseconds(unix_time);
-    LM_DBG("Statsd: statsd_stop at %s\n",unix_time);
-    avp_t* prev_avp;
+	get_milliseconds(unix_time);
+	LM_DBG("Statsd: statsd_stop at %s\n", unix_time);
+	avp_t *prev_avp;
 
-    int_str avp_value, avp_name;
-    avp_name.s.s = key;
-    avp_name.s.len = strlen(avp_name.s.s);
+	int_str avp_value, avp_name;
+	avp_name.s.s = key;
+	avp_name.s.len = strlen(avp_name.s.s);
 
-    prev_avp = search_first_avp(
-        AVP_NAME_STR|AVP_VAL_STR, avp_name, &avp_value, &st);
-    if(avp_value.s.len == 0){
-        LM_ERR("Statsd: statsd_stop not valid key(%s)\n",key);
-        return 1;
-    }
+	prev_avp = search_first_avp(
+			AVP_NAME_STR | AVP_VAL_STR, avp_name, &avp_value, &st);
+	if(avp_value.s.len == 0) {
+		LM_ERR("Statsd: statsd_stop not valid key(%s)\n", key);
+		return 1;
+	}
 
-    start_time = strtol(avp_value.s.s, &endptr,10);
-    if(strlen(endptr) >0){
-      LM_DBG(
-          "Statsd:statsd_stop not valid key(%s) it's not a number value=%s\n",
-          key, avp_value.s.s);
-      return 0;
-    }
+	start_time = strtol(avp_value.s.s, &endptr, 10);
+	if(strlen(endptr) > 0) {
+		LM_DBG("Statsd:statsd_stop not valid key(%s) it's not a number "
+			   "value=%s\n",
+				key, avp_value.s.s);
+		return 0;
+	}
 
-    result = atol(unix_time) - start_time;
-    LM_DBG(
-        "Statsd: statsd_stop Start_time=%ld unix_time=%ld (%i)\n",
-        start_time, atol(unix_time), result);
-    destroy_avp(prev_avp);
-    return statsd_timing(key, result);
+	result = atol(unix_time) - start_time;
+	LM_DBG("Statsd: statsd_stop Start_time=%ld unix_time=%ld (%i)\n",
+			start_time, atol(unix_time), result);
+	destroy_avp(prev_avp);
+	return statsd_timing(key, result);
 }
 
 static int ki_statsd_stop(sip_msg_t *msg, str *key)
 {
-    return func_time_end(msg, key->s);
+	return func_time_end(msg, key->s);
 }
 
 static int func_incr(struct sip_msg *msg, char *key)
 {
-    return statsd_count(key, "+1");
+	return statsd_count(key, "+1");
 }
 
 static int ki_statsd_incr(sip_msg_t *msg, str *key)
 {
-    return statsd_count(key->s, "+1");
+	return statsd_count(key->s, "+1");
 }
 
 static int func_decr(struct sip_msg *msg, char *key)
 {
-    return statsd_count(key, "-1");
+	return statsd_count(key, "-1");
 }
 
 static int ki_statsd_decr(sip_msg_t *msg, str *key)
 {
-    return statsd_count(key->s, "-1");
+	return statsd_count(key->s, "-1");
 }
 
-char* get_milliseconds(char *dst){
-    struct timeval tv;
-    long int millis;
+char *get_milliseconds(char *dst)
+{
+	struct timeval tv;
+	long int millis;
 
-    gettimeofday(&tv, NULL);
-    millis = (tv.tv_sec * (int)1000) + (tv.tv_usec / 1000);
-    snprintf(dst, 21, "%ld", millis);
-    return dst;
+	gettimeofday(&tv, NULL);
+	millis = (tv.tv_sec * (int)1000) + (tv.tv_usec / 1000);
+	snprintf(dst, 21, "%ld", millis);
+	return dst;
 }
 
 /**

--- a/src/modules/statsd/statsd.c
+++ b/src/modules/statsd/statsd.c
@@ -85,20 +85,20 @@ static int mod_init(void)
 {
 	int rc = 0;
 	if(!statsd_params.ip) {
-		LM_INFO("Statsd init ip value is null. use default 127.0.0.1\r\n");
+		LM_INFO("Statsd init ip value is null. use default 127.0.0.1\n");
 	} else {
-		LM_INFO("Statsd init ip value %s \r\n", statsd_params.ip);
+		LM_INFO("Statsd init ip value %s\n", statsd_params.ip);
 	}
 
 	if(!statsd_params.port) {
-		LM_INFO("Statsd init port value is null. use default 8125\r\n");
+		LM_INFO("Statsd init port value is null. use default 8125\n");
 	} else {
-		LM_INFO("Statsd init port value %s\r\n", statsd_params.port);
+		LM_INFO("Statsd init port value %s\n", statsd_params.port);
 	}
 
 	rc = statsd_init(statsd_params.ip, statsd_params.port);
 	if(rc < 0) {
-		LM_ERR("Statsd connection failed (ERROR_CODE: %i) \n", rc);
+		LM_ERR("Statsd connection failed (ERROR_CODE: %i)\n", rc);
 		return -1;
 	} else {
 		LM_INFO("Statsd: success connection to statsd server\n");


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally

#### Description
When the module is loaded the messages have '\r\n'

> INFO: statsd [statsd.c:87]: mod_init(): Statsd init ip value 127.0.0.1 #015
> INFO: statsd [statsd.c:93]: mod_init(): Statsd init port value 8125#015
> INFO: statsd [statsd.c:101]: mod_init(): Statsd: success connection to statsd server

while at it, format the code with our clang-format definition