### PR TITLE
nats: Add one subscriber connection per nats_url

### DIFF
--- a/src/modules/nats/doc/nats_admin.xml
+++ b/src/modules/nats/doc/nats_admin.xml
@@ -97,7 +97,7 @@
 				(str)
 			</title>
 			<para>
-				The nats url.
+				The nats url. More than one url can be configured. For each url, there will be one separate nats connection, either for subscriber or publisher.
 			</para>
 			<para>
 				Usage: nats related.

--- a/src/modules/nats/nats_mod.h
+++ b/src/modules/nats/nats_mod.h
@@ -66,7 +66,7 @@ struct nats_consumer_worker
 	char *subject;
 	char *queue_group;
 	int pid;
-	natsConnection *conn;
+	natsConnection *conn[NATS_MAX_SERVERS];
 	natsOptions *opts;
 	natsSubscription *subscription;
 	uv_loop_t *uvLoop;


### PR DESCRIPTION
Updated doc.
Fixes #2916.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Add a separate connection for each nats_url, for subscriber workers. Basically tested it locally, with 3 nats_url and 2 workers.

Thanks,
Stefan