### PR TITLE
Fix TM Module Doc unmatched_cancel param from string to integer

### DIFF
--- a/src/modules/tm/doc/params.xml
+++ b/src/modules/tm/doc/params.xml
@@ -876,7 +876,7 @@ modparam("tm", "fr_inv_timer_avp", "my_fr_inv_timer")
 	</section>
 
 	<section id="tm.p.unmatched_cancel">
-		<title><varname>unmatched_cancel</varname> (string)</title>
+		<title><varname>unmatched_cancel</varname> (integer)</title>
 		<para>
 			This parameter selects between forwarding CANCELs
 			that do not match any transaction statefully (0,
@@ -899,7 +899,7 @@ modparam("tm", "fr_inv_timer_avp", "my_fr_inv_timer")
 			<title>Set <varname>unmatched_cancel</varname> parameter</title>
 			<programlisting>
 ...
-modparam("tm", "unmatched_cancel", "2")
+modparam("tm", "unmatched_cancel", 2)
 ...
 			</programlisting>
 		</example>


### PR DESCRIPTION
Currently, the documentation states the unmatched_cancel parameter accepts a string input, but it only accepts an integer input. Fixing documentation to match the code's expectations.

https://github.com/kamailio/kamailio/blob/b6cebaa76eaa4b98bbba6e271c50dbfa14a8f9f7/src/modules/tm/config.c#L159
