### PR TITLE
presence: add option to return 200 instead of 202 on subscriptions

### DIFF
--- a/src/modules/presence/doc/presence_admin.xml
+++ b/src/modules/presence/doc/presence_admin.xml
@@ -792,7 +792,7 @@ modparam("presence", "subs_remove_match", 1)
 			so newer documents have higher priority.</para>
         </listitem>
         <listitem>
-			<para><emphasis>delete_subscription</emphasis> - integer value to 
+			<para><emphasis>delete_subscription</emphasis> - integer value to
 			give extra control of deleting the subscription after processing of
 			event_route[presence:notify-reply]. If value = 1, it deletes the subscription.
 			If xavp_cfg parameter is set but this attribute is not in the avp,
@@ -975,6 +975,29 @@ modparam("presence", "delete_same_subs", 1)
 		<programlisting format="linespecific">
 ...
 modparam("presence", "timer_mode", 0)
+...
+</programlisting>
+	</example>
+</section>
+
+<section id="presence.p.subs_respond_200">
+	<title><varname>subs_respond_200</varname> (integer)</title>
+	<para>
+	Specify the response code for accepted SUBSCRIBE requests.
+	If set to 0, 202 Accepted will be returned.
+	If set to 1, 200 OK will be returned instead, in conformance to RFC6665
+	which prohibits 202 responses.
+	</para>
+	<para>
+		<emphasis>
+			Default value is 0.
+		</emphasis>
+	</para>
+	<example>
+		<title>Set <varname>subs_respond_200</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("presence", "subs_respond_200", 1)
 ...
 </programlisting>
 	</example>

--- a/src/modules/presence/presence.c
+++ b/src/modules/presence/presence.c
@@ -166,6 +166,7 @@ int pres_retrieve_order = 0;
 str pres_retrieve_order_by = str_init("priority");
 int pres_enable_dmq = 0;
 int pres_delete_same_subs = 0;
+int pres_subs_respond_200 = 0;
 
 int pres_db_table_lock_type = 1;
 db_locking_t pres_db_table_lock = DB_LOCKING_WRITE;
@@ -243,6 +244,7 @@ static param_export_t params[]={
 	{ "pres_subs_mode",         PARAM_INT, &_pres_subs_mode},
 	{ "delete_same_subs",       PARAM_INT, &pres_delete_same_subs},
 	{ "timer_mode",             PARAM_INT, &pres_timer_mode},
+	{ "subs_respond_200",       PARAM_INT, &pres_subs_respond_200},
 
 	{0,0,0}
 };

--- a/src/modules/presence/presence.h
+++ b/src/modules/presence/presence.h
@@ -99,6 +99,7 @@ extern str pres_xavp_cfg;
 extern int pres_retrieve_order;
 extern str pres_retrieve_order_by;
 extern int pres_enable_dmq;
+extern int pres_subs_respond_200;
 
 extern int phtable_size;
 extern phtable_t *pres_htable;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

RFC 6665 [says](https://datatracker.ietf.org/doc/html/rfc6665#section-8.3.1):

> Implementations conformant with the current specification MUST treat an incoming 202 response as identical to a 200 response and MUST NOT generate 202 response codes to SUBSCRIBE or NOTIFY requests.

I'm not sure if Kamailio is supposed to conform to the older RFC, so this change might not be _acceptable_.