### PR TITLE
tls: update DH initialization for OpenSSL 1.1.x

### DIFF
--- a/src/modules/tls/tls_domain.c
+++ b/src/modules/tls/tls_domain.c
@@ -89,6 +89,10 @@ static void setup_ecdh(SSL_CTX *ctx)
 
 #ifndef OPENSSL_NO_DH
 
+/*
+ * not needed for OpenSSL 1.1.0+ and LibreSSL
+ */
+#if !defined(SSL_CTX_set_dh_auto)
 static unsigned char dh3072_p[] = {
    0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xC9,0x0F,0xDA,0xA2,
    0x21,0x68,0xC2,0x34,0xC4,0xC6,0x62,0x8B,0x80,0xDC,0x1C,0xD1,
@@ -126,9 +130,15 @@ static unsigned char dh3072_p[] = {
 };
 
 static unsigned char dh3072_g[] = { 0x02 };
+#endif
 
 static void setup_dh(SSL_CTX *ctx)
 {
+/*
+ * not needed for OpenSSL 1.1.0+ and LibreSSL
+ * DH_new() is deprecated in OpenSSL 3
+ */
+#if !defined(SSL_CTX_set_dh_auto)
 	DH *dh;
 	BIGNUM *p;
 	BIGNUM *g;
@@ -146,19 +156,17 @@ static void setup_dh(SSL_CTX *ctx)
 		return;
 	}
 
-#if (OPENSSL_VERSION_NUMBER >= 0x1010000fL) && !defined(LIBRESSL_VERSION_NUMBER)
-	/* libssl >= v1.1.0 */
-	DH_set0_pqg(dh, p, NULL, g);
-#else
 	dh->p = p;
 	dh->g = g;
-#endif
 
 
    SSL_CTX_set_options(ctx, SSL_OP_SINGLE_DH_USE);
    SSL_CTX_set_tmp_dh(ctx, dh);
 
    DH_free(dh);
+#else
+   SSL_CTX_set_dh_auto(ctx, 1);
+#endif
 }
 #endif
 


### PR DESCRIPTION
For OpenSSL 3.x, this will fix a deprecation warning.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Update DH initialization with appropriate API for OpenSSL >= 1.1.1. This also fixes a deprecation warning with OpenSSL 3.x.