### PR TITLE
Fix ksr_version_control() for FreeBSD build

### DIFF
--- a/src/core/sr_module.c
+++ b/src/core/sr_module.c
@@ -347,6 +347,9 @@ int ksr_version_control(void *handle, char *path)
 	char **m_flags;
 	char* error;
 
+#ifdef __FreeBSD__
+    (void) dlerror();
+#endif
 	m_ver=(char **)dlsym(handle, "module_version");
 	if ((error=(char *)dlerror())!=0) {
 		LM_ERR("no version info in module <%s>: %s\n", path, error);


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
There's a problem after upgrade to 5.6 on FreeBSD. Kamailio isn't starting successful.
```
14:19:20.540514 kamailio 40921 - - DEBUG: <core> [core/cfg.y:1964]: yyparse(): loading module tls.so
14:19:20.540893 kamailio 40921 - - DEBUG: <core> [core/sr_module.c:513]: ksr_locate_module(): found module to load </usr/local/lib/kamailio/modules/tls.so>
14:19:20.540912 kamailio 40921 - - DEBUG: <core> [core/sr_module.c:563]: load_module(): trying to load </usr/local/lib/kamailio/modules/tls.so>
14:19:20.543301 kamailio 40921 - - ERROR: <core> [core/sr_module.c:352]: ksr_version_control(): no version info in module </usr/local/lib/kamailio/modules/tls.so>: Undefined symbol "_nss_cache_cycle_prevention_function"
```
The problem is in `ksr_version_control()` probably. In FreeBSD environment it should to flush `dlerror` before call `dlsym()` - [dlopen(3)](https://www.freebsd.org/cgi/man.cgi?query=dlopen&sektion=3&format=html).
