### PR TITLE
mqtt: Add tls_alpn module option

### DIFF
--- a/src/modules/mqtt/doc/mqtt_admin.xml
+++ b/src/modules/mqtt/doc/mqtt_admin.xml
@@ -328,6 +328,27 @@ modparam("mqtt", "tls_method", "tlsv1.3")
 		</programlisting>
 		</example>
 	</section>
+	<section id="mqtt.p.tls_alpn">
+		<title><varname>tls_alpn</varname> (str)</title>
+		<para>
+        Used to set the TLS ALPN option for cases where one TLS port is used to share multiple services. Prominent
+        example is AWS IoT, where you have to set the <varname>tls_alpn</varname> to "mqtt" to be able to connect
+        via MQTT.
+		</para>
+		<para>
+		<emphasis>
+			Default value is NULL, where no ALPN is set on the TLS connection.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>tls_alpn</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("mqtt", "tls_alpn", "mqtt")
+...
+		</programlisting>
+		</example>
+	</section>
 	<section id="mqtt.p.certificate">
 		<title><varname>certificate</varname> (str)</title>
 		<para>

--- a/src/modules/mqtt/mqtt_dispatch.c
+++ b/src/modules/mqtt/mqtt_dispatch.c
@@ -224,6 +224,17 @@ int mqtt_run_dispatcher(mqtt_dispatcher_cfg_t* cfg)
 			LM_ERR("mosquitto_tls_set() failed: %d %s\n",errno, strerror(errno));
 			return -1;
 		}
+        if (cfg->tls_alpn != NULL) {
+#if LIBMOSQUITTO_VERSION_NUMBER >= 1006000
+            res = mosquitto_string_option(_mosquitto, MOSQ_OPT_TLS_ALPN, cfg->tls_alpn);
+            if (res != MOSQ_ERR_SUCCESS) {
+                LM_ERR("mosquitto_string_option() failed setting TLS ALPN: %d %s\n",errno, strerror(errno));
+                return -1;
+            }
+#else
+		    LM_WARN("unable to set TLS ALPN due to outdated mosquitto library version, upgrade it to >= 1.6.0\n")
+#endif
+        }
 	}
 
 	res = mosquitto_connect(_mosquitto, cfg->host, cfg->port, cfg->keepalive);

--- a/src/modules/mqtt/mqtt_dispatch.h
+++ b/src/modules/mqtt/mqtt_dispatch.h
@@ -41,6 +41,7 @@ typedef struct mqtt_dispatcher_cfg {
 	char *certificate;
 	char *private_key;
 	char *tls_method;
+	char *tls_alpn;
 	int   verify_certificate;
 	char *cipher_list;
 } mqtt_dispatcher_cfg_t;

--- a/src/modules/mqtt/mqtt_mod.c
+++ b/src/modules/mqtt/mqtt_mod.c
@@ -44,6 +44,7 @@ static char *_mqtt_ca_path            = NULL;
 static char *_mqtt_certificate        = NULL;
 static char *_mqtt_private_key        = NULL;
 static char *_mqtt_tls_method         = NULL;
+static char *_mqtt_tls_alpn           = NULL;
 static int   _mqtt_verify_certificate = 1;
 static char *_mqtt_cipher_list        = NULL;
 
@@ -85,6 +86,7 @@ static param_export_t params[]={
 	{"keepalive",          INT_PARAM,      &_mqtt_keepalive},
 	{"event_callback",     PARAM_STR,      &_mqtt_event_callback},
 	{"tls_method",         PARAM_STRING,   &_mqtt_tls_method},
+	{"tls_alpn",           PARAM_STRING,   &_mqtt_tls_alpn},
 	{"ca_file",            PARAM_STRING,   &_mqtt_ca_file},
 	{"ca_path",            PARAM_STRING,   &_mqtt_ca_path},
 	{"certificate",        PARAM_STRING,   &_mqtt_certificate},
@@ -198,6 +200,7 @@ static int child_init(int rank)
 		cfg.certificate        = _mqtt_certificate;
 		cfg.private_key        = _mqtt_private_key;
 		cfg.tls_method         = _mqtt_tls_method;
+		cfg.tls_alpn           = _mqtt_tls_alpn;
 		cfg.verify_certificate = _mqtt_verify_certificate;
 		cfg.cipher_list        = _mqtt_cipher_list;
 


### PR DESCRIPTION
This is used when a service (like AWS IoT Core) uses one TLS port for multiple services (like https and mqtt), so you have to set the ALPN to 'mqtt' to be able to connect kamailio.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Some services use ALPN to have one single TLS port serving multiple protocols, in order to avoid additional round-trips for negotiating TLS connections. https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation has the details.

One of those services using ALPN is AWS IoT Core, which allows components to send messages both via HTTP and MQTT to AWS for further processing (e.g. logging, analysis, storage to db etc). This patch enables kamailio to communicate with this service by allowing the kamailio admin to set the mqtt.so module mod-param *tls_alpn*  to *mqtt*.