### PR TITLE
presence: No autocommit+rollback if no active watchers

### DIFF
--- a/src/modules/presence/notify.c
+++ b/src/modules/presence/notify.c
@@ -2867,6 +2867,7 @@ int process_dialogs(int round, int presence_winfo)
 	str ev_sname, winfo = str_init("presence.winfo");
 	int now = (int)time(NULL);
 	int updated = 0;
+	int no_active_watchers = 0;
 	db_query_f query_fn = pa_dbf.query_lock ? pa_dbf.query_lock : pa_dbf.query;
 
 	query_cols[n_query_cols] = &str_updated_col;
@@ -2900,13 +2901,6 @@ int process_dialogs(int round, int presence_winfo)
 		goto error;
 	}
 
-	if(pa_dbf.start_transaction) {
-		if(pa_dbf.start_transaction(pa_db, pres_db_table_lock) < 0) {
-			LM_ERR("in start_transaction\n");
-			goto error;
-		}
-	}
-
 	/* Step 1: Find active_watchers that require notification */
 	if(query_fn(pa_db, query_cols, query_ops, query_vals, result_cols,
 			   n_query_cols, n_result_cols, 0, &dialog_list)
@@ -2920,7 +2914,17 @@ int process_dialogs(int round, int presence_winfo)
 	}
 
 	if(dialog_list->n <= 0)
+	{
+		no_active_watchers = 1;
 		goto done;
+	}
+
+	if(pa_dbf.start_transaction) {
+		if(pa_dbf.start_transaction(pa_db, pres_db_table_lock) < 0) {
+			LM_ERR("in start_transaction\n");
+			goto error;
+		}
+	}
 
 	/* Step 2: Update the records so they are not notified again */
 	if(pa_dbf.update(pa_db, query_cols, query_ops, query_vals, update_cols,
@@ -3164,7 +3168,7 @@ error:
 	if(dialog)
 		pa_dbf.free_result(pa_db, dialog);
 
-	if(pa_dbf.abort_transaction) {
+	if(no_active_watchers == 0 && pa_dbf.abort_transaction) {
 		if(pa_dbf.abort_transaction(pa_db) < 0)
 			LM_ERR("in abort_transaction\n");
 	}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This is a small performance improvement, the goal is to avoid issuing rollbacks if not necessary.
On my setup, Kamailio presence executes a lot of ROLLBACKS in MariaDB since function process_dialogs() runs repeatedly.
What see inside MariaDB logs is the following

```
SET autocommit=0
select `presentity_uri`,`callid`,`to_tag`,`from_tag`,`event` from `active_watchers` where `updated`=3 AND `event`<>'presence.winfo'\G
ROLLBACK
```

Maybe we can improve this behaviour telling presence to do autocommit to do not execute them if the select returns zero elements? 
