### PR TITLE
pkg/kamailio/obs: added readline-devel build dependency

### DIFF
--- a/pkg/kamailio/obs/kamailio.spec
+++ b/pkg/kamailio/obs/kamailio.spec
@@ -290,7 +290,7 @@ Conflicts:  kamailio-utils < %ver, kamailio-websocket < %ver
 Conflicts:  kamailio-xhttp-pi < %ver, kamailio-xmlops < %ver
 Conflicts:  kamailio-xmlrpc < %ver, kamailio-xmpp < %ver
 Conflicts:  kamailio-uuid < %ver
-BuildRequires:  bison, flex, which, make, gcc, gcc-c++, readline-devel
+BuildRequires:  bison, flex, which, make, gcc, gcc-c++, pkgconfig, readline-devel
 %if 0%{?rhel} != 6
 Requires:  systemd
 BuildRequires:  systemd-devel

--- a/pkg/kamailio/obs/kamailio.spec
+++ b/pkg/kamailio/obs/kamailio.spec
@@ -290,7 +290,7 @@ Conflicts:  kamailio-utils < %ver, kamailio-websocket < %ver
 Conflicts:  kamailio-xhttp-pi < %ver, kamailio-xmlops < %ver
 Conflicts:  kamailio-xmlrpc < %ver, kamailio-xmpp < %ver
 Conflicts:  kamailio-uuid < %ver
-BuildRequires:  bison, flex, which, make, gcc, gcc-c++, pkgconfig
+BuildRequires:  bison, flex, which, make, gcc, gcc-c++, readline-devel
 %if 0%{?rhel} != 6
 Requires:  systemd
 BuildRequires:  systemd-devel
@@ -2420,6 +2420,8 @@ fi
 
 
 %changelog
+* Tue Sep 13 2022 Gustavo Almeida <galmeida@broadvoice.com>
+  - added readline-devel build dependency
 * Sat Aug 31 2019 Sergey Safarov <s.safarov@gmail.com> 5.3.0-dev7
   - Packaged kemix, lost and xhttp_prom modules
 * Sat Mar 30 2019 Sergey Safarov <s.safarov@gmail.com> 5.3.0-0


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

The purpose of this pull request is to allow, when generating rpm's, the possibility of history/autocomplete to be seen in the interactive mode of kamcmd.

The proposed solution is to ensure that the readline-devel library is a requirement when building Kamailio, thus ensuring that kamcmd is compiled with this library.

Currently the specfile has as BuildRequires, the pkgconfig library. This library is installed by the readline-devel library (via ncurses-devel dependency), i.e. all existing logic remains unchanged. Furthermore, the readline-devel library is accessible on all distros that use this specfile, namely: Centos, Fedora, OpenSuse, RedHat.

Initially in my testing, I thought I needed to change the Makefile of kamcmd to look at mock path’s (find path of readline.h), but this is not necessary (at least in CentOS).

The possibility of adopting this solution in later branches would be useful, especially in the case of branch 5.6.1.

The tests were performed in a CentOS 7 environment (docker image), following the usual process for generating the rpm's (make rpm). This solution was tested on branch 5.5.4 and on master. In both cases, the history/autocomplete is successfully visible in the interactive mode of kamcmd. 

```Shell Script
[root@kamailio-build kamailio]# cat /etc/centos-release
CentOS Linux release 7.9.2009 (Core)
[root@kamailio-build kamailio]# uname -a
Linux kamailio-build 5.10.124-linuxkit #1 SMP PREEMPT Thu Jun 30 08:18:26 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
```
I would appreciate if you could evaluate this solution, since the presence of the autocomplete in kamcmd is very useful. Feel free to adopt changes to the proposed solution.

Thanks.