### PR TITLE
pv_headers: fix possible mem. overflow issue and wrong size string

### DIFF
--- a/src/modules/pv_headers/pvh_func.c
+++ b/src/modules/pv_headers/pvh_func.c
@@ -383,13 +383,13 @@ int pvh_header_param_exists(struct sip_msg *msg, str *hname, str *hvalue)
 
 int pvh_remove_header_param(struct sip_msg *msg, int idx, str *hname, str *elements, str *toRemove)
 {
+	int notTarget, writtenChars;
 	int offset = 0;
 	int ret = -1;
 	char *next_token;
 	char *token;
 	char *result = (char*)pkg_malloc(elements->len - toRemove->len);
-	char *t = (char*)pkg_malloc(elements->len);
-	int maxSize = elements->len;
+	char *t = (char*)pkg_malloc(elements->len+1);
 
 	if (result == NULL || t == NULL)
 	{
@@ -397,37 +397,35 @@ int pvh_remove_header_param(struct sip_msg *msg, int idx, str *hname, str *eleme
 		goto clean;
 	}
 
-	snprintf(result, elements->len - toRemove->len, "%*s", elements->len - toRemove->len, "");
 	snprintf(t, elements->len+1, "%s", elements->s);
 
 	token = strtok_r(t, ", ", &next_token);
 	while(token)
 	{
-		int notTarget = strncmp(token, toRemove->s, toRemove->len);
+		notTarget = strncmp(token, toRemove->s, toRemove->len);
 		if (notTarget)
 		{
-			int n = snprintf(result + offset, maxSize - offset, "%s", token);
-			if (n < 0 || n >= maxSize - offset)
+			writtenChars = snprintf(result + offset, elements->len - offset, "%s", token);
+			if (writtenChars < 0 || writtenChars >= elements->len - offset)
 			{
 				break;
 			}
-			offset += n;
+			offset += writtenChars;
 		}
 		token = strtok_r(NULL, ", ", &next_token);
-		if (token && notTarget && maxSize - offset - toRemove->len > 2)
+		if (token && notTarget && elements->len - offset - toRemove->len > 2)
 		{
-			int n = snprintf(result + offset, maxSize - offset, ", ");
-			if (n < 0 || n >= maxSize - offset)
+			writtenChars = snprintf(result + offset, elements->len - offset, ", ");
+			if (writtenChars < 0 || writtenChars >= elements->len - offset)
 			{
 				break;
 			}
-			offset += n;
+			offset += writtenChars;
 		}
 	}
 
 	if (elements->len-toRemove->len > 0)
 	{
-		snprintf(elements->s, elements->len, "%*s", elements->len-toRemove->len, "");
 		snprintf(elements->s, (strlen(result)%elements->len)+1, "%s", result);
 		elements->len = strlen(result);
 		ret = 1;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
- remove a variable creation
Put two variable accessible to the entire function, renaming one to have some clarity. 
Remove the useless variable.  

- Remove from snprintf that fills the string
This fix possible a memory overflow while using `snprintf`. This also add a \0 at the end of the structure.

- change the destination of an allocated space being smaller than the source
Elements were being put into a smaller string, this commit makes the destination bigger then the source.