### PR TITLE
Pepelux/secfilter

### DIFF
--- a/src/modules/secfilter/doc/secfilter_admin.xml
+++ b/src/modules/secfilter/doc/secfilter_admin.xml
@@ -212,6 +212,47 @@
 		</programlisting>
        </example>
      </section>
+
+	<section id="secfilter.p.reload_delta">
+       <title><varname>reload_delta</varname> (integer)</title>
+ 
+ 		<para> 
+ 		The number of seconds that have to be waited before executing a new RPC reload. 
+ 		By default there is a rate limiting of maximum one reload in five seconds.
+
+                If set to <emphasis>0</emphasis>, no rate limit is configured. 
+    		</para> 
+       <para><emphasis> Default value is 5</emphasis></para>
+ 
+       <example>
+         <title>Set <varname>reload_delta</varname> parameter</title>
+ 
+         <programlisting format="linespecific">
+		...
+		modparam("secfilter", "reload_delta", 1)
+		...
+		</programlisting>
+       </example>
+     </section>
+
+	<section id="secfilter.p.cleanup_interval">
+       <title><varname>cleanup_interval</varname> (integer)</title>
+ 
+ 		<para> 
+ 		The number of seconds that have to be wait before cleanup the previous values from memory after a RPC reload.
+    		</para> 
+       <para><emphasis> Default value is 60</emphasis></para>
+ 
+       <example>
+         <title>Set <varname>cleanup_interval</varname> parameter</title>
+ 
+         <programlisting format="linespecific">
+		...
+		modparam("secfilter", "cleanup_interval", 120)
+		...
+		</programlisting>
+       </example>
+     </section>
 	</section>
 
  	<section>

--- a/src/modules/secfilter/secfilter.c
+++ b/src/modules/secfilter/secfilter.c
@@ -96,7 +96,14 @@ static param_export_t params[] = {{"db_url", PARAM_STRING, &secf_db_url},
 		{"action_col", PARAM_STR, &secf_action_col},
 		{"type_col", PARAM_STR, &secf_type_col},
 		{"data_col", PARAM_STR, &secf_data_col},
+<<<<<<< HEAD
 		{"dst_exact_match", PARAM_INT, &secf_dst_exact_match}, {0, 0, 0}};
+=======
+		{"dst_exact_match", PARAM_INT, &secf_dst_exact_match},
+		{"reload_delta", PARAM_INT, &secf_reload_delta},
+		{"cleanup_interval", PARAM_INT, &secf_reload_interval},
+		{0, 0, 0}};
+>>>>>>> 82258962ed... secfilter: cleanup old data after a reload by timer function
 
 /* Module exports definition */
 struct module_exports exports = {
@@ -763,11 +770,20 @@ int secf_init_data(void)
 	}
 	memset(secf_data, 0, sizeof(secf_data_t));
 
+	secf_data = shm_malloc(sizeof(secf_data_t));
+	if(secf_data == NULL) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+
 	secf_stats = shm_malloc(total_data * sizeof(int));
 	memset(secf_stats, 0, total_data * sizeof(int));
 	
 	if(secf_dst_exact_match != 0)
 		secf_dst_exact_match = 1;
+
+	if(register_timer(secf_ht_timer, NULL, secf_reload_interval) < 0)
+		return -1;
 
 	return 0;
 }
@@ -788,6 +804,10 @@ static int mod_init(void)
 		LM_CRIT("cannot initialize lock.\n");
 		return -1;
 	}
+<<<<<<< HEAD
+=======
+	
+>>>>>>> 82258962ed... secfilter: cleanup old data after a reload by timer function
 	secf_lock = lock_alloc();
 	if (!secf_lock) {
 		LM_CRIT("cannot allocate memory for lock.\n");
@@ -888,7 +908,29 @@ static void free_sec_info(secf_info_p info)
 
 void secf_free_data(void)
 {
+<<<<<<< HEAD
 	lock_get(&secf_data->lock);
+=======
+	if(secf_rpc_reload_time == NULL)
+		return;
+
+	if(*secf_rpc_reload_time != 0
+			&& *secf_rpc_reload_time > time(NULL) - secf_reload_interval)
+			return;
+
+	LM_DBG("cleaning old data list\n");
+	if (*secf_data == secf_data_1) {
+		secf_free_data(secf_data_2);
+	} else {
+		secf_free_data(secf_data_1);
+	}
+}
+
+
+void secf_free_data(secf_data_p secf_fdata)
+{
+	lock_get(&secf_fdata->lock);
+>>>>>>> 82258962ed... secfilter: cleanup old data after a reload by timer function
 
 	LM_DBG("freeing wl\n");
 	free_sec_info(&secf_data->wl);
@@ -900,5 +942,9 @@ void secf_free_data(void)
 	memset(&secf_data->bl_last, 0, sizeof(secf_info_t));
 	LM_DBG("so, ua[%p] should be NULL\n", secf_data->bl.ua);
 
+<<<<<<< HEAD
 	lock_release(&secf_data->lock);
+=======
+	lock_release(&secf_fdata->lock);
+>>>>>>> 82258962ed... secfilter: cleanup old data after a reload by timer function
 }

--- a/src/modules/secfilter/secfilter_db.c
+++ b/src/modules/secfilter/secfilter_db.c
@@ -196,6 +196,17 @@ int secf_load_db(void)
 		return -1;
 	}
 
+<<<<<<< HEAD
+=======
+	/* Choose new hash table and free its old contents */
+	if (*secf_data == secf_data_1) {
+		*secf_data = secf_data_2;
+	} else {
+		*secf_data = secf_data_1;
+	}
+	secf_free_data(*secf_data);
+
+>>>>>>> 82258962ed... secfilter: cleanup old data after a reload by timer function
 	/* Prepare the data for the query */
 	db_cols[0] = &secf_action_col;
 	db_cols[1] = &secf_type_col;

--- a/src/modules/secfilter/secfilter_rpc.c
+++ b/src/modules/secfilter/secfilter_rpc.c
@@ -156,6 +156,7 @@ void secf_rpc_reload(rpc_t *rpc, void *ctx)
 		LM_ERR("Error loading data from database\n");
 		rpc->fault(ctx, 500, "Error loading data from database");
 	} else {
+		LM_INFO("Data reloaded from RPC");
 		rpc->rpl_printf(ctx, "Data reloaded");
 	}
 }


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3263 (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

New params:

- reload_delta: To set the number of seconds that have to be waited before executing a new RPC reload
- cleanup_interval: To set the number of seconds that have to be wait before cleanup the previous values from memory after a RPC reload

The purpose is to avoid problems when accessing data lists while doing an RPC reload.