### PR TITLE
ldap: rename private function ldap_connect

### DIFF
--- a/src/modules/ldap/ldap_connect.c
+++ b/src/modules/ldap/ldap_connect.c
@@ -185,7 +185,7 @@ int ldap_connect_ex(char *_ld_name, int llevel)
 	return 0;
 }
 
-int ldap_connect(char *_ld_name)
+int oldap_connect(char *_ld_name)
 {
 	return ldap_connect_ex(_ld_name, L_DBG);
 }

--- a/src/modules/ldap/ldap_connect.h
+++ b/src/modules/ldap/ldap_connect.h
@@ -31,7 +31,7 @@
 #include "../../core/str.h"
 #include "../../core/dprint.h"
 
-extern int ldap_connect(char *_ld_name);
+extern int oldap_connect(char *_ld_name);
 extern int ldap_disconnect(char *_ld_name);
 extern int ldap_reconnect(char *_ld_name);
 extern int ldap_get_vendor_version(char **_version);

--- a/src/modules/ldap/ldap_mod.c
+++ b/src/modules/ldap/ldap_mod.c
@@ -167,7 +167,7 @@ static int child_init(int rank)
 			return -1;
 		}
 
-		if(ldap_connect(ld_name) != 0) {
+		if(oldap_connect(ld_name) != 0) {
 			LM_ERR("[%s]: failed to connect to LDAP host(s)\n", ld_name);
 			ldap_disconnect(ld_name);
 			return -1;


### PR DESCRIPTION
```
When compiling against openldap 2.6.0 kamailio's private ldap_connect() clashes
with openldap's own. curl dealt with a similar issue earlier (see [1]).

Simply rename the function to avoid the issue.

In file included from ldap_api_fn.c:37:
ldap_connect.h:34:12: error: conflicting types for 'ldap_connect'; have 'int(char *)'
   34 | extern int ldap_connect(char *_ld_name);
      |            ^~~~~~~~~~~~
In file included from ldap_api_fn.c:33:
/home/sk/tmp/sdk/openwrt-sdk-ath79-generic_gcc-11.2.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/ldap.h:1555:1: note: previous declaration of 'ldap_connect' with type 'int(LDAP *)' {aka 'int(struct ldap *)'}
 1555 | ldap_connect( LDAP *ld );
      | ^~~~~~~~~~~~
make[5]: *** [../../Makefile.rules:100: ldap_api_fn.o] Error 1
make[4]: *** [Makefile:511: modules] Error 1

```
[1] https://github.com/curl/curl/commit/8bdde6b14ce3b5fd71c772a578fcbd4b6fa6df19

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Hi all,

Small compile fix. I saw kamailio is failing to build on OpenWrt build bots since a recent openldap bump from 2.4.58 to 2.6.0.

I linked a curl commit in the commit message, they also renamed some of their functions, although they did rename all their ldap_* functions to oldap_. I didn't dare do that in kamailio :) Renaming a single function was enough to make it compile again.

Maybe you want to do something different to address this issue, I don't know.

I didn't runtest this.

Kind regards,
Seb
