### PR TITLE
siptrace: fix pkg memory leak when module configured with core callbacks

### DIFF
--- a/src/modules/siptrace/siptrace_data.h
+++ b/src/modules/siptrace/siptrace_data.h
@@ -40,6 +40,7 @@ typedef struct _siptrace_data
 	int_str avp_value;
 	struct search_state state;
 	str body;
+	int alloc_body;
 	str callid;
 	str method;
 	str status;
@@ -48,6 +49,7 @@ typedef struct _siptrace_data
 	str fromip;
 	str totag;
 	str toip;
+	int alloc_headers;
 	char toip_buff[SIPTRACE_ADDR_MAX];
 	char fromip_buff[SIPTRACE_ADDR_MAX];
 	struct timeval tv;

--- a/src/modules/siptrace/siptrace_send.c
+++ b/src/modules/siptrace/siptrace_send.c
@@ -139,6 +139,7 @@ int sip_trace_xheaders_write(struct _siptrace_data *sto)
 	// Change sto to point to the new buffer.
 	sto->body.s = buf;
 	sto->body.len += bytes_written;
+	sto->alloc_body = 1;
 	return 0;
 error:
 	if(buf != NULL) {
@@ -224,6 +225,7 @@ int sip_trace_xheaders_read(struct _siptrace_data *sto)
 	*eoh = '\r';
 	memmove(xheaders, eoh, sto->body.len - (eoh - sto->body.s));
 	sto->body.len -= eoh - xheaders;
+	sto->alloc_headers = 1;
 
 	return 0;
 
@@ -252,14 +254,15 @@ erroraftermalloc:
  */
 int sip_trace_xheaders_free(struct _siptrace_data *sto)
 {
-	if(trace_xheaders_write != 0) {
+	if(sto->alloc_body != 0) {
 		if(sto->body.s) {
 			pkg_free(sto->body.s);
 			sto->body.s = 0;
 		}
+		sto->alloc_body = 0;
 	}
 
-	if(trace_xheaders_read != 0) {
+	if(sto->alloc_headers != 0) {
 		if(sto->fromip.s) {
 			pkg_free(sto->fromip.s);
 			sto->fromip.s = 0;
@@ -272,6 +275,7 @@ int sip_trace_xheaders_free(struct _siptrace_data *sto)
 			pkg_free(sto->dir);
 			sto->dir = 0;
 		}
+		sto->alloc_headers = 0;
 	}
 
 	return 0;


### PR DESCRIPTION
- Correctly freeng pkg memory in core callbacks when body modifications take place with X-Siptrace headers,
  also fix potential pkg_free with not dynamicaly allocated objects.

<!-- Kamailio Pull Request Template -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Releated to [57b1d5375927b987b162fcf0e2c99a39b717bd65](https://github.com/kamailio/kamailio/commit/57b1d5375927b987b162fcf0e2c99a39b717bd65)