### PR TITLE
nats: Add publish function

### DIFF
--- a/src/modules/nats/doc/nats_admin.xml
+++ b/src/modules/nats/doc/nats_admin.xml
@@ -151,6 +151,43 @@ modparam("nats", "subject_queue_group", "MyQueue2:2021")
 			</example>
 		</section>
 	</section>
+
+	<section>
+		<title>Functions</title>
+		<section id="nats.f.nats_publish">
+			<title>
+				<function moreinfo="none">nats_publish(payload[, url, subject])</function>
+			</title>
+			<para>
+				Publishes the payload text to all configured nats urls, to all configured subject queues.
+			</para>
+			<para>
+				If "url" optional parameter is specified, will publish just to that url. Note that the url must be configured in the first place.
+			</para>
+			<para>
+				If "subject" optional parameter is specified, will publish just to that subject. Note that the subject must be configured in the first place.
+			</para>
+			<para>
+				Mixing of optional parameters are allowed, as in the example below.
+			</para>
+			<example>
+				<title><function>nats_publish</function> usage</title>
+				<programlisting format="linespecific">
+...
+$var(my_info)="$ci=" + $ci + " $fU=" + $fU;
+
+nats_publish($var(my_info));					# publish to all configured urls, all configured subjects
+nats_publish($var(my_info), "", "");				# same as the above ^
+
+nats_publish($var(my_info), "nats://127.0.0.3:4222", "foo");	# publish to "nats://127.0.0.3:4222" url, "foo" subject
+nats_publish($var(my_info), "", "foo");				# publish to all configured urls, "foo" subject
+nats_publish($var(my_info), "nats://127.0.0.3:4222", "");	# publish to "nats://127.0.0.3:4222" url, all configured subjects
+...
+				</programlisting>
+			</example>
+		</section>
+	</section>
+
 	<section>
 		<title>Pseudo Variables</title>
 		<itemizedlist>

--- a/src/modules/nats/nats_mod.h
+++ b/src/modules/nats/nats_mod.h
@@ -53,6 +53,7 @@ typedef struct _init_nats_sub
 typedef struct _init_nats_server
 {
 	char *url;
+	natsConnection *conn;
 	struct _init_nats_server *next;
 } init_nats_server, *init_nats_server_ptr;
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Added a publish function to nats module. When the function is called, the routing process tries to connect to the url (param) and tries to send the payload (param) to the subject queue (param). No libuv is used for this.

Probably a better approach is to make publisher workers (like subscriber workers) and pass payload from routing processes to publisher worker processes via shared memory. Right now I see this as an improvement and find the new function good enough, for now.

@eschmidbauer what do you think of this?

Thank you,
Stefan

P.S. Will update doc after review.