### PR TITLE
topos: don't insert contact header for 4xx replies

### DIFF
--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -1167,6 +1167,11 @@ int tps_response_sent(sip_msg_t *msg)
 				&& msg->contact==NULL) {
 		contact_keep = 1;
 	}
+	if(contact_keep==0 && msg->first_line.u.reply.statuscode>=400
+				&& msg->first_line.u.reply.statuscode<500
+				&& msg->contact==NULL) {
+		contact_keep = 1;
+	}
 	if(contact_keep==0) {
 		tps_remove_headers(msg, HDR_CONTACT_T);
 		if(direction==TPS_DIR_DOWNSTREAM) {


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally

#### Description

Topos is adding Contact header to the 407 reply

![image](https://user-images.githubusercontent.com/63080/174794224-b9a6f9d9-f496-4be0-b903-489bd8a4a261.png)

![image](https://user-images.githubusercontent.com/63080/174794351-14000f4c-185c-48b9-adde-476ba6744c30.png)

Related to https://github.com/kamailio/kamailio/pull/3149 even with https://github.com/kamailio/kamailio/commit/414c7dd608584df18f871b42e05f401e21ba775d applied

