### PR TITLE
kamctl:Index "inserted_time"+"status" in watchers

### DIFF
--- a/src/lib/srdb1/schema/pr_watchers.xml
+++ b/src/lib/srdb1/schema/pr_watchers.xml
@@ -63,7 +63,7 @@
         <natural/>
     </column>
 
-    <column>
+    <column id="status">
         <name>status</name>
         <type>int</type>
         <size>11</size>
@@ -78,7 +78,7 @@
         <description>Reason</description>
     </column>
 
-    <column>
+    <column id="inserted_time">
         <name>inserted_time</name>
         <type>int</type>
         <size>11</size>
@@ -91,6 +91,12 @@
         <colref linkend="watcher_domain"/>
         <colref linkend="event"/>
         <unique/>
+    </index>
+
+    <index>
+        <name>time_status_idx</name>
+        <colref linkend="inserted_time"/>
+        <colref linkend="status"/>
     </index>
 
 </table>

--- a/utils/kamctl/db_sqlite/presence-create.sql
+++ b/utils/kamctl/db_sqlite/presence-create.sql
@@ -69,6 +69,8 @@ CREATE TABLE watchers (
     CONSTRAINT watchers_watcher_idx UNIQUE (presentity_uri, watcher_username, watcher_domain, event)
 );
 
+CREATE INDEX watchers_time_status_idx ON watchers (inserted_time, status);
+
 INSERT INTO version (table_name, table_version) values ('watchers','3');
 
 CREATE TABLE xcap (

--- a/utils/kamctl/mysql/presence-create.sql
+++ b/utils/kamctl/mysql/presence-create.sql
@@ -69,6 +69,8 @@ CREATE TABLE `watchers` (
     CONSTRAINT watcher_idx UNIQUE (`presentity_uri`, `watcher_username`, `watcher_domain`, `event`)
 );
 
+CREATE INDEX time_status_idx ON watchers (`inserted_time`, `status`);
+
 INSERT INTO version (table_name, table_version) values ('watchers','3');
 
 CREATE TABLE `xcap` (

--- a/utils/kamctl/oracle/presence-create.sql
+++ b/utils/kamctl/oracle/presence-create.sql
@@ -93,6 +93,8 @@ END watchers_tr;
 /
 BEGIN map2users('watchers'); END;
 /
+CREATE INDEX watchers_time_status_idx  ON watchers (inserted_time, status);
+
 INSERT INTO version (table_name, table_version) values ('watchers','3');
 
 CREATE TABLE xcap (

--- a/utils/kamctl/postgres/presence-create.sql
+++ b/utils/kamctl/postgres/presence-create.sql
@@ -69,6 +69,8 @@ CREATE TABLE watchers (
     CONSTRAINT watchers_watcher_idx UNIQUE (presentity_uri, watcher_username, watcher_domain, event)
 );
 
+CREATE INDEX watchers_time_status_idx ON watchers (inserted_time, status);
+
 INSERT INTO version (table_name, table_version) values ('watchers','3');
 
 CREATE TABLE xcap (


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Function ps_watchers_db_timer_clean() inside src/modules/presence/subscribe.c is called repeatedly on my setup.
Each time is called it performs a delete inside table watchers comparing columns inserted_time and status which are not indexed:

```
MariaDB [kamailio]> explain delete from `watchers` where `inserted_time`<1656252889 AND `status`=2;
+------+-------------+----------+------+---------------+------+---------+------+------+-------------+
| id   | select_type | table    | type | possible_keys | key  | key_len | ref  | rows | Extra       |
+------+-------------+----------+------+---------------+------+---------+------+------+-------------+
|    1 | SIMPLE      | watchers | ALL  | NULL          | NULL | NULL    | NULL | 1    | Using where |
+------+-------------+----------+------+---------------+------+---------+------+------+-------------+
```

Can we consider adding an index improving performance a bit?

```
MariaDB [kamailio]> CREATE INDEX inserted_time_status_idx ON watchers (`inserted_time`, `status`);
Query OK, 0 rows affected (0.015 sec)
Records: 0  Duplicates: 0  Warnings: 0

MariaDB [kamailio]> explain delete from `watchers` where `inserted_time`<1656252889 AND `status`=2;
+------+-------------+----------+-------+--------------------------+--------------------------+---------+------+------+-------------+
| id   | select_type | table    | type  | possible_keys            | key                      | key_len | ref  | rows | Extra       |
+------+-------------+----------+-------+--------------------------+--------------------------+---------+------+------+-------------+
|    1 | SIMPLE      | watchers | range | inserted_time_status_idx | inserted_time_status_idx | 4       | NULL | 1    | Using where |
+------+-------------+----------+-------+--------------------------+--------------------------+---------+------+------+-------------+
1 row in set (0.001 sec)
```


