### PR TITLE
ims_usrloc_pcscf:   implementation of db_mode DB_ONLY (value 3)

### DIFF
--- a/src/modules/ims_usrloc_pcscf/README
+++ b/src/modules/ims_usrloc_pcscf/README
@@ -175,6 +175,17 @@ modparam("ims_usrloc_pcscf", "db_url",
        reflected in the database. This is slow but very reliable. This
        mode will ensure that no registration data is lost as a result of a
        restart or crash.
+     * 3 - DB_ONLY Scheme. All changes to usrloc are immediately
+       reflected in the database and additionally PCSCF usrloc data are downloaded
+       from db and inserted into PCSCF usrloc cache if required - i.e. If 
+       contact data cannot be found in cache a db
+       query for the contact is done in table location and when contact is
+       found there its respective data are inserted in PCSCF usrloc cache.
+       Also an audit had been added for removal of long expired PCSCF usrloc data
+       in table location.
+       Some of the db queries do only support Mysql.
+       This mode will ensure that no registration data is lost as a result of a
+       restart or crash.
 
    Default value is 0.
 

--- a/src/modules/ims_usrloc_pcscf/doc/ims_usrloc_pcscf_admin.xml
+++ b/src/modules/ims_usrloc_pcscf/doc/ims_usrloc_pcscf_admin.xml
@@ -142,6 +142,20 @@ modparam("ims_usrloc_pcscf", "db_url",
           reliable. This mode will ensure that no registration data is lost as
           a result of a restart or crash.</para>
         </listitem>
+
+        <listitem>
+          <para>3 - DB_ONLY Scheme. All changes to usrloc are immediately
+          reflected in the database and additionally PCSCF usrloc data are downloaded
+          from db and inserted into PCSCF usrloc cache if required - i.e. If
+          contact data cannot be found in cache a db
+          query for the contact is done in table location and when contact is
+          found there its respective data are inserted in PCSCF usrloc cache.
+          Also an audit had been added for removal of long expired PCSCF usrloc data
+          in table location.
+          This mode will ensure that no registration data is lost as a result of a
+          restart or crash.</para>
+        </listitem>
+
       </itemizedlist>
 
       <para><emphasis>Default value is 0.</emphasis></para>
@@ -202,6 +216,55 @@ modparam("ims_usrloc_pcscf", "expires_grace", 1800)
       </example>
     </section>
     
+    <section>
+      <title>audit_expired_pcontacts_interval (int)</title>
+
+      <para>Number of seconds between two audit runs.
+      Note: audit is used for db_mode DB_ONLY (3) only.
+      The module uses this audit to
+      delete expired contacts found in db table location which are expired
+      at least as the audit_expired_pcontacts_timeout value.
+      Such expired contacts in location  may appear when these contacts
+      are not present in usrloc cache because PCSCF crashed before
+      contact expiry.
+      </para>
+
+      <para><emphasis> Default value is 60. </emphasis></para>
+
+      <example>
+        <title>Set audit_expired_pcontacts_interval parameter</title>
+
+        <programlisting format="linespecific">...
+modparam("ims_usrloc_pcscf", "audit_expired_pcontacts_interval", 120)
+...
+</programlisting>
+      </example>
+    </section>
+
+    <section>
+      <title>audit_expired_pcontacts_timeout (int)</title>
+
+      <para>Number of seconds the contacts must be already expired before the audit
+      starts working on them.
+      It is recommended to set only values greater than the Default value 40.
+      The module uses this audit to
+      delete expired contacts found in db table location which are expired
+      at least as many seconds as the sum of this timeout parameter value plus
+      the value of the expires_grace parameter.
+      </para>
+
+      <para><emphasis> Default value is 40. </emphasis></para>
+
+      <example>
+        <title>Set audit_expired_pcontacts_timeout parameter</title>
+
+        <programlisting format="linespecific">...
+modparam("ims_usrloc_pcscf", "audit_expired_pcontacts_timeout", 120)
+...
+</programlisting>
+      </example>
+    </section>
+    
   </section>
 
   <section>
@@ -241,3 +304,4 @@ modparam("ims_usrloc_pcscf", "expires_grace", 1800)
     </section>
   </section>
 </chapter>
+

--- a/src/modules/ims_usrloc_pcscf/ims_usrloc_pcscf_mod.c
+++ b/src/modules/ims_usrloc_pcscf/ims_usrloc_pcscf_mod.c
@@ -40,6 +40,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+ 
 
 #include <stdio.h>
 #include "ims_usrloc_pcscf_mod.h"
@@ -61,6 +62,11 @@ MODULE_VERSION
 
 #define DEFAULT_DBG_FILE "/var/log/usrloc_debug"
 static FILE *debug_file;
+
+int audit_expired_pcontacts_timeout = 40;
+int audit_expired_pcontacts_interval = 60;
+
+static void audit_usrloc_expired_pcontacts_timer(unsigned int ticks, void* param);
 
 static int mod_init(void);                          /*!< Module initialization function */
 static void destroy(void);                          /*!< Module destroy function */
@@ -110,8 +116,10 @@ static param_export_t params[] = {
 	{"timer_interval",      INT_PARAM, &timer_interval  },
 	{"db_mode",             INT_PARAM, &db_mode         },
 
-	{"match_contact_host_port",		INT_PARAM, &match_contact_host_port	},
-        {"expires_grace",		INT_PARAM, &expires_grace	},
+	{"match_contact_host_port",	                   INT_PARAM, &match_contact_host_port },
+         {"audit_expired_pcontacts_timeout",            INT_PARAM, &audit_expired_pcontacts_timeout },
+         {"audit_expired_pcontacts_interval",           INT_PARAM, &audit_expired_pcontacts_interval },
+         {"expires_grace",       INT_PARAM, &expires_grace },
 
 	{0, 0, 0}
 };
@@ -177,6 +185,11 @@ static int mod_init(void) {
 	/* Register cache timer */
 	LM_DBG("Registering cache timer");
 	register_timer(timer, 0, timer_interval);
+
+        /* Register audit timer */
+        if (db_mode == DB_ONLY)
+            register_timer(audit_usrloc_expired_pcontacts_timer, 0, audit_expired_pcontacts_interval);
+
 
 	/* init the callbacks list */
 	if (init_ulcb_list() < 0) {
@@ -261,6 +274,11 @@ static void destroy(void)
 
 	if (db_mode)
 		destroy_db();
+}
+
+static void audit_usrloc_expired_pcontacts_timer(unsigned int ticks, void* param) {
+
+     audit_usrloc_expired_pcontacts(root->d);
 }
 
 

--- a/src/modules/ims_usrloc_pcscf/ims_usrloc_pcscf_mod.h
+++ b/src/modules/ims_usrloc_pcscf/ims_usrloc_pcscf_mod.h
@@ -59,5 +59,6 @@ extern int desc_time_order;
 extern int cseq_delay;
 extern int ul_fetch_rows;
 extern int ul_hash_size;
+extern int db_mode;
 
 #endif /* UL_MOD_H */

--- a/src/modules/ims_usrloc_pcscf/pcontact.c
+++ b/src/modules/ims_usrloc_pcscf/pcontact.c
@@ -277,6 +277,17 @@ int new_pcontact(struct udomain* _d, str* _contact, struct pcontact_info* _ci, s
 			(*_c)->num_service_routes = _ci->num_service_routes;
 		}
 	}
+	// add the rx session id
+	if ((_ci->rx_regsession_id) && (_ci->rx_regsession_id->len > 0) && (_ci->rx_regsession_id->s)) {
+		(*_c)->rx_session_id.s = shm_malloc(_ci->rx_regsession_id->len);
+		if (!((*_c)->rx_session_id.s)) {
+			LM_ERR("no more shm mem\n");
+			goto out_of_memory;
+		}
+		memcpy((*_c)->rx_session_id.s, _ci->rx_regsession_id->s, _ci->rx_regsession_id->len);
+		(*_c)->rx_session_id.len = _ci->rx_regsession_id->len;
+	}
+        //(*_c)->str_callback_registered = 0;
         
         LM_DBG("New contact host:port [%.*s:%d]\n", (*_c)->contact_host.len, (*_c)->contact_host.s, (*_c)->contact_port);
         LM_DBG("New contact via host:port:proto: [%.*s:%d:%d]\n", (*_c)->via_host.len, (*_c)->via_host.s, (*_c)->via_port, (*_c)->via_proto);
@@ -357,18 +368,68 @@ static inline void nodb_timer(pcontact_t* _c)
         
         if ((_c->expires - act_time) + expires_grace <= 0) {//we've allowed some grace time TODO: add as parameter
         //if ((_c->expires - act_time) <= -10) {//we've allowed some grace time TODO: add as parameter
-		LM_DBG("pcscf contact <%.*s> has expired and will be removed\n", _c->aor.len, _c->aor.s);
-		if (exists_ulcb_type(PCSCF_CONTACT_EXPIRE)) {
-			run_ul_callbacks(PCSCF_CONTACT_EXPIRE, _c);
-		}
+        	LM_DBG("pcscf contact <%.*s> has expired and will be removed\n", _c->aor.len, _c->aor.s);
 
-		if (db_mode == WRITE_THROUGH && db_delete_pcontact(_c) != 0) {
-			LM_ERR("Error deleting ims_usrloc_pcscf record in DB");
-		}
+                // check expiry again by updating expiry from DB
+                if (db_mode == DB_ONLY){
+                   if  (db_load_pcontact(_c->slot->d, &_c->aor, 0/*insert_cache*/, &_c, NULL)){
+                        if ((_c->reg_state == PCONTACT_REG_PENDING_AAR) || (_c->reg_state == PCONTACT_REG_PENDING)){
+                           //we do not need expires_grace here as contact is not registered in scscf 
+                           if ((_c->expires - act_time)  <= 0) {
+                               _c->reg_state = PCONTACT_DEREG_PENDING_PUBLISH;
+                               delete_pcontact(_c->slot->d,  _c);
+                               return;
+                           }
+                        }
+                        else{
+                           if ((_c->expires - act_time) + expires_grace >= 0) {
+                               return;
+                           }
+                        }
+                    }
+                    else{
+                        // not found in DB: better delete in cache also
+                        update_stat(_c->slot->d->expired, 1);
+                        mem_delete_pcontact(_c->slot->d, _c);
+                        return;
+                    }
+                    // PRM1945 : PUBLISH already sent:  delete pcontact and pua after time window 30 secs
+                    // currently not clear what happens if more contacts existing for one public_identity (pua)
+                    // which are not expired
+                    if ((_c->reg_state == PCONTACT_DEREG_PENDING_PUBLISH) &&
+                        ((_c->expires - act_time) + expires_grace + 30 <= 0)){
+                       LM_INFO("Deleting expired pcontact: <%.*s>\n", _c->aor.len, _c->aor.s);
+                       if (&_c->head->public_identity){
+                           if (&_c->head->public_identity.s && &_c->head->public_identity.len)
+                               db_delete_presentityuri_from_pua(&_c->head->public_identity);
+                       }
+                       delete_pcontact(_c->slot->d,  _c);
+                       return;
+                    }
+                    
+                   _c->reg_state = PCONTACT_DEREG_PENDING_PUBLISH;
+					if(db_delete_pcontact(_c) !=0) {
+						LM_ERR("Error deleting ims_usrloc_pcscf record in DB");
+					} //delete contact in DB to not process this contact in several units
+                   if (exists_ulcb_type(PCSCF_CONTACT_UPDATE)) {
+                        run_ul_callbacks(PCSCF_CONTACT_UPDATE, _c);
+                        LM_INFO("pcscf contact <%.*s> has expired - sending PUBLISH\n", _c->aor.len, _c->aor.s);
+                        return;
+                   }
+                }
+                else{
+	           if (exists_ulcb_type(PCSCF_CONTACT_EXPIRE)) {
+			        run_ul_callbacks(PCSCF_CONTACT_EXPIRE, _c);
+		       }
 
-		update_stat(_c->slot->d->expired, 1);
-		mem_delete_pcontact(_c->slot->d, _c);
-		return;
+		    if (db_mode == WRITE_THROUGH && db_delete_pcontact(_c) != 0) {
+			     LM_ERR("Error deleting ims_usrloc_pcscf record in DB");
+		    }
+
+		    update_stat(_c->slot->d->expired, 1);
+		    mem_delete_pcontact(_c->slot->d, _c);
+		    return;
+		    }
 	}
 
 	//TODO: this is just for tmp debugging

--- a/src/modules/ims_usrloc_pcscf/udomain.h
+++ b/src/modules/ims_usrloc_pcscf/udomain.h
@@ -40,6 +40,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+ 
 
 #ifndef UDOMAIN_H
 #define UDOMAIN_H
@@ -82,5 +83,7 @@ int update_security(udomain_t* _d, security_type _t, security_t* _s, struct pcon
 int update_temp_security(udomain_t* _d, security_type _t, security_t* _s, struct pcontact* _c);
 
 int preload_udomain(db1_con_t* _c, udomain_t* _d);
-
+int audit_usrloc_expired_pcontacts(udomain_t* _d);
+int db_load_pcontact(udomain_t* _d, str *_aor, int insert_cache, struct pcontact** _c, pcontact_info_t* contact_info);
+int db_delete_presentityuri_from_pua(str *presentity_uri);
 #endif

--- a/src/modules/ims_usrloc_pcscf/udomain.h
+++ b/src/modules/ims_usrloc_pcscf/udomain.h
@@ -85,5 +85,4 @@ int update_temp_security(udomain_t* _d, security_type _t, security_t* _s, struct
 int preload_udomain(db1_con_t* _c, udomain_t* _d);
 int audit_usrloc_expired_pcontacts(udomain_t* _d);
 int db_load_pcontact(udomain_t* _d, str *_aor, int insert_cache, struct pcontact** _c, pcontact_info_t* contact_info);
-int db_delete_presentityuri_from_pua(str *presentity_uri);
 #endif

--- a/src/modules/ims_usrloc_pcscf/ul_callback.h
+++ b/src/modules/ims_usrloc_pcscf/ul_callback.h
@@ -53,7 +53,6 @@
 #include "../../core/ut.h"
 #include "../ims_usrloc_pcscf/usrloc.h" 
 #include "../../lib/ims/ims_getters.h"
-// %KTACT%-END bugfix__PRM19/0000138_no_str_sent
 
 struct pcontact;
 

--- a/src/modules/ims_usrloc_pcscf/ul_callback.h
+++ b/src/modules/ims_usrloc_pcscf/ul_callback.h
@@ -42,11 +42,18 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  * 
  */
+ 
 
 #ifndef _UL_CALLBACKS_H
 #define _UL_CALLBACKS_H
 
 #include "../../core/dprint.h"
+#include "../../core/parser/msg_parser.h"
+#include "../../core/parser/contact/parse_contact.h" 
+#include "../../core/ut.h"
+#include "../ims_usrloc_pcscf/usrloc.h" 
+#include "../../lib/ims/ims_getters.h"
+// %KTACT%-END bugfix__PRM19/0000138_no_str_sent
 
 struct pcontact;
 
@@ -58,6 +65,7 @@ struct pcontact;
 
 typedef void (ul_cb) (struct pcontact *c, int type, void *param);		/*! \brief callback function prototype */
 typedef int (*register_ulcb_t)(struct pcontact *c, int cb_types, ul_cb f, void *param);	/*! \brief register callback function prototype */
+typedef int (*is_ulcb_registered_t)(struct pcontact *c, ul_cb f);
 
 struct ul_callback {
 	int types;                   /*!< types of events that trigger the callback*/
@@ -82,7 +90,9 @@ void destroy_ulcb_list(void);
 void destroy_ul_callbacks_list(struct ul_callback* cb);
 int register_ulcb( struct pcontact *c, int types, ul_cb f, void *param);
 void delete_ulcb(struct pcontact* c, int type);
+int register_ulcb_method( struct pcontact *c, int types, ul_cb f, void *param);
 void run_ul_callbacks( int type , struct pcontact *c);
 void run_ul_create_callbacks(struct pcontact *c);
+int is_ulcb_registered(struct pcontact *c, ul_cb f);
 
 #endif

--- a/src/modules/ims_usrloc_pcscf/ul_rpc.c
+++ b/src/modules/ims_usrloc_pcscf/ul_rpc.c
@@ -42,13 +42,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  * 
  */
-
+ 
 #include "../../core/ip_addr.h"
 #include "../../core/dprint.h"
 
 #include "ul_rpc.h"
 #include "dlist.h"
 #include "udomain.h"
+#include "pcontact.h"
+#include "utime.h"
 
 static const char* ul_rpc_dump_doc[2] = {
 	"Dump PCSCF contacts and associated identitites",
@@ -58,13 +60,15 @@ static const char* ul_rpc_dump_doc[2] = {
 static void ul_rpc_dump(rpc_t* rpc, void* ctx) {
 	dlist_t* dl;
 	udomain_t* dom;
-//	time_t t;
+	time_t t;
 	void* th;
 	void* ah;
 	void* sh;
 	int max, n, i;
 
-//	t = time(0);
+        pcontact_t* c;
+
+	t = time(0);
 	for (dl = root; dl; dl = dl->next) {
 		dom = dl->d;
 		if (rpc->add(ctx, "{", &th) < 0) {
@@ -78,82 +82,82 @@ static void ul_rpc_dump(rpc_t* rpc, void* ctx) {
 		}
 
 		for (i = 0, n = 0, max = 0; i < dom->size; i++) {
-//			lock_ulslot(dom, i);
+			lock_ulslot(dom, i);
 			n += dom->table[i].n;
 			if (max < dom->table[i].n)
 				max = dom->table[i].n;
-//			for (c = dom->table[i].first; c; c = c->next) {
-//				if (rpc->struct_add(ah, "S", "AoR", &c->aor) < 0) {
-//					unlock_ulslot(dom, i);
-//					rpc->fault(ctx, 500, "Internal error creating aor struct");
-//					return;
-//				}
-//				if (rpc->struct_add(ah, "s", "State", reg_state_to_string(c->reg_state)) < 0) {
-//					unlock_ulslot(dom, i);
-//					rpc->fault(ctx, 500, "Internal error creating reg state struct");
-//					return;
-//				}
-//				if (c->expires == 0) {
-//					if (rpc->struct_add(ah, "s", "Expires", "permanent") < 0) {
-//						unlock_ulslot(dom, i);
-//						rpc->fault(ctx, 500, "Internal error adding expire");
-//						return;
-//					}
-//				} else if (c->expires == -1/*UL_EXPIRED_TIME*/) {
-//					if (rpc->struct_add(ah, "s", "Expires", "deleted") < 0) {
-//						unlock_ulslot(dom, i);
-//						rpc->fault(ctx, 500, "Internal error adding expire");
-//						return;
-//					}
-//				} else if (t > c->expires) {
-//					if (rpc->struct_add(ah, "s", "Expires", "expired") < 0) {
-//						unlock_ulslot(dom, i);
-//						rpc->fault(ctx, 500, "Internal error adding expire");
-//						return;
-//					}
-//				} else {
-//					if (rpc->struct_add(ah, "d", "Expires", (int) (c->expires - t)) < 0) {
-//						unlock_ulslot(dom, i);
-//						rpc->fault(ctx, 500, "Internal error adding expire");
-//						return;
-//					}
-//				}
-//
-//				if (rpc->struct_add(ah, "S", "Path", &c->path) < 0) {
-//					unlock_ulslot(dom, i);
-//					rpc->fault(ctx, 500, "Internal error creating path struct");
-//					return;
-//				}
-//
-//				if (rpc->struct_add(ah, "{", "Service Routes", &sr) < 0) {
-//					unlock_ulslot(dom, i);
-//					rpc->fault(ctx, 500, "Internal error creating Service Routes");
-//					return;
-//				}
-//
-//				for (j = 0; j < c->num_service_routes; j++) {
-//					if (rpc->struct_add(sr, "S", "Route", &c->service_routes[j]) < 0) {
-//						unlock_ulslot(dom, i);
-//						rpc->fault(ctx, 500, "Internal error creating Service Route struct");
-//						return;
-//					}
-//				}
-//
-//				if (rpc->struct_add(ah, "{", "Public Identities", &ih) < 0) {
-//					unlock_ulslot(dom, i);
-//					rpc->fault(ctx, 500, "Internal error creating IMPU struct");
-//					return;
-//				}
-//
-//				for (p = c->head; p; p = p->next) {
-//					if (rpc->struct_add(ih, "S", "IMPU", &p->public_identity) < 0) {
-//						unlock_ulslot(dom, i);
-//						rpc->fault(ctx, 500, "Internal error creating IMPU struct");
-//						return;
-//					}
-//				}
-//			}
-//			unlock_ulslot(dom, i);
+			for (c = dom->table[i].first; c; c = c->next) {
+				if (rpc->struct_add(ah, "S", "AoR", &c->aor) < 0) {
+					unlock_ulslot(dom, i);
+					rpc->fault(ctx, 500, "Internal error creating aor struct");
+					return;
+				}
+				if (rpc->struct_add(ah, "s", "State", reg_state_to_string(c->reg_state)) < 0) {
+					unlock_ulslot(dom, i);
+					rpc->fault(ctx, 500, "Internal error creating reg state struct");
+					return;
+				}
+				if (c->expires == 0) {
+					if (rpc->struct_add(ah, "s", "Expires", "permanent") < 0) {
+						unlock_ulslot(dom, i);
+						rpc->fault(ctx, 500, "Internal error adding expire");
+						return;
+					}
+				} else if (c->expires == -1/*UL_EXPIRED_TIME*/) {
+					if (rpc->struct_add(ah, "s", "Expires", "deleted") < 0) {
+						unlock_ulslot(dom, i);
+						rpc->fault(ctx, 500, "Internal error adding expire");
+						return;
+					}
+				} else if (t > c->expires) {
+					if (rpc->struct_add(ah, "s", "Expires", "expired") < 0) {
+						unlock_ulslot(dom, i);
+						rpc->fault(ctx, 500, "Internal error adding expire");
+						return;
+					}
+				} else {
+					if (rpc->struct_add(ah, "d", "Expires", (int) (c->expires - t)) < 0) {
+						unlock_ulslot(dom, i);
+						rpc->fault(ctx, 500, "Internal error adding expire");
+						return;
+					}
+				}
+
+				if (rpc->struct_add(ah, "S", "Path", &c->path) < 0) {
+					unlock_ulslot(dom, i);
+					rpc->fault(ctx, 500, "Internal error creating path struct");
+					return;
+				}
+
+		//		if (rpc->struct_add(ah, "{", "Service Routes", &sr) < 0) {
+		//			unlock_ulslot(dom, i);
+		//			rpc->fault(ctx, 500, "Internal error creating Service Routes");
+		//			return;
+		//		}
+
+          //				for (j = 0; j < c->num_service_routes; j++) {
+	//				if (rpc->struct_add(sr, "S", "Route", &c->service_routes[j]) < 0) {
+	//					unlock_ulslot(dom, i);
+	//					rpc->fault(ctx, 500, "Internal error creating Service Route struct");
+	//					return;
+	//				}
+		//		}
+
+	//			if (rpc->struct_add(ah, "{", "Public Identities", &ih) < 0) {
+	//				unlock_ulslot(dom, i);
+	//				rpc->fault(ctx, 500, "Internal error creating IMPU struct");
+	//				return;
+	//			}
+
+	//			for (p = c->head; p; p = p->next) {
+	//				if (rpc->struct_add(ih, "S", "IMPU", &p->public_identity) < 0) {
+	//					unlock_ulslot(dom, i);
+	//					rpc->fault(ctx, 500, "Internal error creating IMPU struct");
+	//					return;
+	//				}
+	//			}
+			}
+			unlock_ulslot(dom, i);
 		}
 		if (rpc->struct_add(ah, "{", "Stats", &sh) > 0) {
 			rpc->fault(ctx, 500, "Internal error creating stats");

--- a/src/modules/ims_usrloc_pcscf/usrloc.c
+++ b/src/modules/ims_usrloc_pcscf/usrloc.c
@@ -42,7 +42,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  * 
  */
-
+ 
 #include "usrloc.h"
 #include "dlist.h"
 #include "pcontact.h"
@@ -70,7 +70,7 @@ int bind_usrloc(usrloc_api_t* api) {
 	api->unlock_udomain = unlock_udomain;
 	api->insert_pcontact = insert_pcontact;
 	api->delete_pcontact = delete_pcontact;
-    api->unreg_pending_contacts_cb = unreg_pending_contacts_cb;
+        api->unreg_pending_contacts_cb = unreg_pending_contacts_cb;
 	api->get_pcontact = get_pcontact;
 	api->assert_identity = assert_identity;
 	api->update_pcontact = update_pcontact;
@@ -80,6 +80,9 @@ int bind_usrloc(usrloc_api_t* api) {
 	api->update_temp_security = update_temp_security;
 	api->register_ulcb = register_ulcb;
 	api->get_number_of_contacts = get_number_of_contacts;
+	api->is_ulcb_registered = is_ulcb_registered;
+	api->register_ulcb_method = register_ulcb_method;
+        api->db_delete_presentityuri_from_pua = db_delete_presentityuri_from_pua;
 
 	return 0;
 }

--- a/src/modules/ims_usrloc_pcscf/usrloc.c
+++ b/src/modules/ims_usrloc_pcscf/usrloc.c
@@ -87,6 +87,8 @@ int bind_usrloc(usrloc_api_t* api) {
 	api->is_ulcb_registered = is_ulcb_registered;
 	api->register_ulcb_method = register_ulcb_method;
 
+        api->db_mode    = db_mode;
+
 	return 0;
 }
 

--- a/src/modules/ims_usrloc_pcscf/usrloc.c
+++ b/src/modules/ims_usrloc_pcscf/usrloc.c
@@ -53,6 +53,10 @@
 
 extern int ims_ulp_init_flag;
 
+struct ul_callback *cbp_registrar = 0;
+struct ul_callback *cbp_qos = 0;
+
+
 int bind_usrloc(usrloc_api_t* api) {
 	if (!api) {
 		LM_ERR("invalid parameter value\n");
@@ -82,7 +86,6 @@ int bind_usrloc(usrloc_api_t* api) {
 	api->get_number_of_contacts = get_number_of_contacts;
 	api->is_ulcb_registered = is_ulcb_registered;
 	api->register_ulcb_method = register_ulcb_method;
-        api->db_delete_presentityuri_from_pua = db_delete_presentityuri_from_pua;
 
 	return 0;
 }

--- a/src/modules/ims_usrloc_pcscf/usrloc.h
+++ b/src/modules/ims_usrloc_pcscf/usrloc.h
@@ -41,6 +41,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
+ 
 
 #ifndef USRLOC_H
 #define USRLOC_H
@@ -56,7 +57,7 @@
 #define NO_DB         0
 #define WRITE_THROUGH 1
 #define WRITE_BACK    2		//not implemented yet
-#define DB_ONLY	      3		//not implemented yet
+#define DB_ONLY	      3
 
 #define SEARCH_NORMAL 0
 #define SEARCH_RECEIVED 1
@@ -239,6 +240,10 @@ typedef struct pcontact {
 
 typedef int (*get_pcontact_t)(struct udomain* _d, pcontact_info_t* contact_info, struct pcontact** _c, int reverse_search);
 
+typedef int (*db_delete_presentityuri_from_pua_t)(str *presentity_uri);
+typedef int (*db_load_pcontact_t)(udomain_t* _d, str *_aor, int insert_cache, struct pcontact** _c, pcontact_info_t* contact_info);
+struct ul_callback *cbp_registrar; 
+struct ul_callback *cbp_qos; 
 typedef int (*assert_identity_t)(struct udomain* _d, str * _host, unsigned short _port, unsigned short _proto, str * _identity);
 
 typedef int (*insert_pcontact_t)(struct udomain* _d, str* _aor, struct pcontact_info* ci, struct pcontact** _c);
@@ -286,6 +291,11 @@ typedef struct usrloc_api {
     register_ulcb_t register_ulcb;
 
 	get_number_of_contacts_t get_number_of_contacts;
+	
+    is_ulcb_registered_t is_ulcb_registered;
+    register_ulcb_t register_ulcb_method;
+    db_load_pcontact_t db_load_pcontact;
+    db_delete_presentityuri_from_pua_t db_delete_presentityuri_from_pua;
 } usrloc_api_t;
 
 /*! usrloc API export bind function */

--- a/src/modules/ims_usrloc_pcscf/usrloc.h
+++ b/src/modules/ims_usrloc_pcscf/usrloc.h
@@ -240,10 +240,9 @@ typedef struct pcontact {
 
 typedef int (*get_pcontact_t)(struct udomain* _d, pcontact_info_t* contact_info, struct pcontact** _c, int reverse_search);
 
-typedef int (*db_delete_presentityuri_from_pua_t)(str *presentity_uri);
 typedef int (*db_load_pcontact_t)(udomain_t* _d, str *_aor, int insert_cache, struct pcontact** _c, pcontact_info_t* contact_info);
-struct ul_callback *cbp_registrar; 
-struct ul_callback *cbp_qos; 
+extern struct ul_callback *cbp_registrar; 
+extern struct ul_callback *cbp_qos; 
 typedef int (*assert_identity_t)(struct udomain* _d, str * _host, unsigned short _port, unsigned short _proto, str * _identity);
 
 typedef int (*insert_pcontact_t)(struct udomain* _d, str* _aor, struct pcontact_info* ci, struct pcontact** _c);
@@ -295,7 +294,6 @@ typedef struct usrloc_api {
     is_ulcb_registered_t is_ulcb_registered;
     register_ulcb_t register_ulcb_method;
     db_load_pcontact_t db_load_pcontact;
-    db_delete_presentityuri_from_pua_t db_delete_presentityuri_from_pua;
 } usrloc_api_t;
 
 /*! usrloc API export bind function */

--- a/src/modules/ims_usrloc_pcscf/usrloc_db.c
+++ b/src/modules/ims_usrloc_pcscf/usrloc_db.c
@@ -122,18 +122,23 @@ int use_location_pcscf_table(str* domain)
 
 	return 0;
 }
+db1_con_t* get_db_handle () 
+{
+    return ul_dbh;
+
+}
 
 int db_update_pcontact(pcontact_t* _c)
 {
 	str impus, service_routes;
 
 	db_val_t match_values[2];
-	db_key_t match_keys[2] = { &aor_col, &received_port_col };
-    db_op_t op[2];
-	db_key_t update_keys[8] = { &expires_col, &reg_state_col,
-								&service_routes_col, &received_col,
-								&received_port_col, &received_proto_col,
-								&rx_session_id_col, &public_ids_col };
+	//db_key_t match_keys[2] = { &aor_col, &received_port_col };
+   //     db_op_t op[2];
+	//db_key_t update_keys[8] = { &expires_col, &reg_state_col,
+	//							&service_routes_col, &received_col,
+	//							&received_port_col, &received_proto_col,
+	//							&rx_session_id_col, &public_ids_col };
 	db_val_t values[8];
         
 	LM_DBG("updating pcontact: aor[%.*s], received port %u\n", _c->aor.len, _c->aor.s, _c->received_port);
@@ -146,8 +151,8 @@ int db_update_pcontact(pcontact_t* _c)
 	VAL_NULL(match_values + 1)	= 0;
 	VAL_INT(match_values + 1)	= _c->received_port;
 	
-	op[0]=OP_EQ;
-	op[1]=OP_EQ;
+    //	op[0]=OP_EQ;
+    //	op[1]=OP_EQ;
 
 	if (use_location_pcscf_table(_c->domain) < 0) {
 		LM_ERR("Error trying to use table %.*s\n", _c->domain->len, _c->domain->s);
@@ -195,17 +200,22 @@ int db_update_pcontact(pcontact_t* _c)
 	SET_PROPER_NULL_FLAG(impus, values, 7);
 	SET_STR_VALUE(values + 7, impus);
 
-	if((ul_dbf.update(ul_dbh, match_keys, op, match_values, update_keys,values, 2, 8)) !=0){
-		LM_ERR("could not update database info\n");
-	    return -1;
-	}
+	//if((ul_dbf.update(ul_dbh, match_keys, op, match_values, update_keys,values, 2, 8)) !=0){
+	//	LM_ERR("could not update database info\n");
+	//    return -1;
+	//}
 
-	if (ul_dbf.affected_rows && ul_dbf.affected_rows(ul_dbh) == 0) {
-		LM_DBG("no existing rows for an update... doing insert\n");
-		if (db_insert_pcontact(_c) != 0) {
-			LM_ERR("Failed to insert a pcontact on update\n");
-		}
-	}
+        if (db_insert_pcontact(_c) != 0) {
+                      LM_ERR("Failed to insert a pcontact on update\n");
+                      return -1;
+       }
+
+//	if (ul_dbf.affected_rows && ul_dbf.affected_rows(ul_dbh) == 0) {
+//		LM_DBG("no existing rows for an update... doing insert\n");
+//		if (db_insert_pcontact(_c) != 0) {
+//			LM_ERR("Failed to insert a pcontact on update\n");
+//		}
+//	}
 
 	return 0;
 }
@@ -301,7 +311,7 @@ int db_insert_pcontact(struct pcontact* _c)
 	SET_PROPER_NULL_FLAG(_c->rinstance, values, LP_RINSTANCE_IDX);
 	SET_PROPER_NULL_FLAG(_c->rx_session_id, values, LP_RX_SESSION_ID_IDX);
 
-	VAL_DOUBLE(GET_FIELD_IDX(values, LP_REG_STATE_IDX)) = _c->reg_state;
+	VAL_INT(GET_FIELD_IDX(values, LP_REG_STATE_IDX)) = _c->reg_state;
 	VAL_TIME(GET_FIELD_IDX(values, LP_EXPIRES_IDX)) = _c->expires;
 	VAL_NULL(GET_FIELD_IDX(values, LP_REG_STATE_IDX)) = 0;
 	VAL_NULL(GET_FIELD_IDX(values, LP_EXPIRES_IDX)) = 0;
@@ -341,7 +351,7 @@ int db_insert_pcontact(struct pcontact* _c)
 		return -1;
 	}
 
-	if (ul_dbf.insert(ul_dbh, keys, values, 16) < 0) {
+	if (ul_dbf.insert_update(ul_dbh, keys, values, 16) < 0) {
 		LM_ERR("inserting contact in db failed\n");
 		return -1;
 	}

--- a/src/modules/ims_usrloc_pcscf/usrloc_db.c
+++ b/src/modules/ims_usrloc_pcscf/usrloc_db.c
@@ -133,12 +133,12 @@ int db_update_pcontact(pcontact_t* _c)
 	str impus, service_routes;
 
 	db_val_t match_values[2];
-	//db_key_t match_keys[2] = { &aor_col, &received_port_col };
-   //     db_op_t op[2];
-	//db_key_t update_keys[8] = { &expires_col, &reg_state_col,
-	//							&service_routes_col, &received_col,
-	//							&received_port_col, &received_proto_col,
-	//							&rx_session_id_col, &public_ids_col };
+	db_key_t match_keys[2] = { &aor_col, &received_port_col };
+        db_op_t op[2];
+	db_key_t update_keys[8] = { &expires_col, &reg_state_col,
+								&service_routes_col, &received_col,
+								&received_port_col, &received_proto_col,
+								&rx_session_id_col, &public_ids_col };
 	db_val_t values[8];
         
 	LM_DBG("updating pcontact: aor[%.*s], received port %u\n", _c->aor.len, _c->aor.s, _c->received_port);
@@ -151,8 +151,8 @@ int db_update_pcontact(pcontact_t* _c)
 	VAL_NULL(match_values + 1)	= 0;
 	VAL_INT(match_values + 1)	= _c->received_port;
 	
-    //	op[0]=OP_EQ;
-    //	op[1]=OP_EQ;
+    	op[0]=OP_EQ;
+    	op[1]=OP_EQ;
 
 	if (use_location_pcscf_table(_c->domain) < 0) {
 		LM_ERR("Error trying to use table %.*s\n", _c->domain->len, _c->domain->s);
@@ -200,22 +200,18 @@ int db_update_pcontact(pcontact_t* _c)
 	SET_PROPER_NULL_FLAG(impus, values, 7);
 	SET_STR_VALUE(values + 7, impus);
 
-	//if((ul_dbf.update(ul_dbh, match_keys, op, match_values, update_keys,values, 2, 8)) !=0){
-	//	LM_ERR("could not update database info\n");
-	//    return -1;
-	//}
+	if((ul_dbf.update(ul_dbh, match_keys, op, match_values, update_keys,values, 2, 8)) !=0){
+		LM_ERR("could not update database info\n");
+	    return -1;
+	}
 
-        if (db_insert_pcontact(_c) != 0) {
-                      LM_ERR("Failed to insert a pcontact on update\n");
-                      return -1;
-       }
 
-//	if (ul_dbf.affected_rows && ul_dbf.affected_rows(ul_dbh) == 0) {
-//		LM_DBG("no existing rows for an update... doing insert\n");
-//		if (db_insert_pcontact(_c) != 0) {
-//			LM_ERR("Failed to insert a pcontact on update\n");
-//		}
-//	}
+	if (ul_dbf.affected_rows && ul_dbf.affected_rows(ul_dbh) == 0) {
+		LM_DBG("no existing rows for an update... doing insert\n");
+		if (db_insert_pcontact(_c) != 0) {
+			LM_ERR("Failed to insert a pcontact on update\n");
+		}
+	}
 
 	return 0;
 }
@@ -351,7 +347,7 @@ int db_insert_pcontact(struct pcontact* _c)
 		return -1;
 	}
 
-	if (ul_dbf.insert_update(ul_dbh, keys, values, 16) < 0) {
+	if (ul_dbf.insert(ul_dbh, keys, values, 16) < 0) {
 		LM_ERR("inserting contact in db failed\n");
 		return -1;
 	}

--- a/src/modules/ims_usrloc_pcscf/usrloc_db.h
+++ b/src/modules/ims_usrloc_pcscf/usrloc_db.h
@@ -142,5 +142,5 @@ int db_delete_pcontact(pcontact_t* _c);
 int db_update_pcontact(pcontact_t* _c);
 int db_update_pcontact_security_temp(struct pcontact* _c, security_type _t, security_t* _s);
 int db_update_pcontact_security(struct pcontact* _c, security_type _t, security_t* _s);
-
+db1_con_t* get_db_handle ();
 #endif /* USRLOC_DB_H_ */


### PR DESCRIPTION
In order to support a redundant PCSCF configuration - i.e. a logical PCSCF consists of 2 physical nodes (node1 and node2) some enhancements were introduced for handling of contacts. Redundancy means that SIP messages for a client are normally handled by node1 but in case node1 is not reachable SIP messages are redirected to node2. Of course the DB_ONLY mode must work also for single PCSCF node configuration. Important aspects of this implementation are database integrity - i.e. avoid invalid table entries (for example data which are expired long time ago or have invalid states) - and keeping PCSCF cache in sync with database tables. A wrapper was built for method get_pcontact which tries to find the pcontact in cache and if search is not successful tries to download and insert from db location table - also some effort is added here to find the pcontact if it exists in cache. The contact expiry handler was modified to sync contact expiry in cache with db location entry and in case of real contact expiry sends PUBLISH to SCSCF to let NOTIFY finally delete the contact. An audit for older expired pcontacts was introduced which cares for getting rid of these contacts.
So db queries for this db mode are only supported for Mysql.
Some code was introduced to help registering callbacks for contacts which are inserted into cache when being downloaded from database - for example ims_qos callback as at the time of insertion the message that triggered the original callback registering is long gone.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally in local branch based on 5.5.4
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- see top of this section -->
