### PR TITLE
core: improve SDP parser to support ICE media stream options / improve existing data structures cloning in the SDP parser

### DIFF
--- a/src/core/parser/sdp/sdp.h
+++ b/src/core/parser/sdp/sdp.h
@@ -36,6 +36,16 @@
 #define RFC2543_HOLD 1
 #define RFC3264_HOLD 2
 
+#define HOLD_IP_STR "0.0.0.0"
+#define HOLD_IP_LEN 7
+
+#define HOLD_PORT_ICE_TRICKLE_STR "9"
+#define HOLD_PORT_ICE_TRICKLE_LEN 1
+
+#define ICE_OPTIONS "a=ice-options:"
+#define ICE_OPT_TRICKLE_STR "trickle"
+#define ICE_OPT_TRICKLE_LEN 7
+
 typedef struct sdp_payload_attr {
 	struct sdp_payload_attr *next;
 	int payload_num; /**< payload index inside stream */
@@ -46,15 +56,20 @@ typedef struct sdp_payload_attr {
 	str fmtp_string;
 } sdp_payload_attr_t;
 
+typedef struct sdp_ice_opt {
+	struct sdp_ice_opt *next;
+	str option; /* for e.g. 'trickle', 'rtp+ecn' */
+} sdp_ice_opt_t;
+
 typedef struct sdp_ice_attr {
-    struct sdp_ice_attr *next;
-    str foundation;
-    unsigned int component_id;
-    str transport;
-    str connection_addr;
-    str port;
-    str candidate_type;
-    int candidateType; /* ICE_HOST/ICE_SRFLX/ICE_PRFLX/ICE_RELAY/ICE_UNKNOWN */
+	struct sdp_ice_attr *next;
+	str foundation;
+	unsigned int component_id;
+	str transport;
+	str connection_addr;
+	str port;
+	str candidate_type;
+	int candidateType;			/* ICE_HOST/ICE_SRFLX/ICE_PRFLX/ICE_RELAY/ICE_UNKNOWN */
 } sdp_ice_attr_t;
 
 typedef struct sdp_stream_cell {
@@ -88,10 +103,11 @@ typedef struct sdp_stream_cell {
 	str raw_stream;                           /**< fast access to raw stream string */
 	struct sdp_payload_attr **p_payload_attr; /**< fast access pointers to payloads */
 	struct sdp_payload_attr *payload_attr;
-	int ice_attrs_num;                        /**< number of ICE attrs inside a stream */
-	/* add fast access pointers to ice attributes if you need them */
-	sdp_ice_attr_t *ice_attr;
-	str remote_candidates;                    /**< ICE a:remote-candidates */
+	int ice_attrs_num;                        /* number of candidate ICE attrs inside a stream */
+	sdp_ice_attr_t *ice_attr;                 /* add fast access pointers to ice candidate attributes */
+	int ice_opt_num;                          /* number of media level ICE options inside the stream */
+	sdp_ice_opt_t *ice_opt;                   /* add fast access pointers to media level ICE options */
+	str remote_candidates;                    /* ICE a:remote-candidates */
 } sdp_stream_cell_t;
 
 typedef struct sdp_session_cell {

--- a/src/core/parser/sdp/sdp_helpr_funcs.h
+++ b/src/core/parser/sdp/sdp_helpr_funcs.h
@@ -52,6 +52,7 @@ int extract_mediaip(str *body, str *mediaip, int *pf, char *line);
 int extract_media_attr(str *body, str *mediamedia, str *mediaport, str *mediatransport, str *mediapayload, int *is_rtp);
 int extract_bwidth(str *body, str *bwtype, str *bwwitdth);
 int extract_candidate(str *body, sdp_stream_cell_t *stream);
+int extract_ice_option(str *body, sdp_stream_cell_t *stream);
 int extract_sess_version(str* oline, str* sess_version);
 
 /* RFC3605 attributes */


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [X] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Commits are separated per change dedication, even though they concern the same component.
- core: add support of ICE media options to SDP parser
- core: improve an existing data structures cloning in the SDP parser

---

core: add support of ICE media options to SDP parser

In the current implementation only parsing of ICE candidate
attributes is supported, which makes it Possible to work
with ICE candidates and parameters specifically related per
candidate, but makes it Impossible to work
with ICE options of the media stream level (ICE options which
have an impact on the whole specific media stream).

ICE candidate attributes and ICE media options have different
dedication.

In order to target this matter, a new linked list is introduced
to store ICE media stream options.

Additionally, now when parsing media stream's attributes,
a couple of new helper functions have been introduced to
properly extract and store ICE media options:
- extract_ice_option()
- add_sdp_ice_opt()

The following extraction approaches are supported:
- multi-valued ICE options attribute (more than one value per a= header)
- one value per attribute (multiple a= headers with ICE options present)

Also now the way how a "zeroed" on-hold is detected is improved,
in case of the ICE (re)negotiation (when the connection address is equal
to '0.0.0.0', the media port is equal to '9' and ice-option 'trickle' is
present) the SDP is Not considered as an on-hold case, and it clearly
detects it's the ICE (re)negotiation (RFC 8840), which for e.g.
leads to a proper work of other side modules' functions (which use SDP
parser's data structures),
such as 'is_audio_on_hold()' from the textops.so module.

---

core: improve existing data structures cloning in the SDP parser

It's been noticed that the cloning of SDP session(s) and
SDP stream(s) structures doesn't allocate the ICE candidate attributes,
nor it allocates (recently introduced) ICE media stream options.

In order to target this a couple of new functions have been introduced:
- clone_sdp_opt_attr()
- clone_sdp_ice_attr()

And additionally the following functions have been improved, in order to
properly clone/free ICE candidate attributes and (recently introduced)
ICE media stream options:
- clone_sdp_stream_cell()
- free_cloned_sdp_stream()
- free_sdp()
- print_sdp_stream()

Additionally for a proper new structure length calculation, the following
function is fixed:
- clone_sdp_session_cell()

---

Tagging project members to review the changes: @miconda @henningw @linuxmaniac 
