### PR TITLE
core: Add virtual flag to listen config to ignore inactive ip addresses

### DIFF
--- a/src/core/cfg.lex
+++ b/src/core/cfg.lex
@@ -305,6 +305,7 @@ XAVPVIAPARAMS	xavp_via_params
 XAVPVIAFIELDS	xavp_via_fields
 LISTEN		listen
 ADVERTISE	advertise|ADVERTISE
+VIRTUAL		virtual
 STRNAME		name|NAME
 ALIAS		alias
 SR_AUTO_ALIASES	auto_aliases
@@ -741,6 +742,7 @@ IMPORTFILE      "import_file"
 <INITIAL>{XAVPVIAFIELDS}	{ yylval.strval=yytext; return XAVPVIAFIELDS; }
 <INITIAL>{LISTEN}	{ count(); yylval.strval=yytext; return LISTEN; }
 <INITIAL>{ADVERTISE}	{ count(); yylval.strval=yytext; return ADVERTISE; }
+<INITIAL>{VIRTUAL}	{ count(); yylval.strval=yytext; return VIRTUAL; }
 <INITIAL>{STRNAME}	{ count(); yylval.strval=yytext; return STRNAME; }
 <INITIAL>{ALIAS}	{ count(); yylval.strval=yytext; return ALIAS; }
 <INITIAL>{SR_AUTO_ALIASES}	{ count(); yylval.strval=yytext;

--- a/src/core/cfg.y
+++ b/src/core/cfg.y
@@ -328,6 +328,7 @@ extern char *default_routename;
 %token XAVPVIAFIELDS
 %token LISTEN
 %token ADVERTISE
+%token VIRTUAL
 %token STRNAME
 %token ALIAS
 %token SR_AUTO_ALIASES
@@ -1503,6 +1504,19 @@ assign_stm:
 		}
 		free_socket_id_lst($3);
 	}
