### PR TITLE
userblocklist: fix restart errors

### DIFF
--- a/src/modules/userblocklist/db_userblocklist.c
+++ b/src/modules/userblocklist/db_userblocklist.c
@@ -91,7 +91,6 @@ int userblocklist_db_init(void) {
 		userblocklist_db_close();
 		return -1;
 	}
-	userblocklist_db_close();
 	return 0;
 }
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Spotted this ERRORs on kamailio restart:
```
ERROR: <core> [db.c:481]: db_use_table(): invalid connection parameter
ERROR: userblocklist [db.c:123]: db_reload_source(): cannot use db table 'globalblocklist'
ERROR: userblocklist [userblocklist.c:425]: load_source(): cannot load source from 'globalblocklist
```

Debugging it further, seen that the above ERRORs appear on ```check_allowlist()``` function fixup. This was happening because db connection is closed in mod_init and re-done in child_init. But the fixups happen before child_init and they need db connection.

Decided to not close the db connection after mod_init because it is later, first closed and then re-opened, in each child. Figured out this fix after checked where each function of db_userblocklist.c is used.

ERRORs no longer appear on restart.

Thank you,
Stefan