### PR TITLE
siputils: fix time_t warning and a typo

### DIFF
--- a/src/modules/siputils/siputils.c
+++ b/src/modules/siputils/siputils.c
@@ -563,7 +563,7 @@ static int ki_hdr_date_check(sip_msg_t* msg, int tdiff)
 	}
 
 	if (tnow > tmsg + tdiff) {
-		LM_ERR("autdated date header value (%ld sec)\n", tnow - tmsg + tdiff);
+		LM_ERR("outdated date header value (%" TIME_T_FMT " sec)\n", TIME_T_CAST(tnow - tmsg + tdiff));
 		return -4;
 	} else {
 		LM_ERR("Date header value OK\n");


### PR DESCRIPTION
Fix the below warning one gets when compiling siputils for a 32 bit target against a time64 libc (musl).

Also fix a spelling mistake on the same line ("autdated" -> "outdated").

```
siputils.c: In function 'ki_hdr_date_check':
../../core/parser/../dprint.h:321:73: warning: format '%ld' expects argument of type 'long int', but argument 11 has type 'time_t' {aka 'long long int'} [-Wformat=]
  321 |                                                         fprintf(stderr, "%2d(%d) %s: %.*s%s%s%s" fmt, \
      |                                                                         ^~~~~~~~~~~~~~~~~~~~~~~~
../../core/parser/../dprint.h:345:25: note: in expansion of macro 'LOG_FX'
  345 |                         LOG_FX(facility, level, lname, prefix, _FUNC_NAME_, fmt, ## args)
      |                         ^~~~~~
../../core/parser/../dprint.h:351:25: note: in expansion of macro 'LOG_FL'
  351 |                         LOG_FL(facility, level, NULL, prefix, fmt, ## args)
      |                         ^~~~~~
../../core/parser/../dprint.h:354:25: note: in expansion of macro 'LOG_FP'
  354 |                         LOG_FP(DEFAULT_FACILITY, (level), LOC_INFO, fmt, ## args)
      |                         ^~~~~~
../../core/parser/../dprint.h:392:37: note: in expansion of macro 'LOG'
  392 | #       define ERR(fmt, args...)    LOG(L_ERR,    fmt , ## args)
      |                                     ^~~
../../core/parser/../dprint.h:418:16: note: in expansion of macro 'ERR'
  418 | #define LM_ERR ERR
      |                ^~~
siputils.c:562:17: note: in expansion of macro 'LM_ERR'
  562 |                 LM_ERR("autdated date header value (%ld sec)\n", tnow - tmsg + tdiff);
      |                 ^~~~~~
```

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Hi all,

I ticked "Tested changes locally" because I ran kamailio with siputils module loaded, but I wouldn't know how to trigger the exact code path to end up with the error message I updated. But the compile warning goes away with this change and the same mechanism for time_t format handling is used elsewhere in kamailio already.

Kind regards,
Seb