### PR TITLE
siptrace: Trace in-dialog ACK and spiraled dialogs

### DIFF
--- a/src/modules/siptrace/doc/siptrace_admin.xml
+++ b/src/modules/siptrace/doc/siptrace_admin.xml
@@ -651,6 +651,43 @@ modparam("siptrace", "evcb_msg", "ksr_siptrace_msg")
 </programlisting>
                 </example>
         </section>
+
+	<section id="siptrace.p.trace_dialog_ack">
+                <title><varname>trace_dialog_ack</varname> (str)</title>
+                <para>
+			Enable tracing of in-dialog ACK.
+                </para>
+                <para>
+			Default value is 0 (disabled).
+                </para>
+                <example>
+			<title>Set <varname>trace_dialog_ack</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("siptrace", "trace_dialog_ack", 1)
+...
+</programlisting>
+                </example>
+        </section>
+
+	<section id="siptrace.p.trace_dialog_spiral">
+                <title><varname>trace_dialog_spiral</varname> (str)</title>
+                <para>
+			Enable tracing of dialog spirals.
+                </para>
+                <para>
+			Default value is 0 (disabled).
+                </para>
+                <example>
+			<title>Set <varname>trace_dialog_spiral</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("siptrace", "trace_dialog_spiral", 1)
+...
+</programlisting>
+                </example>
+        </section>
+
 	</section>
 
 	<section>

--- a/src/modules/siptrace/siptrace.c
+++ b/src/modules/siptrace/siptrace.c
@@ -195,6 +195,10 @@ static str trace_local_ip = {NULL, 0};
 static db1_con_t *db_con = NULL; /*!< database connection */
 static db_func_t db_funcs;		  /*!< Database functions */
 
+int trace_dialog_ack = 0;
+int trace_dialog_spiral = 0;
+static int spiral_tracked;
+
 int pv_parse_siptrace_name(pv_spec_t *sp, str *in);
 int pv_get_siptrace(sip_msg_t *msg, pv_param_t *param,
 		pv_value_t *res);
@@ -263,6 +267,8 @@ static param_export_t params[] = {
 	{"trace_init_mode", PARAM_INT, &_siptrace_init_mode},
 	{"trace_mode", PARAM_INT, &_siptrace_mode},
 	{"evcb_msg", PARAM_STR, &_siptrace_evcb_msg},
+	{"trace_dialog_ack", PARAM_INT, &trace_dialog_ack},
+	{"trace_dialog_spiral", PARAM_INT, &trace_dialog_spiral},
 	{0, 0, 0}
 };
 /* clang-format on */
@@ -1979,12 +1985,19 @@ static void trace_dialog(struct dlg_cell* dlg, int type, struct dlg_cb_params *p
 	}
 
 	/* request - params->req */
-	if (params == NULL || params->req == NULL) {
+	if (params == NULL || (!trace_dialog_spiral && params->req == NULL)) {
 		LM_ERR("Invalid args!\n");
 		return;
 	}
 
-	if (!(params->req->msg_flags & FL_SIPTRACE)) {
+	if (trace_dialog_spiral && *params->param == NULL) {
+		LM_DBG("Spiraled dialog!\n");
+		if (dlgb.register_dlgcb(dlg, DLGCB_SPIRALED, trace_dialog, &spiral_tracked, NULL) != 0) {
+			LM_ERR("could not register consider_exporting() for dialog event DLGCB_SPIRALED\n");
+		}
+	}
+
+	if (!trace_dialog_spiral && !(params->req->msg_flags & FL_SIPTRACE)) {
 		LM_DBG("Trace is off for this request...\n");
 		return;
 	}
@@ -2004,6 +2017,13 @@ static void trace_dialog(struct dlg_cell* dlg, int type, struct dlg_cb_params *p
 	if(dlgb.register_dlgcb(dlg, DLGCB_REQ_WITHIN,
 				trace_dialog_transaction, xavp->val.v.vptr, 0) != 0) {
 		LM_ERR("Failed to register DLGCB_REQ_WITHIN callback!\n");
+		return;
+	}
+
+	/* this will trace in-dialog ACK */
+	if(trace_dialog_ack && dlgb.register_dlgcb(dlg, DLGCB_CONFIRMED,
+				trace_dialog_transaction, xavp->val.v.vptr, 0) != 0) {
+		LM_ERR("Failed to register DLGCB_CONFIRMED callback!\n");
 		return;
 	}
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

While testing this module, I've seen it doesn't trace in-dialog ACKs.
Found this old maillist discussion: https://lists.kamailio.org/pipermail/sr-users/2015-June/088731.html 
Added a condition to trace also the in-dialog ACKs. Is it ok to keep it as default or should I guard it via a modparam?

Thanks,
Stefan