### PR TITLE
auth: Add pv_auth_check overload with second passwd parameter

### DIFF
--- a/src/modules/auth/doc/auth_functions.xml
+++ b/src/modules/auth/doc/auth_functions.xml
@@ -342,7 +342,7 @@ if (!pv_proxy_authenticate("$fd", "$avp(password)", "0")) {
 
 	<section id="auth.f.pv_auth_check">
 		<title>
-			<function moreinfo="none">pv_auth_check(realm, passwd, flags, checks)</function>
+			<function moreinfo="none">pv_auth_check(realm, passwd[, passwd2], flags, checks)</function>
 		</title>
 		<para>
 		The function combines the functionalities of


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

This change modifies the `pv_auth_check` function to take an optional second password argument `passwd2`. The motivation for this change is to allow authenticating against two passwords, which is useful if you want to eg. rotate passwords periodically and still allow using the previous password during a transition period. You can technically do this with two calls to `pv_auth_check`, but with `nonce_count` enabled the first call will invalidate nc which will always cause the second call to fail.
