### PR TITLE
APKBUILD: remove python2 references

### DIFF
--- a/pkg/kamailio/alpine/APKBUILD
+++ b/pkg/kamailio/alpine/APKBUILD
@@ -26,7 +26,7 @@ license="GPL-2.0"
 depends="gawk"
 options="!check"
 makedepends="bison db-dev flex freeradius-client-dev expat-dev
-	lksctp-tools-dev perl-dev postgresql-dev python2-dev python3-dev
+	lksctp-tools-dev perl-dev postgresql-dev python3-dev
 	pcre-dev mariadb-dev libxml2-dev curl-dev unixodbc-dev
 	confuse-dev ncurses-dev sqlite-dev lua-dev openldap-dev openssl-dev
 	net-snmp-dev libuuid libev-dev jansson-dev json-c-dev libevent-dev
@@ -162,9 +162,6 @@ _mod_list_lua="app_lua app_lua_sr"
 # - modules depending on perl library
 _mod_list_perl="app_perl db_perlvdb"
 
-# - modules depending on python2 library
-_mod_list_python="app_python"
-
 # - modules depending on ruby library
 _mod_list_ruby="app_ruby"
 
@@ -255,7 +252,7 @@ for _i in db postgres sqlite dbtext mysql \
 	ldap utils tls presence lua ims outbound debugger \
 	extras json websocket authephemeral mongodb\
 	uuid ev memcached redis geoip2 jansson sqlang sipdump \
-	jsdt http_async kazoo rabbitmq sctp radius perl python \
+	jsdt http_async kazoo rabbitmq sctp radius perl \
 	python3 ruby; do
 
    subpackages="$subpackages $pkgname-$_i"
@@ -543,11 +540,6 @@ sctp() {
 perl() {
 	_generic_pkg "Perl extensions and database driver for Kamailio" \
 		"$_mod_list_perl"
-}
-
-python() {
-	_generic_pkg "Execute embedded Python2 scripts" \
-		"$_mod_list_python"
 }
 
 ruby() {


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3257

#### Description
Do not build python2 module with default APKBUILD file due to python2 being sunsetted within Alpine Linux (there is no python2 APK).
