### PR TITLE
Update sca.c - Fix done for Appearance purge stale

### DIFF
--- a/src/modules/sca/sca.c
+++ b/src/modules/sca/sca.c
@@ -381,8 +381,8 @@ static int sca_mod_init(void)
 
 	register_timer(sca_subscription_purge_expired, sca,
 			sca->cfg->purge_expired_interval);
-	register_timer(
-			sca_appearance_purge_stale, sca, sca->cfg->purge_expired_interval);
+	//register_timer(
+	//		sca_appearance_purge_stale, sca, sca->cfg->purge_expired_interval);
 
 	// register separate timer process to write subscriptions to DB.
 	// move to 3.3+ timer API (register_basic_timer) at some point.


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
We have observed that when the call is answered and it is in active state more than 30 seconds, kamailio sends the notify messages with the "Idle" appearance to all the subscribed extensions. Practically it should not send the idle notification when the call is in active state.
	We have tried to change the mod parameter "purge_expired_interval" to 3600 seconds. but still idle notification transmit in 30 seconds. To overcome this issue, we have commented below line in the sca.c file.
	
		register_timer( sca_appearance_purge_stale, sca, sca->cfg->purge_expired_interval);
