### PR TITLE
pkg alpine renamed malloc_test to misctest

### DIFF
--- a/pkg/kamailio/alpine/APKBUILD
+++ b/pkg/kamailio/alpine/APKBUILD
@@ -77,7 +77,7 @@ _mod_list_dbuid="db2_ops uid_auth_db uid_avp_db uid_domain uid_gflags \
 		uid_uri_db"
 
 # - modules for devel purposes
-_mod_list_devel="malloc_test print print_lib"
+_mod_list_devel="misctest print print_lib"
 
 # - modules depending on pcre3 library
 _mod_list_pcre="dialplan lcr regex"


### PR DESCRIPTION
FIX #3091 Building APKs fail due to rename of malloc_test module

<!-- Kamailio Pull Request Template -->


#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue FIX #3091

#### Description
Refactored reference to `malloc_test` in `pkg/kamailio/alpine/APKBUILDER` to `misctest` due to module rename.
