### PR TITLE
tls: fix wrong macro used to detect OpenSSL 1.1.0+

### DIFF
--- a/src/modules/tls/tls_domain.c
+++ b/src/modules/tls/tls_domain.c
@@ -62,7 +62,7 @@ extern EVP_PKEY * tls_engine_private_key(const char* key_id);
  * prime256v1 by default.  This is Apache mod_ssl's initialization
  * policy, so we should be safe. OpenSSL 1.1 has it enabled by default.
  */
-#if !defined(OPENSSL_NO_ECDH) && !defined(OPENSSL_VERSION_1_1)
+#if !defined(OPENSSL_NO_ECDH) && OPENSSL_VERSION_NUMBER < 0x10100000L
 static void setup_ecdh(SSL_CTX *ctx)
 {
 #if !defined(SSL_CTX_set_ecdh_auto)
@@ -701,7 +701,7 @@ static int set_cipher_list(tls_domain_t* d)
 					tls_domain_str(d), cipher_list);
 			return -1;
 		}
-#if !defined(OPENSSL_NO_ECDH) && !defined(OPENSSL_VERSION_1_1)
+#if !defined(OPENSSL_NO_ECDH) && OPENSSL_VERSION_NUMBER < 0x10100000L
                 setup_ecdh(d->ctx[i]);
 #endif
 #ifndef OPENSSL_NO_DH


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
In commit 27904530d1f8efd26e2b96fa5f18a3aad887919b we attempt to detect OpenSSL 1.1.0+ to fix initialization of EC.
The wrong macro `OPENSSL_VERSION_1_1` was used; this is not actually defined in the OpenSSL headers.

Use the correct macro `OPENSSL_VERSION_NUMBER`.