### PR TITLE
rtpengine: Fix set selection

### DIFF
--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -1810,6 +1810,7 @@ mod_init(void)
 
 	/* select the default set */
 	default_rtpp_set = select_rtpp_set(setid_default);
+	active_rtpp_set = default_rtpp_set;
 	if (!default_rtpp_set) {
 		LM_NOTICE("Default rtpp set %u NOT found\n", setid_default);
 	} else {
@@ -2689,9 +2690,6 @@ static bencode_item_t *rtpp_function_call(bencode_buffer_t *bencbuf, struct sip_
 		LM_ERR("out of memory - bencode failed\n");
 		goto error;
 	}
-
-	if(msg->id != current_msg_id)
-		active_rtpp_set = default_rtpp_set;
 
 select_node:
 	do {


### PR DESCRIPTION
When set_rtpengine_set() config function is called.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
After calling set_rtpengine_set(), the new set is not set for further rtpengine delete(). This is because active_rtpp_set is set to default_rtpp_set when msg id != current_msg_id (which is set once by set_rtpengine_set())

I've removed the msg id != current_msg_id condition, and initialized active_rtpp_set in mod_init().

Basically tested locally with 2 sets with 1 rtpengine each.