### PR TITLE
pua dialoginfo: improvements

### DIFF
--- a/src/modules/pua_dialoginfo/doc/pua_dialoginfo_admin.xml
+++ b/src/modules/pua_dialoginfo/doc/pua_dialoginfo_admin.xml
@@ -620,6 +620,25 @@ modparam("pua_dialoginfo", "publish_dialog_req_within", 0)
                 </example>
                 </section>
 
+		<section id="pua_dialoginfo.p.local_identity_dlg_var">
+		<title><varname>local_identity_dlg_var</varname> (str)</title>
+		<para>
+			PUBLISH-requests reporting dialog-information will use the value of
+			the dialog variable if exists
+		</para>
+		<para>
+			<emphasis>Default value is <quote>NULL</quote>.</emphasis>
+		</para>
+		<example>
+			<title>Set <varname>local_identity_dlg_var</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("pua_dialoginfo", "local_identity_dlg_var", "local_identity")
+...
+</programlisting>
+		</example>
+		</section>
+
         <section id="pua_dialoginfo.p.attribute_display">
             <title><varname>attribute_display</varname> (int)</title>
             <para>

--- a/src/modules/pua_dialoginfo/doc/pua_dialoginfo_admin.xml
+++ b/src/modules/pua_dialoginfo/doc/pua_dialoginfo_admin.xml
@@ -433,7 +433,25 @@ modparam("pua_dialoginfo", "use_pubruri_avps", 1)
 </programlisting>
 		</example>
 		</section>
-		
+
+	<section id="pua_dialoginfo.p.refresh_pubruri_avps_flag">
+		<title><varname>refresh_pubruri_avps_flag</varname> (int)</title>
+		<para>
+			If use_pubruri_avps is enabled, this message flag indicates whether to refresh R-Uri from avps before sending the PUBLISH requests.
+		</para>
+		<para>
+			<emphasis>Default value is <quote>-1</quote>.</emphasis>
+		</para>
+		<example>
+			<title>Set <varname>refresh_pubruri_avps_flag</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("pua_dialoginfo", "refresh_pubruri_avps_flag", 11)
+...
+</programlisting>
+		</example>
+		</section>
+
 		<section>
 		<title><varname>pubruri_caller_avp</varname> (str)</title>
 		<para>

--- a/src/modules/pua_dialoginfo/pua_dialoginfo.c
+++ b/src/modules/pua_dialoginfo/pua_dialoginfo.c
@@ -87,6 +87,7 @@ static str caller_dlg_var = {0, 0}; /* pubruri_caller */
 static str callee_dlg_var = {0, 0}; /* pubruri_callee */
 static str caller_entity_when_publish_disabled = {0, 0}; /* pubruri_caller */
 static str callee_entity_when_publish_disabled = {0, 0}; /* pubruri_callee */
+static str local_identity_dlg_var = STR_NULL;
 
 /* Module parameter variables */
 int include_callid         = DEF_INCLUDE_CALLID;
@@ -132,6 +133,7 @@ static param_export_t params[]={
 	{"pubruri_callee_avp",  PARAM_STRING, &pubruri_callee_avp },
 	{"pubruri_caller_dlg_var",  PARAM_STR, &caller_dlg_var },
 	{"pubruri_callee_dlg_var",  PARAM_STR, &callee_dlg_var },
+	{"local_identity_dlg_var",  PARAM_STR, &local_identity_dlg_var },
 	{"callee_trying",       INT_PARAM, &callee_trying },
 	{"disable_caller_publish_flag",   INT_PARAM, &disable_caller_publish_flag },
 	{"disable_callee_publish_flag",   INT_PARAM, &disable_callee_publish_flag },
@@ -312,6 +314,17 @@ void refresh_pubruri_avps(struct dlginfo_cell *dlginfo, str *uri)
 	}
 }
 
