### PR TITLE
Fix PHONENUM, RTP_MEDIA_SERVER and WEBSOCKET for build on FreeBSD

### DIFF
--- a/src/modules/phonenum/Makefile
+++ b/src/modules/phonenum/Makefile
@@ -5,13 +5,11 @@ include ../../Makefile.defs
 auto_gen=
 NAME=phonenum.so
 
-CXX=g++
-LD=g++
-LIB_DIR = /opt/local/lib
+CXX?=g++
+LD?=g++
 
-LIBS= -L${LIB_DIR} cphonenumber.o -lphonenumber -lgeocoding
-
-DEFS+= -I/opt/local/include
+LIBS+=-L$(LOCALBASE)/lib cphonenumber.o -lphonenumber -lgeocoding
+DEFS+=-I$(LOCALBASE)/include
 
 CXXFLAGS=$(CFLAGS:-Wno-deprecated option=)
 CXXFLAGS+=-Wno-write-strings -Wno-deprecated -Wno-unused-function -Wno-sign-compare -Wno-strict-aliasing

--- a/src/modules/rtp_media_server/Makefile
+++ b/src/modules/rtp_media_server/Makefile
@@ -2,11 +2,11 @@ include ../../Makefile.defs
 auto_gen=
 NAME=rtp_media_server.so
 
-DEFS+=-I$(LOCALBASE)/lib
+DEFS+=-I$(LOCALBASE)/include
 
 ORTPLIBS=-lortp
 BCUNITLIBS=-lbcunit
 MS2LIBS=-lmediastreamer
 
-LIBS=$(ORTPLIBS) $(BCUNITLIBS) $(MS2LIBS)
+LIBS+=-L$(LOCALBASE)/lib $(ORTPLIBS) $(BCUNITLIBS) $(MS2LIBS)
 include ../../Makefile.modules

--- a/src/modules/websocket/Makefile
+++ b/src/modules/websocket/Makefile
@@ -39,7 +39,8 @@ endif
 LIBS+= $(TLS_EXTRA_LIBS)
 
 ifeq ($(EMBEDDED_UTF8_DECODE),0)
-	LIBS+= -lunistring
+	DEFS += -I$(LOCALBASE)/include
+	LIBS += -lunistring
 else
 	DEFS += -DEMBEDDED_UTF8_DECODE
 endif


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
`websocket` and `phonenum` are not build on FreeBSD environment.
The proposed patch fixes it and makes modules are consistent with the rest of modules.