### PR TITLE
Path MTU discovery for IPv6

### DIFF
--- a/doc/misc/NEWS
+++ b/doc/misc/NEWS
@@ -720,7 +720,7 @@ new config variables:
          dropping the connection. Linux only.
   tcp_crlf_ping = yes | no (set by default) - enable CRLF keepalives aka
          SIP outbound.
-  pmtu_discovery = 0 | 1 (default 0) - set DF bit in outbound IP if enabled
+  pmtu_discovery = 0 | 1 (default 0) - set DF bit in outbound IPv4 if enabled
   dns_srv_lb = yes | no (default no) - enable dns srv weight based load 
     balancing (see doc/dns.txt)
   dns_try_naptr = yes | no (default no) - enable naptr support 

--- a/src/core/udp_server.c
+++ b/src/core/udp_server.c
@@ -329,12 +329,22 @@ int udp_init(struct socket_info* sock_info)
 	}
 
 #if defined (__OS_linux) && defined(UDP_ERRORS)
+	/* Ask for the ability to recvmsg (...,MSG_ERRQUEUE) for immediate
+	 * resend when hitting Path MTU limits. */
 	optval=1;
 	/* enable error receiving on unconnected sockets */
-	if(setsockopt(sock_info->socket, SOL_IP, IP_RECVERR,
+	if (addr->s.sa_family==AF_INET){
+		if(setsockopt(sock_info->socket, SOL_IP, IP_RECVERR,
 					(void*)&optval, sizeof(optval)) ==-1){
-		LM_ERR("setsockopt: %s\n", strerror(errno));
-		goto error;
+			LM_ERR("setsockopt: %s\n", strerror(errno));
+			goto error;
+		}
+	} else if (addr->s.sa_family==AF_INET6){
+		if(setsockopt(sock_info->socket, SOL_IPV6, IPV6_RECVERR,
+					(void*)&optval, sizeof(optval)) ==-1){
+			LM_ERR("setsockopt: %s\n", strerror(errno));
+			goto error;
+		}
 	}
 #endif
 #if defined (__OS_linux)


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches (no, it is a requirement to use UDP/IPv6 with everyone)
- [X] Tested changes locally (same results as before with the Kamailio test framework)
- [x] Related to issue #3119

#### Description

The IPv6 support for Path MTU discovery is absent, but IPv6 has no DF flag to allow downstream fragmentation.  See Issue #3119 for my discovery / learning path.  In short, unconnected UDP sockets do not learn Path MTU problems, so a message dropped once will be dropped again on resend.  Using `IPV6_PMTUDISC_WANT`, any knowledge in the kernel can be used to fragment the message at sending time, as intended for IPv6.

These patches actually correct two IPv6-related things in the `core/udp_server.c`,

 1. Benefit from any kernel knowledge about Path MTU for IPv6
 2. The same option to learn from UDP_ERRORS is now available for IPv6

Do note that the last has not been implemented for IPv4 or IPv6.  It is more useful for IPv6, allowing instant "tm" resends for Path MTU, but not "sl" I think.  I cannot do that work, but this brings IPv6 to the same level as IPv4.

```
commit 0f90cff05c1a448eb2f85f83b4c087ab32ede11
Author: Rick van Rein <rick@openfortress.nl>
Date:   Sat Jun 11 10:57:32 2022 +0000

    core: Issue 3119.  Handling ICMPv6 Packet too Big
    
    - This was only defined for IPv4 under flag UDP_ERRORS
    - IPv6 has no toggle DF to clear for en-route fragmentation
    - Kamailio currently does not collect with recvmsg(...,MSG_ERRQUEUE)
    - The benefits of adding that can be instant resends for "tm" messages
    - Note that "sl" messages will have been forgotten at this point

commit 6b404b5f9807174177bee36eaf3543be0794f55e
Author: Rick van Rein <rick@openfortress.nl>
Date:   Sat Jun 11 10:44:27 2022 +0000

    core: Issue #3119.  Path MTU kernel info for IPv6
    
    - For IPv4, DF is an option; for IPv6 it is always active
    - This makes pmtu_discover an IPv4-only option
    - This means that we should set IPV6_MTU_DISCOVER to IPV6_PMTUDISC_WANT
    - Unconnected UDP sockets can now learn from ICMPv6 "Packet too Big"
    - As a result, hitting a Path MTU upper bound is a learning process
    - This should stop consistent SIP packet drops due to Path MTU
  ```
