### PR TITLE
Fix Makefile.groups and SLACK for build on FreeBSD

### DIFF
--- a/src/Makefile.groups
+++ b/src/Makefile.groups
@@ -38,7 +38,7 @@ mod_list_dbuid=db2_ops uid_auth_db uid_avp_db uid_domain uid_gflags \
 				 uid_uri_db
 
 # - modules for devel purposes
-mod_list_devel=malloc_test print print_lib
+mod_list_devel=misctest print print_lib
 
 # - modules depending on pcre3 library
 mod_list_pcre=dialplan lcr regex

--- a/src/modules/slack/Makefile
+++ b/src/modules/slack/Makefile
@@ -8,5 +8,21 @@ include ../../Makefile.defs
 auto_gen=
 NAME=slack.so
 
+ifeq ($(CROSS_COMPILE),)
+CURL_BUILDER=$(shell \
+	if pkg-config --exists libcurl; then \
+		echo 'pkg-config libcurl'; \
+	else \
+		which curl-config; \
+	fi)
+endif
+
+ifneq ($(CURL_BUILDER),)
+	DEFS += $(shell $(CURL_BUILDER) --cflags )
+	LIBS += $(shell $(CURL_BUILDER) --libs)
+else
+	DEFS+=-I$(LOCALBASE)/include
+	LIBS+=-L$(LOCALBASE)/lib -lcurl
+endif
 
 include ../../Makefile.modules


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [X] Related to issue #3091

#### Description
`module_group_standard` and `slack` are not build on FreeBSD environment.
The proposed patch fixes it and makes the module is consistent with the rest of modules.