### PR TITLE
pv_headers: Add support to remove a specific value from a header

### DIFF
--- a/src/modules/pv_headers/doc/functions.xml
+++ b/src/modules/pv_headers/doc/functions.xml
@@ -11,7 +11,7 @@
 
 <section id="pv_headers.funtions" xmlns:xi="http://www.w3.org/2001/XInclude">
     <sectioninfo>
-    </sectioninfo>\
+    </sectioninfo>
 
     <title>Functions</title>
 	<section id="pv_headers.f.pvh_collect_headers">
@@ -128,4 +128,37 @@
 		pvh_collect_headers()</link> or with <quote>auto_msg</quote> parameter enabled.
 		</para>
 	</section>
+	<section id="pv_headers.f.pvh_header_param_exists">
+		<title>
+			<function moreinfo="none">pvh_value_exists(hname, hparameter)</function>
+		</title>
+		<para>
+			Checks if the parameter <quote>hparameter</quote> is present in the header <quote>hname</quote> from XAVP.
+		</para>
+		<para>
+			This function can be used from ANY_ROUTE but only after <link linked="pv_headers.f.pvh_collect_headers">
+			pvh_collect_headers()</link> have been called or with <quote>auto_msg</quote> parameter enabled.
+		</para>
 	</section>
+	<section id="pv_headers.f.pvh_remove_header_param">
+		<title>
+			<function moreinfo="none">pvh_remove_header_param(hname, hparameter)</function>
+		</title>
+		<para>
+			Removes an existing parameter <quote>hparameter</quote> in the header <quote>hname</quote> from the XAVP.
+		</para>
+		<para>
+			If there are multiple headers, only the one containing the parameter will be modified.
+		</para>
+		<para>
+			The parameter can be located in any position (begining, middle or end) of the list of parameters.
+		</para>
+		<para>
+			If the parameter is the only one present, the header will be removed.
+		</para>
+		<para>
+			This function can be used from ANY_ROUTE but only after <link linked="pv_headers.f.pvh_collect_headers">
+			pvh_collect_headers()</link> have been called or with <quote>auto_msg</quote> parameter enabled.
+		</para>
+ 	</section>
+</section>

--- a/src/modules/pv_headers/doc/pv_headers.xml
+++ b/src/modules/pv_headers/doc/pv_headers.xml
@@ -26,6 +26,12 @@
 		    <email>vseva@sipwise.com</email>
 		<affiliation><orgname>Sipwise GmbH</orgname></affiliation>
 	    </editor>
+		<editor>
+			<firstname>Fabricio</firstname>
+			<surname>Santolin da Silva</surname>
+				<email>fabricio.santolin-da-silva@al-enterprise.com</email>
+			<affiliation><orgname>Alcatel-Lucent Enterprise</orgname></affiliation>
+		</editor>
 	</authorgroup>
 	<copyright>
 	    <year>2018</year>

--- a/src/modules/pv_headers/pvh_func.h
+++ b/src/modules/pv_headers/pvh_func.h
@@ -38,5 +38,7 @@ int pvh_check_header(struct sip_msg *msg, str *hname);
 int pvh_append_header(struct sip_msg *msg, str *hname, str *hvalue);
 int pvh_modify_header(struct sip_msg *msg, str *hname, str *hvalue, int indx);
 int pvh_remove_header(struct sip_msg *msg, str *hname, int indx);
+int pvh_header_param_exists(struct sip_msg *msg, str *hname, str *hvalue);
+int pvh_remove_header_param(struct sip_msg *msg, int idx, str *hname, str *elements, str *toRemove);
 
 #endif /* PV_FUNC_H */


### PR DESCRIPTION
- To be used with headers containing values separated by commas
- pvh_header_param_exists() check if the value is present to a given header
- pvh_remove_header_param() remove the value from the given header or the entire header if no other value is present

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Previously, to remove a parameter from a header it was needed to create a complex method on the configuration file for each header/parameter. This modification moves this complexity to the 'pv_headers' module.

Two new functions:
  * pvh_header_param_exists
  * pvh_remove_header_param

Both functions take as parameters the name of the header and the name of the parameter.

It returns '-1' if the combination header/parameter:
  - is not found (pvh_header_param_exists)
  - couldn't be removed (pvh_remove_header_param).

Examples (proxy configuration):

if (pvh_header_param_exists("Supported", "100rel"))
{
  // "100rel" is present on the "Supported" header
}

if (pvh_remove_header_param("Supported", "100rel"))
{
  // "100rel" removed from header "Supported"
}