+        | LISTEN EQUAL id_lst VIRTUAL {
+                for(lst_tmp=$3; lst_tmp; lst_tmp=lst_tmp->next) {
+			lst_tmp->flags |= SI_IS_VIRTUAL;
+                        if (add_listen_iface(   lst_tmp->addr_lst->name,
+                                                                        lst_tmp->addr_lst->next,
+                                                                        lst_tmp->port, lst_tmp->proto,
+                                                                        lst_tmp->flags)!=0) {
+                                LM_CRIT("cfg. parser: failed to add listen address\n");
+                                break;
+                        }
+                }
+                free_socket_id_lst($3);
+        }
 	| LISTEN EQUAL id_lst STRNAME STRING {
 		for(lst_tmp=$3; lst_tmp; lst_tmp=lst_tmp->next) {
 			if (add_listen_iface_name(lst_tmp->addr_lst->name,
@@ -1515,6 +1529,19 @@ assign_stm:
 		}
 		free_socket_id_lst($3);
 	}
+        | LISTEN EQUAL id_lst STRNAME STRING VIRTUAL {
+                for(lst_tmp=$3; lst_tmp; lst_tmp=lst_tmp->next) {
+                        lst_tmp->flags |= SI_IS_VIRTUAL;
+                        if (add_listen_iface_name(lst_tmp->addr_lst->name,
+                                                                        lst_tmp->addr_lst->next,
+                                                                        lst_tmp->port, lst_tmp->proto, $5,
+                                                                        lst_tmp->flags)!=0) {
+                                LM_CRIT("cfg. parser: failed to add listen address\n");
+                                break;
+                        }
+                }
+                free_socket_id_lst($3);
+        }
 	| LISTEN EQUAL id_lst ADVERTISE listen_id COLON NUMBER {
 		for(lst_tmp=$3; lst_tmp; lst_tmp=lst_tmp->next) {
 			if (add_listen_advertise_iface(	lst_tmp->addr_lst->name,
@@ -1528,6 +1555,20 @@ assign_stm:
 		}
 		free_socket_id_lst($3);
 	}
+        | LISTEN EQUAL id_lst ADVERTISE listen_id COLON NUMBER VIRTUAL {
+                for(lst_tmp=$3; lst_tmp; lst_tmp=lst_tmp->next) {
+			lst_tmp->flags |= SI_IS_VIRTUAL;
+                        if (add_listen_advertise_iface( lst_tmp->addr_lst->name,
+                                                                        lst_tmp->addr_lst->next,
+                                                                        lst_tmp->port, lst_tmp->proto,
+                                                                        $5, $7,
+                                                                        lst_tmp->flags)!=0) {
+                                LM_CRIT("cfg. parser: failed to add listen address\n");
+                                break;
+                        }
+                }
+                free_socket_id_lst($3);
+        }
 	| LISTEN EQUAL id_lst ADVERTISE listen_id COLON NUMBER STRNAME STRING {
 		for(lst_tmp=$3; lst_tmp; lst_tmp=lst_tmp->next) {
 			if (add_listen_advertise_iface_name(lst_tmp->addr_lst->name,
@@ -1541,6 +1582,20 @@ assign_stm:
 		}
 		free_socket_id_lst($3);
 	}
+        | LISTEN EQUAL id_lst ADVERTISE listen_id COLON NUMBER STRNAME STRING VIRTUAL {
+                for(lst_tmp=$3; lst_tmp; lst_tmp=lst_tmp->next) {
+			lst_tmp->flags |= SI_IS_VIRTUAL;
+                        if (add_listen_advertise_iface_name(lst_tmp->addr_lst->name,
+                                                                        lst_tmp->addr_lst->next,
+                                                                        lst_tmp->port, lst_tmp->proto,
+                                                                        $5, $7, $9,
+                                                                        lst_tmp->flags)!=0) {
+                                LM_CRIT("cfg. parser: failed to add listen address\n");
+                                break;
+                        }
+                }
+                free_socket_id_lst($3);
+        }
 	| LISTEN EQUAL id_lst ADVERTISE listen_id {
 		for(lst_tmp=$3; lst_tmp; lst_tmp=lst_tmp->next) {
 			if (add_listen_advertise_iface(	lst_tmp->addr_lst->name,
@@ -1554,6 +1609,20 @@ assign_stm:
 		}
 		free_socket_id_lst($3);
 	}
+        | LISTEN EQUAL id_lst ADVERTISE listen_id VIRTUAL {
+                for(lst_tmp=$3; lst_tmp; lst_tmp=lst_tmp->next) {
+			lst_tmp->flags |= SI_IS_VIRTUAL;
+                        if (add_listen_advertise_iface( lst_tmp->addr_lst->name,
+                                                                        lst_tmp->addr_lst->next,
+                                                                        lst_tmp->port, lst_tmp->proto,
+                                                                        $5, 0,
+                                                                        lst_tmp->flags)!=0) {
+                                LM_CRIT("cfg. parser: failed to add listen address\n");
+                                break;
+                        }
+                }
+                free_socket_id_lst($3);
+        }
 	| LISTEN EQUAL id_lst ADVERTISE listen_id STRNAME STRING {
 		for(lst_tmp=$3; lst_tmp; lst_tmp=lst_tmp->next) {
 			if (add_listen_advertise_iface_name(lst_tmp->addr_lst->name,
@@ -1567,6 +1636,20 @@ assign_stm:
 		}
 		free_socket_id_lst($3);
 	}
+        | LISTEN EQUAL id_lst ADVERTISE listen_id STRNAME STRING VIRTUAL {
+                for(lst_tmp=$3; lst_tmp; lst_tmp=lst_tmp->next) {
+			lst_tmp->flags |= SI_IS_VIRTUAL;
+                        if (add_listen_advertise_iface_name(lst_tmp->addr_lst->name,
+                                                                        lst_tmp->addr_lst->next,
+                                                                        lst_tmp->port, lst_tmp->proto,
+                                                                        $5, 0, $7,
+                                                                        lst_tmp->flags)!=0) {
+                                LM_CRIT("cfg. parser: failed to add listen address\n");
+                                break;
+                        }
+                }
+                free_socket_id_lst($3);
+        }
 	| LISTEN EQUAL  error { yyerror("ip address, interface name or"
 									" hostname expected"); }
 	| ALIAS EQUAL  id_lst {

--- a/src/core/core_cmd.c
+++ b/src/core/core_cmd.c
@@ -955,10 +955,11 @@ static void core_sockets_list(rpc_t* rpc, void* c)
 				for (ai=si->addr_info_lst; ai; ai=ai->next)
 					rpc->struct_add(ha, "ss",
 						"address", ai->address_str.s);
-				rpc->struct_add(ha, "sss",
+				rpc->struct_add(ha, "ssss",
 						"port", si->port_no_str.s,
 						"mcast", si->flags & SI_IS_MCAST ? "yes" : "no",
-						"mhomed", si->flags & SI_IS_MHOMED ? "yes" : "no");
+						"mhomed", si->flags & SI_IS_MHOMED ? "yes" : "no",
+						"virtual", si->flags & SI_IS_VIRTUAL ? "yes" : "no");
 			} else {
 				printf("             %s: %s",
 						get_proto_name(proto),
@@ -969,10 +970,11 @@ static void core_sockets_list(rpc_t* rpc, void* c)
 				if (!(si->flags & SI_IS_IP))
 					rpc->struct_add(ha, "s",
 						"ipaddress", si->address_str.s);
-				rpc->struct_add(ha, "sss",
+				rpc->struct_add(ha, "ssss",
 						"port", si->port_no_str.s,
 						"mcast", si->flags & SI_IS_MCAST ? "yes" : "no",
-						"mhomed", si->flags & SI_IS_MHOMED ? "yes" : "no");
+						"mhomed", si->flags & SI_IS_MHOMED ? "yes" : "no",
+						"virtual", si->flags & SI_IS_VIRTUAL ? "yes" : "no");
 			}
 		}
 	} while((proto=next_proto(proto)));

--- a/src/core/ip_addr.h
+++ b/src/core/ip_addr.h
@@ -84,6 +84,7 @@ typedef enum si_flags {
 	SI_IS_MCAST     = (1<<2),
 	SI_IS_ANY       = (1<<3),
 	SI_IS_MHOMED    = (1<<4),
+	SI_IS_VIRTUAL	= (1<<5),
 } si_flags_t;
 
 typedef struct addr_info {

--- a/src/modules/corex/corex_rpc.c
+++ b/src/modules/corex/corex_rpc.c
@@ -95,10 +95,11 @@ static void corex_rpc_list_sockets(rpc_t* rpc, void* ctx)
 				}
 			}
 
-			if(rpc->struct_add(th, "sssss",
+			if(rpc->struct_add(th, "ssssss",
 					"PORT", si->port_no_str.s,
 					"MCAST", si->flags & SI_IS_MCAST ? "yes" : "no",
-					"MHOMED", si->flags & SI_IS_MHOMED? "yes" : "no",
+					"MHOMED", si->flags & SI_IS_MHOMED ? "yes" : "no",
+					"VIRTUAL", si->flags & SI_IS_VIRTUAL ? "yes" : "no",
 					"SOCKNAME", si->sockname.s? si->sockname.s : "-",
 					"ADVERTISE", si->useinfo.name.s?si->useinfo.name.s:"-")<0)
 			{

--- a/src/modules/ims_ipsec_pcscf/ims_ipsec_pcscf_mod.c
+++ b/src/modules/ims_ipsec_pcscf/ims_ipsec_pcscf_mod.c
@@ -140,9 +140,9 @@ static void ipsec_print_all_socket_lists()
 				}
 
 				if(si->port_no_str.s){
-					sprintf(buf + cnt, "):%s%s%s", si->port_no_str.s, si->flags & SI_IS_MCAST ? " mcast" : "", si->flags & SI_IS_MHOMED? " mhomed" : "");
+					sprintf(buf + cnt, "):%s%s%s%s", si->port_no_str.s, si->flags & SI_IS_MCAST ? " mcast" : "", si->flags & SI_IS_MHOMED ? " mhomed" : "", si->flags & SI_IS_VIRTUAL ? " virtual" : "");
 				}else{
-					sprintf(buf + cnt, "):%u%s%s", si->port_no, si->flags & SI_IS_MCAST ? " mcast" : "", si->flags & SI_IS_MHOMED? " mhomed" : "");
+					sprintf(buf + cnt, "):%u%s%s%s", si->port_no, si->flags & SI_IS_MCAST ? " mcast" : "", si->flags & SI_IS_MHOMED ? " mhomed" : "", si->flags & SI_IS_VIRTUAL ? " virtual" : "");
 				}
 				cnt = strlen(buf);
 			}else{
@@ -157,9 +157,9 @@ static void ipsec_print_all_socket_lists()
 				}
 
 				if(si->port_no_str.s){
-					sprintf(buf + cnt, ":%s%s%s", si->port_no_str.s, si->flags & SI_IS_MCAST ? " mcast" : "", si->flags & SI_IS_MHOMED? " mhomed" : "");
+					sprintf(buf + cnt, ":%s%s%s%s", si->port_no_str.s, si->flags & SI_IS_MCAST ? " mcast" : "", si->flags & SI_IS_MHOMED ? " mhomed" : "", si->flags & SI_IS_VIRTUAL ? " virtual" : "");
 				}else{
-					sprintf(buf + cnt, ":%u%s%s", si->port_no, si->flags & SI_IS_MCAST ? " mcast" : "", si->flags & SI_IS_MHOMED? " mhomed" : "");
+					sprintf(buf + cnt, ":%u%s%s%s", si->port_no, si->flags & SI_IS_MCAST ? " mcast" : "", si->flags & SI_IS_MHOMED ? " mhomed" : "", si->flags & SI_IS_VIRTUAL ? " virtual" : "");
 				}
 				cnt = strlen(buf);
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #2984

#### Description

A new option to "listen" has been added called "virtual". This sets a flag on the listening socket to modify the behaviour of grep_sock_info. When this flag is set, grep_sock_info will only consider the listening IP a match if the IP is found in the system's current list of local IP addresses. If the IP is not currently local, then the matching IP is ignored.

If the virtual flag is not set on the socket then existing behaviour used instead.

This feature is intended for scenarios where you have two Kamailio nodes in active/active setup, with virtual IPs, where you need to be able to listen on a virtual IP but it may not always be active locally. With this flag applied to a `listen=` socket, Kamailio will only consider traffic destined to this IP local, when the IP is actually active on the system, and other times the match is ignored.