### PR TITLE
stirshaken: Add PVs to allow access to x509 subject and ppt grants

### DIFF
--- a/src/modules/stirshaken/doc/stirshaken_admin.xml
+++ b/src/modules/stirshaken/doc/stirshaken_admin.xml
@@ -256,6 +256,47 @@ modparam("stirshaken", "vs_cache_expire_s", 15)
 </programlisting>
 		</example>
 	</section>
+		<section>
+		<title><varname>vs_certsubject_pvname</varname> (str)</title>
+		<para>
+		If vs_certsubject_pvname is set then the Subject of the authenticated x509 certificate will be written to this pseudo-variable when
+		stirshaken_check_identity() is executed.  If the Identity header cannot be fully authenticated the pseudo-variable will be set to $null.
+		</para>
+		<para>
+		<emphasis>
+			Default value is blank (disabled).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>vs_certsubject_pvname</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("stirshaken", "vs_certsubject_pvname", "$vn(certsubject)")
+...
+</programlisting>
+		</example>
+	</section>
+		</section>
+		<section>
+		<title><varname>vs_pptgrants_pvname</varname> (str)</title>
+		<para>
+		If vs_pptgrants_pvname is set then the JSON string of the authenticated PASSporT's grants will be written to this pseudo-variable when
+		stirshaken_check_identity() is executed.  If the Identity header cannot be fully authenticated the pseudo-variable will be set to $null.
+		</para>
+		<para>
+		<emphasis>
+			Default value is blank (disabled).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>vs_pptgrants_pvname</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("stirshaken", "vs_pptgrants_pvname", "$vn(grants)")
+...
+</programlisting>
+		</example>
+	</section>
 
 	</section>
 


### PR DESCRIPTION
- added vs_certsubject_pvname and vs_pptgrants_pvname config params
- adjusted log level of load/unload events

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
The stirshaken module currently does not allow any access to the information provided in the Identity header.  These changes allow key components of a signed call to be available in user-specified pseudo variables.

Specifically, the Subject of the certificate used to sign the call will be written to the PV specified in vs_certsubject_pvname and the JWT payload that has been verified will be written to the PV specified in vs_pptgrants_pvname.

There is no change to any behaviour whether these configuration options are set or not other than to write the appropriate values into the indicated PVs.