### PR TITLE
topos: disable multiple comma separated values in One Single Via, Record-Route or Route header if needed

### DIFF
--- a/src/modules/topos/doc/topos_admin.xml
+++ b/src/modules/topos/doc/topos_admin.xml
@@ -546,6 +546,34 @@ modparam("topos", "methods_nocontact", "CANCEL,PRACK")
 </programlisting>
 		</example>
 	</section>
+	<section id="topos.p.separate_header_values">
+		<title><varname>separate_header_values</varname> (int)</title>
+		<para>
+			List of headers to disable multiple comma separated values inserted in compact form.
+			Altough compact form is RFC compliant this paramter gives possibilty to disable
+			compact form header values for UA that dont support/handle it.
+
+			The following options are available:
+
+			(1) - disable multiple comma separated values for Via  header
+			(2) - disable multiple comma separated values for Record-Route header
+			(4) - disable multiple comma separated values for Route header
+
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>separate_header_values</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("topos", "separate_header_values", 1)
+...
+</programlisting>
+		</example>
+	</section>
 	<section id="topos.p.methods_noinitial">
 		<title><varname>methods_noinitial</varname> (str)</title>
 		<para>

--- a/src/modules/topos/doc/topos_admin.xml
+++ b/src/modules/topos/doc/topos_admin.xml
@@ -546,8 +546,8 @@ modparam("topos", "methods_nocontact", "CANCEL,PRACK")
 </programlisting>
 		</example>
 	</section>
-	<section id="topos.p.separate_header_values">
-		<title><varname>separate_header_values</varname> (int)</title>
+	<section id="topos.p.header_mode">
+		<title><varname>header_mode</varname> (int)</title>
 		<para>
 			List of headers to disable multiple comma separated values inserted in compact form.
 			Altough compact form is RFC compliant this paramter gives possibilty to disable
@@ -566,10 +566,10 @@ modparam("topos", "methods_nocontact", "CANCEL,PRACK")
 		</emphasis>
 		</para>
 		<example>
-		<title>Set <varname>separate_header_values</varname> parameter</title>
+		<title>Set <varname>header_mode</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("topos", "separate_header_values", 1)
+modparam("topos", "header_mode", 1)
 ...
 </programlisting>
 		</example>

--- a/src/modules/topos/topos_mod.c
+++ b/src/modules/topos/topos_mod.c
@@ -81,7 +81,7 @@ static str _tps_db_url = str_init(DEFAULT_DB_URL);
 int _tps_param_mask_callid = 0;
 int _tps_sanity_checks = 0;
 int _tps_rr_update = 0;
-int _tps_separate_via = 0;
+int _tps_separate_hv = 0;
 str _tps_storage = str_init("db");
 
 extern int _tps_branch_expire;
