### PR TITLE
kazoo: Allow optional AMQP-headers in kazoo_query and kazoo_publish

### DIFF
--- a/src/modules/kazoo/doc/kazoo_admin.xml
+++ b/src/modules/kazoo/doc/kazoo_admin.xml
@@ -560,10 +560,10 @@ modparam("kazoo", "pua_mode", 0)
 			<section>
 				<title>
 					<function moreinfo="none">kazoo_publish(exchange, routing_key,
-						json_payload)</function>
+						json_payload [, amqp_headers])</function>
 				</title>
 				<para>The function publishes a json payload to rabbitmq. The routing_key parameter
-					should be encoded.</para>
+					should be encoded. Optional AMQP-Headers are specified in the format key1=value1;key2=value2</para>
 				<para>This function can be used from ANY ROUTE.</para>
 
 				<example>
@@ -581,12 +581,12 @@ kazoo_publish("callmgr", $var(amqp_routing_key), $var(amqp_payload_request));
 			<section>
 				<title>
 					<function moreinfo="none">kazoo_query(exchange, routing_key, json_payload [,
-						target_var])</function>
+						target_var] [, amqp_headers])</function>
 				</title>
 				<para>The function publishes a json payload to rabbitmq, waits for a correlated
 					messageand puts the result in target_var. The routing_key parameter should be
 					encoded. target_var is optional as the function also puts the result in
-					pseudo-variable $kzR.</para>
+					pseudo-variable $kzR. Optional AMQP-Headers are specified in the format key1=value1;key2=value2</para>
 				<para>This function can be used from ANY ROUTE.</para>
 
 				<example>

--- a/src/modules/kazoo/kazoo.c
+++ b/src/modules/kazoo/kazoo.c
@@ -149,6 +149,7 @@ static cmd_export_t cmds[] = {
     {"kazoo_publish", (cmd_function) kz_amqp_publish, 3, fixup_kz_amqp, fixup_kz_amqp_free, ANY_ROUTE},
     {"kazoo_publish", (cmd_function) kz_amqp_publish_ex, 4, fixup_kz_amqp, fixup_kz_amqp_free, ANY_ROUTE},
     {"kazoo_query", (cmd_function) kz_amqp_query, 4, fixup_kz_amqp, fixup_kz_amqp_free, ANY_ROUTE},
+    {"kazoo_query", (cmd_function) kz_amqp_query, 5, fixup_kz_amqp, fixup_kz_amqp_free, ANY_ROUTE},
     {"kazoo_query", (cmd_function) kz_amqp_query_ex, 3, fixup_kz_amqp, fixup_kz_amqp_free, ANY_ROUTE},
     {"kazoo_pua_publish", (cmd_function) kz_pua_publish, 1, 0, 0, ANY_ROUTE},
     {"kazoo_pua_publish_mwi", (cmd_function) kz_pua_publish_mwi, 1, 0, 0, ANY_ROUTE},

--- a/src/modules/kazoo/kz_amqp.h
+++ b/src/modules/kazoo/kz_amqp.h
@@ -122,6 +122,7 @@ typedef struct {
 	char* queue;
 	char* payload;
 	char* return_payload;
+	char* headers;
 	str* message_id;
 	int   return_code;
 	int   consumer;
@@ -273,10 +274,10 @@ void kz_amqp_destroy();
 int kz_amqp_add_connection(modparam_t type, void* val);
 
 int kz_amqp_publish(struct sip_msg* msg, char* exchange, char* routing_key, char* payload);
-int kz_amqp_publish_ex(struct sip_msg* msg, char* exchange, char* routing_key, char* payload, char* _pub_flags);
-int ki_kz_amqp_publish(sip_msg_t* msg, str* exchange, str* routing_key, str* payload);
-int kz_amqp_query(struct sip_msg* msg, char* exchange, char* routing_key, char* payload, char* dst);
-int kz_amqp_query_ex(struct sip_msg* msg, char* exchange, char* routing_key, char* payload);
+int kz_amqp_publish_ex(struct sip_msg* msg, char* exchange, char* routing_key, char* payload, char* headers);
+int ki_kz_amqp_publish(sip_msg_t* msg, str* exchange, str* routing_key, str* payload, str* headers);
+int kz_amqp_query(struct sip_msg* msg, char* exchange, char* routing_key, char* payload, char* dst, char* headers);
+int kz_amqp_query_ex(struct sip_msg* msg, char* exchange, char* routing_key, char* payload, char* headers);
 int kz_amqp_subscribe(struct sip_msg* msg, char* payload);
 int ki_kz_amqp_subscribe(sip_msg_t* msg, str* payload);
 int kz_amqp_subscribe_simple(struct sip_msg* msg, char* exchange, char* exchange_type, char* queue_name, char* routing_key);
@@ -326,6 +327,8 @@ void kz_amqp_routing_free(kz_amqp_routings_ptr routing);
 kz_amqp_queue_ptr kz_amqp_queue_new(str *name);
 kz_amqp_exchange_ptr kz_amqp_exchange_new(str *name, str* type);
 kz_amqp_routings_ptr kz_amqp_routing_new(char* routing);
+
+int add_amqp_headers (char * headers, amqp_basic_properties_t * props );
 
 static inline int kz_amqp_error(char const *context, amqp_rpc_reply_t x)
 {


### PR DESCRIPTION
- implements GH #2895

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2895

#### Description
Allows adding additional AMQP-headers in the format header1=value1;header2=value2;...

Remark: 
I decided to re-use the definition 
`{"kazoo_publish", (cmd_function) kz_amqp_publish_ex, 4, fixup_kz_amqp, fixup_kz_amqp_free, ANY_ROUTE},`
resp. to modify the existing method signature
`int kz_amqp_publish_ex(struct sip_msg* msg, char* exchange, char* routing_key, char* payload, char* _pub_flags)`
to 
`int kz_amqp_publish_ex(struct sip_msg* msg, char* exchange, char* routing_key, char* payload, char* _pub_flags)`
as the param _pub_flags is neither described in the docs, nor it was evaluated/used, and thus was useless anyhow.