### PR TITLE
pv: log uninit $var()

### DIFF
--- a/src/modules/pv/pv_core.c
+++ b/src/modules/pv/pv_core.c
@@ -2597,6 +2597,11 @@ int pv_get_scriptvar(struct sip_msg *msg,  pv_param_t *param,
 		res->ri = sv->v.value.n;
 		res->flags = PV_VAL_STR|PV_VAL_INT|PV_TYPE_INT;
 	}
+
+	if (!sv->init) {
+		LM_WARN("Script variable \"$var(%.*s)\" used uninitialized!\n", sv->name.len, sv->name.s);
+	}
+
 	return 0;
 }
 
@@ -2899,6 +2904,10 @@ int pv_set_scriptvar(struct sip_msg* msg, pv_param_t *param,
 		LM_ERR("error - cannot find svar\n");
 		goto error;
 	}
+
+	script_var_t *sv = (param->pvn.u.dname);
+	sv->init = 1;
+
 	if((val==NULL) || (val->flags&PV_VAL_NULL))
 	{
 		if(((script_var_t*)param->pvn.u.dname)->v.flags&VAR_TYPE_NULL)

--- a/src/modules/pv/pv_svar.h
+++ b/src/modules/pv/pv_svar.h
@@ -46,6 +46,7 @@ typedef struct script_var {
 	str name;
 	script_val_t v;
 	struct script_var *next;
+	int init;
 } script_var_t, *script_var_p;
 
 script_var_t* add_var(str *name, int vtype);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
We've come into the rare issue when a kamailio process used the old $var() value for the current request message and messed some things up.

LOG_WARN when $var() is used uninitialized in config. I can also just LOG_NOTICE this.

Can this be brought to 5.6?

Thank you,
Stefan