### PR TITLE
usrloc: re-use TCP connections for keepalive

### DIFF
--- a/src/modules/usrloc/dlist.c
+++ b/src/modules/usrloc/dlist.c
@@ -114,6 +114,7 @@ int ul_ka_db_records(int partidx)
 	keys2[5] = &ul_ruid_col;
 	keys2[6] = &ul_user_col;
 	keys2[7] = &ul_domain_col;
+	keys2[8] = &ul_con_id_col;
 
 	/* where fields */
 	keys1[0] = &ul_expires_col;
@@ -255,6 +256,9 @@ int ul_ka_db_records(int partidx)
 			}
 			ur.aorhash = ul_get_aorhash(&ur.aor);
 			ur.contacts = &uc;
+
+			/* tcpconn_id */
+			uc.tcpconn_id = VAL_INT(ROW_VALUES(row)+8);
 
 			ul_ka_urecord(&ur);
 		} /* row cycle */

--- a/src/modules/usrloc/doc/usrloc_admin.xml
+++ b/src/modules/usrloc/doc/usrloc_admin.xml
@@ -1317,9 +1317,15 @@ modparam("usrloc", "version_table", 0)
 		contact records stored in memory.
 		</para>
 		<para>
-		Note: it is recommeder to set 'timer_procs' parameter in order to have
+		Note: it is recommended to set 'timer_procs' parameter in order to have
 		dedicated timer processes for usrloc module and off-load the keepalive
 		sending process from the core timers.
+		</para>
+		<para>
+		Note: Keepalives will be sent to the IP and port using the transport
+		defined in the “received” column.  If not set, then keepalives will be sent
+		to the AOR using UDP as a default transport.  If available, the TCP
+		connection will be re-used for WS, TCP and TLS.
 		</para>
 		<para>
 		Default value is <quote>0 (keepalive disabled)</quote>.
@@ -1780,4 +1786,3 @@ modparam("usrloc", "db_clean_tcp", 1)
 
 
 </chapter>
-

--- a/src/modules/usrloc/ul_keepalive.c
+++ b/src/modules/usrloc/ul_keepalive.c
@@ -200,6 +200,7 @@ int ul_ka_urecord(urecord_t *ur)
 		}
 		idst.proto = dproto;
 		idst.send_sock = ssock;
+		idst.id = uc->tcpconn_id;
 
 		if(ssock->useinfo.name.len > 0) {
 			if (ssock->useinfo.address.af == AF_INET6) {
@@ -270,19 +271,16 @@ static int ul_ka_send(str *kamsg, dest_info_t *kadst)
 #ifdef USE_TCP
 	else if(kadst->proto == PROTO_WS || kadst->proto == PROTO_WSS) {
 		/*ws-wss*/
-		kadst->id=0;
 		return wss_send(kadst, kamsg->s, kamsg->len);
 	}
 	else if(kadst->proto == PROTO_TCP) {
 		/*tcp*/
-		kadst->id=0;
 		return tcp_send(kadst, 0, kamsg->s, kamsg->len);
 	}
 #endif
 #ifdef USE_TLS
 	else if(kadst->proto == PROTO_TLS) {
 		/*tls*/
-		kadst->id=0;
 		return tcp_send(kadst, 0, kamsg->s, kamsg->len);
 	}
 #endif


### PR DESCRIPTION
- Fixes GH #3178. Sets TCP connection id for keepalive based on the value in the database
  If unset, tcpconn_id will remain 0 and keepalives will work the same as they do today
- Update documentation to clarify when it will use received vs AOR for keepalive

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [X] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #3178 (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Updated usrloc module to re-use an active TCP session (if it exists).  I marked this breaking only because the current code will use a UDP OPTIONS keepalive method even if the device is registered over TCP.  I doubt that's what anyone would be expecting so I think the change is ok.
