### PR TITLE
tcpclose event_routes issue

### DIFF
--- a/src/core/tcp_conn.h
+++ b/src/core/tcp_conn.h
@@ -193,12 +193,22 @@ typedef struct tcp_conn_alias {
 #endif
 
 
+enum tcp_closed_reason {
+	TCP_CLOSED_EOF = 0,
+	TCP_CLOSED_TIMEOUT,
+	TCP_CLOSED_RESET,
+
+	_TCP_CLOSED_REASON_MAX /* /!\ keep this one always at the end */
+};
+
+
 typedef struct tcp_connection {
 	int s; /*socket, used by "tcp main" */
 	int fd; /* used only by "children", don't modify it! private data! */
 	gen_lock_t write_lock;
 	int id; /* id (unique!) used to retrieve a specific connection when
 			 * reply-ing */
+	enum tcp_closed_reason event; /* connection close reason */
 	int reader_pid; /* pid of the active reader process */
 	struct receive_info rcv; /* src & dst ip, ports, proto a.s.o*/
 	ksr_coninfo_t cinfo; /* connection info (e.g., for haproxy ) */
@@ -342,14 +352,6 @@ typedef struct tcp_event_info {
 	struct receive_info *rcv;
 	struct tcp_connection *con;
 } tcp_event_info_t;
-
-enum tcp_closed_reason {
-	TCP_CLOSED_EOF = 0,
-	TCP_CLOSED_TIMEOUT,
-	TCP_CLOSED_RESET,
-
-	_TCP_CLOSED_REASON_MAX /* /!\ keep this one always at the end */
-};
 
 typedef struct tcp_closed_event_info {
 	enum tcp_closed_reason reason;

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -3649,7 +3649,7 @@ inline static int handle_tcp_child(struct tcp_child* tcp_c, int fd_i)
 				/* if refcnt was 1 => it was used only in the
 				   tcp reader => it's not hashed or watched for IO
 				   anymore => no need to io_watch_del() */
-				tcp_emit_closed_event(c, TCP_CLOSED_EOF);
+				tcp_emit_closed_event(tcpconn, TCP_CLOSED_EOF);
 				tcpconn_destroy(tcpconn);
 				break;
 			}
@@ -3661,7 +3661,7 @@ inline static int handle_tcp_child(struct tcp_child* tcp_c, int fd_i)
 						tcpconn->flags &= ~F_CONN_WRITE_W;
 					}
 #endif /* TCP_ASYNC */
-					tcp_emit_closed_event(c, TCP_CLOSED_EOF);
+					tcp_emit_closed_event(tcpconn, TCP_CLOSED_EOF);
 					tcpconn_put_destroy(tcpconn);
 				}
 #ifdef TCP_ASYNC
@@ -3713,7 +3713,7 @@ inline static int handle_tcp_child(struct tcp_child* tcp_c, int fd_i)
 							io_watch_del(&io_h, tcpconn->s, -1, IO_FD_CLOSING);
 							tcpconn->flags&=~F_CONN_WRITE_W;
 						}
-						tcp_emit_closed_event(c, TCP_CLOSED_EOF);
+						tcp_emit_closed_event(tcpconn, TCP_CLOSED_EOF);
 						tcpconn_put_destroy(tcpconn);
 					} else if (unlikely(tcpconn->flags & F_CONN_WRITE_W)){
 						BUG("unhashed connection watched for write\n");
@@ -3750,7 +3750,7 @@ inline static int handle_tcp_child(struct tcp_child* tcp_c, int fd_i)
 						tcpconn->flags&=~F_CONN_WRITE_W;
 					}
 #endif /* TCP_ASYNC */
-					tcp_emit_closed_event(c, TCP_CLOSED_EOF);
+					tcp_emit_closed_event(tcpconn, TCP_CLOSED_EOF);
 					tcpconn_put_destroy(tcpconn);
 				}
 #ifdef TCP_ASYNC
@@ -3782,7 +3782,7 @@ inline static int handle_tcp_child(struct tcp_child* tcp_c, int fd_i)
 #endif /* TCP_ASYNC */
 				if (tcpconn_try_unhash(tcpconn))
 					tcpconn_put(tcpconn);
-				tcp_emit_closed_event(c, TCP_CLOSED_EOF);
+				tcp_emit_closed_event(tcpconn, TCP_CLOSED_EOF);
 				tcpconn_put_destroy(tcpconn); /* deref & delete if refcnt==0 */
 				break;
 		default:


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
We faced an issue that tcp:close (timeout and reset) event routes don't execute in rare cases. Debugging and testing show that in the case when a connection is marked as BAD or write timeout etc our event routes don't execute. 
I found that executing event routes is in the read function only. So in case when a connection is destroyed triggered by other reasons we don't have a notification about this. 
I propose to do this in main file every time when we destroy connections. But in this case, we don't have I reason to destroy (timeout reset or EOF).
In our lab with these changes issue is gone. But sure this is just a concept. 