+void refresh_local_identity(struct dlg_cell *dlg, str *uri) {
+	str *s = dlg_api.get_dlg_var(dlg, &local_identity_dlg_var);
+
+	if(s != NULL) {
+		uri->s = s->s;
+		uri->len = s->len;
+		LM_DBG("Found local_identity in dialog '%.*s'\n",
+				uri->len, uri->s);
+	}
+}
+
 static void
 __dialog_sendpublish(struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
 {
@@ -355,6 +368,10 @@ __dialog_sendpublish(struct dlg_cell *dlg, int type, struct dlg_cb_params *_para
 	{
 		lock_get(&dlginfo->lock);
 		refresh_pubruri_avps(dlginfo, &uri);
+	}
+
+	if(local_identity_dlg_var.len > 0) {
+		refresh_local_identity(dlg, &uri);
 	}
 
 	switch (type) {

--- a/src/modules/pua_dialoginfo/pua_dialoginfo.c
+++ b/src/modules/pua_dialoginfo/pua_dialoginfo.c
@@ -41,6 +41,7 @@
 #include "../../core/str_list.h"
 #include "../../core/mem/mem.h"
 #include "../../core/pt.h"
+#include "../../core/ut.h"
 #include "../../core/utils/sruid.h"
 #include "../dialog/dlg_load.h"
 #include "../dialog/dlg_hash.h"
@@ -59,6 +60,7 @@ MODULE_VERSION
 #define DEF_OVERRIDE_LIFETIME 0
 #define DEF_SEND_PUBLISH_FLAG -1
 #define DEF_USE_PUBRURI_AVPS 0
+#define DEF_REFRESH_PUBRURI_AVPS_FLAG -1
 #define DEF_PUBRURI_CALLER_AVP 0
 #define DEF_PUBRURI_CALLEE_AVP 0
 #define DEF_CALLEE_TRYING 0
@@ -95,6 +97,7 @@ int caller_confirmed       = DEF_CALLER_ALWAYS_CONFIRMED;
 int include_req_uri        = DEF_INCLUDE_REQ_URI;
 int send_publish_flag      = DEF_SEND_PUBLISH_FLAG;
 int use_pubruri_avps       = DEF_USE_PUBRURI_AVPS;
+int refresh_pubruri_avps_flag = DEF_REFRESH_PUBRURI_AVPS_FLAG;
 int callee_trying          = DEF_CALLEE_TRYING;
 int disable_caller_publish_flag = DEF_DISABLE_CALLER_PUBLISH_FLAG;
 int disable_callee_publish_flag = DEF_DISABLE_CALLEE_PUBLISH_FLAG;
@@ -124,6 +127,7 @@ static param_export_t params[]={
 	{"include_req_uri",     INT_PARAM, &include_req_uri },
 	{"send_publish_flag",   INT_PARAM, &send_publish_flag },
 	{"use_pubruri_avps",    INT_PARAM, &use_pubruri_avps },
+	{"refresh_pubruri_avps_flag",   INT_PARAM, &refresh_pubruri_avps_flag },
 	{"pubruri_caller_avp",  PARAM_STRING, &pubruri_caller_avp },
 	{"pubruri_callee_avp",  PARAM_STRING, &pubruri_callee_avp },
 	{"pubruri_caller_dlg_var",  PARAM_STR, &caller_dlg_var },
@@ -256,6 +260,58 @@ __dialog_cbtest(struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
 }
 #endif
 
+static struct str_list* get_str_list(unsigned short avp_flags, int_str avp_name);
+static int is_ruri_in_list(struct str_list *list, str *ruri);
+
+void refresh_pubruri_avps(struct dlginfo_cell *dlginfo, str *uri)
+{
+	struct str_list *pubruris = get_str_list(pubruri_caller_avp_type,
+			pubruri_caller_avp_name);
+	struct str_list *list, *next;
+	str target = STR_NULL;
+
+	if(pubruris) {
+		list = dlginfo->pubruris_caller;
+		while(list) {
+			if(is_ruri_in_list(pubruris, &list->s) == 0) {
+				LM_DBG("ruri:'%.*s' removed from pubruris_caller list\n",
+					list->s.len, list->s.s);
+				next = list->next; list->next = NULL;
+				dialog_publish_multi("terminated", list,
+						&(dlginfo->from_uri), uri, &(dlginfo->callid), 1,
+						10, 0, 0, &(dlginfo->from_contact),
+						&target, send_publish_flag==-1?1:0, &(dlginfo->uuid));
+				list->next = next;
+			}
+			list = list->next;
+		}
+		free_str_list_all(dlginfo->pubruris_caller);
+		dlginfo->pubruris_caller = pubruris;
+		LM_DBG("refreshed pubruris_caller info from avp\n");
+	}
+	pubruris = get_str_list(pubruri_callee_avp_type,
+			pubruri_callee_avp_name);
+	if(pubruris) {
+		list = dlginfo->pubruris_callee;
+		while(list) {
+			if(is_ruri_in_list(pubruris, &list->s) == 0) {
+				LM_DBG("ruri:'%.*s' removed from pubruris_callee list\n",
+					list->s.len, list->s.s);
+				next = list->next; list->next = NULL;
+				dialog_publish_multi("terminated", list,
+						uri, &(dlginfo->from_uri), &(dlginfo->callid), 0,
+						10, 0, 0, &target, &(dlginfo->from_contact),
+						send_publish_flag==-1?1:0, &(dlginfo->uuid));
+				list->next = next;
+			}
+			list = list->next;
+		}
+		free_str_list_all(dlginfo->pubruris_callee);
+		dlginfo->pubruris_callee = pubruris;
+		LM_DBG("refreshed pubruris_callee info from avp\n");
+	}
+}
+
 static void
 __dialog_sendpublish(struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
 {
@@ -292,6 +348,12 @@ __dialog_sendpublish(struct dlg_cell *dlg, int type, struct dlg_cb_params *_para
 
 	if (dlginfo->disable_callee_publish) {
 		uri=callee_entity_when_publish_disabled;
+	}
+
+	if(use_pubruri_avps && (refresh_pubruri_avps_flag > -1
+		|| (request->flags & (1<<refresh_pubruri_avps_flag))))
+	{
+		refresh_pubruri_avps(dlginfo, &uri);
 	}
 
 	switch (type) {
@@ -883,6 +945,19 @@ void free_dlginfo_cell(void *param) {
 	shm_free(param);
 }
 
+
+int is_ruri_in_list(struct str_list *list, str *ruri) {
+	struct str_list *pubruris = list;
+	LM_DBG("search:'%.*s'\n", ruri->len, ruri->s);
+	while(pubruris) {
+		LM_DBG("compare with:'%.*s'\n", pubruris->s.len, pubruris->s.s);
+		if(str_strcmp(&pubruris->s, ruri) == 0) {
+			return 1;
+		}
+		pubruris = pubruris->next;
+	}
+	return 0;
+}
 
 void free_str_list_all(struct str_list * del_current) {
 

--- a/src/modules/pua_dialoginfo/pua_dialoginfo.h
+++ b/src/modules/pua_dialoginfo/pua_dialoginfo.h
@@ -23,6 +23,7 @@
 
 #ifndef _PUA_DLGINFO_H
 #define _PUA_DLGINFO_H
+#include "../../core/locking.h"
 #include "../pua/pua_bind.h"
 
 extern send_publish_t pua_send_publish;
@@ -35,6 +36,7 @@ void dialog_publish_multi(char *state, struct str_list* ruris, str *entity, str 
  * dlg_cell during the callback (as this could create a race condition
  * if the dlg_cell gets meanwhile deleted) */
 struct dlginfo_cell {
+	gen_lock_t lock;
 	str from_uri;
 	str to_uri;
 	str callid;


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally

#### Description
Changes from Sipwise flavor:
- refresh_pubruri_avps_flag: if enabled, this message flag indicates whether to refresh R-Uri from avps before sending the PUBLISH requests.
- improvement for use_pubruri_avps: use locking to avoid crashes since we are using shared memory
- local_identity_dlg_var: reporting dialog-information will use the value of the dialog variable if exists
