### PR TITLE
dialog: add local_only paramter to RPC dlg.stats_active

### DIFF
--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -2858,16 +2858,21 @@ static void rpc_dlg_stats_active(rpc_t *rpc, void *c)
 {
 	dlg_cell_t *dlg;
 	unsigned int i;
+	int dlg_own = 0;
 	int dlg_starting = 0;
 	int dlg_connecting = 0;
 	int dlg_answering = 0;
 	int dlg_ongoing = 0;
 	void *h;
 
+	if(rpc->scan(c, "*d", &dlg_own) < 1)
+		dlg_own = 0;
 	for( i=0 ; i<d_table->size ; i++ ) {
 		dlg_lock( d_table, &(d_table->entries[i]) );
 
 		for( dlg=d_table->entries[i].first ; dlg ; dlg=dlg->next ) {
+			if(dlg_own != 0 && dlg->bind_addr[0] == NULL)
+				continue;
 			switch(dlg->state) {
 				case DLG_STATE_UNCONFIRMED:
 					dlg_starting++;

--- a/src/modules/dialog/doc/dialog_admin.xml
+++ b/src/modules/dialog/doc/dialog_admin.xml
@@ -2801,7 +2801,13 @@ dlg_reset_property("timeout-noreset");
 			(not relying on core stats framework).
 		</para>
 		<para>Name: <emphasis>dlg.stats_active</emphasis></para>
-		<para>Parameters: none.</para>
+		<para>Parameters:</para>
+		<itemizedlist>
+			<listitem><para>
+				<emphasis>local_only</emphasis> (optional) - if not 0 then filter out
+				non local dialogues. No bind_addr info in memory.
+			</para></listitem>
+		</itemizedlist>
 		<para>Returned fields</para>
 		<itemizedlist>
 			<listitem><para>


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2920

#### Description
allows to filter out non local dialogs from stats using a new argument

fix #2920
