### PR TITLE
dialog: set context iuid for CANCEL requests

### DIFF
--- a/src/modules/dialog/dlg_handlers.c
+++ b/src/modules/dialog/dlg_handlers.c
@@ -1256,6 +1256,9 @@ dlg_cell_t *dlg_lookup_msg_dialog(sip_msg_t *msg, unsigned int *dir)
 				msg->callid->body.len, msg->callid->body.s);
 		return NULL;
 	}
+        if(msg->first_line.u.request.method_value == METHOD_CANCEL) {
+                dlg_set_ctx_iuid(dlg);
+        }
 	if(dir) *dir = vdir;
 	return dlg;
 }


### PR DESCRIPTION
set context iuid for CANCEL requests to let isflagset function return the right value in case a dialog flag was previously set on the call

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Using kamailio 5.4 version, we have seen that dlg_isflagset is not detecting a dialog flag set in the request route for the initial INVITE, when a CANCEL request arrives.

We have applied this change to set the dialog context unique ide for this request. Since it's done on dlg_onreply, dlg_onroute and dlg_ontimeout functions. This way, dlg_get_by_iuid(&dctx->iuid) in the function ki_dlg_isflagset is not NULL and dialog flags are detected.

Is this change correct? Or can it generate any kind of issues?

thanks a lot and regards
David