### PR TITLE
tm: new option to add additional response codes for trying next destinations when failover with multiple ips

### DIFF
--- a/src/modules/tm/doc/params.xml
+++ b/src/modules/tm/doc/params.xml
@@ -1623,4 +1623,29 @@ modparam("tm", "enable_uac_fr", 1)
 		</example>
 	</section>
 
+	<section id="tm.p.failover_reply_codes">
+		<title><varname>failover_reply_codes</varname> (string)</title>
+		<para>
+			This parameter defines the response codes (only codes >= 300 and class >= 3), which enable
+			dns failover  to continue to try next ips when previous one fail. It is a list separated by
+			colons, where you may define either a single code (e.g. "code=408" would accept 408 as an 
+			additional response code) or a class of responses, you want to accept (e.g. "class=3" would accept
+			everything from 300 to 999 as valid response). 
+			(with default behaviour only 503 code or no response from previous one will try next ip).
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote></quote>
+		</emphasis>
+		</para>
+		<example>
+		<title>Set the <quote>failover_reply_codes</quote> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("tm", "failover_reply_codes", "code=403;code=488;class=5")
+...
+</programlisting>
+		</example>
+	</section>
+
 </section>

--- a/src/modules/tm/t_funcs.c
+++ b/src/modules/tm/t_funcs.c
@@ -43,6 +43,11 @@
  * end (this allows the script writter to send its own error reply) */
 #define TM_DELAYED_REPLY
 
+#ifdef USE_DNS_FAILOVER
+extern int** failover_reply_codes;
+extern int* failover_reply_codes_cnt;
+#endif
+
 /* fr_timer AVP specs */
 static int     fr_timer_avp_type = 0;
 static int_str fr_timer_avp = {0};
@@ -83,6 +88,12 @@ void tm_shutdown()
 
 	LM_DBG("start\n");
 
+#ifdef USE_DNS_FAILOVER
+	if(failover_reply_codes)
+		shm_free(failover_reply_codes);
+	if(failover_reply_codes_cnt)
+		shm_free(failover_reply_codes_cnt);
+#endif
 	/* destroy the hash table */
 	LM_DBG("emptying hash table\n");
 	free_hash_table( );

--- a/src/modules/tm/t_reply.h
+++ b/src/modules/tm/t_reply.h
@@ -228,4 +228,8 @@ int t_get_picked_branch(void);
 int t_get_this_branch_instance(struct sip_msg *msg, str *instance);
 int t_get_this_branch_ruid(struct sip_msg *msg, str *ruid);
 
+#ifdef USE_DNS_FAILOVER
+int t_failover_check_reply_code(int code);
+#endif
+
 #endif

--- a/src/modules/tm/tm.c
+++ b/src/modules/tm/tm.c
@@ -104,6 +104,9 @@ static int fixup_t_is_set(void** param, int param_no);
 static int mod_init(void);
 static int child_init(int rank);
 
+#ifdef USE_DNS_FAILOVER
+static int t_failover_parse_reply_codes();
+#endif
 
 /* exported functions */
 static int w_t_check(struct sip_msg* msg, char* str, char* str2);
@@ -221,6 +224,12 @@ str ulattrs_xavp_name = {NULL, 0};
 str on_sl_reply_name = {NULL, 0};
 int tm_remap_503_500 = 1;
 str _tm_event_callback_lres_sent = {NULL, 0};
+
+#ifdef USE_DNS_FAILOVER
+str failover_reply_codes_str = {NULL, 0};
+int** failover_reply_codes = NULL;
+int* failover_reply_codes_cnt;
+#endif
 
 /* control if reply should be relayed
  * when transaction reply status is RPS_PUSHED_AFTER_COMPLETION */
@@ -487,6 +496,9 @@ static param_export_t params[]={
 	{"exec_time_check" ,    PARAM_INT, &tm_exec_time_check_param             },
 	{"reply_relay_mode",    PARAM_INT, &tm_reply_relay_mode                  },
 	{"enable_uac_fr",       PARAM_INT, &default_tm_cfg.enable_uac_fr         },
+#ifdef USE_DNS_FAILOVER
+	{"failover_reply_codes",PARAM_STR, &failover_reply_codes_str             },
+#endif
 	{0,0,0}
 };
 
@@ -780,6 +792,18 @@ static int mod_init(void)
 	}
 
 #ifdef USE_DNS_FAILOVER
+	/* Initialize code and counter  for other failover reply codes*/
+	failover_reply_codes = (int **)shm_malloc(sizeof(unsigned int *));
+	*failover_reply_codes = 0;
+	failover_reply_codes_cnt = (int *)shm_malloc(sizeof(int));
+	*failover_reply_codes_cnt = 0;
+	if(failover_reply_codes_str.s && failover_reply_codes_str.len > 0) {
+		if(t_failover_parse_reply_codes() < 0) {
+			LM_ERR("failed to parse failover_reply_codes\n");
+			return -1;
+		}
+	}
+
 	if (default_tm_cfg.reparse_on_dns_failover && mhomed) {
 		LM_WARN("reparse_on_dns_failover is enabled on a"
 				" multihomed host -- check the readme of tm module!\n");
@@ -3052,6 +3076,121 @@ static int ki_t_clean(sip_msg_t* msg)
 	tm_clean_lifetime();
 	return 1;
 }
