### PR TITLE
core: added parser mode check

### DIFF
--- a/src/core/parser/msg_parser.c
+++ b/src/core/parser/msg_parser.c
@@ -623,9 +623,11 @@ int parse_headers(struct sip_msg* const msg, const hdr_flags_t flags, const int 
 
 skip:
 	msg->unparsed=tmp;
-	if(msg->headers==NULL) {
-		/* nothing parsed - invalid input sip message */
-		goto error1;
+	if(ksr_sip_parser_mode & KSR_SIP_PARSER_MODE_STRICT) {
+		if(msg->headers==NULL) {
+			/* nothing parsed - invalid input sip message */
+			goto error1;
+		}
 	}
 	/* restore original flags */
 	msg->parsed_flag |= orig_flag;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
When I upgraded kamailio version to 5.6.1, some http requests hit msg headers control and failed.
I think ksr_sip_parser_mode check should be added here for backward compatibility.