### PR TITLE
add function t_continue_skip_timer to enable skipping of timer checks

### DIFF
--- a/src/modules/ims_registrar_scscf/cxdx_sar.c
+++ b/src/modules/ims_registrar_scscf/cxdx_sar.c
@@ -286,7 +286,7 @@ done:
     //free path vector pkg memory
 //    reset_path_vector(req);
 
-    tmb.t_continue(data->tindex, data->tlabel, data->act);
+    tmb.t_continue_skip_timer(data->tindex, data->tlabel, data->act);
     free_saved_transaction_data(data);
     return;
 

--- a/src/modules/tm/t_lookup.c
+++ b/src/modules/tm/t_lookup.c
@@ -1587,7 +1587,7 @@ int t_get_canceled_ident(struct sip_msg* msg, unsigned int* hash_index,
  *                0).
  * @param hash_index - searched transaction hash_index (part of the ident).
  * @param label - searched transaction label (part of the ident).
- * @param filter - if 1, skip transaction put on-wait (terminated state).
+ * @param filter - if 1, filter out transactions put on-wait (terminated state).
  * @return -1 on error/not found, 1 on success (found)
  * Side-effects: sets T and T_branch (T_branch always to T_BR_UNDEFINED).
  */

--- a/src/modules/tm/t_suspend.c
+++ b/src/modules/tm/t_suspend.c
@@ -163,8 +163,8 @@ int t_suspend(struct sip_msg *msg,
  * 	0  - success
  * 	<0 - failure
  */
-int t_continue_helper(unsigned int hash_index, unsigned int label,
-		struct action *rtact, str *cbname, str *cbparam)
+static int t_continue_helper(unsigned int hash_index, unsigned int label,
+		struct action *rtact, str *cbname, str *cbparam, int skip_timer)
 {
 	tm_cell_t *t;
 	tm_cell_t *backup_T = T_UNDEFINED;
@@ -192,7 +192,7 @@ int t_continue_helper(unsigned int hash_index, unsigned int label,
 	backup_T = get_t();
 	backup_T_branch = get_t_branch();
 
-	if (t_lookup_ident_filter(&t, hash_index, label, 1) < 0) {
+	if (t_lookup_ident_filter(&t, hash_index, label, skip_timer) < 0) {
 		set_t(backup_T, backup_T_branch);
 		LM_WARN("active transaction not found\n");
 		return -1;
@@ -592,13 +592,18 @@ kill_trans:
 int t_continue(unsigned int hash_index, unsigned int label,
 		struct action *route)
 {
-	return t_continue_helper(hash_index, label, route, NULL, NULL);
+	return t_continue_helper(hash_index, label, route, NULL, NULL, 1);
+}
+int t_continue_skip_timer(unsigned int hash_index, unsigned int label,
+		struct action *route)
+{
+	return t_continue_helper(hash_index, label, route, NULL, NULL, 0);
 }
 
 int t_continue_cb(unsigned int hash_index, unsigned int label,
 		str *cbname, str *cbparam)
 {
-	return t_continue_helper(hash_index, label, NULL, cbname, cbparam);
+	return t_continue_helper(hash_index, label, NULL, cbname, cbparam, 0);
 }
 
 /* Revoke the suspension of the SIP request, i.e.

--- a/src/modules/tm/t_suspend.h
+++ b/src/modules/tm/t_suspend.h
@@ -29,6 +29,8 @@ typedef int (*t_suspend_f)(struct sip_msg *msg,
 
 int t_continue(unsigned int hash_index, unsigned int label,
 		struct action *route);
+int t_continue_skip_timer(unsigned int hash_index, unsigned int label,
+		struct action *route);
 typedef int (*t_continue_f)(unsigned int hash_index, unsigned int label,
 		struct action *route);
 

--- a/src/modules/tm/tm_load.c
+++ b/src/modules/tm/tm_load.c
@@ -115,6 +115,7 @@ int load_tm( struct tm_binds *tmb)
 	tmb->t_get_canceled_ident = t_get_canceled_ident;
 	tmb->t_suspend = t_suspend;
 	tmb->t_continue = t_continue;
+	tmb->t_continue_skip_timer = t_continue_skip_timer;
 	tmb->t_continue_cb = t_continue_cb;
 	tmb->t_cancel_suspend = t_cancel_suspend;
 	tmb->t_get_reply_totag = t_get_reply_totag;

--- a/src/modules/tm/tm_load.h
+++ b/src/modules/tm/tm_load.h
@@ -95,6 +95,7 @@ struct tm_binds {
 	t_get_canceled_ident_f    t_get_canceled_ident;
 	t_suspend_f	t_suspend;
 	t_continue_f	t_continue;
+	t_continue_f	t_continue_skip_timer;
 	t_continue_cb_f	t_continue_cb;
 	t_cancel_suspend_f	t_cancel_suspend;
 	tget_reply_totag_f t_get_reply_totag;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This is done because IMS third party registration requests would be skipped because
t_continue would get called on the transaction _way_ before the timer timeout.
All this resulted in the correct route not being called.