### PR TITLE
src/Makefile: Also stop compiling kamcmd from here

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -202,7 +202,7 @@ cmodules=$(foreach mods,$(modules_dirs), $($(mods)))
 
 
 # list of utils directories that should be compiled by make utils
-C_COMPILE_UTILS=	../utils/kamcmd
+C_COMPILE_UTILS= # kamcmd is now installed by ctl
 # list of binaries that should be installed alongside
 # (they should be created after make utils, see C_COMPILE_UTILS)
 C_INSTALL_BIN=	# kamcmd is now installed by ctl


### PR DESCRIPTION
Building ``kamcmd`` twice was not only a (marginal) waste of build time, but also created a race condition where the first linking sometimes failed due to reading the incomplete file from the ongoing second build of ``kamcmd.o``:

https://buildd.debian.org/status/fetch.php?pkg=kamailio&arch=s390x&ver=5.5.3-1&stamp=1638905109&raw=0

```
gcc -pthread -DKSR_PTHREAD_MUTEX_SHARED -Wall -Wdate-time -D_FORTIFY_SOURCE=2 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -DVERSION_NODATE    -DNAME='"kamcmd"' -DSRNAME='"kamailio"' -DVERSION='"1.5"' -D__OS_linux -DRUN_DIR='"/var/run/kamailio/"'  -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -DMOD_NAME="utils/kamcmd" -c kamcmd.c -o kamcmd.o
...
gcc -pthread -DKSR_PTHREAD_MUTEX_SHARED -Wall -Wdate-time -D_FORTIFY_SOURCE=2 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -DVERSION_NODATE    -DNAME='"kamcmd"' -DSRNAME='"kamailio"' -DVERSION='"1.5"' -D__OS_linux -DRUN_DIR='"/var/run/kamailio/"'  -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -DMOD_NAME="utils/kamcmd" -c kamcmd.c -o kamcmd.o
gcc -pthread -DKSR_PTHREAD_MUTEX_SHARED -Wall -Wdate-time -D_FORTIFY_SOURCE=2 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -DVERSION_NODATE    -DNAME='"kamcmd"' -DSRNAME='"kamailio"' -DVERSION='"1.5"' -D__OS_linux -DRUN_DIR='"/var/run/kamailio/"'  -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -DMOD_NAME="utils/kamcmd" -c parse_listen_id.c -o parse_listen_id.o
gcc -g -Wl,-O2 -Wl,-E  -Wl,-z,relro -Wl,-z,now -pthread -rdynamic "-ldl" -Wl,-Bsymbolic-functions kamcmd.o parse_listen_id.o  -lresolv -lreadline   -o kamcmd
/usr/bin/ld: /usr/lib/gcc/s390x-linux-gnu/11/../../../s390x-linux-gnu/Scrt1.o: in function `_start':
(.text+0x34): undefined reference to `main'
collect2: error: ld returned 1 exit status
make[4]: *** [../../src//Makefile.rules:191: kamcmd] Error 1
make[3]: *** [Makefile:536: utils] Error 1
make[3]: *** Waiting for unfinished jobs....
gcc -pthread -DKSR_PTHREAD_MUTEX_SHARED -Wall -Wdate-time -D_FORTIFY_SOURCE=2 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -DVERSION_NODATE    -DNAME='"kamcmd"' -DSRNAME='"kamailio"' -DVERSION='"1.5"' -D__OS_linux -DRUN_DIR='"/var/run/kamailio/"'  -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -DMOD_NAME="utils/kamcmd" -c parse_listen_id.c -o parse_listen_id.o
gcc -g -Wl,-O2 -Wl,-E  -Wl,-z,relro -Wl,-z,now -pthread -rdynamic "-ldl" -Wl,-Bsymbolic-functions kamcmd.o parse_listen_id.o  -lresolv -lreadline   -o kamcmd
```