### PR TITLE
siptrace: fix hardcoded PROTO_UDP in duplicate_uri module parameter

### DIFF
--- a/src/modules/siptrace/siptrace_send.c
+++ b/src/modules/siptrace/siptrace_send.c
@@ -305,7 +305,7 @@ int trace_send_duplicate(char *buf, int len, dest_info_t *dst2)
 
 	if(!dst2) {
 		/* create a temporary proxy from dst param */
-		dst.proto = PROTO_UDP;
+		dst.proto = trace_dup_uri->proto;
 		p = mk_proxy(&trace_dup_uri->host,
 				(trace_dup_uri->port_no) ? trace_dup_uri->port_no : SIP_PORT, dst.proto);
 		if(p == 0) {


### PR DESCRIPTION
Possibility to switch to other then UDP transport protocol in diplicate_uri

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Sometimes it's preferable to do the duplication over TCP or another transport, this little fix removes the hard-coded UDP from the diplicate_uri module parameter.

