### PR TITLE
core: cfg.lex support for undefned env vars

### DIFF
--- a/src/core/ppcfg.h
+++ b/src/core/ppcfg.h
@@ -25,8 +25,10 @@
 
 #include "str.h"
 
-#define KSR_PPDEF_NORMAL (0)     /* define normal value */
-#define KSR_PPDEF_QUOTED (1<<0)  /* define quoted value */
+#define KSR_PPDEF_NORMAL (0)       /* define normal value */
+#define KSR_PPDEF_QUOTED (1<<0)    /* define quoted value */
+#define KSR_PPDEF_NONULL (0)       /* disallow undef values for envdefn* */
+#define KSR_PPDEF_NULLABLE (1<<0)  /* allow undef values for envdefn* */ 
 
 typedef struct ksr_ppdefine {
 	str name;
@@ -47,7 +49,7 @@ int  pp_define(int len, const char *text);
 int  pp_define_set(int len, char *text, int mode);
 int  pp_define_set_type(int type);
 str *pp_define_get(int len, const char * text);
-int  pp_define_env(const char * text, int len, int qmode);
+int  pp_define_env(const char * text, int len, int qmode, int nullable);
 
 void pp_ifdef_level_update(int val);
 int pp_ifdef_level_check(void);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->


#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] New feature (non-breaking change which adds new functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #2967 

#### Description
Add new preprocessor keywords `trydefenv` and `trydefenvs` that work like `defenv` and `defenvs` respectively, with the difference that if the environmental variable is not defined, then the value in Kamailio will not be defined.

For example:
```
#!KAMAILIO

loadmodule "xlog"
loadmodule "pv"

#!trydefenv EXTRALOG

request_route {
    #!ifdef EXTRALOG
       xlog("L_I", "Some Extra Logging here\n");
    #!endif
    forward ();
}
```
If the environmental variable `$EXTRALOG` is defined, the log line will be written.  If the environmental variable is not set, then in Kamailio `EXTRALOG` will not be defined and the `#!ifdef` section will not be loaded.



