### PR TITLE
ims: fix a crash with contact parsing

### DIFF
--- a/src/lib/ims/ims_getters.c
+++ b/src/lib/ims/ims_getters.c
@@ -99,7 +99,6 @@ contact_body_t *cscf_parse_contacts(struct sip_msg *msg)
 							ptr->body.s);
 				}
 			}
-			ptr = ptr->next;
 		}
 
 		return msg->contact->parsed;

--- a/src/lib/ims/ims_getters.c
+++ b/src/lib/ims/ims_getters.c
@@ -89,23 +89,26 @@ contact_body_t *cscf_parse_contacts(struct sip_msg *msg)
 		LM_ERR("Error parsing headers \n");
 		return 0;
 	}
+
 	if(msg->contact) {
-		ptr = msg->contact;
-		while(ptr) {
+		for (ptr = msg->contact; ptr; ptr = ptr->next) {
 			if(ptr->type == HDR_CONTACT_T) {
-				if(ptr->parsed == 0) {
-					if(parse_contact(ptr) < 0) {
-						LM_DBG("error parsing contacts [%.*s]\n", ptr->body.len,
-								ptr->body.s);
-					}
+				ptr->parsed = NULL;
+				if(parse_contact(ptr) < 0) {
+					LM_ERR("error parsing contacts [%.*s]\n", ptr->body.len,
+							ptr->body.s);
 				}
 			}
 			ptr = ptr->next;
 		}
+
+		return msg->contact->parsed;
 	}
-	if(!msg->contact)
+	else
+	{
+		LM_DBG("No contact header!\n");
 		return 0;
-	return msg->contact->parsed;
+	}
 }
 
 /**


### PR DESCRIPTION
When running as a P-CSCF a crash would occur with certain in-dialog
replies. The `msg->contact->parsed` pointer is unreliably reused and
would point to garbage.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
When running as a P-CSCF a crash would occur with certain in-dialog replies. The `msg->contact->parsed` pointer is unreliably reused and would point to garbage.