### PR TITLE
Update mod_stats.c Random crash in CTL handler

### DIFF
--- a/src/modules/kex/mod_stats.c
+++ b/src/modules/kex/mod_stats.c
@@ -82,6 +82,12 @@ static const char* rpc_mod_mem_statsx_doc[2] = {
 /* test if the current mod info was already printed */
 static int rpc_mod_is_printed_one(mem_counter *stats, mem_counter *current) {
 	mem_counter *iter = stats;
+	
+	if ( stats == NULL || current == NULL )
+	{
+		LM_ERR("rpc_mod_is_printed_one -> funtion parameter contains null value \n");
+		return 1;
+	}
 
 	while (iter && iter != current) {
 		if (strcmp(iter->mname, current->mname) == 0) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
We have found a random crash in the CTL module handler and we are using kamailio 5.4.7. Based on the core log analysis, we have identified that, due to some of the RPC events this crash happens. 

	This crash happen when "rpc_mod_is_printed_one" function receives the parameter ( mem_counter *stats ) as NULL. To avoid the crash.
	
	
