### PR TITLE
tls: cert serial number can exceed uint64

### DIFF
--- a/src/modules/tls/tls_select.c
+++ b/src/modules/tls/tls_select.c
@@ -630,24 +630,35 @@ static int pv_validity(sip_msg_t* msg, pv_param_t* param, pv_value_t* res)
 }
 
 
-static int get_sn(str* res, int* ires, int local, sip_msg_t* msg)
+static int get_sn(str* res, int local, sip_msg_t* msg)
 {
-	static char buf[INT2STR_MAX_LEN];
+	static char buf[80]; // handle 256-bit > log(2^256,10)
 	X509* cert;
 	struct tcp_connection* c;
-	char* sn;
-	int num;
+	char* sn = NULL;
+	BIGNUM* bn = NULL;
 
 	if (get_cert(&cert, &c, msg, local) < 0) return -1;
 
-	num = ASN1_INTEGER_get(X509_get_serialNumber(cert));
-	sn = int2str(num, &res->len);
+	if (!(bn = BN_new())) goto error;
+	if (!ASN1_INTEGER_to_BN(X509_get_serialNumber(cert), bn)) goto error;
+	if (!(sn = BN_bn2dec(bn)) || strlen(sn) > 80) goto error;
+
+	res->len = strlen(sn);
 	memcpy(buf, sn, res->len);
 	res->s = buf;
-	if (ires) *ires = num;
+
 	if (!local) X509_free(cert);
 	tcpconn_put(c);
+
+	BN_free(bn);
+	OPENSSL_free(sn);
 	return 0;
+
+ error:
+	if (sn) OPENSSL_free(sn);
+	if (bn) BN_free(bn);
+	return -1;
 }
 
 static int sel_sn(str* res, select_t* s, sip_msg_t* msg)
@@ -662,7 +673,7 @@ static int sel_sn(str* res, select_t* s, sip_msg_t* msg)
 		return -1;
 	}
 
-	return get_sn(res, NULL, local, msg);
+	return get_sn(res, local, msg);
 }
 
 
@@ -679,11 +690,11 @@ static int pv_sn(sip_msg_t* msg, pv_param_t* param, pv_value_t* res)
 		return pv_get_null(msg, param, res);
 	}
 	
-	if (get_sn(&res->rs, &res->ri, local, msg) < 0) {
+	if (get_sn(&res->rs, local, msg) < 0) {
 		return pv_get_null(msg, param, res);
 	}
 	
-	res->flags = PV_VAL_STR | PV_VAL_INT;
+	res->flags = PV_VAL_STR;
 	return 0;
 }
 


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [  ] Small bug fix (non-breaking change which fixes an issue)
- [  ] New feature (non-breaking change which adds new functionality)
- [X] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #3168

#### Description
Certificate serial numbers can be large integers (> 2^64). Parse them as BIGNUM and store the string
in pv; we cannot store as integer anymore. The original code handles 2^64 with a static buffer of 19.
We upsize to 2^256 with a static buffer of 80.

**May break configurations** that try to extract the sn pv as an integer
(does anyone actually do this?)

Addresses #3168.