### PR TITLE
WIP app_python3: need a test for a real child process

### DIFF
--- a/src/modules/app_python3/app_python3_mod.c
+++ b/src/modules/app_python3/app_python3_mod.c
@@ -180,6 +180,9 @@ static int mod_init(void)
  */
 static int child_init(int rank)
 {
+
+	pid_t parent_pid = 0;
+
 	if(rank==PROC_INIT) {
 		/*
 		 * this is called before any process is forked
@@ -189,6 +192,7 @@ static int child_init(int rank)
 		 * TODO: is PyOS_AfterFork_Parent() necesary
 		 * in the main process?
 		 */
+		parent_pid = getpid();
 #if PY_VERSION_HEX >= 0x03070000
 		PyOS_BeforeFork() ;
 #endif
@@ -206,7 +210,11 @@ static int child_init(int rank)
 	}
 	_apy_process_rank = rank;
 
-	if (rank > 0) {
+	if (parent_pid != getpid()) {
+		/* this must only be called in a real child process
+		 * kamailio has a non-fork mode so rank > 0 is not
+		 * a sufficient test
+		 */
 #if PY_VERSION_HEX >= 0x03070000
 		PyOS_AfterFork_Child();
 #else


### PR DESCRIPTION
app_python3 needs to call `PyOS_AfterFork_Child()`/`PyOS_AfterFork()`
in real child processes.

We need a test for this: rank > 0 may not be sufficient due to
non-forking mode. This POC uses getpid().

- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
@miconda @henningw : this PR is for discussion only: in KEMI Python there is an interpreter function that needs to be called after `fork()` in real child processes. I realise that `rank > 0` may not be a completely correct test as kamailio has a non-forking mode(this is the test used in master and 5.6 to fix GH#3125). Your comments would be appreciated.

This POC uses `getpid()` to detect a &ldquo;real&rdquo; child process.

Is there a flag somewhere that a module can tell that it is running in a child process?