### PR TITLE
sanity: Prevent segfault related to contact URI check

### DIFF
--- a/src/modules/sanity/sanity.c
+++ b/src/modules/sanity/sanity.c
@@ -820,7 +820,8 @@ int check_parse_uris(sip_msg_t* msg, int checks) {
 				}
 				return SANITY_CHECK_FAILED;
 			}
-			if (parse_uri(
+			if (!((struct contact_body*)msg->contact->parsed)->star
+					&& parse_uri(
 						((struct contact_body*)msg->contact->parsed)->contacts->uri.s,
 						((struct contact_body*)msg->contact->parsed)->contacts->uri.len,
 						&uri) != 0) {


### PR DESCRIPTION
For star Contacts, there are no URIs that can be checked.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

If Contact URI should be checked, there is no URI if the Contact is a star Contact [1].

[1] https://www.rfc-editor.org/rfc/rfc3261#section-10.2.2