### PR TITLE
dialog: dont reset dlg_db_mode in POSTCHILDINIT for DB_MODE_SHUTDOWN

### DIFF
--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -824,7 +824,7 @@ static int child_init(int rank)
 
 	/* in DB_MODE_SHUTDOWN only PROC_MAIN will do a DB dump at the end, so
 	 * for the rest of the processes will be the same as DB_MODE_NONE */
-	if (dlg_db_mode==DB_MODE_SHUTDOWN && rank!=PROC_MAIN)
+	if (dlg_db_mode==DB_MODE_SHUTDOWN && rank!=PROC_POSTCHILDINIT)
 		dlg_db_mode = DB_MODE_NONE;
 	/* in DB_MODE_REALTIME and DB_MODE_DELAYED the PROC_MAIN have no DB handle */
 	if ( (dlg_db_mode==DB_MODE_REALTIME || dlg_db_mode==DB_MODE_DELAYED) &&


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->


#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3218

#### Description

Per the DB issue in #3218:

I've determined the commit where dialog with db_mode SHUTDOWN stopped working is 1ff86ffceede46c7a67fec92c8319c34c916a545.

This is the change where  `PROC_POSTCHILDINIT` was enabled/used.

In dialog.c `child_init()`, there is code that resets the DB mode to NONE if not running in the main process:

```c
	/* in DB_MODE_SHUTDOWN only PROC_MAIN will do a DB dump at the end, so
	 * for the rest of the processes will be the same as DB_MODE_NONE */
	if (dlg_db_mode==DB_MODE_SHUTDOWN && rank!=PROC_MAIN)
		dlg_db_mode = DB_MODE_NONE;
```

However, because PROC_POSTCHILDINIT has now been enabled for the module, this code effectively disables DB persistence as PROC_POSTCHILDINIT is called in the main process after PROC_MAIN.

I have modified the rank check to `rank!=PROC_POSTCHILDINIT` and can confirm that DB persistence in SHUTDOWN mode is working once again.

Note that the PR changes the logic to:

```c
	if (dlg_db_mode==DB_MODE_SHUTDOWN && rank!=PROC_POSTCHILDINIT)
		dlg_db_mode = DB_MODE_NONE;
```

Technically dlg_db_mode will be reset to DB_MODE_NONE when called with rank PROC_MAIN, but the value will be restored when PROC_POSTCHILDINIT is called. I assume this behavior is OK, but otherwise I can change it to:

```c
	if (dlg_db_mode==DB_MODE_SHUTDOWN && rank!=PROC_MAIN && rank!=PROC_POSTCHILDINIT)
		dlg_db_mode = DB_MODE_NONE;
```