### PR TITLE
cplc: manage case where TZ environment variable is not set.

### DIFF
--- a/src/modules/cplc/cpl_switches.h
+++ b/src/modules/cplc/cpl_switches.h
@@ -815,7 +815,7 @@ static inline char *run_time_switch( struct cpl_interpreter *intr )
 				/* does the recv_time match the specified interval?  */
 				j = cpl_check_tmrec( &trt, &att, 0);
 				/* restore the orig TZ */
-				if ( flags&(1<<7) )
+                                if ((flags&(1<<7)) && cpl_env.orig_tz.s && (cpl_env.orig_tz.len > 3))
 					set_TZ(cpl_env.orig_tz.s);
 				/* reset flags */
 				flags &= (1<<7);
@@ -850,7 +850,7 @@ static inline char *run_time_switch( struct cpl_interpreter *intr )
 	cpl_tmrec_free( &trt );
 	return DEFAULT_ACTION;
 runtime_error:
-	if ( flags&(1<<7) )
+        if ((flags&(1<<7)) && cpl_env.orig_tz.s && (cpl_env.orig_tz.len > 3))
 		set_TZ(cpl_env.orig_tz.s);
 	cpl_ac_tm_free( &att );
 	cpl_tmrec_free( &trt );
@@ -859,7 +859,7 @@ parse_err:
 	LM_ERR("error parsing attr [%d][%s]\n",
 		attr_name,attr_str?(char*)attr_str:"NULL");
 script_error:
-	if ( flags&(1<<7) )
+        if ((flags&(1<<7)) && cpl_env.orig_tz.s && (cpl_env.orig_tz.len > 3))
 		set_TZ(cpl_env.orig_tz.s);
 	cpl_ac_tm_free( &att );
 	cpl_tmrec_free( &trt );


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
cplc: manage case where TZ environment variable is not set.
When TZ environment variable was not set, only the first time based CPL worked correctly.