### PR TITLE
core: crypto add support for SHA-512/256 for RFCs 8760/7616

### DIFF
--- a/src/core/crypto/sha256.c
+++ b/src/core/crypto/sha256.c
@@ -301,6 +301,18 @@ const static sha2_word64 sha512_initial_hash_value[8] = {
 	0x5be0cd19137e2179ULL
 };
 
+/* Initial hash value H for SHA-512/256 */
+const static sha2_word64 sha512_256_initial_hash_value[8] = {
+	0x22312194FC2BF72CULL,
+	0x9F555FA3C84C64C2ULL,
+	0x2393B86B6F53B151ULL,
+	0x963877195940EABDULL,
+	0x96283EE2A88EFFE3ULL,
+	0xBE5E1E2553863992ULL,
+	0x2B0199FC2C85B8AAULL,
+	0x0EB72DDC81C52CA2ULL
+};
+
 /*
  * Constant used by SHA256/384/512_End() functions for converting the
  * digest to a readable hexadecimal character string:
@@ -636,12 +648,21 @@ char* sr_SHA256_Data(const sha2_byte* data, size_t len, char digest[SHA256_DIGES
 }
 
 
-/*** SHA-512: *********************************************************/
+/*** SHA-512 SHA-512/256: *********************************************************/
 void sr_SHA512_Init(SHA512_CTX* context) {
 	if (context == (SHA512_CTX*)0) {
 		return;
 	}
 	MEMCPY_BCOPY(context->state, sha512_initial_hash_value, SHA512_DIGEST_LENGTH);
+	MEMSET_BZERO(context->buffer, SHA512_BLOCK_LENGTH);
+	context->bitcount[0] = context->bitcount[1] =  0;
+}
+
+void sr_SHA512_256_Init(SHA512_CTX* context) {
+	if (context == (SHA512_CTX*)0) {
+		return;
+	}
+	MEMCPY_BCOPY(context->state, sha512_256_initial_hash_value, SHA512_DIGEST_LENGTH);
 	MEMSET_BZERO(context->buffer, SHA512_BLOCK_LENGTH);
 	context->bitcount[0] = context->bitcount[1] =  0;
 }

--- a/src/core/crypto/sha256.h
+++ b/src/core/crypto/sha256.h
@@ -97,6 +97,7 @@ char* sr_SHA384_End(SHA384_CTX*, char[SHA384_DIGEST_STRING_LENGTH]);
 char* sr_SHA384_Data(const uint8_t*, size_t, char[SHA384_DIGEST_STRING_LENGTH]);
 
 void sr_SHA512_Init(SHA512_CTX*);
+void sr_SHA512_256_Init(SHA512_CTX*);
 void sr_SHA512_Update(SHA512_CTX*, const uint8_t*, size_t);
 void sr_SHA512_Final(sha2_byte[SHA512_DIGEST_LENGTH], SHA512_CTX*);
 char* sr_SHA512_End(SHA512_CTX*, char[SHA512_DIGEST_STRING_LENGTH]);
@@ -117,6 +118,7 @@ char* sr_SHA384_End();
 char* sr_SHA384_Data();
 
 void sr_SHA512_Init();
+void sr_SHA512_256_Init();
 void sr_SHA512_Update();
 void sr_SHA512_Final();
 char* sr_SHA512_End();


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This adds `core/` support for SHA-512/256.

This is required for adding the SHA-512/256(&ldquo;SHA-512-256&rdquo;) digest algorithm to the `auth` module.

References:
* [RFC8760](https://datatracker.ietf.org/doc/html/rfc8760)
* [RFC7616](https://datatracker.ietf.org/doc/html/rfc7616) and [errata](https://www.rfc-editor.org/errata_search.php?rfc=7616&rec_status=0) — the example given in RFC7616 for SHA-512-256 is incorrect (it truncated SHA-512 to 64 bytes instead of using the correct implementation of SHA-512/256 which has a different set of initial hash values)
* [SHA-512/256 initial hash values](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf)