### PR TITLE
htable: wrong printf format

### DIFF
--- a/src/modules/htable/ht_db.c
+++ b/src/modules/htable/ht_db.c
@@ -495,7 +495,7 @@ int ht_db_load_table(ht_t *ht, str *dbtable, int mode)
 				if (ht->htexpire > 0 && expires.n > 0) {
 					expires.n -= now;
 					if(ht_set_cell_expire(ht, &hname, 0, &expires)) {
-						LM_ERR("error setting expires to hash entry [%*.s]\n", hname.len, hname.s);
+						LM_ERR("error setting expires to hash entry [%.*s]\n", hname.len, hname.s);
 						goto error;
 					}
 				}


### PR DESCRIPTION
"%*.s"  used instead of "%.*s"

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
"%*.s"  used instead of "%.*s": "The result is padded with space characters" (https://en.cppreference.com/w/cpp/io/c/fprintf)
Probably harmless (but still wrong) if the string ends with '\0'.
