### PR TITLE
uac: enable "uac:reply" event route for UAC SIP message timeouts

### DIFF
--- a/src/modules/tm/config.c
+++ b/src/modules/tm/config.c
@@ -95,7 +95,8 @@ struct cfg_group_tm	default_tm_cfg = {
 		  CANCELs; on by default */
 	1,  /* e2e_cancel_reason -- copy the Reason headers from incoming CANCELs
 		  into the corresp. hop-by-hop CANCELs, on by default */
-	0   /* relay_100 -- by default, assume stateful proxy and do not relay SIP 100 */
+	0,   /* relay_100 -- by default, assume stateful proxy and do not relay SIP 100 */
+	0  /* enable_uac_fr */
 };
 
 void	*tm_cfg = &default_tm_cfg;
@@ -206,5 +207,7 @@ cfg_def_t	tm_cfg_def[] = {
 		" the corresponding generated hop-by-hop CANCELs"},
 	{"relay_100",		CFG_VAR_INT | CFG_ATOMIC,	0, 1, 0, 0,
 		"if set to 1, relay SIP 100 messages as a stateless proxy"},
+	{"enable_uac_fr",		CFG_VAR_INT | CFG_ATOMIC,	0, 1, 0, 0,
+		"if set, enables failure route for UAC messages"},
 	{0, 0, 0, 0, 0, 0}
 };

--- a/src/modules/tm/config.h
+++ b/src/modules/tm/config.h
@@ -130,6 +130,7 @@ struct cfg_group_tm {
 	int local_cancel_reason;
 	int e2e_cancel_reason;
 	unsigned int relay_100;
+	int enable_uac_fr;
 };
 
 extern struct cfg_group_tm	default_tm_cfg;

--- a/src/modules/tm/doc/params.xml
+++ b/src/modules/tm/doc/params.xml
@@ -1607,4 +1607,20 @@ modparam("tm", "reply_relay_mode", 0)
 		</example>
 	</section>
 
+	<section id="tm.p.enable_uac_fr">
+		<title><varname>enable_uac_fr</varname> (int)</title>
+		<para>
+			Enable failure route trigger, for uac. This will copy the tm uac into uas.
+			Thus, failure route can be triggered even for uac messages.
+		</para>
+		<example>
+			<title>enable_uac_fr example</title>
+			<programlisting>
+...
+modparam("tm", "enable_uac_fr", 1)
+....
+			</programlisting>
+		</example>
+	</section>
+
 </section>

--- a/src/modules/tm/tm.c
+++ b/src/modules/tm/tm.c
@@ -486,6 +486,7 @@ static param_export_t params[]={
 	{"event_callback_lres_sent", PARAM_STR, &_tm_event_callback_lres_sent    },
 	{"exec_time_check" ,    PARAM_INT, &tm_exec_time_check_param             },
 	{"reply_relay_mode",    PARAM_INT, &tm_reply_relay_mode                  },
+	{"enable_uac_fr",       PARAM_INT, &default_tm_cfg.enable_uac_fr         },
 	{0,0,0}
 };
 

--- a/src/modules/tm/uac.c
+++ b/src/modules/tm/uac.c
@@ -548,7 +548,7 @@ static inline int t_uac_prepare(uac_req_t *uac_r,
 
 #ifdef USE_DNS_FAILOVER
 	/* Set the outgoing message as UAS, so the failover code has something to work with */
-	if(cfg_get(core, core_cfg, use_dns_failover)) {
+	if(cfg_get(core, core_cfg, use_dns_failover) || cfg_get(tm, tm_cfg, enable_uac_fr)) {
 		if(likely(t_build_msg_from_buf(&lreq, buf, buf_len, uac_r, &dst) == 0)) {
 			if (parse_headers(&lreq, HDR_EOH_F, 0) == -1) {
 				LM_ERR("failed to parse headers on uas for failover\n");

--- a/src/modules/uac/doc/uac_admin.xml
+++ b/src/modules/uac/doc/uac_admin.xml
@@ -1241,11 +1241,20 @@ failure_route[REMOTE_AUTH] {
 				<function moreinfo="none">event_route[uac:reply]</function>
 			</title>
 		<para>
-			Event route executed for the final reply of the branch for the
-			request sent with uac_req_send(). The associated $uac_req(evroute)
-			has to be set to 1. If the request is challenged for authentication
+		The associated $uac_req(evroute) can have either of the following values:
+		<itemizedlist>
+			<listitem><para>
+				<emphasis>1</emphasis> : event route executed for the <emphasis>final reply</emphasis> of the branch for the
+			request sent with uac_req_send(). If the request is challenged for authentication
 			with 401/407, then the event_route is executed twice, first for
 			401/407 and second for final reply of the transaction.
+			</para></listitem>
+			<listitem><para>
+				<emphasis>2</emphasis> : event route executed for <emphasis>failure</emphasis> of the branch for the
+			request sent with uac_req_send(). event route will execute also for timeout.
+			In order for this to work, please also enable TM module "enable_uac_fr" modparam.
+			</para></listitem>
+		</itemizedlist>
 		</para>
 		<example>
 		<title><function>event_route[uac:reply]</function> usage</title>

--- a/src/modules/uac/uac_send.c
+++ b/src/modules/uac/uac_send.c
@@ -886,9 +886,21 @@ int uac_req_send(void)
 			return -1;
 		}
 
-		uac_r.cb_flags = TMCB_LOCAL_COMPLETED;
-		/* Callback function */
-		uac_r.cb  = uac_send_tm_callback;
+		switch (_uac_req.evroute)
+		{
+
+			case 2: 
+				uac_r.cb_flags = TMCB_ON_FAILURE;
+				/* Callback function */
+				uac_r.cb  = uac_resend_tm_callback;
+				break;
+			case 1:
+			default:
+				uac_r.cb_flags = TMCB_LOCAL_COMPLETED;
+				/* Callback function */
+				uac_r.cb  = uac_send_tm_callback;
+				break;
+		}
 		/* Callback parameter */
 		uac_r.cbp = (void*)tp;
 	}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

This PR adds 1 UAC module function and 1 TM module modparam. It enables "uac:reply" event route trigger on timeout or non-2xx replies. Basically it:
- adds TMCB_ON_FAILURE callback for UAC
- copies the TM uac content into uas; thus failure route will have the uas to work with. => this part of the code was already there, i just enabled it via (another) modparam. 

So far, is basically tested on our side, without any apparent issues. More testing will follow.

Please have a look on this and tell me what you think about it.

Thank you,
Stefan