### PR TITLE
Fix LOST for build on FreeBSD

### DIFF
--- a/src/modules/lost/Makefile
+++ b/src/modules/lost/Makefile
@@ -16,6 +16,12 @@ XML2CFG=$(shell \
 		echo 'pkg-config libxml-2.0'; \
 	fi)
 endif
+CURL_BUILDER=$(shell \
+	if pkg-config --exists libcurl; then \
+		echo 'pkg-config libcurl'; \
+	else \
+		which curl-config; \
+	fi)
 endif
 
 ifneq ($(XML2CFG),)
@@ -24,6 +30,14 @@ ifneq ($(XML2CFG),)
 else
 	DEFS+=-I$(LOCALBASE)/include/libxml2 -I$(LOCALBASE)/include
 	LIBS+=-L$(LOCALBASE)/lib -lxml2
+endif
+
+ifneq ($(CURL_BUILDER),)
+	DEFS += $(shell $(CURL_BUILDER) --cflags )
+	LIBS += $(shell $(CURL_BUILDER) --libs)
+else
+	DEFS+=-I$(LOCALBASE)/include
+	LIBS+=-L$(LOCALBASE)/lib -lcurl
 endif
 
 include ../../Makefile.modules


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
`lost` is not build on FreeBSD environment.
The proposed patch fixes it and makes the module is consistent with the rest of modules.