### PR TITLE
auth: Add flag for not invalidating nc on auth failure

### DIFF
--- a/src/modules/auth/api.c
+++ b/src/modules/auth/api.c
@@ -34,7 +34,7 @@
 #include "rfc2617_sha256.h"
 #include "challenge.h"
 
-static int auth_check_hdr_md5(struct sip_msg* msg, auth_body_t* auth_body,
+static int auth_check_hdr_md5_default(struct sip_msg* msg, auth_body_t* auth_body,
 		auth_result_t* auth_res);
 
 /*
@@ -94,7 +94,7 @@ auth_result_t pre_auth(struct sip_msg* msg, str* realm, hdr_types_t hftype,
 
 	/* check authorization header field's validity */
 	if (check_auth_hdr == NULL) {
-		check_hf = auth_check_hdr_md5;
+		check_hf = auth_check_hdr_md5_default;
 	} else {	/* use check function of external authentication module */
 		check_hf = check_auth_hdr;
 	}
@@ -113,8 +113,8 @@ auth_result_t pre_auth(struct sip_msg* msg, str* realm, hdr_types_t hftype,
  * @result if authentication should continue (1) or not (0)
  *
  */
-static int auth_check_hdr_md5(struct sip_msg* msg, auth_body_t* auth,
-		auth_result_t* auth_res)
+int auth_check_hdr_md5(struct sip_msg* msg, auth_body_t* auth,
+		auth_result_t* auth_res, int update_nonce)
 {
 	int ret;
 
@@ -125,7 +125,7 @@ static int auth_check_hdr_md5(struct sip_msg* msg, auth_body_t* auth,
 		return 0;
 	}
 
-	ret = check_nonce(auth, &secret1, &secret2, msg);
+	ret = check_nonce(auth, &secret1, &secret2, msg, update_nonce);
 	if (ret!=0){
 		if (ret==3 || ret==4){
 			/* failed auth_extra_checks or stale */
@@ -143,6 +143,12 @@ static int auth_check_hdr_md5(struct sip_msg* msg, auth_body_t* auth,
 		}
 	}
 	return 1;
+}
+
+static int auth_check_hdr_md5_default(struct sip_msg* msg, auth_body_t* auth,
+		auth_result_t* auth_res)
+{
+	return auth_check_hdr_md5(msg, auth, auth_res, 1);
 }
 
 /**

--- a/src/modules/auth/api.h
+++ b/src/modules/auth/api.h
@@ -82,6 +82,9 @@ typedef int (*check_auth_hdr_t)(struct sip_msg* msg, auth_body_t* auth_body,
 int check_auth_hdr(struct sip_msg* msg, auth_body_t* auth_body,
 		auth_result_t* auth_res);
 
+int auth_check_hdr_md5(struct sip_msg* msg, auth_body_t* auth,
+		auth_result_t* auth_res, int update_nonce);
+
 /*
  * Purpose of this function is to find credentials with given realm,
  * do sanity check, validate credential correctness and determine if

--- a/src/modules/auth/auth_mod.c
+++ b/src/modules/auth/auth_mod.c
@@ -476,6 +476,19 @@ int w_has_credentials(sip_msg_t *msg, char* realm, char* s2)
 	}
 	return ki_has_credentials(msg, &srealm);
 }
+
+#ifdef USE_NC
+/**
+ * Calls auth_check_hdr_md5 with the update_nonce flag set to false.
+ * Used when flag 32 is set in pv_authenticate.
+ */
+static int auth_check_hdr_md5_noupdate(struct sip_msg* msg, auth_body_t* auth,
+		auth_result_t* auth_res)
+{
+	return auth_check_hdr_md5(msg, auth, auth_res, 0);
+}
+#endif
+
 /**
  * @brief do WWW-Digest authentication with password taken from cfg var
  */
@@ -490,11 +503,17 @@ int pv_authenticate(struct sip_msg *msg, str *realm, str *passwd,
 	avp_value_t val;
 	static char ha1[256];
 	struct qp *qop = NULL;
+	check_auth_hdr_t check_auth_hdr = NULL;
 
 	cred = 0;
 	ret = AUTH_ERROR;
 
-	switch(pre_auth(msg, realm, hftype, &h, NULL)) {
+#ifdef USE_NC
+	if (nc_enabled && (flags & 32))
+		check_auth_hdr = auth_check_hdr_md5_noupdate;
+#endif
+
+	switch(pre_auth(msg, realm, hftype, &h, check_auth_hdr)) {
 		case NONCE_REUSED:
 			LM_DBG("nonce reused");
 			ret = AUTH_NONCE_REUSED;
@@ -561,6 +580,16 @@ int pv_authenticate(struct sip_msg *msg, str *realm, str *passwd,
 		else
 			ret = AUTH_ERROR;
 	}
+
+#ifdef USE_NC
+	/* On success we need to update the nonce if flag 32 is set */
+	if (nc_enabled && ret == AUTH_OK && (flags & 32)) {
+		if (check_nonce(cred, &secret1, &secret2, msg, 1) < 0) {
+			LM_ERR("check_nonce failed after post_auth");
+			ret = AUTH_ERROR;
+		}
+	}
+#endif
 
 end:
 	if (ret < 0) {

--- a/src/modules/auth/doc/auth_functions.xml
+++ b/src/modules/auth/doc/auth_functions.xml
@@ -274,6 +274,10 @@ if (!auth_check("$fd", "subscriber", "1")) {
 				<para><emphasis>16</emphasis> - build challenge header with
 					stale=true</para>
 			</listitem>
+			<listitem>
+				<para><emphasis>32</emphasis> - don't invalidate nc on
+					authentication failure</para>
+			</listitem>
 
 			</itemizedlist>
 		</listitem>

--- a/src/modules/auth/nc.c
+++ b/src/modules/auth/nc.c
@@ -213,7 +213,7 @@ nid_t nc_new(nid_t id, unsigned char p)
  * NC_TOO_BIG       (nc value got too big and cannot be held anymore)
  * NC_REPLAY        (nc value is <= the current stored one)
  */
-enum nc_check_ret nc_check_val(nid_t id, unsigned pool, unsigned int nc)
+enum nc_check_ret nc_check_val(nid_t id, unsigned pool, unsigned int nc, int update)
 {
 	unsigned int i;
 	unsigned n, r;
@@ -234,6 +234,8 @@ enum nc_check_ret nc_check_val(nid_t id, unsigned pool, unsigned int nc)
 		crt_nc=(v>>(r*8)) & ((1U<<(sizeof(nc_t)*8))-1);
 		if (crt_nc>=nc)
 			return NC_REPLAY;
+		if (!update)
+			break;
 		/* set corresponding array cell byte/short to new nc */
 		new_v=(v & ~(((1U<<(sizeof(nc_t)*8))-1)<< (r*8)) )|
 				(nc << (r*8));

--- a/src/modules/auth/nc.h
+++ b/src/modules/auth/nc.h
@@ -64,7 +64,7 @@ enum nc_check_ret{
 
 /* check if nonce-count nc w/ index i is expected/valid and record its
  * value */
-enum nc_check_ret nc_check_val(nid_t i, unsigned pool, unsigned int nc);
+enum nc_check_ret nc_check_val(nid_t i, unsigned pool, unsigned int nc, int update);
 
 /* re-init the stored nc for nonce id in pool pool_no */
 nid_t nc_new(nid_t id, unsigned char pool_no);

--- a/src/modules/auth/nonce.c
+++ b/src/modules/auth/nonce.c
@@ -307,7 +307,7 @@ static inline int l8hex2int(char* _s, unsigned int *_r)
  *          6 - nonce reused
  */
 int check_nonce(auth_body_t* auth, str* secret1, str* secret2,
-		struct sip_msg* msg)
+		struct sip_msg* msg, int update_nonce)
 {
 	str * nonce;
 	int since, b_nonce2_len, b_nonce_len, cfg;
@@ -418,7 +418,7 @@ if (!memcmp(&b_nonce.n.md5_1[0], &b_nonce2.n.md5_1[0], 16)) {
 			LM_ERR("bad nc value %.*s\n", auth->digest.nc.len, auth->digest.nc.s);
 			return 5; /* invalid nc */
 		}
-		switch(nc_check_val(n_id, pf & NF_POOL_NO_MASK, nc)){
+		switch(nc_check_val(n_id, pf & NF_POOL_NO_MASK, nc, update_nonce)){
 			case NC_OK:
 				/* don't perform extra checks or one-time nonce checks
 				 * anymore, if we have nc */

--- a/src/modules/auth/nonce.h
+++ b/src/modules/auth/nonce.h
@@ -219,7 +219,7 @@ int calc_nonce(char* nonce, int* nonce_len, int cfg, int since, int expires,
  * Check nonce value received from UA
  */
 int check_nonce(auth_body_t* auth, str* secret1, str* secret2,
-					struct sip_msg* msg);
+					struct sip_msg* msg, int update_nonce);
 
 
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

This change modifies `pv_www_authenticate` and related functions to add flag 32. If the flag is set and `nonce_count` is enabled then we skip updating nc in `pre_auth`. On success we call `check_nonce` once more to do the nc update. This can be used to chain calls to authenticate against multiple passwords.