@@ -157,7 +157,7 @@ static param_export_t params[]={
 	{"db_url",		PARAM_STR, &_tps_db_url},
 	{"mask_callid",		PARAM_INT, &_tps_param_mask_callid},
 	{"sanity_checks",	PARAM_INT, &_tps_sanity_checks},
-	{"separate_via",    PARAM_INT, &_tps_separate_via},
+	{"separate_header_values",	PARAM_INT, &_tps_separate_hv},
 	{"branch_expire",	PARAM_INT, &_tps_branch_expire},
 	{"dialog_expire",	PARAM_INT, &_tps_dialog_expire},
 	{"clean_interval",	PARAM_INT, &_tps_clean_interval},

--- a/src/modules/topos/topos_mod.c
+++ b/src/modules/topos/topos_mod.c
@@ -81,6 +81,7 @@ static str _tps_db_url = str_init(DEFAULT_DB_URL);
 int _tps_param_mask_callid = 0;
 int _tps_sanity_checks = 0;
 int _tps_rr_update = 0;
+int _tps_separate_via = 0;
 str _tps_storage = str_init("db");
 
 extern int _tps_branch_expire;
@@ -156,6 +157,7 @@ static param_export_t params[]={
 	{"db_url",		PARAM_STR, &_tps_db_url},
 	{"mask_callid",		PARAM_INT, &_tps_param_mask_callid},
 	{"sanity_checks",	PARAM_INT, &_tps_sanity_checks},
+	{"separate_via",    PARAM_INT, &_tps_separate_via},
 	{"branch_expire",	PARAM_INT, &_tps_branch_expire},
 	{"dialog_expire",	PARAM_INT, &_tps_dialog_expire},
 	{"clean_interval",	PARAM_INT, &_tps_clean_interval},

--- a/src/modules/topos/topos_mod.c
+++ b/src/modules/topos/topos_mod.c
@@ -81,7 +81,7 @@ static str _tps_db_url = str_init(DEFAULT_DB_URL);
 int _tps_param_mask_callid = 0;
 int _tps_sanity_checks = 0;
 int _tps_rr_update = 0;
-int _tps_separate_hv = 0;
+int _tps_header_mode = 0;
 str _tps_storage = str_init("db");
 
 extern int _tps_branch_expire;
@@ -157,7 +157,7 @@ static param_export_t params[]={
 	{"db_url",		PARAM_STR, &_tps_db_url},
 	{"mask_callid",		PARAM_INT, &_tps_param_mask_callid},
 	{"sanity_checks",	PARAM_INT, &_tps_sanity_checks},
-	{"separate_header_values",	PARAM_INT, &_tps_separate_hv},
+	{"header_mode",	PARAM_INT, &_tps_header_mode},
 	{"branch_expire",	PARAM_INT, &_tps_branch_expire},
 	{"dialog_expire",	PARAM_INT, &_tps_dialog_expire},
 	{"clean_interval",	PARAM_INT, &_tps_clean_interval},

--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -636,20 +636,16 @@ int tps_reappend_via_separate_header(sip_msg_t *msg, tps_data_t *ptsd, str *hbod
 {
         str hname = str_init("Via");
         int i;
-        int c;
         str sb;
         char *p = NULL;
 
         if(hbody==NULL || hbody->s==NULL || hbody->len<=0 || hbody->s[0]=='\0')
             return 0;
 
-
-        c = 0;
         sb.len = 1;
         p = hbody->s;
         for(i=0; i<hbody->len-1; i++) {
             if(hbody->s[i]==',') {
-                c = 1;
                 if(sb.len>0) {
                     sb.s = p;
                     if(sb.s[sb.len-1]==',') sb.len--;
@@ -663,15 +659,15 @@ int tps_reappend_via_separate_header(sip_msg_t *msg, tps_data_t *ptsd, str *hbod
             sb.len++;
         }
 
-        if(c==0 || c== 1) {
-            if(sb.len>0) {
+
+        if(sb.len>0) {
                 sb.s = p;
                 if(sb.s[sb.len-1]==',') sb.len--;
                 if(tps_add_headers(msg, &hname, &sb, 0)<0) {
                     return -1;
                 }
-            }
         }
+
 
         return 0;
 }

--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -50,7 +50,7 @@ extern int _tps_param_mask_callid;
 extern int _tps_contact_mode;
 extern str _tps_cparam_name;
 extern int _tps_rr_update;
-extern int _tps_separate_via;
+extern int _tps_separate_hv;
 
 extern str _tps_context_param;
 extern str _tps_context_value;
@@ -632,9 +632,9 @@ int tps_remove_name_headers(sip_msg_t *msg, str *hname)
 /**
  *
  */
-int tps_reappend_via_separate_header(sip_msg_t *msg, tps_data_t *ptsd, str *hbody)
+int tps_reappend_separate_header_values(sip_msg_t *msg, tps_data_t *ptsd, str *hbody, str *hname)
 {
-        str hname = str_init("Via");
+
         int i;
         str sb;
         char *p = NULL;
@@ -649,7 +649,7 @@ int tps_reappend_via_separate_header(sip_msg_t *msg, tps_data_t *ptsd, str *hbod
                 if(sb.len>0) {
                     sb.s = p;
                     if(sb.s[sb.len-1]==',') sb.len--;
-                    if(tps_add_headers(msg, &hname, &sb, 0)<0) {
+                    if(tps_add_headers(msg, hname, &sb, 0)<0) {
                         return -1;
                     }
                 }
@@ -663,7 +663,7 @@ int tps_reappend_via_separate_header(sip_msg_t *msg, tps_data_t *ptsd, str *hbod
         if(sb.len>0) {
                 sb.s = p;
                 if(sb.s[sb.len-1]==',') sb.len--;
-                if(tps_add_headers(msg, &hname, &sb, 0)<0) {
+                if(tps_add_headers(msg, hname, &sb, 0)<0) {
                     return -1;
                 }
         }
@@ -676,8 +676,8 @@ int tps_reappend_via(sip_msg_t *msg, tps_data_t *ptsd, str *hbody)
 {
 	str hname = str_init("Via");
 
-    if (_tps_separate_via!= 0)
-        return tps_reappend_via_separate_header(msg, ptsd, hbody);
+	if (TPS_SEPERATE_VIA & _tps_separate_hv)
+		return tps_reappend_separate_header_values(msg, ptsd, hbody,&hname);
 
 	if(tps_add_headers(msg, &hname, hbody, 0)<0) {
 		return -1;
@@ -788,6 +788,9 @@ int tps_reappend_rr(sip_msg_t *msg, tps_data_t *ptsd, str *hbody)
 {
 	str hname = str_init("Record-Route");
 
+	if (TPS_SEPERATE_RECORD_ROUTE & _tps_separate_hv)
+		return tps_reappend_separate_header_values(msg, ptsd, hbody,&hname);
+
 	if(tps_add_headers(msg, &hname, hbody, 0)<0) {
 		return -1;
 	}
@@ -842,6 +845,8 @@ int tps_reappend_route(sip_msg_t *msg, tps_data_t *ptsd, str *hbody, int rev)
 	trim_zeros_lr(&sb);
 	trim(&sb);
 	if(sb.len>0 && sb.s[sb.len-1]==',') sb.len--;
+	if (TPS_SEPERATE_ROUTE & _tps_separate_hv)
+		return tps_reappend_separate_header_values(msg, ptsd, &sb,&hname);
 	if(tps_add_headers(msg, &hname, &sb, 0)<0) {
 		return -1;
 	}

--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -50,6 +50,7 @@ extern int _tps_param_mask_callid;
 extern int _tps_contact_mode;
 extern str _tps_cparam_name;
 extern int _tps_rr_update;
+extern int _tps_separate_via;
 
 extern str _tps_context_param;
 extern str _tps_context_value;
@@ -631,9 +632,56 @@ int tps_remove_name_headers(sip_msg_t *msg, str *hname)
 /**
  *
  */
+int tps_reappend_via_separate_header(sip_msg_t *msg, tps_data_t *ptsd, str *hbody)
+{
+        str hname = str_init("Via");
+        int i;
+        int c;
+        str sb;
+        char *p = NULL;
+
+        if(hbody==NULL || hbody->s==NULL || hbody->len<=0 || hbody->s[0]=='\0')
+            return 0;
+
+
+        c = 0;
+        sb.len = 1;
+        p = hbody->s;
+        for(i=0; i<hbody->len-1; i++) {
+            if(hbody->s[i]==',') {
+                c = 1;
+                if(sb.len>0) {
+                    sb.s = p;
+                    if(sb.s[sb.len-1]==',') sb.len--;
+                    if(tps_add_headers(msg, &hname, &sb, 0)<0) {
+                        return -1;
+                    }
+                }
+                sb.len = 0;
+                p = hbody->s + i + 1;
+            }
+            sb.len++;
+        }
+
+        if(c==0 || c== 1) {
+            if(sb.len>0) {
+                sb.s = p;
+                if(sb.s[sb.len-1]==',') sb.len--;
+                if(tps_add_headers(msg, &hname, &sb, 0)<0) {
+                    return -1;
+                }
+            }
+        }
+
+        return 0;
+}
+
 int tps_reappend_via(sip_msg_t *msg, tps_data_t *ptsd, str *hbody)
 {
 	str hname = str_init("Via");
+
+    if (_tps_separate_via!= 0)
+        return tps_reappend_via_separate_header(msg, ptsd, hbody);
 
 	if(tps_add_headers(msg, &hname, hbody, 0)<0) {
 		return -1;

--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -50,7 +50,7 @@ extern int _tps_param_mask_callid;
 extern int _tps_contact_mode;
 extern str _tps_cparam_name;
 extern int _tps_rr_update;
-extern int _tps_separate_hv;
+extern int _tps_header_mode;
 
 extern str _tps_context_param;
 extern str _tps_context_value;
@@ -676,7 +676,7 @@ int tps_reappend_via(sip_msg_t *msg, tps_data_t *ptsd, str *hbody)
 {
 	str hname = str_init("Via");
 
-	if (TPS_SPLIT_VIA & _tps_separate_hv)
+	if (TPS_SPLIT_VIA & _tps_header_mode)
 		return tps_reappend_separate_header_values(msg, ptsd, hbody,&hname);
 
 	if(tps_add_headers(msg, &hname, hbody, 0)<0) {
@@ -788,7 +788,7 @@ int tps_reappend_rr(sip_msg_t *msg, tps_data_t *ptsd, str *hbody)
 {
 	str hname = str_init("Record-Route");
 
-	if (TPS_SPLIT_RECORD_ROUTE & _tps_separate_hv)
+	if (TPS_SPLIT_RECORD_ROUTE & _tps_header_mode)
 		return tps_reappend_separate_header_values(msg, ptsd, hbody,&hname);
 
 	if(tps_add_headers(msg, &hname, hbody, 0)<0) {
@@ -845,7 +845,7 @@ int tps_reappend_route(sip_msg_t *msg, tps_data_t *ptsd, str *hbody, int rev)
 	trim_zeros_lr(&sb);
 	trim(&sb);
 	if(sb.len>0 && sb.s[sb.len-1]==',') sb.len--;
-	if (TPS_SPLIT_ROUTE & _tps_separate_hv)
+	if (TPS_SPLIT_ROUTE & _tps_header_mode)
 		return tps_reappend_separate_header_values(msg, ptsd, &sb,&hname);
 	if(tps_add_headers(msg, &hname, &sb, 0)<0) {
 		return -1;

--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -676,7 +676,7 @@ int tps_reappend_via(sip_msg_t *msg, tps_data_t *ptsd, str *hbody)
 {
 	str hname = str_init("Via");
 
-	if (TPS_SEPERATE_VIA & _tps_separate_hv)
+	if (TPS_SPLIT_VIA & _tps_separate_hv)
 		return tps_reappend_separate_header_values(msg, ptsd, hbody,&hname);
 
 	if(tps_add_headers(msg, &hname, hbody, 0)<0) {
@@ -788,7 +788,7 @@ int tps_reappend_rr(sip_msg_t *msg, tps_data_t *ptsd, str *hbody)
 {
 	str hname = str_init("Record-Route");
 
-	if (TPS_SEPERATE_RECORD_ROUTE & _tps_separate_hv)
+	if (TPS_SPLIT_RECORD_ROUTE & _tps_separate_hv)
 		return tps_reappend_separate_header_values(msg, ptsd, hbody,&hname);
 
 	if(tps_add_headers(msg, &hname, hbody, 0)<0) {
@@ -845,7 +845,7 @@ int tps_reappend_route(sip_msg_t *msg, tps_data_t *ptsd, str *hbody, int rev)
 	trim_zeros_lr(&sb);
 	trim(&sb);
 	if(sb.len>0 && sb.s[sb.len-1]==',') sb.len--;
-	if (TPS_SEPERATE_ROUTE & _tps_separate_hv)
+	if (TPS_SPLIT_ROUTE & _tps_separate_hv)
 		return tps_reappend_separate_header_values(msg, ptsd, &sb,&hname);
 	if(tps_add_headers(msg, &hname, &sb, 0)<0) {
 		return -1;

--- a/src/modules/topos/tps_msg.h
+++ b/src/modules/topos/tps_msg.h
@@ -31,6 +31,10 @@
 
 #include "../../core/parser/msg_parser.h"
 
+#define TPS_SEPERATE_VIA            (1<<0)
+#define TPS_SEPERATE_RECORD_ROUTE   (1<<1)
+#define TPS_SEPERATE_ROUTE          (1<<2)
+
 int tps_update_hdr_replaces(sip_msg_t *msg);
 char* tps_msg_update(sip_msg_t *msg, unsigned int *olen);
 int tps_skip_msg(sip_msg_t *msg);

--- a/src/modules/topos/tps_msg.h
+++ b/src/modules/topos/tps_msg.h
@@ -31,9 +31,9 @@
 
 #include "../../core/parser/msg_parser.h"
 
-#define TPS_SEPERATE_VIA            (1<<0)
-#define TPS_SEPERATE_RECORD_ROUTE   (1<<1)
-#define TPS_SEPERATE_ROUTE          (1<<2)
+#define TPS_SPLIT_VIA            (1<<0)
+#define TPS_SPLIT_RECORD_ROUTE   (1<<1)
+#define TPS_SPLIT_ROUTE          (1<<2)
 
 int tps_update_hdr_replaces(sip_msg_t *msg);
 char* tps_msg_update(sip_msg_t *msg, unsigned int *olen);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->
Topos module always put a single Via header with multiple comma separated values.
Even if this behaviour is RFC compliant there should a possibilty to disable that behaviour four uas that dont support/handle that.

this pull request adds a new parameter topos module to disable that behaviour if needed otherwise the default topos compact form is used.

```
modparam("topos", "separate_header_values", 1) # for Via only 
modparam("topos", "separate_header_values", 2) # for Record-Route only 
modparam("topos", "separate_header_values", 4) # for Route only 

modparam("topos", "separate_header_values", 7) # for Via, Record-Route  and Route 


The following options are available:

 (1) - disable multiple comma separated values for Via  header
 (2) - disable multiple comma separated values for Record-Route header
 (4) - disable multiple comma separated values for Route header
```
<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3216

#### Description
<!-- Describe your changes in detail -->
