### PR TITLE
dispatcher: fix alog13 gateway selections

### DIFF
--- a/src/modules/dispatcher/dispatch.c
+++ b/src/modules/dispatcher/dispatch.c
@@ -2112,16 +2112,20 @@ int ds_select_dst_limit(sip_msg_t *msg, int set, int alg, uint32_t limit,
 typedef struct sorted_ds {
 	int idx;
 	int priority;
+	int flags;
+	ds_dest_t *dest;
 } sorted_ds_t;
 
-int ds_manage_routes_fill_reodered_xavp(sorted_ds_t *ds_sorted, ds_set_t *idx, ds_select_state_t *rstate)
+int ds_manage_routes_fill_reordered_xavp(sorted_ds_t *ds_sorted, ds_set_t *idx, ds_select_state_t *rstate)
 {
 	int i;
 	if(!(ds_flags & DS_FAILOVER_ON))
 		return 1;
 	for(i=0; i < idx->nr && rstate->cnt < rstate->limit; i++) {
-		if(ds_sorted[i].idx < 0 || ds_skip_dst(idx->dlist[i].flags)
-				|| (ds_use_default != 0 && ds_sorted[i].idx == (idx->nr - 1))) {
+
+		if(ds_sorted[i].idx < 0 || ds_skip_dst(ds_sorted[i].flags) || (ds_use_default != 0 && ds_sorted[i].idx == (idx->nr - 1))) {
+			LM_DBG("[%d|%.*s|idx:%d]skipped %d || %d\n", i, ds_sorted[i].dest->uri.len, ds_sorted[i].dest->uri.s, ds_sorted[i].idx,
+				ds_sorted[i].idx < 0, ds_skip_dst(ds_sorted[i].flags));
 			continue;
 		}
 		if(ds_add_xavp_record(idx, ds_sorted[i].idx, rstate->setid, rstate->alg,
@@ -2199,16 +2203,23 @@ int ds_manage_routes_fill_xavp(unsigned int hash, ds_set_t *idx, ds_select_state
 
 void ds_sorted_by_priority(sorted_ds_t * sorted_ds, int size) {
 	int i,ii;
+
 	for(i=0;i<size;++i) {
 		for(ii=1;ii<size;++ii) {
 			sorted_ds_t temp;
 			if(sorted_ds[ii-1].priority < sorted_ds[ii].priority) {
 				temp.idx = sorted_ds[ii].idx;
 				temp.priority = sorted_ds[ii].priority;
+				temp.flags = sorted_ds[ii].flags;
+				temp.dest = sorted_ds[ii].dest;
 				sorted_ds[ii].idx = sorted_ds[ii-1].idx;
 				sorted_ds[ii].priority = sorted_ds[ii-1].priority;
+				sorted_ds[ii].flags = sorted_ds[ii-1].flags;
+				sorted_ds[ii].dest = sorted_ds[ii-1].dest;
 				sorted_ds[ii-1].idx = temp.idx;
 				sorted_ds[ii-1].priority = temp.priority;
+				sorted_ds[ii-1].flags = temp.flags;
+				sorted_ds[ii-1].dest = temp.dest;
 			}
 		}
 	}
@@ -2232,7 +2243,7 @@ int ds_manage_route_algo13(ds_set_t *idx, ds_select_state_t *rstate) {
 		int gw_latency = ds_dest->latency_stats.estimate;
 		int gw_inactive = ds_skip_dst(ds_dest->flags);
 		// if cc is enabled, the latency is the congestion ms instead of the estimated latency.
-		if (ds_dest->attrs.congestion_control)
+		if(ds_dest->attrs.congestion_control)
 			gw_latency = ds_dest->latency_stats.estimate - ds_dest->latency_stats.average;
 		if(!gw_inactive) {
 			if(gw_latency > gw_priority && gw_priority > 0)
@@ -2242,17 +2253,20 @@ int ds_manage_route_algo13(ds_set_t *idx, ds_select_state_t *rstate) {
 				ds_dest->attrs.rpriority = 1;
 			ds_sorted[y].idx = z;
 			ds_sorted[y].priority = ds_dest->attrs.rpriority;
-			LM_DBG("[active]idx[%d]uri[%.*s]priority[%d-%d=%d]latency[%dms]flag[%d]\n",
-				z, ds_dest->uri.len, ds_dest->uri.s,
+			LM_DBG("[active][%d]idx[%d]uri[%.*s]priority[%d-%d=%d]latency[%dms]flag[%d]\n",
+				y,z, ds_dest->uri.len, ds_dest->uri.s,
 				gw_priority, latency_priority_handicap,
 				ds_dest->attrs.rpriority, gw_latency, ds_dest->flags);
 		} else {
 			ds_sorted[y].idx = -1;
 			ds_sorted[y].priority = -1;
-			LM_DBG("[inactive]idx[%d]uri[%.*s]priority[%d]latency[%dms]flag[%d]",
-				z, ds_dest->uri.len, ds_dest->uri.s,
+			LM_DBG("[inactive][%d]idx[%d]uri[%.*s]priority[%d]latency[%dms]flag[%d]\n",
+				y,-1, ds_dest->uri.len, ds_dest->uri.s,
 				gw_priority, gw_latency, ds_dest->flags);
 		}
+		ds_sorted[y].flags = ds_dest->flags;
+		ds_sorted[y].dest = ds_dest;
+
 		if(ds_use_default != 0 && idx->nr != 1)
 			z = (z + 1) % (idx->nr - 1);
 		else
@@ -2264,7 +2278,7 @@ int ds_manage_route_algo13(ds_set_t *idx, ds_select_state_t *rstate) {
 		hash = ds_sorted[0].idx;
 		active_priority = ds_sorted[0].priority;
 	}
-	ds_manage_routes_fill_reodered_xavp(ds_sorted, idx, rstate);
+	ds_manage_routes_fill_reordered_xavp(ds_sorted, idx, rstate);
 	idx->last = (hash + 1) % idx->nr;
 	LM_DBG("priority[%d]gateway_selected[%d]next_index[%d]\n", active_priority, hash, idx->last);
 	pkg_free(ds_sorted);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

I found how the indexes could get mixed up between the call to ds_sorted_by_priority() and ds_manage_routes_fill_reordered_xavp() resulting in invalid gateway list selection. 


```
// TEST logs
I made some tests with 3 and 6 gateways, disabling one and then two.

Some test data :

INSERT INTO dispatcher VALUES(1,1,'sip:[192.168.0.1:5060](http://192.168.0.1:5060/)',0,12,'','');
INSERT INTO dispatcher VALUES(2,1,'sip:[192.168.0.2:5060](http://192.168.0.2:5060/)',0,12,'','');
INSERT INTO dispatcher VALUES(3,1,'sip:[192.168.0.3:5060](http://192.168.0.3:5060/)',0,12,'','');
INSERT INTO dispatcher VALUES(4,1,'sip:[192.168.0.4:5060](http://192.168.0.4:5060/)',0,12,'','');
INSERT INTO dispatcher VALUES(5,1,'sip:[192.168.0.5:5060](http://192.168.0.5:5060/)',0,12,'','');
INSERT INTO dispatcher VALUES(6,1,'sip:[192.168.0.6:5060](http://192.168.0.6:5060/)',0,12,'','');

Then disabling 2 gateways :

dispatcher.set_state i 1 sip:[192.168.0.1:5060](http://192.168.0.1:5060/)
dispatcher.set_state i 1 sip:[192.168.0.3:5060](http://192.168.0.3:5060/)


// ----------------- Routing Logic -----------------
//
route {
        xinfo("[MAIN][$rm][$ci]from[$fU]to[$tU]ruri[$ru]Rp[$Rp]Ri[$Ri]\n");
        if (!ds_select_dst("1","13", "-1")) {
                xinfo("[MAIN] no gateway available !\n");
        }                                                                                                                                                                                     
        while (defined $xavp(_dsdst_)) {
                xinfo("[MAIN] URI : $xavp(_dsdst_=>uri) \n");
                pv_unset("$xavp(_dsdst_)");
        }
        return;
}

// Logs showing the gateways returned.

 0(398491) DEBUG: dispatcher [dispatch.c:2263]: ds_manage_route_algo13(): [active][0]idx[1]uri[sip:[192.168.0.5:5060](http://192.168.0.5:5060/)]priority[12-0=12]latency[0ms]flag[0]
 0(398491) DEBUG: dispatcher [dispatch.c:2263]: ds_manage_route_algo13(): [active][1]idx[2]uri[sip:192.168.0.4:5060]priority[12-0=12]latency[0ms]flag[0]
 0(398491) DEBUG: dispatcher [dispatch.c:2270]: ds_manage_route_algo13(): [inactive][2]idx[-1]uri[sip:192.168.0.3:5060]priority[12]latency[0ms]flag[1]
 0(398491) DEBUG: dispatcher [dispatch.c:2263]: ds_manage_route_algo13(): [active][3]idx[4]uri[sip:192.168.0.2:5060]priority[12-0=12]latency[0ms]flag[0]
 0(398491) DEBUG: dispatcher [dispatch.c:2270]: ds_manage_route_algo13(): [inactive][4]idx[-1]uri[sip:192.168.0.1:5060]priority[12]latency[0ms]flag[1]
 0(398491) DEBUG: dispatcher [dispatch.c:2263]: ds_manage_route_algo13(): [active][5]idx[0]uri[sip:192.168.0.6:5060]priority[12-0=12]latency[0ms]flag[0]

 0(398491) DEBUG: dispatcher [dispatch.c:2128]: ds_manage_routes_fill_reordered_xavp(): [4|sip:192.168.0.3:5060|idx:-1]skipped 1 || 1
 0(398491) DEBUG: dispatcher [dispatch.c:2128]: ds_manage_routes_fill_reordered_xavp(): [5|sip:192.168.0.1:5060|idx:-1]skipped 1 || 1
 0(398491) DEBUG: dispatcher [dispatch.c:2300]: ds_manage_route_algo13(): priority[12]gateway_selected[1]next_index[2]
 0(398491) DEBUG: dispatcher [dispatch.c:2465]: ds_manage_routes(): using alg [13] hash [1]
 0(398491) DEBUG: dispatcher [dispatch.c:2512]: ds_manage_routes(): selected [13-1-0/1] <sip:[192.168.0.5:5060](http://192.168.0.5:5060/)>
 0(398491) DEBUG: dispatcher [dispatch.c:2107]: ds_select_dst_limit(): selected target destinations: 4
 0(398491) INFO: <script>: [MAIN][sip:[192.168.0.5:5060](http://192.168.0.5:5060/)]
 0(398491) INFO: <script>: [MAIN] URI : sip:192.168.0.5:5060
 0(398491) INFO: <script>: [MAIN] URI : sip:[192.168.0.4:5060](http://192.168.0.4:5060/)
 0(398491) INFO: <script>: [MAIN] URI : sip:[192.168.0.2:5060](http://192.168.0.2:5060/)
 0(398491) INFO: <script>: [MAIN] URI : sip:[192.168.0.6:5060](http://192.168.0.6:5060/)
 ```
