### PR TITLE
core/crypto: fix several mismatched bound warnings

### DIFF
--- a/src/core/crypto/sha256.c
+++ b/src/core/crypto/sha256.c
@@ -94,10 +94,6 @@
 #error Define BYTE_ORDER to be equal to either LITTLE_ENDIAN or BIG_ENDIAN
 #endif
 
-typedef uint8_t  sha2_byte;	/* Exactly 1 byte */
-typedef uint32_t sha2_word32;	/* Exactly 4 bytes */
-typedef uint64_t sha2_word64;	/* Exactly 8 bytes */
-
 /*** SHA-256/384/512 Various Length Definitions ***********************/
 /* NOTE: Most of these are in sha2.h */
 #define SHA256_SHORT_BLOCK_LENGTH	(SHA256_BLOCK_LENGTH - 8)
@@ -545,7 +541,7 @@ void sr_SHA256_Update(SHA256_CTX* context, const sha2_byte *data, size_t len) {
 	usedspace = freespace = 0;
 }
 
-void sr_SHA256_Final(sha2_byte digest[], SHA256_CTX* context) {
+void sr_SHA256_Final(sha2_byte digest[SHA256_DIGEST_LENGTH], SHA256_CTX* context) {
 	sha2_word32	*d = (sha2_word32*)digest;
 	unsigned int	usedspace;
 
@@ -608,7 +604,7 @@ void sr_SHA256_Final(sha2_byte digest[], SHA256_CTX* context) {
 	usedspace = 0;
 }
 
-char *sr_SHA256_End(SHA256_CTX* context, char buffer[]) {
+char *sr_SHA256_End(SHA256_CTX* context, char buffer[SHA256_DIGEST_STRING_LENGTH]) {
 	sha2_byte	digest[SHA256_DIGEST_LENGTH], *d = digest;
 	int		i;
 
@@ -908,7 +904,7 @@ void SHA512_Last(SHA512_CTX* context) {
 	SHA512_Transform(context, (sha2_word64*)context->buffer);
 }
 
-void sr_SHA512_Final(sha2_byte digest[], SHA512_CTX* context) {
+void sr_SHA512_Final(sha2_byte digest[SHA512_DIGEST_LENGTH], SHA512_CTX* context) {
 	sha2_word64	*d = (sha2_word64*)digest;
 
 	/* Sanity check: */
@@ -937,7 +933,7 @@ void sr_SHA512_Final(sha2_byte digest[], SHA512_CTX* context) {
 	MEMSET_BZERO(context, sizeof(*context));
 }
 
-char *sr_SHA512_End(SHA512_CTX* context, char buffer[]) {
+char *sr_SHA512_End(SHA512_CTX* context, char buffer[SHA512_DIGEST_STRING_LENGTH]) {
 	sha2_byte	digest[SHA512_DIGEST_LENGTH], *d = digest;
 	int		i;
 
@@ -983,7 +979,7 @@ void sr_SHA384_Update(SHA384_CTX* context, const sha2_byte* data, size_t len) {
 	sr_SHA512_Update((SHA512_CTX*)context, data, len);
 }
 
-void sr_SHA384_Final(sha2_byte digest[], SHA384_CTX* context) {
+void sr_SHA384_Final(sha2_byte digest[SHA384_DIGEST_LENGTH], SHA384_CTX* context) {
 	sha2_word64	*d = (sha2_word64*)digest;
 
 	/* Sanity check: */
@@ -1012,7 +1008,7 @@ void sr_SHA384_Final(sha2_byte digest[], SHA384_CTX* context) {
 	MEMSET_BZERO(context, sizeof(*context));
 }
 
-char *sr_SHA384_End(SHA384_CTX* context, char buffer[]) {
+char *sr_SHA384_End(SHA384_CTX* context, char buffer[SHA384_DIGEST_STRING_LENGTH]) {
 	sha2_byte	digest[SHA384_DIGEST_LENGTH], *d = digest;
 	int		i;
 

--- a/src/core/crypto/sha256.h
+++ b/src/core/crypto/sha256.h
@@ -77,25 +77,28 @@ typedef struct _SHA512_CTX {
 
 typedef SHA512_CTX SHA384_CTX;
 
+typedef uint8_t  sha2_byte;   /* Exactly 1 byte */
+typedef uint32_t sha2_word32; /* Exactly 4 bytes */
+typedef uint64_t sha2_word64; /* Exactly 8 bytes */
 
 /*** SHA-256/384/512 Function Prototypes ******************************/
 #ifndef NOPROTO
 
 void sr_SHA256_Init(SHA256_CTX *);
 void sr_SHA256_Update(SHA256_CTX*, const uint8_t*, size_t);
-void sr_SHA256_Final(uint8_t[SHA256_DIGEST_LENGTH], SHA256_CTX*);
+void sr_SHA256_Final(sha2_byte[SHA256_DIGEST_LENGTH], SHA256_CTX*);
 char* sr_SHA256_End(SHA256_CTX*, char[SHA256_DIGEST_STRING_LENGTH]);
 char* sr_SHA256_Data(const uint8_t*, size_t, char[SHA256_DIGEST_STRING_LENGTH]);
 
 void sr_SHA384_Init(SHA384_CTX*);
 void sr_SHA384_Update(SHA384_CTX*, const uint8_t*, size_t);
-void sr_SHA384_Final(uint8_t[SHA384_DIGEST_LENGTH], SHA384_CTX*);
+void sr_SHA384_Final(sha2_byte[SHA384_DIGEST_LENGTH], SHA384_CTX*);
 char* sr_SHA384_End(SHA384_CTX*, char[SHA384_DIGEST_STRING_LENGTH]);
 char* sr_SHA384_Data(const uint8_t*, size_t, char[SHA384_DIGEST_STRING_LENGTH]);
 
 void sr_SHA512_Init(SHA512_CTX*);
 void sr_SHA512_Update(SHA512_CTX*, const uint8_t*, size_t);
-void sr_SHA512_Final(uint8_t[SHA512_DIGEST_LENGTH], SHA512_CTX*);
+void sr_SHA512_Final(sha2_byte[SHA512_DIGEST_LENGTH], SHA512_CTX*);
 char* sr_SHA512_End(SHA512_CTX*, char[SHA512_DIGEST_STRING_LENGTH]);
 char* sr_SHA512_Data(const uint8_t*, size_t, char[SHA512_DIGEST_STRING_LENGTH]);
 


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [*] Commit message has the format required by CONTRIBUTING guide
- [*] Commits are split per component (core, individual modules, libs, utils, ...)
- [*] Each component has a single commit (if not, squash them into one commit)
- [*] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [*] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Fix for the following compiler warnings:
```
core/crypto/sha256.c:548:32: warning: argument 1 of type ‘sha2_byte[]’ {aka ‘unsigned char[]’} with mismatched bound [-Warray-parameter=]
  548 | void sr_SHA256_Final(sha2_byte digest[], SHA256_CTX* context) {
      |                      ~~~~~~~~~~^~~~~~~~
In file included from core/crypto/sha256.c:36:
core/crypto/sha256.h:86:22: note: previously declared as ‘uint8_t[32]’ {aka ‘unsigned char[32]’}
   86 | void sr_SHA256_Final(uint8_t[SHA256_DIGEST_LENGTH], SHA256_CTX*);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/crypto/sha256.c:611:47: warning: argument 2 of type ‘char[]’ with mismatched bound [-Warray-parameter=]
  611 | char *sr_SHA256_End(SHA256_CTX* context, char buffer[]) {
      |                                          ~~~~~^~~~~~~~
In file included from core/crypto/sha256.c:36:
core/crypto/sha256.h:87:34: note: previously declared as ‘char[65]’
   87 | char* sr_SHA256_End(SHA256_CTX*, char[SHA256_DIGEST_STRING_LENGTH]);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/crypto/sha256.c:911:32: warning: argument 1 of type ‘sha2_byte[]’ {aka ‘unsigned char[]’} with mismatched bound [-Warray-parameter=]
  911 | void sr_SHA512_Final(sha2_byte digest[], SHA512_CTX* context) {
      |                      ~~~~~~~~~~^~~~~~~~
In file included from core/crypto/sha256.c:36:
core/crypto/sha256.h:98:22: note: previously declared as ‘uint8_t[64]’ {aka ‘unsigned char[64]’}
   98 | void sr_SHA512_Final(uint8_t[SHA512_DIGEST_LENGTH], SHA512_CTX*);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/crypto/sha256.c:940:47: warning: argument 2 of type ‘char[]’ with mismatched bound [-Warray-parameter=]
  940 | char *sr_SHA512_End(SHA512_CTX* context, char buffer[]) {
      |                                          ~~~~~^~~~~~~~
In file included from core/crypto/sha256.c:36:
core/crypto/sha256.h:99:34: note: previously declared as ‘char[129]’
   99 | char* sr_SHA512_End(SHA512_CTX*, char[SHA512_DIGEST_STRING_LENGTH]);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/crypto/sha256.c:986:32: warning: argument 1 of type ‘sha2_byte[]’ {aka ‘unsigned char[]’} with mismatched bound [-Warray-parameter=]
  986 | void sr_SHA384_Final(sha2_byte digest[], SHA384_CTX* context) {
      |                      ~~~~~~~~~~^~~~~~~~
In file included from core/crypto/sha256.c:36:
core/crypto/sha256.h:92:22: note: previously declared as ‘uint8_t[48]’ {aka ‘unsigned char[48]’}
   92 | void sr_SHA384_Final(uint8_t[SHA384_DIGEST_LENGTH], SHA384_CTX*);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/crypto/sha256.c:1015:47: warning: argument 2 of type ‘char[]’ with mismatched bound [-Warray-parameter=]
 1015 | char *sr_SHA384_End(SHA384_CTX* context, char buffer[]) {
      |                                          ~~~~~^~~~~~~~
In file included from core/crypto/sha256.c:36:
core/crypto/sha256.h:93:34: note: previously declared as ‘char[97]’
   93 | char* sr_SHA384_End(SHA384_CTX*, char[SHA384_DIGEST_STRING_LENGTH]);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
