### PR TITLE
ims_registrar_pcscf:  changes for ul db_mode DB_ONLY

### DIFF
--- a/src/modules/ims_registrar_pcscf/doc/ims_registrar_pcscf_admin.xml
+++ b/src/modules/ims_registrar_pcscf/doc/ims_registrar_pcscf_admin.xml
@@ -319,6 +319,47 @@ pcscf_save("location");
 			</para>
 		</listitem>
 		</itemizedlist>
+		<para>The return code may have the following values:</para>
+
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>( 1)</emphasis> OK</para>
+		</listitem>
+		<listitem>
+			<para><emphasis>(-1)</emphasis> Parsing of contact data failed</para>
+		</listitem>
+		<listitem>
+			<para><emphasis>(-2)</emphasis> Deregistration in progress</para>
+		</listitem>
+		</itemizedlist>
+		<para>For db_mode = DB_ONLY (3) setting for ims_usrloc_pcscf module modparam following logic is implemented:</para>
+		<itemizedlist>
+		<listitem>
+		<para>To avoid race time conditions between a REREGISTER and the expiry handler state machine in the scscf
+		 an approach is chosen to refuse a REREGISTER in time window of 20 seconds after pcontact expiry on the
+		 pcscf (thus allowing expiry handling to finish). REREGISTER is refused in this scenario with
+		 return code -2.</para>
+		</listitem>
+		<listitem>
+		<para>In case a REREGISTER arrives at pcscf and the respective pcontact is expired longer than time
+		 window of 20 seconds registration also is refused with return code -2 and additionaly PUBLISH is sent to
+		 scscf with expiry = 0.</para>
+		</listitem>
+		<listitem>
+		<para>The rc -2 shall be handled in register.cfg script as follows:</para>
+		<para>
+		</para>
+			<para>  pcscf_save_pending("location");</para>
+				<para>  switch ($retcode) {</para>
+					<para>case -1:</para>
+						<para>.......</para>
+					<para>case -2:</para>
+						<para>send_reply("500", "Deregister in progress - Please try again");</para>
+						<para>exit;</para>
+						<para>break;</para>
+				<para>}</para>
+		</listitem>
+		</itemizedlist>
   </section>
 
    <section>

--- a/src/modules/ims_registrar_pcscf/ims_registrar_pcscf_mod.c
+++ b/src/modules/ims_registrar_pcscf/ims_registrar_pcscf_mod.c
@@ -67,6 +67,7 @@
 #include "async_reginfo.h"
 
 #include "ims_registrar_pcscf_mod.h"
+#include "ul_callback.h"
 #include "save.h"
 #include "service_routes.h"
 MODULE_VERSION
@@ -260,6 +261,12 @@ static int mod_init(void) {
 
 	if (bind_usrloc(&ul) < 0) {
 		return -1;
+	}
+	if (ul.db_mode == DB_ONLY){
+		if (!(ul.register_ulcb_method(NULL, PCSCF_CONTACT_UPDATE, callback_pcscf_contact_cb, NULL) == 1)){
+			LM_ERR("Can't register ulcb method\n");
+			return -1;
+		}
 	}
 	LM_DBG("Successfully bound to PCSCF Usrloc module\n");
 

--- a/src/modules/ims_registrar_pcscf/notify.c
+++ b/src/modules/ims_registrar_pcscf/notify.c
@@ -113,8 +113,7 @@ int process_contact(udomain_t * _d, int expires, str contact_uri, int contact_st
     expires = local_time_now + expires; //turn expires into correct time since epoch format
     LM_DBG("Changed expires to format time since the epoch: %d", expires);
     ci.expires = expires;
-    ci.reg_state = PCONTACT_REGISTERED;
-
+    ci.reg_state = PCONTACT_ANY;
 
     ul.lock_udomain(_d, &puri.host, puri.port_no, puri.proto);
     ci.aor = contact_uri;
@@ -213,6 +212,7 @@ int process_contact(udomain_t * _d, int expires, str contact_uri, int contact_st
                     TIME_T_CAST(pcontact->expires),
                     expires,
                     expires - local_time_now);
+            ci.reg_state = PCONTACT_REGISTERED;
             if (ul.update_pcontact(_d, &ci, pcontact) != 0) {
                 LM_ERR("failed to update pcscf contact\n");
                 ret = RESULT_ERROR;


### PR DESCRIPTION
Enable registration of pcscf contact callback during download from db location table and inserting pcontact (normally this callback is registered during handling of REGISTER). Refuse REGISTER when pcontact is expired since [0 to 20] seconds. Within this time window a NOTIFY is expected from scscf and in order to avoid race time conditions between scscf and pcscf REGISTER will be refused. Refuse REGISTER when pcontact is expired longer than 20 seconds - send PUBLISH (contact expired) to scscf to trigger NOTIFY. In both REGISTER refused scenarios routing script should reply 500 - Deregister in progress.


<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ x] Commit message has the format required by CONTRIBUTING guide
- [ x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ x] Each component has a single commit (if not, squash them into one commit)
- [ x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
In case a pcontact found in location db has to be inserted into pcscf cache depending on contact state also callbacks have  to be registered for this pcontact.  Registering of callback_pcscf_contact_cb is enabled in this module.

Handling of contact expiry is usually triggered in the scscf (mem_timer_udomain which runs every 10 secs). Sending of NOTIFY to pcscf may take up to 20 seconds from start of expiry due to timing conditions.

To avoid race time conditions between a REREGISTER and the expiry handler state machine in the scscf an approach is chosen to refuse a REREGISTER in time window of 20 seconds after pcontact expiry on the pcscf (thus allowing  expiry handling to finish). REREGISTER is refused in this scenario with new return_code -2.

In case a REREGISTER arrives at pcscf and the respective pcontact is expired longer than time window of 20 seconds registration also is refused with rc -2 and additionaly PUBLISH is sent to scscf with expiry = 0.

The rc -2 shall be handled in register.cfg script as follows:

```
                pcscf_save_pending("location");
                switch ($retcode) {
                        case -1:
                                # Missing/wrong Information in REGISTER.
                                send_reply("400", "Information wrong - See log.");
                                exit;
                                break;
                        case -2:
                                # De-Register in Progress, or PUBLISH ongoing due to registration expiry,
                                # or new REGISTER blocked because registration just expired (up to 20sec).
                                append_to_reply("Retry-After: 30\r\n");
                                send_reply("500", "Deregister in progress - Please try again");
                                exit;
                                break;
                }
```

