### PR TITLE
Pepelux/secfilter

### DIFF
--- a/src/modules/secfilter/secfilter.c
+++ b/src/modules/secfilter/secfilter.c
@@ -358,6 +358,7 @@ static int w_check_ua(struct sip_msg *msg)
 	len = ua.len;
 
 	/* User-agent whitelisted */
+	lock_get(&secf_data->lock);
 	list = secf_data->wl.ua;
 	while(list) {
 		if(ua.len > list->s.len)
@@ -375,7 +376,6 @@ static int w_check_ua(struct sip_msg *msg)
 	}
 
 	/* User-agent blacklisted */
-	lock_get(&secf_data->lock);
 	list = secf_data->bl.ua;
 	while(list) {
 		if(ua.len > list->s.len)

--- a/src/modules/secfilter/secfilter.c
+++ b/src/modules/secfilter/secfilter.c
@@ -304,6 +304,7 @@ static int w_check_dst(struct sip_msg *msg, char *val)
 	dst.s = val;
 	dst.len = strlen(val);
 
+	lock_get(&secf_data->lock);
 	list = secf_data->bl.dst;
 	while(list) {
 		if(secf_dst_exact_match == 1) {
@@ -313,6 +314,7 @@ static int w_check_dst(struct sip_msg *msg, char *val)
 					lock_get(secf_lock);
 					secf_stats[BL_DST]++;
 					lock_release(secf_lock);
+					lock_release(&secf_data->lock);
 					return -2;
 				}
 			}
@@ -324,11 +326,13 @@ static int w_check_dst(struct sip_msg *msg, char *val)
 				lock_get(secf_lock);
 				secf_stats[BL_DST]++;
 				lock_release(secf_lock);
+				lock_release(&secf_data->lock);
 				return -2;
 			}
 		}
 		list = list->next;
 	}
+	lock_release(&secf_data->lock);
 
 	return 1;
 }
@@ -363,6 +367,7 @@ static int w_check_ua(struct sip_msg *msg)
 			lock_get(secf_lock);
 			secf_stats[WL_UA]++;
 			lock_release(secf_lock);
+			lock_release(&secf_data->lock);
 			return 2;
 		}
 		list = list->next;
@@ -370,6 +375,7 @@ static int w_check_ua(struct sip_msg *msg)
 	}
 
 	/* User-agent blacklisted */
+	lock_get(&secf_data->lock);
 	list = secf_data->bl.ua;
 	while(list) {
 		if(ua.len > list->s.len)
@@ -380,10 +386,13 @@ static int w_check_ua(struct sip_msg *msg)
 			secf_stats[BL_UA]++;
 			lock_release(secf_lock);
 			return -2;
+			lock_release(&secf_data->lock);
 		}
 		list = list->next;
 		ua.len = len;
 	}
+	lock_release(&secf_data->lock);
+	
 	return 1;
 }
 
@@ -457,6 +466,7 @@ static int check_user(struct sip_msg *msg, int type)
 	dlen = domain.len;
 
 	/* User whitelisted */
+	lock_get(&secf_data->lock);
 	list = secf_data->wl.user;
 	while(list) {
 		if(name.len > list->s.len)
@@ -477,6 +487,7 @@ static int check_user(struct sip_msg *msg, int type)
 						break;
 				}
 				lock_release(secf_lock);
+				lock_release(&secf_data->lock);
 				return 4;
 			}
 		}
@@ -497,6 +508,7 @@ static int check_user(struct sip_msg *msg, int type)
 					break;
 			}
 			lock_release(secf_lock);
+			lock_release(&secf_data->lock);
 			return 2;
 		}
 		list = list->next;
@@ -524,6 +536,7 @@ static int check_user(struct sip_msg *msg, int type)
 						break;
 				}
 				lock_release(secf_lock);
+				lock_release(&secf_data->lock);
 				return -4;
 			}
 		}
@@ -544,6 +557,7 @@ static int check_user(struct sip_msg *msg, int type)
 					break;
 			}
 			lock_release(secf_lock);
+			lock_release(&secf_data->lock);
 			return -2;
 		}
 		list = list->next;
@@ -571,6 +585,7 @@ static int check_user(struct sip_msg *msg, int type)
 					break;
 			}
 			lock_release(secf_lock);
+			lock_release(&secf_data->lock);
 			return 3;
 		}
 		list = list->next;
@@ -596,11 +611,13 @@ static int check_user(struct sip_msg *msg, int type)
 					break;
 			}
 			lock_release(secf_lock);
+			lock_release(&secf_data->lock);
 			return -3;
 		}
 		list = list->next;
 		domain.len = dlen;
 	}
+	lock_release(&secf_data->lock);
 
 	return 1;
 }
@@ -629,6 +646,7 @@ static int w_check_ip(struct sip_msg *msg)
 	len = ip.len;
 
 	/* IP address whitelisted */
+	lock_get(&secf_data->lock);
 	list = secf_data->wl.ip;
 	while(list) {
 		if(ip.len > list->s.len)
@@ -638,6 +656,7 @@ static int w_check_ip(struct sip_msg *msg)
 			lock_get(secf_lock);
 			secf_stats[WL_IP]++;
 			lock_release(secf_lock);
+			lock_release(&secf_data->lock);
 			return 2;
 		}
 		list = list->next;
