### PR TITLE
nats: fix the nats:connected event_route not being triggered on a successful connect

### DIFF
--- a/src/modules/nats/nats_mod.c
+++ b/src/modules/nats/nats_mod.c
@@ -298,7 +298,10 @@ int _nats_pub_worker_proc(
 			!= NATS_OK) {
 		LM_ERR("could not connect to nats servers [%s]\n",
 				natsStatus_GetText(s));
+	} else {
+		connectedCB(worker->nc->conn, NULL);
 	}
+
 	s = natsOptions_SetEventLoop(worker->nc->opts, (void *)worker->uvLoop,
 			natsLibuv_Attach, natsLibuv_Read, natsLibuv_Write,
 			natsLibuv_Detach);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

according to nats docs: http://nats-io.github.io/nats.c/group__opts_group.html#ga20946800d024b7089e73d63454d1c19f

If [natsConnection_Connect()](http://nats-io.github.io/nats.c/group__conn_mgt_group.html#ga740be1ba16a8570eb98ef6755ebf52ce) returns NATS_OK (that is, a connection to a NATS Server was established in that call), then the connectedCb callback will not be invoked.

this patch fixes it by manually call the callback function.