### PR TITLE
Erlang: Fixes to get the module functional again

### DIFF
--- a/src/modules/erlang/pv_atom.c
+++ b/src/modules/erlang/pv_atom.c
@@ -51,6 +51,9 @@ int pv_atom_parse_name(pv_spec_t *sp, str *in)
 
 	name.s = p;
 
+	/*pvi.type now defaults to 4, breaking the erlang module's type management*/
+	sp->pvp.pvi.type = 0;
+
 	while (is_in_str(p, in)) {
 		if (*p == '[' || *p== '=')
 			break;

--- a/src/modules/erlang/pv_pid.c
+++ b/src/modules/erlang/pv_pid.c
@@ -54,6 +54,9 @@ int pv_pid_parse_name(pv_spec_t *sp, str *in)
 
 	name.s = p;
 
+	/*pvi.type now defaults to 4, breaking the erlang module's type management*/
+	sp->pvp.pvi.type = 0;
+
 	while (is_in_str(p, in)) {
 		if (*p == '[' || *p== '=')
 			break;

--- a/src/modules/erlang/pv_ref.c
+++ b/src/modules/erlang/pv_ref.c
@@ -54,6 +54,9 @@ int pv_ref_parse_name(pv_spec_t *sp, str *in)
 
 	name.s = p;
 
+	/*pvi.type now defaults to 4, breaking the erlang module's type management*/
+	sp->pvp.pvi.type = 0;
+
 	while (is_in_str(p, in)) {
 		if (*p == '[' || *p== '=')
 			break;

--- a/src/modules/erlang/pv_xbuff.c
+++ b/src/modules/erlang/pv_xbuff.c
@@ -86,10 +86,14 @@ sr_xavp_t *xbuff_new(str *name)
 
 	if(!xbuffs_root)
 	{
-		xbuff = xavp_add_xavp_value(&xbuff_list,name,&xbuff_val,xavp_get_crt_list());
-	} else {
-		xbuff = xavp_get_child(&xbuff_list, name);
+		xbuffs_root = xavp_add_xavp_value(&xbuff_list,name,&xbuff_val,xavp_get_crt_list());
+		if (!xbuffs_root){
+				LM_ERR("cannot create xbuffs_root \n");
+				return NULL;
+			}
 	}
+
+	xbuff = xavp_get_child(&xbuff_list, name);
 
 	if (!xbuff) {
 

--- a/src/modules/erlang/pv_xbuff.c
+++ b/src/modules/erlang/pv_xbuff.c
@@ -198,6 +198,9 @@ int pv_xbuff_parse_name(pv_spec_t *sp, str *in)
 
 	name.s = p;
 
+	/*pvi.type now defaults to 4, breaking the erlang module's type management*/
+	sp->pvp.pvi.type = 0;
+
 	while (is_in_str(p, in)) {
 		if (*p == '[' || *p== '=')
 			break;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2069 

#### Description
The Erlang module is not working at all with newer Kamailio versions.   One of the issues was already found in #2069 but no code was submitted.   The second one I believe is related to https://github.com/kamailio/kamailio/commit/7bb2669528a819ec29a8193eebc9c641edd69993 in that the erlang module assumes that pvi.type is zero and uses that field to type the custom fields it manages and this commit starts populating pvi.type with a 4. 

I don't have a solid grasp on pvapi.c so if the experts have a better way to fix this up I am all ears.  These two commits do get the module working properly and I am able to use both the custom erlang PV terms and the RPC feature from my proxy now.
