### PR TITLE
dialog: dlg_set_var() support empty totag parameter

### DIFF
--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -1922,7 +1922,7 @@ static int ki_dlg_set_var(sip_msg_t *msg, str *sc, str *sf, str *st, str *key, s
 		LM_ERR("invalid From tag parameter\n");
 		return -1;
 	}
-	if(st==NULL || st->s==NULL || st->len == 0) {
+	if(st==NULL) {
 		LM_ERR("invalid To tag parameter\n");
 		return -1;
 	}
@@ -1966,11 +1966,7 @@ static int w_dlg_set_var(struct sip_msg *msg, char *ci, char *ft, char *tt, char
 		LM_ERR("unable to get To Tag\n");
 		return -1;
 	}
-	if(st.s==NULL || st.len == 0)
-	{
-		LM_ERR("invalid To tag parameter\n");
-		return -1;
-	}
+
 	if(fixup_get_svalue(msg, (gparam_p)key, &k)!=0)
 	{
 		LM_ERR("unable to get key name\n");

--- a/src/modules/dialog/doc/dialog_admin.xml
+++ b/src/modules/dialog/doc/dialog_admin.xml
@@ -2239,7 +2239,7 @@ if(dlg_get_var("$var(ci)", "$var(ft)", "456", "test", "$var(tmp)"))
 			</para>
 		</listitem>
 		<listitem>
-			<para><emphasis>ttag</emphasis> - SIP To tag.
+			<para><emphasis>ttag</emphasis> - SIP To tag. Use "" value to indicate early dialog.
 			</para>
 		</listitem>
 		<listitem>
@@ -2260,6 +2260,11 @@ if(dlg_get_var("$var(ci)", "$var(ft)", "456", "test", "$var(tmp)"))
 		<programlisting format="linespecific">
 ...
 if(dlg_set_var("$var(ci)", "$var(ft)", "456", "test", "$var(tmp)"))
+{
+	xdbg("set $$dlg_var(test):$var(tmp)\n");
+}
+# you can set vars in early dialog too
+if(dlg_set_var("$var(ci)", "$var(ft)", "", "test", "$var(tmp)"))
 {
 	xdbg("set $$dlg_var(test):$var(tmp)\n");
 }


### PR DESCRIPTION
<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally

#### Description

support setting vars for non established dialogs