@@ -653,11 +672,13 @@ static int w_check_ip(struct sip_msg *msg)
 			lock_get(secf_lock);
 			secf_stats[BL_IP]++;
 			lock_release(secf_lock);
+			lock_release(&secf_data->lock);
 			return -2;
 		}
 		list = list->next;
 		ip.len = len;
 	}
+	lock_release(&secf_data->lock);
 
 	return 1;
 }
@@ -682,6 +703,7 @@ static int w_check_country(struct sip_msg *msg, char *val)
 	len = country.len;
 
 	/* Country whitelisted */
+	lock_get(&secf_data->lock);
 	list = secf_data->wl.country;
 	while(list) {
 		if(country.len > list->s.len)
@@ -691,6 +713,7 @@ static int w_check_country(struct sip_msg *msg, char *val)
 			lock_get(secf_lock);
 			secf_stats[WL_COUNTRY]++;
 			lock_release(secf_lock);
+			lock_release(&secf_data->lock);
 			return 2;
 		}
 		list = list->next;
@@ -706,11 +729,13 @@ static int w_check_country(struct sip_msg *msg, char *val)
 			lock_get(secf_lock);
 			secf_stats[BL_COUNTRY]++;
 			lock_release(secf_lock);
+			lock_release(&secf_data->lock);
 			return -2;
 		}
 		list = list->next;
 		country.len = len;
 	}
+	lock_release(&secf_data->lock);
 
 	return 1;
 }

--- a/src/modules/secfilter/secfilter.h
+++ b/src/modules/secfilter/secfilter.h
@@ -50,7 +50,9 @@ typedef struct _secf_data
 	secf_info_t bl_last;
 } secf_data_t, *secf_data_p;
 
-extern secf_data_p secf_data;
+extern secf_data_p *secf_data;
+extern secf_data_p secf_data_1;
+extern secf_data_p secf_data_2;
 
 extern int *secf_stats;
 void secf_reset_stats(void);
@@ -66,7 +68,7 @@ int secf_get_contact(struct sip_msg *msg, str *user, str *domain);
 /* Database functions */
 int secf_init_db(void);
 int secf_init_data(void);
-void secf_free_data(void);
+void secf_free_data(secf_data_p secf_fdata);
 int secf_load_db(void);
 
 /* Extern variables */
@@ -76,6 +78,9 @@ extern str secf_action_col;
 extern str secf_type_col;
 extern str secf_data_col;
 extern int secf_dst_exact_match;
+extern int secf_reload_delta;
+extern int secf_reload_interval;
+extern time_t *secf_rpc_reload_time;
 
 /* RPC commands */
 void secf_rpc_reload(rpc_t *rpc, void *ctx);

--- a/src/modules/secfilter/secfilter_db.c
+++ b/src/modules/secfilter/secfilter_db.c
@@ -113,11 +113,11 @@ int secf_append_rule(int action, int type, str *value)
 	}
 
 	if(action == 1) {
-		ini = &secf_data->wl;
-		last = &secf_data->wl_last;
+		ini = &(*secf_data)->wl;
+		last = &(*secf_data)->wl_last;
 	} else {
-		ini = &secf_data->bl;
-		last = &secf_data->bl_last;
+		ini = &(*secf_data)->bl;
+		last = &(*secf_data)->bl_last;
 	}
 
 	switch(type) {
@@ -196,6 +196,14 @@ int secf_load_db(void)
 		return -1;
 	}
 
+	/* Choose new hash table and free its old contents */
+	if (*secf_data == secf_data_1) {
+		secf_data = &secf_data_2;
+	} else {
+		secf_data = &secf_data_1;
+	}
+	secf_free_data(*secf_data);
+
 	/* Prepare the data for the query */
 	db_cols[0] = &secf_action_col;
 	db_cols[1] = &secf_type_col;
@@ -221,7 +229,7 @@ int secf_load_db(void)
 		goto clean;
 	}
 
-	lock_get(&secf_data->lock);
+	lock_get(&(*secf_data)->lock);
 	for(i = 0; i < rows; i++) {
 		action = (int)RES_ROWS(db_res)[i].values[0].val.int_val;
 		type = (int)RES_ROWS(db_res)[i].values[1].val.int_val;
@@ -233,11 +241,11 @@ int secf_load_db(void)
 		if(secf_append_rule(action, type, &str_data) < 0) {
 			LM_ERR("Can't append_rule with action:%d type:%d\n", action, type);
 			res = -1;
-			lock_release(&secf_data->lock);
+			lock_release(&(*secf_data)->lock);
 			goto clean;
 		}
 	}
-	lock_release(&secf_data->lock);
+	lock_release(&(*secf_data)->lock);
 
 clean:
 	if(db_res) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
New params:
- reload_delta: To set the number of seconds that have to be waited before executing a new RPC reload
- cleanup_interval: To set the number of seconds that have to be wait before cleanup the previous values from memory after a RPC reload

The purpose is to avoid problems when accessing data lists while doing an RPC reload.