+
+#ifdef USE_DNS_FAILOVER
+/* parse reply codes for failover given in module paraleter */
+static int t_failover_parse_reply_codes()
+{
+	param_t *params_list = NULL;
+	param_t *pit = NULL;
+	int list_size = 0;
+	int i = 0;
+	int pos = 0;
+	int code = 0;
+	str input = {0, 0};
+	int *new_failover_reply_codes = NULL;
+	int *old_failover_reply_codes = NULL;
+
+	/* validate input string */
+	if(failover_reply_codes_str.s == 0 || failover_reply_codes_str.len <= 0)
+		return 0;
+
+	/* parse_params() updates the string pointer of .s -- make a copy */
+	input.s = failover_reply_codes_str.s;
+	input.len = failover_reply_codes_str.len;
+
+	if(parse_params(&input, CLASS_ANY, 0, &params_list) < 0)
+		return -1;
+
+	/* get the number of entries in the list */
+	for(pit = params_list; pit; pit = pit->next) {
+		if(pit->name.len == 4 && strncasecmp(pit->name.s, "code", 4) == 0) {
+			str2sint(&pit->body, &code);
+			if((code >= 300) && (code < 700))
+				list_size += 1;
+		} else if(pit->name.len == 5
+				  && strncasecmp(pit->name.s, "class", 5) == 0) {
+			str2sint(&pit->body, &code);
+			if((code >= 3) && (code < 7))
+				list_size += 1;
+		}
+	}
+	LM_DBG("expecting %d reply codes and classes\n", list_size);
+
+	if(list_size > 0) {
+		/* Allocate Memory for the new list: */
+		new_failover_reply_codes = (int *)shm_malloc(list_size * sizeof(int));
+		if(new_failover_reply_codes == NULL) {
+			free_params(params_list);
+			LM_ERR("no more memory\n");
+			return -1;
+		}
+
+		/* Now create the list of valid reply-codes: */
+		for(pit = params_list; pit; pit = pit->next) {
+			if(pit->name.len == 4 && strncasecmp(pit->name.s, "code", 4) == 0) {
+				str2sint(&pit->body, &code);
+				if((code >= 300) && (code < 700)) {
+					new_failover_reply_codes[pos++] = code;
+				}
+			} else if(pit->name.len == 5
+					  && strncasecmp(pit->name.s, "class", 5) == 0) {
+				str2sint(&pit->body, &code);
+				if((code >= 3) && (code < 7)) {
+					new_failover_reply_codes[pos++] = code;
+				}
+			}
+		}
+	} else {
+		new_failover_reply_codes = 0;
+	}
+	free_params(params_list);
+
+	if(list_size > *failover_reply_codes_cnt) {
+		/* if more reply-codes -- change pointer and then set number of codes */
+		old_failover_reply_codes = *failover_reply_codes;
+		*failover_reply_codes = new_failover_reply_codes;
+		*failover_reply_codes_cnt = list_size;
+		if(old_failover_reply_codes)
+			shm_free(old_failover_reply_codes);
+	} else {
+		/* less or equal reply codea -- set the number of codes first */
+		*failover_reply_codes_cnt = list_size;
+		old_failover_reply_codes = *failover_reply_codes;
+		*failover_reply_codes = new_failover_reply_codes;
+		if(old_failover_reply_codes)
+			shm_free(old_failover_reply_codes);
+	}
+	/* Print the list as INFO: */
+	for(i = 0; i < *failover_reply_codes_cnt; i++) {
+		LM_DBG("accepting reply %s %d (%d/%d) as valid\n",
+				((*failover_reply_codes)[i]/10)?"code":"class",
+				(*failover_reply_codes)[i], (i + 1), *failover_reply_codes_cnt);
+	}
+	return 0;
+}
+
+int t_failover_check_reply_code(int code)
+{
+	int i;
+
+	for(i = 0; i < *failover_reply_codes_cnt; i++) {
+		if((*failover_reply_codes)[i] / 10) {
+			/* reply code */
+			if((*failover_reply_codes)[i] == code) {
+				return 1;
+			}
+		} else {
+			/* reply class */
+			if(((*failover_reply_codes)[i] / 100) == code) {
+				return 1;
+			}
+		}
+	}
+
+	return 0;
+}
+#endif
 
 /**
  *


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This change allows the tm module to continue to try next destinations on receiving reply codes other than 503 from previous destinations when dns failover resolves to multiple ips.

A new parameter **failover_reply_codes**  added to the module gives hand to add codes or class of code to continue to try 
next destinations.
this parameter has the same format as ds_ping_reply_codes of dispatcher module.

```
modparam("tm", "failover_reply_codes", "code=403;code=488;class=5")
```
