### PR TITLE
core: add an option to trigger also an RST on tcp connection close

### DIFF
--- a/src/core/cfg.lex
+++ b/src/core/cfg.lex
@@ -421,6 +421,7 @@ TCP_OPT_ACCEPT_HEP3	"tcp_accept_hep3"
 TCP_OPT_ACCEPT_HAPROXY	"tcp_accept_haproxy"
 TCP_CLONE_RCVBUF	"tcp_clone_rcvbuf"
 TCP_REUSE_PORT		"tcp_reuse_port"
+TCP_OPT_CLOSE_RST	"tcp_close_rst"
 DISABLE_TLS		"disable_tls"|"tls_disable"
 ENABLE_TLS		"enable_tls"|"tls_enable"
 TLSLOG			"tlslog"|"tls_log"
@@ -912,6 +913,7 @@ IMPORTFILE      "import_file"
 <INITIAL>{TCP_CLONE_RCVBUF}		{ count(); yylval.strval=yytext;
 									return TCP_CLONE_RCVBUF; }
 <INITIAL>{TCP_REUSE_PORT}	{ count(); yylval.strval=yytext; return TCP_REUSE_PORT; }
+<INITIAL>{TCP_OPT_CLOSE_RST}	{ count(); yylval.strval=yytext; return TCP_OPT_CLOSE_RST; }
 <INITIAL>{DISABLE_TLS}	{ count(); yylval.strval=yytext; return DISABLE_TLS; }
 <INITIAL>{ENABLE_TLS}	{ count(); yylval.strval=yytext; return ENABLE_TLS; }
 <INITIAL>{TLSLOG}		{ count(); yylval.strval=yytext; return TLS_PORT_NO; }

--- a/src/core/cfg.y
+++ b/src/core/cfg.y
@@ -451,6 +451,7 @@ extern char *default_routename;
 %token TCP_OPT_ACCEPT_HAPROXY
 %token TCP_CLONE_RCVBUF
 %token TCP_REUSE_PORT
+%token TCP_OPT_CLOSE_RST
 %token DISABLE_TLS
 %token ENABLE_TLS
 %token TLSLOG
@@ -1319,6 +1320,14 @@ assign_stm:
 		#endif
 	}
 	| TCP_REUSE_PORT EQUAL error { yyerror("boolean value expected"); }
+	| TCP_OPT_CLOSE_RST EQUAL NUMBER {
+        #ifdef USE_TCP
+            tcp_default_cfg.close_rst=$3;
+        #else
+            warn("tcp support not compiled in");
+        #endif
+    }
+    | TCP_OPT_CLOSE_RST EQUAL error { yyerror("boolean value expected"); }
 	| DISABLE_TLS EQUAL NUMBER {
 		#ifdef USE_TLS
 			tls_disable=$3;

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -3167,6 +3167,13 @@ inline static void tcpconn_close_main_fd(struct tcp_connection* tcpconn)
 #endif
 #ifdef TCP_FD_CACHE
 	if (likely(cfg_get(tcp, tcp_cfg, fd_cache))) shutdown(fd, SHUT_RDWR);
+	if(unlikely(cfg_get(tcp, tcp_cfg, close_rst))) {
+		struct linger sl = {
+			.l_onoff = 1,  /* non-zero value enables linger option in kernel */
+			.l_linger = 0, /* timeout interval in seconds */
+		};
+		setsockopt(fd, SOL_SOCKET, SO_LINGER, &sl, sizeof(sl));
+	}
 #endif /* TCP_FD_CACHE */
 	if (unlikely(tcp_safe_close(fd)<0))
 		LM_ERR("(%p): %s close(%d) failed (flags 0x%x): %s (%d)\n", tcpconn,

--- a/src/core/tcp_options.c
+++ b/src/core/tcp_options.c
@@ -108,6 +108,8 @@ static cfg_def_t tcp_cfg_def[] = {
 		"accept TCP messages without Content-Length "},
 	{ "reuse_port",   CFG_VAR_INT | CFG_ATOMIC,   0,        1,  0,         0,
 		"reuse TCP ports "},
+	{ "close_rst",     CFG_VAR_INT | CFG_READONLY,    0,   1,      0,         0,
+		"trigger an RST on connection close"},
 	/* internal and/or "fixed" versions of some vars
 	   (not supposed to be writeable, read will provide only debugging value*/
 	{ "rd_buf_size", CFG_VAR_INT | CFG_ATOMIC,    512,    16777216,  0,         0,
@@ -164,6 +166,7 @@ void init_tcp_options()
 	tcp_default_cfg.rd_buf_size=DEFAULT_TCP_BUF_SIZE;
 	tcp_default_cfg.wq_blk_size=DEFAULT_TCP_WBUF_SIZE;
 	tcp_default_cfg.reuse_port=0;
+	tcp_default_cfg.close_rst=0;
 }
 
 

--- a/src/core/tcp_options.h
+++ b/src/core/tcp_options.h
@@ -138,6 +138,7 @@ struct cfg_group_tcp{
 	int new_conn_alias_flags;
 	int accept_no_cl;  /* on/off - accept messages without content-length */
 	int reuse_port;  /* enable SO_REUSEPORT */
+	int close_rst; /* on /off trigger an RST on connection close */
 
 	/* internal, "fixed" vars */
 	unsigned int rd_buf_size; /* read buffer size (should be > max. datagram)*/


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
We have seen that in deployments where there are strict port requirements on both side, there are tcp connections in TIME_WAIT state causing no fresh TCP connections possible until the TIME_WAIT is gone. In a lot of these case the clients are sending from them self a RST after they send a FIN,ACK from there side but some aren't doing this. The basic idea of this PR is to give an extra option for the tcp configuration from the cfg to trigger always an RST on connection close from Kamailio side. This currently done by enabling SO_LINGER with a value of 0 just before close.
