### PR TITLE
carrierroute module functions export to kemi

### DIFF
--- a/src/modules/carrierroute/carrierroute.c
+++ b/src/modules/carrierroute/carrierroute.c
@@ -284,6 +284,31 @@ static sr_kemi_t sr_kemi_carrierroute_exports[] = {
 		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
+	{ str_init("carrierroute"), str_init("cr_route"),
+		SR_KEMIP_INT, ki_cr_route5,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
+			SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE }
+	},
+	{ str_init("carrierroute"), str_init("cr_route_info"),
+		SR_KEMIP_INT, ki_cr_route,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
+			SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR }
+	},
+	{ str_init("carrierroute"), str_init("cr_nofallback_route"),
+		SR_KEMIP_INT, ki_cr_nofallback_route5,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
+			SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE }
+	},
+	{ str_init("carrierroute"), str_init("cr_nofallback_route_info"),
+		SR_KEMIP_INT, ki_cr_nofallback_route,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
+			SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR }
+	},
+	{ str_init("carrierroute"), str_init("cr_next_domain"),
+		SR_KEMIP_INT, ki_cr_load_next_domain,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
+			SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR }
+	},
 
 	{ {0, 0}, {0, 0}, 0, NULL, { 0, 0, 0, 0, 0, 0 } }
 };

--- a/src/modules/carrierroute/carrierroute.c
+++ b/src/modules/carrierroute/carrierroute.c
@@ -88,19 +88,20 @@ static void mod_destroy(void);
 
 /************* Module Exports **********************************************/
 static cmd_export_t cmds[]={
-	{"cr_user_carrier",  (cmd_function)cr_load_user_carrier,  3,
+	{"cr_user_carrier",  (cmd_function)cr_load_user_carrier,   3,
 		cr_load_user_carrier_fixup, cr_load_user_carrier_fixup_free,
 		REQUEST_ROUTE | FAILURE_ROUTE },
 	{"cr_route",         (cmd_function)cr_route5,              5,
-		cr_route_fixup,             0, REQUEST_ROUTE | FAILURE_ROUTE },
-	{"cr_route",         (cmd_function)cr_route,              6,
-		cr_route_fixup,             0, REQUEST_ROUTE | FAILURE_ROUTE },
-	{"cr_nofallback_route",(cmd_function)cr_nofallback_route5,     5,
-		cr_route_fixup,             0, REQUEST_ROUTE | FAILURE_ROUTE },
-	{"cr_nofallback_route",(cmd_function)cr_nofallback_route,     6,
-		cr_route_fixup,             0, REQUEST_ROUTE | FAILURE_ROUTE },
-	{"cr_next_domain",   (cmd_function)cr_load_next_domain,   6,
-		cr_load_next_domain_fixup,  0, REQUEST_ROUTE | FAILURE_ROUTE },
+		cr_route_fixup, cr_route_fixup_free, REQUEST_ROUTE | FAILURE_ROUTE },
+	{"cr_route",         (cmd_function)cr_route,               6,
+		cr_route_fixup, cr_route_fixup_free, REQUEST_ROUTE | FAILURE_ROUTE },
+	{"cr_nofallback_route",(cmd_function)cr_nofallback_route5, 5,
+		cr_route_fixup, cr_route_fixup_free, REQUEST_ROUTE | FAILURE_ROUTE },
+	{"cr_nofallback_route",(cmd_function)cr_nofallback_route,  6,
+		cr_route_fixup, cr_route_fixup_free, REQUEST_ROUTE | FAILURE_ROUTE },
+	{"cr_next_domain",   (cmd_function)cr_load_next_domain,    6,
+		cr_load_next_domain_fixup, cr_load_next_domain_fixup_free,
+		REQUEST_ROUTE | FAILURE_ROUTE },
 	{0, 0, 0, 0, 0, 0}
 };
 

--- a/src/modules/carrierroute/carrierroute.c
+++ b/src/modules/carrierroute/carrierroute.c
@@ -285,22 +285,22 @@ static sr_kemi_t sr_kemi_carrierroute_exports[] = {
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
 	{ str_init("carrierroute"), str_init("cr_route"),
-		SR_KEMIP_INT, ki_cr_route5,
+		SR_KEMIP_INT, ki_cr_route,
 		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
 			SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE }
 	},
 	{ str_init("carrierroute"), str_init("cr_route_info"),
-		SR_KEMIP_INT, ki_cr_route,
+		SR_KEMIP_INT, ki_cr_route_info,
 		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
 			SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR }
 	},
 	{ str_init("carrierroute"), str_init("cr_nofallback_route"),
-		SR_KEMIP_INT, ki_cr_nofallback_route5,
+		SR_KEMIP_INT, ki_cr_nofallback_route,
 		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
 			SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE }
 	},
 	{ str_init("carrierroute"), str_init("cr_nofallback_route_info"),
-		SR_KEMIP_INT, ki_cr_nofallback_route,
+		SR_KEMIP_INT, ki_cr_nofallback_route_info,
 		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
 			SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR }
 	},

--- a/src/modules/carrierroute/cr_fixup.c
+++ b/src/modules/carrierroute/cr_fixup.c
@@ -90,22 +90,41 @@ static int domain_name_2_id(const str *name) {
  *
  * @return the enum value on success, -1 on failure
  */
-static enum hash_source hash_fixup(const char * my_hash_source) {
-	if (strcasecmp("call_id", my_hash_source) == 0) {
-		return shs_call_id;
-	} else if (strcasecmp("from_uri", my_hash_source) == 0) {
-		return shs_from_uri;
-	} else if (strcasecmp("from_user", my_hash_source) == 0) {
-		return shs_from_user;
-	} else if (strcasecmp("to_uri", my_hash_source) == 0) {
-		return shs_to_uri;
-	} else if (strcasecmp("to_user", my_hash_source) == 0) {
-		return shs_to_user;
-	} else if (strcasecmp("rand", my_hash_source) == 0) {
-		return shs_rand;
-	} else {
-		return shs_error;
+static int hash_fixup(void ** param) {
+	enum hash_source my_hash_source = shs_error;
+	char * hash_name;
+
+	if (fixup_spve_null(param, 1) !=0) {
+		LM_ERR("could not fixup parameter");
+		return -1;
 	}
+
+	if (((gparam_p)(*param))->type == GPARAM_TYPE_STR) {
+		hash_name = ((gparam_p)(*param))->v.str.s;
+
+		if (strcasecmp("call_id", hash_name) == 0) {
+			my_hash_source = shs_call_id;
+		} else if (strcasecmp("from_uri", hash_name) == 0) {
+			my_hash_source = shs_from_uri;
+		} else if (strcasecmp("from_user", hash_name) == 0) {
+			my_hash_source = shs_from_user;
+		} else if (strcasecmp("to_uri", hash_name) == 0) {
+			my_hash_source = shs_to_uri;
+		} else if (strcasecmp("to_user", hash_name) == 0) {
+			my_hash_source = shs_to_user;
+		} else if (strcasecmp("rand", hash_name) == 0) {
+			my_hash_source = shs_rand;
+		} else {
+			LM_ERR("invalid hash source\n");
+			pkg_free(*param);
+			return -1;
+		}
+	}
+
+	pkg_free(*param);
+	*param = (void *)my_hash_source;
+
+	return 0;
 }
 
 
@@ -167,34 +186,7 @@ static int domain_fixup(void ** param) {
 		}
 		((gparam_p)(*param))->v.i = id;
 	}
-	return 0;
-}
 
-
-/**
- * Fixes the module functions' parameters in case of AVP names.
- *
- * @param param the parameter
- *
- * @return 0 on success, -1 on failure
- */
-static int avp_name_fixup(void ** param) {
-
-	if (fixup_spve_null(param, 1) !=0) {
-		LM_ERR("could not fixup parameter");
-		return -1;
-	}
-	if(*param==NULL || ((gparam_p)(*param))->v.pve==NULL
-			|| ((gparam_p)(*param))->v.pve->spec==NULL) {
-		LM_ERR("invalid AVP type definition\n");
-		return -1;
-	}
-	if (((gparam_p)(*param))->v.pve->spec->type == PVT_AVP &&
-			((gparam_p)(*param))->v.pve->spec->pvp.pvn.u.isname.name.s.len == 0 &&
-			((gparam_p)(*param))->v.pve->spec->pvp.pvn.u.isname.name.s.s == 0) {
-		LM_ERR("malformed or non AVP type definition\n");
-		return -1;
-	}
 	return 0;
 }
 
@@ -210,8 +202,6 @@ static int avp_name_fixup(void ** param) {
  * @return 0 on success, -1 on failure
  */
 int cr_route_fixup(void ** param, int param_no) {
-	enum hash_source my_hash_source;
-
 	if (param_no == 1) {
 		/* carrier */
 		if (carrier_fixup(param) < 0) {
@@ -235,22 +225,43 @@ int cr_route_fixup(void ** param, int param_no) {
 	}
 	else if (param_no == 5) {
 		/* hash source */
-		if ((my_hash_source = hash_fixup((char *)*param)) == shs_error) {
-			LM_ERR("invalid hash source\n");
+		if (hash_fixup(param) != 0) {
+			LM_ERR("cannot fixup parameter %d\n", param_no);
 			return -1;
 		}
-		pkg_free(*param);
-		*param = (void *)my_hash_source;
 	}
 	else if (param_no == 6) {
 		/* destination avp name */
-		if (avp_name_fixup(param) < 0) {
-			LM_ERR("cannot fixup parameter %d\n", param_no);
+		if(fixup_pvar_null(param, 1) != 0) {
+			LM_ERR("failed to fixup result pvar\n");
+			return -1;
+		}
+		if(((pv_spec_t *)(*param))->setf == NULL) {
+			LM_ERR("dst var is not writeble\n");
 			return -1;
 		}
 	}
 
 	return 0;
+}
+
+
+/**
+ *
+ */
+int cr_route_fixup_free(void ** param, int param_no) {
+	if((param_no >= 1) && (param_no <= 5)) {
+		/* carrier, domain, prefix matching, rewrite user, hash source */
+		return fixup_free_spve_null(param, 1);
+	}
+
+	if(param_no == 6) {
+		/* destination var name */
+		return fixup_free_pvar_null(param, 1);
+	}
+
+	LM_ERR("invalid parameter number <%d>\n", param_no);
+	return -1;
 }
 
 
@@ -288,13 +299,36 @@ int cr_load_next_domain_fixup(void ** param, int param_no) {
 	}
 	else if (param_no == 6) {
 		/* destination avp name */
-		if (avp_name_fixup(param) < 0) {
-			LM_ERR("cannot fixup parameter %d\n", param_no);
+		if(fixup_pvar_null(param, 1) != 0) {
+			LM_ERR("failed to fixup result pvar\n");
+			return -1;
+		}
+		if(((pv_spec_t *)(*param))->setf == NULL) {
+			LM_ERR("dst var is not writeble\n");
 			return -1;
 		}
 	}
 
 	return 0;
+}
+
+
+/**
+ *
+ */
+int cr_load_next_domain_fixup_free(void ** param, int param_no) {
+	if((param_no >= 1) && (param_no <= 5)) {
+		/* carrier, domain, prefix matching, host, reply code */
+		return fixup_free_spve_null(param, 1);
+	}
+
+	if(param_no == 6) {
+		/* destination var name */
+		return fixup_free_pvar_null(param, 1);
+	}
+
+	LM_ERR("invalid parameter number <%d>\n", param_no);
+	return -1;
 }
 
 
@@ -329,22 +363,23 @@ int cr_load_user_carrier_fixup(void ** param, int param_no) {
 			LM_ERR("dst var is not writeble\n");
 			return -1;
 		}
-		return 0;
 	}
 
 	return 0;
 }
 
+
 /**
  *
  */
-int cr_load_user_carrier_fixup_free(void **param, int param_no)
-{
+int cr_load_user_carrier_fixup_free(void **param, int param_no) {
 	if((param_no >= 1) && (param_no <= 2)) {
+		/* user, domain */
 		return fixup_free_spve_null(param, 1);
 	}
 
 	if(param_no == 3) {
+		/* destination var name */
 		return fixup_free_pvar_null(param, 1);
 	}
 

--- a/src/modules/carrierroute/cr_fixup.c
+++ b/src/modules/carrierroute/cr_fixup.c
@@ -145,16 +145,20 @@ static int carrier_fixup(void ** param) {
 	}
 
 	if (((gparam_p)(*param))->type == GPARAM_TYPE_STR) {
+		if (str2sint(&(((gparam_p)(*param))->v.str), &id) != 0) {
+			/* get carrier id */
+			if ((id = carrier_name_2_id(&((gparam_p)(*param))->v.str)) < 0) {
+				LM_ERR("could not find carrier name '%.*s' in map\n", ((gparam_p)(*param))->v.str.len, ((gparam_p)(*param))->v.str.s);
+				pkg_free(*param);
+				return -1;
+			}
+		}
+
 		/* This is a name string, convert to an int */
 		((gparam_p)(*param))->type=GPARAM_TYPE_INT;
-		/* get carrier id */
-		if ((id = carrier_name_2_id(&((gparam_p)(*param))->v.str)) < 0) {
-			LM_ERR("could not find carrier name '%.*s' in map\n", ((gparam_p)(*param))->v.str.len, ((gparam_p)(*param))->v.str.s);
-			pkg_free(*param);
-			return -1;
-		}
 		((gparam_p)(*param))->v.i = id;
 	}
+
 	return 0;
 }
 
@@ -176,14 +180,17 @@ static int domain_fixup(void ** param) {
 	}
 
 	if (((gparam_p)(*param))->type == GPARAM_TYPE_STR) {
+		if (str2sint(&(((gparam_p)(*param))->v.str), &id) != 0) {
+			/* get domain id */
+			if ((id = domain_name_2_id(&(((gparam_p)(*param))->v.str))) < 0) {
+				LM_ERR("could not find domain name '%.*s' in map\n", ((gparam_p)(*param))->v.str.len, ((gparam_p)(*param))->v.str.s);
+				pkg_free(*param);
+				return -1;
+			}
+		}
+
 		/* This is a name string, convert to an int */
 		((gparam_p)(*param))->type=GPARAM_TYPE_INT;
-		/* get domain id */
-		if ((id = domain_name_2_id(&(((gparam_p)(*param))->v.str))) < 0) {
-			LM_ERR("could not find domain name '%.*s' in map\n", ((gparam_p)(*param))->v.str.len, ((gparam_p)(*param))->v.str.s);
-			pkg_free(*param);
-			return -1;
-		}
 		((gparam_p)(*param))->v.i = id;
 	}
 

--- a/src/modules/carrierroute/cr_fixup.h
+++ b/src/modules/carrierroute/cr_fixup.h
@@ -42,6 +42,8 @@
  */
 int cr_route_fixup(void ** param, int param_no);
 
+int cr_route_fixup_free(void ** param, int param_no);
+
 
 /**
  * Fixes the module functions' parameters.
@@ -66,5 +68,7 @@ int cr_load_user_carrier_fixup_free(void ** param, int param_no);
  * @return 0 on success, -1 on failure
  */
 int cr_load_next_domain_fixup(void ** param, int param_no);
+
+int cr_load_next_domain_fixup_free(void ** param, int param_no);
 
 #endif

--- a/src/modules/carrierroute/cr_func.h
+++ b/src/modules/carrierroute/cr_func.h
@@ -70,9 +70,22 @@ int cr_route(struct sip_msg * _msg, char *_carrier,
 		char *_domain, char *_prefix_matching,
 		char *_rewrite_user, enum hash_source _hsrc,
 		char *_descavp);
+
+
+int ki_cr_route(sip_msg_t* _msg, str *_carrier,
+		str *_domain, str *_prefix_matching,
+		str *_rewrite_user, str *_hsrc,
+		str *_descavp);
+
+
 int cr_route5(struct sip_msg * _msg, char *_carrier,
 		char *_domain, char *_prefix_matching,
 		char *_rewrite_user, enum hash_source _hsrc);
+
+
+int ki_cr_route5(sip_msg_t* _msg, str *_carrier,
+		str *_domain, str *_prefix_matching,
+		str *_rewrite_user, str *_hsrc);
 
 
 /**
@@ -96,9 +109,22 @@ int cr_nofallback_route(struct sip_msg * _msg, char *_carrier,
 		char *_domain, char *_prefix_matching,
 		char *_rewrite_user, enum hash_source _hsrc,
 		char *_dstavp);
+
+
+int ki_cr_nofallback_route(sip_msg_t* _msg, str *_carrier,
+		str *_domain, str *_prefix_matching,
+		str *_rewrite_user, str *_hsrc,
+		str *_dstavp);
+
+
 int cr_nofallback_route5(struct sip_msg * _msg, char *_carrier,
 		char *_domain, char *_prefix_matching,
 		char *_rewrite_user, enum hash_source _hsrc);
+
+
+int ki_cr_nofallback_route5(sip_msg_t* _msg, str *_carrier,
+		str *_domain, str *_prefix_matching,
+		str *_rewrite_user, str *_hsrc);
 
 
 /**
@@ -117,5 +143,10 @@ int cr_nofallback_route5(struct sip_msg * _msg, char *_carrier,
 int cr_load_next_domain(struct sip_msg * _msg, char *_carrier,
 		char *_domain, char *_prefix_matching, char *_host,
 		char *_reply_code, char *_dstavp);
+
+
+int ki_cr_load_next_domain(sip_msg_t* _msg, str *_carrier,
+		str *_domain, str *_prefix_matching,
+		str *_host, str *_reply_code, str *_dstavp);
 
 #endif

--- a/src/modules/carrierroute/cr_func.h
+++ b/src/modules/carrierroute/cr_func.h
@@ -72,7 +72,7 @@ int cr_route(struct sip_msg * _msg, char *_carrier,
 		char *_descavp);
 
 
-int ki_cr_route(sip_msg_t* _msg, str *_carrier,
+int ki_cr_route_info(sip_msg_t* _msg, str *_carrier,
 		str *_domain, str *_prefix_matching,
 		str *_rewrite_user, str *_hsrc,
 		str *_descavp);
@@ -83,7 +83,7 @@ int cr_route5(struct sip_msg * _msg, char *_carrier,
 		char *_rewrite_user, enum hash_source _hsrc);
 
 
-int ki_cr_route5(sip_msg_t* _msg, str *_carrier,
+int ki_cr_route(sip_msg_t* _msg, str *_carrier,
 		str *_domain, str *_prefix_matching,
 		str *_rewrite_user, str *_hsrc);
 
@@ -111,7 +111,7 @@ int cr_nofallback_route(struct sip_msg * _msg, char *_carrier,
 		char *_dstavp);
 
 
-int ki_cr_nofallback_route(sip_msg_t* _msg, str *_carrier,
+int ki_cr_nofallback_route_info(sip_msg_t* _msg, str *_carrier,
 		str *_domain, str *_prefix_matching,
 		str *_rewrite_user, str *_hsrc,
 		str *_dstavp);
@@ -122,7 +122,7 @@ int cr_nofallback_route5(struct sip_msg * _msg, char *_carrier,
 		char *_rewrite_user, enum hash_source _hsrc);
 
 
-int ki_cr_nofallback_route5(sip_msg_t* _msg, str *_carrier,
+int ki_cr_nofallback_route(sip_msg_t* _msg, str *_carrier,
 		str *_domain, str *_prefix_matching,
 		str *_rewrite_user, str *_hsrc);
 

--- a/src/modules/carrierroute/cr_func.h
+++ b/src/modules/carrierroute/cr_func.h
@@ -66,13 +66,13 @@ int ki_cr_load_user_carrier(struct sip_msg *_msg,
  *
  * @return 1 on success, -1 on failure
  */
-int cr_route(struct sip_msg * _msg, gparam_t *_carrier,
-		gparam_t *_domain, gparam_t *_prefix_matching,
-		gparam_t *_rewrite_user, enum hash_source _hsrc,
-		gparam_t *_descavp);
-int cr_route5(struct sip_msg * _msg, gparam_t *_carrier,
-		gparam_t *_domain, gparam_t *_prefix_matching,
-		gparam_t *_rewrite_user, enum hash_source _hsrc);
+int cr_route(struct sip_msg * _msg, char *_carrier,
+		char *_domain, char *_prefix_matching,
+		char *_rewrite_user, enum hash_source _hsrc,
+		char *_descavp);
+int cr_route5(struct sip_msg * _msg, char *_carrier,
+		char *_domain, char *_prefix_matching,
+		char *_rewrite_user, enum hash_source _hsrc);
 
 
 /**
@@ -92,13 +92,13 @@ int cr_route5(struct sip_msg * _msg, gparam_t *_carrier,
  *
  * @return 1 on success, -1 on failure
  */
-int cr_nofallback_route(struct sip_msg * _msg, gparam_t *_carrier,
-		gparam_t *_domain, gparam_t *_prefix_matching,
-		gparam_t *_rewrite_user, enum hash_source _hsrc,
-		gparam_t *_dstavp);
-int cr_nofallback_route5(struct sip_msg * _msg, gparam_t *_carrier,
-		gparam_t *_domain, gparam_t *_prefix_matching,
-		gparam_t *_rewrite_user, enum hash_source _hsrc);
+int cr_nofallback_route(struct sip_msg * _msg, char *_carrier,
+		char *_domain, char *_prefix_matching,
+		char *_rewrite_user, enum hash_source _hsrc,
+		char *_dstavp);
+int cr_nofallback_route5(struct sip_msg * _msg, char *_carrier,
+		char *_domain, char *_prefix_matching,
+		char *_rewrite_user, enum hash_source _hsrc);
 
 
 /**
@@ -114,8 +114,8 @@ int cr_nofallback_route5(struct sip_msg * _msg, gparam_t *_carrier,
  *
  * @return 1 on success, -1 on failure
  */
-int cr_load_next_domain(struct sip_msg * _msg, gparam_t *_carrier,
-		gparam_t *_domain, gparam_t *_prefix_matching, gparam_t *_host,
-		gparam_t *_reply_code, gparam_t *_dstavp);
+int cr_load_next_domain(struct sip_msg * _msg, char *_carrier,
+		char *_domain, char *_prefix_matching, char *_host,
+		char *_reply_code, char *_dstavp);
 
 #endif

--- a/src/modules/carrierroute/doc/carrierroute.xml
+++ b/src/modules/carrierroute/doc/carrierroute.xml
@@ -1,32 +1,44 @@
 <?xml version="1.0" encoding='UTF-8'?>
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
-
-<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
-%docentities;
-
+  "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+  <!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+  %docentities;
 ]>
 
 <book xmlns:xi="http://www.w3.org/2001/XInclude">
-	<bookinfo>
-	<title>carrierroute</title>
-	<productname class="trade">&kamailioname;</productname>
-	<authorgroup>		
-		<author>
-		<firstname>Henning</firstname>
-		<surname>Westerholt</surname>
-		<affiliation><orgname>1&amp;1 Internet AG</orgname></affiliation>
-		<address>
-			<email>henning.westerholt@1und1.de</email>
-		</address>
-		</author>
-		<editor>
-		<firstname>Lucian</firstname>
-		<surname>Balaceanu</surname>
-		<affiliation><orgname>1&amp;1 Internet AG</orgname></affiliation>
-		<email>lucian.balaceanu@1and1.ro</email>
-		</editor>
-		<!--
+  <bookinfo>
+    <title>carrierroute</title>
+    <productname class="trade">&kamailioname;</productname>
+    <authorgroup>
+      <author>
+        <firstname>Henning</firstname>
+        <surname>Westerholt</surname>
+        <affiliation>
+          <orgname>1&amp;1 Internet AG</orgname>
+        </affiliation>
+        <address>
+          <email>henning.westerholt@1und1.de</email>
+        </address>
+      </author>
+      <editor>
+        <firstname>Lucian</firstname>
+        <surname>Balaceanu</surname>
+        <affiliation>
+          <orgname>1&amp;1 Internet AG</orgname>
+        </affiliation>
+        <email>lucian.balaceanu@1and1.ro</email>
+      </editor>
+      <editor>
+        <firstname>Muhammad Shahzad</firstname>
+        <surname>Shafi</surname>
+        <affiliation>
+          <orgname>1&amp;1 Internet AG</orgname>
+        </affiliation>
+        <address>
+          <email>muhammad.shafi@1und1.de</email>
+        </address>
+      </editor>
+      <!--
 		<editor>
 		<firstname>EditorFirstname</firstname>
 		<surname>EditorLastname</surname>
@@ -35,14 +47,13 @@
 		</address>
 		</editor>
 		-->
-	</authorgroup>
-	<copyright>
-		<year>2007</year>
-		<holder>1&amp;1 Internet AG</holder>
-	</copyright>
-	</bookinfo>
-	<toc></toc>
-
-	<xi:include href="carrierroute_admin.xml"/>
-	<xi:include href="carrierroute_db.xml"/>
+    </authorgroup>
+    <copyright>
+      <year>2007</year>
+      <holder>1&amp;1 Internet AG</holder>
+    </copyright>
+  </bookinfo>
+  <toc/>
+  <xi:include href="carrierroute_admin.xml"/>
+  <xi:include href="carrierroute_db.xml"/>
 </book>

--- a/src/modules/carrierroute/doc/carrierroute_admin.xml
+++ b/src/modules/carrierroute/doc/carrierroute_admin.xml
@@ -1,398 +1,382 @@
 <?xml version="1.0" encoding='UTF-8'?>
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
-"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
-<!ENTITY % local.common.attrib
-	"xmlns:xi CDATA #FIXED 'http://www.w3.org/2001/XInclude'">
-<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
-%docentities;
-
+  "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+  <!ENTITY % local.common.attrib "xmlns:xi CDATA #FIXED 'http://www.w3.org/2001/XInclude'">
+  <!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+  %docentities;
 ]>
 
 <chapter>
-    <title>&adminguide;</title>
-
+  <title>&adminguide;</title>
+  <section>
+    <title>Overview</title>
+    <para>A module which provides routing, balancing and blocklisting capabilities.</para>
+    <para>
+        The module provides routing, balancing and blocklisting capabilities.
+        It reads routing entries from a database source or from a config file at &kamailio;
+        startup. It can use one routing tree (for one carrier), or if needed, for every user
+        a different routing tree (unique for each carrier) for number prefix based routing.
+        It supports several route tree domains, e.g. for fallback routes or different routing
+        rules for VoIP and PSTN targets.
+    </para>
+    <para>
+        Based on the tree, the module decides which number prefixes are forwarded to which
+        gateway. It can also distribute the traffic by ratio parameters. Furthermore, the
+        requests can be distributed by a hash function to predictable destinations. The hash
+        source is configurable, two different hash functions are available.
+    </para>
+    <para>
+        This modules scales up to more than a few million users, and is able to handle
+        more than several hundred thousand routing table entries. We received reports of
+        some setups that used more than a million routing table entries. It also supports
+        a large number of carriers and domains which can be efficiently looked up in most of
+        the cases (see below for more informations). In load balancing scenarios the usage
+        of the config file mode is recommended, to avoid the additional complexity that the
+        database driven routing creates.
+    </para>
+    <para>
+        Routing tables can be reloaded and edited (in config file mode) with the RPC
+        interface, the config file is updated according to the changes. This is not
+        implemented for the db interface, because its easier to do the changes
+        directly on the db. But the reload and dump functions work of course here
+        as well.
+    </para>
+    <para>
+        Some module functionality is not fully available in the config file mode, as
+        it is not possible to specify all information that can be stored in the database
+        tables in the config file. Further information about these limitations is given
+        in a later sections. For user based routing or LCR you should use the database mode.
+    </para>
+    <para>
+        In database mode, this module supports names and IDs for the carriers and domains.
+        When using IDs for the routing functions, efficient binary search is used to find the
+        needed data structures. If you are using constant strings as parameter, these will
+        be converted to IDs during the fixup procedure using learner search to find the needed
+        data structures. So from a performance point of view it is better to pass only IDs in
+        the routing functions.
+    </para>
+    <para>
+        Basically this module could be used as a replacement for the lcr and the
+        dispatcher module, if you have certain flexibility, integration and/or performance
+        requirements that can not be satisfied with these modules. But for smaller
+        installations it probably make more sense to use the lcr and dispatcher module.
+    </para>
+    <para>
+        Starting with version 3.1 , if you want to use this module in failure routes,
+        it is not needed to call<quote>append_branch()</quote> after rewriting the request URI
+        in order to relay the message to the new target. It also supports the usage of database
+        drived failure routing decisions using the carrierfailureroute table.
+    </para>
+  </section>
+  <section>
+    <title>Dependencies</title>
     <section>
-	<title>Overview</title>
-	<para>A module which provides routing, balancing and blocklisting capabilities.</para>
-	<para>
-		The module provides routing, balancing and blocklisting capabilities.
-		It reads routing entries from a database source or from a config file at &kamailio;
-		startup. It can use one routing tree (for one carrier), or if needed for every user
-		a different routing tree (unique for each carrier) for number prefix based routing.
-		It supports several route tree domains,	e.g. for fallback routes or different routing
-		rules for VoIP and PSTN targets.
-	</para>
-	<para>
-		Based on the tree, the module decides which number prefixes are forwarded to which
-		gateway. It can also distribute the traffic by ratio parameters. Furthermore, the
-		requests can be distributed by a hash function to predictable destinations. The hash
-		source is configurable, two different hash functions are available.
-	</para>
-	<para>
-		This modules scales up to more than a few million users, and is able to handle
-		more than several hundred thousand routing table entries. We received reports of
-		some setups that used more than a million routing table entries. It also supports
-		a large number of carriers and domains which can be efficiently looked up in most of
-		the cases (see below for more informations). In load balancing scenarios the usage
-		of the config file mode is recommended, to avoid the additional complexity that the
-		database driven routing creates.
-	</para>
-	<para>
-		Routing tables can be reloaded and edited (in config file mode) with the RPC
-		interface, the config file is updated according the changes. This is not
-		implemented for the db interface, because its easier to do the changes
-		directly on the db. But the reload and dump functions work of course here
-		too.
-	</para>
-	<para>
-		Some module functionality is not fully available in the config file mode, as
-		it is not possible to specify all information that can be stored in the database
-		tables in the config file. Further information about these limitations is given
-		in later sections. For user based routing or LCR you should use the database mode.
-	</para>
-	<para>
-		In database mode, this module supports names and IDs for the carriers and domains.
-		When using IDs for the routing functions, efficient binary search is used to find the
-		needed data structures. If you are using constant strings as parameter, these will
-		be converted to IDs during the fixup procedure. However, if you are using AVPs as
-		parameter and they contain strings, this cannot be converted to IDs during the
-		fixup procedure. In that case linear search is performed to find the needed data
-		structures. So from a performance point of view it is better to pass only IDs in
-		AVPs to the routing functions.
-	</para>
-	<para>
-		Basically this module could be used as a replacement for the lcr and the
-		dispatcher module, if you have certain flexibility, integration and/or performance
-		requirements that can't be satisfied with these modules. But for smaller
-		installations it probably make more sense to use the lcr and dispatcher module.
-	</para>
-	<para>
-		Starting with version 3.1 , if you want to use this module in failure routes,
-		it is not needed to call<quote>append_branch()</quote> after rewriting the request URI in order to
-		relay the message to the new target. Its also supports the usage of database
-		derived failure routing decisions with the carrierfailureroute table.
-	</para>
+      <title>&kamailio; Modules</title>
+      <para>
+        The following module must be loaded before this module:
+        <itemizedlist>
+          <listitem>
+            <para>
+              <emphasis>a database module</emphasis>,
+              when a database is used as configuration data source.
+              Only SQL based databases are supported, as this module needs the capability to
+              issue raw queries. Its not possible to use the dbtext or db_berkeley module at the moment.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              The <emphasis>tm module</emphasis>,
+              when you want to use the $T_reply_code pseudo-variable in the <quote>cr_next_domain</quote>
+              function.
+            </para>
+          </listitem>
+        </itemizedlist>
+      </para>
     </section>
+  </section>
+  <section>
+    <title>Parameters</title>
     <section>
-	<title>Dependencies</title>
-	<section>
-	    <title>&kamailio; Modules</title>
-	    <para>
-		The following module must be loaded before this module:
-	    	<itemizedlist>
-		    <listitem>
-			<para>
-				<emphasis>a database module</emphasis>, when a database is used as configuration data source.
-				Only SQL based databases are supported, as this module needs the capability to
-				issue raw queries. Its not possible to use the dbtext or db_berkeley module at the moment.
-			</para>
-		    </listitem>
-			<listitem>
-			<para>
-				The <emphasis>tm module</emphasis>, when you want to use the $T_reply_code pseudo-variable in
-				the <quote>cr_next_domain</quote> function.
-			</para>
-			</listitem>
-	    	</itemizedlist>
-	    </para>
-	</section>
-    </section>
-    <section>
-	<title>Parameters</title>
-    <section>
-	    <title><varname>subscriber_table</varname> (string)</title>
-	    <para>
-		    The name of the table containing the subscribers
-	    </para>
-	    <para>
-		    <emphasis>
-			    Default value is <quote>subscriber</quote>.
-		    </emphasis>
-	    </para>
-	    <example>
-		    <title>Set <varname>subscriber_table</varname> parameter</title>
-		    <programlisting format="linespecific">
+      <title><varname>subscriber_table</varname> (string)</title>
+      <para>
+        The name of the table containing the subscribers
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>subscriber</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Set <varname>subscriber_table</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "subscriber_table", "subscriber")
 ...
-		    </programlisting>
-	    </example>
+        </programlisting>
+      </example>
     </section>
-
     <section>
-	    <title><varname>subscriber_user_col</varname> (string)</title>
-	    <para>
-		    The name of the column in the subscriber table containing the usernames.
-	    </para>
-	    <para>
-		    <emphasis>
-			    Default value is <quote>username</quote>.
-		    </emphasis>
-	    </para>
-	    <example>
-		    <title>Set <varname>subscriber_user_col</varname> parameter</title>
-		    <programlisting format="linespecific">
+      <title><varname>subscriber_user_col</varname> (string)</title>
+      <para>
+        The name of the column in the subscriber table containing the usernames.
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>username</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Set <varname>subscriber_user_col</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "subscriber_user_col", "username")
 ...
-		    </programlisting>
-	    </example>
+        </programlisting>
+      </example>
     </section>
-
     <section>
-	    <title><varname>subscriber_domain_col</varname> (string)</title>
-	    <para>
-		    The name of the column in the subscriber table containing the domain of 
-		    the subscriber.
-	    </para>
-	    <para>
-		    <emphasis>
-			    Default value is <quote>domain</quote>.
-		    </emphasis>
-	    </para>
-	    <example>
-		    <title>Set <varname>subscriber_domain_col</varname> parameter</title>
-		    <programlisting format="linespecific">
+      <title><varname>subscriber_domain_col</varname> (string)</title>
+      <para>
+        The name of the column in the subscriber table containing the domain of 
+        the subscriber.
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>domain</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Set <varname>subscriber_domain_col</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "subscriber_domain_col", "domain")
 ...
-		    </programlisting>
-	    </example>
+        </programlisting>
+      </example>
     </section>
-
     <section>
-	    <title><varname>subscriber_carrier_col</varname> (string)</title>
-	    <para>
-		    The name of the column in the subscriber table containing the carrier id
-		    of the subscriber.
-
-	    </para>
-	    <para>
-		    <emphasis>
-			    Default value is <quote>cr_preferred_carrier</quote>.
-		    </emphasis>
-	    </para>
-	    <example>
-		    <title>Set <varname>subscriber_carrier_col</varname> parameter</title>
-		    <programlisting format="linespecific">
+      <title><varname>subscriber_carrier_col</varname> (string)</title>
+      <para>
+        The name of the column in the subscriber table containing the carrier id
+        of the subscriber.
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>cr_preferred_carrier</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Set <varname>subscriber_carrier_col</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "subscriber_carrier_col", "cr_preferred_carrier")
 ...
-		    </programlisting>
-	    </example>
+        </programlisting>
+      </example>
     </section>
-
     <section>
-	    <title><varname>config_source</varname> (string)</title>
-	    <para>
-		    Specifies whether the module loads its config data from a file or from a
-		    database. Possible values are file or db.
-	    </para>
-	    <para>
-		    <emphasis>
-			    Default value is <quote>file</quote>.
-		    </emphasis>
-	    </para>
-	    <example>
-		    <title>Set <varname>config_source</varname> parameter</title>
-		    <programlisting format="linespecific">
+      <title><varname>config_source</varname> (string)</title>
+      <para>
+        Specifies whether the module loads its config data from a file or from a
+        database. Possible values are <quote>file</quote> and <quote>db</quote>.
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>file</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Set <varname>config_source</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "config_source", "file")
 ...
-		    </programlisting>
-	    </example>
+        </programlisting>
+      </example>
     </section>
-
     <section>
-	    <title><varname>config_file</varname> (string)</title>
-	    <para>
-			Specifies the path to the config file. The file has to be owned by
-			the user and group used to run &kamailio;.
-	    </para>
-	    <para>
-		    <emphasis>
-			    Default value is <quote>/etc/kamailio/carrierroute.conf</quote>.
-		    </emphasis>
-	    </para>
-	    <example>
-		    <title>Set <varname>config_file</varname> parameter</title>
-		    <programlisting format="linespecific">
+      <title><varname>config_file</varname> (string)</title>
+      <para>
+        Specifies the path to the config file. The file has to be owned by
+        the user and group used to run &kamailio;.
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>/etc/kamailio/carrierroute.conf</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Set <varname>config_file</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "config_file", "/etc/kamailio/carrierroute.conf")
 ...
-		    </programlisting>
-	    </example>
+        </programlisting>
+      </example>
     </section>
-
     <section>
-	    <title><varname>default_tree</varname> (string)</title>
-	    <para>
-		    The name of the carrier tree used per default (if the current
-		    subscriber has no preferred tree)
-	    </para>
-	    <para>
-		    <emphasis>
-			    Default value is <quote>default</quote>.
-		    </emphasis>
-	    </para>
-	    <example>
-		    <title>Set <varname>default_tree</varname> parameter</title>
-		    <programlisting format="linespecific">
+      <title><varname>default_tree</varname> (string)</title>
+      <para>
+        The name of the carrier tree used per default (if the current
+        subscriber has no preferred tree)
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>default</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Set <varname>default_tree</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "default_tree", "default")
 ...
-		    </programlisting>
-	    </example>
+        </programlisting>
+      </example>
     </section>
-
     <section>
-	    <title><varname>use_domain</varname> (int)</title>
-	    <para>
-		    When using tree lookup per user, this parameter specifies whether
-		    to use the domain part for user matching or not. This parameter
-		    is tunable via the ser cfg framework.
-	    </para>
-	    <para>
-		    <emphasis>
-			    Default value is <quote>0</quote>.
-		    </emphasis>
-	    </para>
-	    <example>
-		    <title>Set <varname>use_domain</varname> parameter</title>
-		    <programlisting format="linespecific">
+      <title><varname>use_domain</varname> (int)</title>
+      <para>
+        When using tree lookup per user, this parameter specifies whether
+        to use the domain part for user matching or not. This parameter
+        is tunable via the ser cfg framework.
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>0</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Set <varname>use_domain</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "use_domain", 0)
 ...
-		    </programlisting>
-	    </example>
+        </programlisting>
+      </example>
     </section>
-
     <section>
-	    <title><varname>fallback_default</varname> (int)</title>
-	    <para>
-		    This parameter defines the behaviour when using user-based tree
-		    lookup. If the user has a non-existing tree set and fallback_default
-		    is set to 1, the default tree is used. Otherwise, cr_user_rewrite_uri
-		    returns an error. This parameter is tunable via the ser cfg framework.
-	    </para>
-	    <para>
-		    <emphasis>
-			    Default value is <quote>1</quote>.
-		    </emphasis>
-	    </para>
-	    <example>
-		    <title>Set <varname>fallback_default</varname> parameter</title>
-		    <programlisting format="linespecific">
+      <title><varname>fallback_default</varname> (int)</title>
+      <para>
+        This parameter defines the behaviour when using user-based tree
+        lookup. If the user has a non-existing tree set and fallback_default
+        is set to 1, the default tree is used. Otherwise, cr_user_rewrite_uri
+        returns an error. This parameter is tunable via the ser cfg framework.
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>1</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Set <varname>fallback_default</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "fallback_default", 1)
 ...
-		    </programlisting>
-	    </example>
+        </programlisting>
+      </example>
     </section>
-		<section>
-		<title><varname>fetch_rows</varname> (integer)</title>
-		<para>
-		The number of the rows to be fetched at once from database
-		when loading the routing data. This value can be used to tune
-		the load time at startup. For 1MB of private memory (default)
-		it should be below 3750. The database driver must support the
-		fetch_result() capability. This parameter is tunable via the ser
-		cfg framework.
-		</para>
-		<para>
-		<emphasis>
-			Default value is <quote>2000</quote>.
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>fetch_rows</varname> parameter</title>
-		<programlisting format="linespecific">
+    <section>
+      <title><varname>fetch_rows</varname> (integer)</title>
+      <para>
+        The number of the rows to be fetched at once from database
+        when loading the routing data. This value can be used to tune
+        the load time at startup. For 1MB of private memory (default)
+        it should be below 3750. The database driver must support the
+        fetch_result() capability. This parameter is tunable via the ser
+        cfg framework.
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>2000</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Set <varname>fetch_rows</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "fetch_rows", 3000)
 ...
-</programlisting>
-		</example>
-	</section>
-<section>
-		<title><varname>db_load_description</varname> (integer)</title>
-		<para>
-		Toggle on/off loading in memory the description column in the 
-		carrierroute/carrierfailureroute database tables. This reduces the 
-		shared memory used by the module.
-		</para>
-		<para>
-		<emphasis>
-			Default value is <quote>1</quote>.
-		</emphasis>
-		</para>
-		<example>
-		<title>Unset <varname>db_load_description</varname> parameter</title>
-		<programlisting format="linespecific">
+        </programlisting>
+      </example>
+    </section>
+    <section>
+      <title><varname>db_load_description</varname> (integer)</title>
+      <para>
+        Toggle on/off loading in memory the description column in the 
+        carrierroute/carrierfailureroute database tables. This reduces the 
+        shared memory used by the module.
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>1</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Unset <varname>db_load_description</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "db_load_description", 0)
 ...
-</programlisting>
-		</example>
-	</section>
-	<section>
-		<title><varname>match_mode</varname> (integer)</title>
-		<para>
-		The number of individual characters that are used for matching.
-		Valid values are 10 or 128. When you specify 10, only digits
-		will be used for matching, this operation mode is equivalent to
-		the old behaviour. When configured with 128, all standard ascii
-		chars are available for matching. Please be aware that memory
-		requirements for storing the routing tree in shared memory
-		will also increase by a factor of 12.8.
-		</para>
-		<para>
-		<emphasis>
-			Default value is <quote>10</quote>.
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>match_mode</varname> parameter</title>
-		<programlisting format="linespecific">
+        </programlisting>
+      </example>
+    </section>
+    <section>
+      <title><varname>match_mode</varname> (integer)</title>
+      <para>
+        The number of individual characters that are used for matching.
+        Valid values are 10 or 128. When you specify 10, only digits
+        will be used for matching, this operation mode is equivalent to
+        the old behaviour. When configured with 128, all standard ascii
+        chars are available for matching. Please be aware that memory
+        requirements for storing the routing tree in shared memory
+        will also increase by a factor of 12.8.
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>10</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Set <varname>match_mode</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "match_mode", 10)
 ...
-</programlisting>
-		</example>
-	</section>
-
-	<section>
-		<title><varname>avoid_failed_destinations</varname> (integer)</title>
-		<para>
-		Integer parameter to toggle on/off the possibility that in the failurerouting cases 
-		destinations that previously failed are avoided. Possible values are 0 (off), 1 (on).
-		Also see cr_route section.
-		</para>
-		<para>
-		<emphasis>
-			Default value is <quote>1</quote>.
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>avoid_failed_destinations</varname> parameter</title>
-		<programlisting format="linespecific">
+        </programlisting>
+      </example>
+    </section>
+    <section>
+      <title><varname>avoid_failed_destinations</varname> (integer)</title>
+      <para>
+        Integer parameter to toggle on/off the possibility that in the failurerouting cases 
+        destinations that previously failed are avoided. Possible values are 0 (off), 1 (on).
+        Also see cr_route section.
+      </para>
+      <para>
+        <emphasis>
+          Default value is <quote>1</quote>.
+        </emphasis>
+      </para>
+      <example>
+        <title>Set <varname>avoid_failed_destinations</varname> parameter</title>
+        <programlisting format="linespecific">
 ...
 modparam("carrierroute", "avoid_failed_destinations", 0)
 ...
-</programlisting>
-		</example>
-	</section>
-
-</section>
-
-    <section>
-	<title>Functions</title>
-	<para>
-    Previous versions of carrierroute had some more function. All the
-    old semantics can be achieved by using the few new functions
-    like this:
-	</para>
-
-  <programlisting format="linespecific">
+        </programlisting>
+      </example>
+    </section>
+  </section>
+  <section>
+    <title>Functions</title>
+    <para>
+      Previous versions of carrierroute had some more function. All the
+      old semantics can be achieved by using the few new functions
+      like this:
+    </para>
+    <programlisting format="linespecific">
 cr_rewrite_uri(domain, hash_source)
 -> cr_route("default", domain, "$rU", "$rU", hash_source)
 
@@ -408,361 +392,375 @@ cr_user_rewrite_uri(uri, domain)
 
 cr_tree_rewrite_uri(tree, domain)
 -> cr_route(tree, domain, "$rU", "$rU", "call_id")
-  </programlisting>
-		
-	<section>
-	    <title>
-		<function moreinfo="none">cr_user_carrier(user, domain, dstvar)</function>
-	    </title>
-	    <para>
-      This function loads the carrier and stores it in a config variable.
-      It cannot be used in the config file mode, as it needs a mapping of the
-	  given user to a certain carrier. The is derived from a database entry
-	  belonging to the user parameter. This mapping must be available in the
-	  table that is specified in the <quote>subscriber_table</quote> variable.
-	  This data is not cached in memory, that means for every execution of this
-	  function a database query will be done.
-	    </para>
-	    <para>Meaning of the parameters is as follows:</para>
-	    <itemizedlist>
+
+    </programlisting>
+    <section>
+      <title>
+        <function moreinfo="none">cr_user_carrier(user, domain, dstvar)</function>
+      </title>
+      <para>
+        This function loads the carrier and stores it in a config variable.
+        It cannot be used in the config file mode, as it needs a mapping of the
+        given user to a certain carrier. The is drived from a database entry
+        belonging to the user parameter. This mapping must be available in the
+        table that is specified in the <quote>subscriber_table</quote> variable.
+        This data is not cached in memory, that means for every execution of this
+        function a database query will be done.
+      </para>
+      <para>Meaning of the parameters is as follows:</para>
+      <itemizedlist>
         <listitem>
-          <para><emphasis>user</emphasis> - Name of the user for the carrier tree lookup.
-            Additional to a string any pseudo-variable could
-            be used as input.
-		      </para>
+          <para>
+            <emphasis>user</emphasis> - Name of the user for the carrier tree lookup.
+            Additional to a string any pseudo-variable could be used as input.
+          </para>
         </listitem>
         <listitem>
-          <para><emphasis>domain</emphasis> - Name of the routing domain to be used.
-            Additional to a string any pseudo-variable could
-            be used as input.
-		      </para>
+          <para>
+            <emphasis>domain</emphasis> - Name of the routing domain to be used.
+            Additional to a string any pseudo-variable could be used as input.
+          </para>
         </listitem>
-	      <listitem>
-			<para><emphasis>dstvar</emphasis> - Name of the writaable variable (e.g., an AVP)
-			  where to store the carrier id.
-		      </para>
+        <listitem>
+          <para>
+            <emphasis>dstvar</emphasis> - Name of the writaable config variable
+            (e.g., an AVP) where to store the carrier id.
+          </para>
         </listitem>
-	    </itemizedlist>
-	</section>
-	<section>
-	    <title>
-		<function moreinfo="none">cr_route(carrier, domain, prefix_matching, rewrite_user, hash_source, descavp)</function>
-	    </title>
-	    <para>
+      </itemizedlist>
+    </section>
+    <section>
+      <title>
+        <function moreinfo="none">cr_route(carrier, domain, prefix_matching, rewrite_user, hash_source, descavp)</function>
+      </title>
+      <para>
         This function searches for the longest match for the user given
-        in prefix_matching at the given domain in the given carrier tree.
+        in prefix_matching with the given domain in the given carrier tree.
         The Request URI is rewritten using rewrite_user and the given
         hash source and algorithm. Returns -1 if there is no data found
-        or an empty rewrite host on the longest match is found. On success
-        also the description is stored in the given AVP (if omitted, nothing
-        is stored in an AVP). This is useful if you need some additional
-        informations that belongs to each gw, like the destination or the
-        number of channels.
-		</para>
-		<para>
-		Depending on the value of the avoid_failed_destinations module parameter,
-		the function pays special attention to the failurerouting cases, so that
-		any destination that has failed to provide a successful response will not
-		be reused in a subsequent call of cr_route. This situation can appear when
-		different route domains contain a set of common gateways.
-		</para>
-        <para>
+        or an empty rewrite host on the longest match is found. On success,
+        it also stores the carrier description in the given AVP (if present).
+        This is useful if you need some additional informations that belongs
+        to each gw, like the destination uri, force socket or any arbitrary info.
+      </para>
+      <para>
+        Depending on the value of the avoid_failed_destinations module parameter,
+        the function pays special attention to the failurerouting cases, so that
+        any destination that has failed to provide a successful response will not
+        be reused in a subsequent call of this function. This situation can appear
+        when different route domains contain a set of common gateways.
+      </para>
+      <para>
         This function is only usable with rewrite_user and prefix_matching
         containing a valid string. This string needs to be numerical if the match_mode
         parameter is set to 10. It uses the standard CRC32 algorithm to calculate
         the hash values.
-        </para>
-        <para>
+      </para>
+      <para>
         If flags and masks values are specified in the routing rule, they will be
         compared by this function to the message flags. Specify a flag and mask value of
         <quote>0</quote> to match to all possible message flags (this is the default value).
         If flags and mask are not zero, and no match to the message flags is possible, no
         routing will be done. The calculation of the hash and the load-balancing is done
         after the flags matching.
-	    </para>
-	    <para>Meaning of the parameters is as follows:</para>
-	    <itemizedlist>
+      </para>
+      <para>
+        Meaning of the parameters is as follows:
+      </para>
+      <itemizedlist>
         <listitem>
-		      <para><emphasis>carrier</emphasis> - The routing tree to be used. Additional to a string
-            any pseudo-variable could be used as input.
-  		    </para>
+          <para>
+            <emphasis>carrier</emphasis> - The routing tree to be used. It must be 
+            string containing either carrier id (nummeric) or carrier name (arbitrary string).
+            It also accepts any pseudo-variable as input.
+          </para>
         </listitem>
         <listitem>
-		      <para><emphasis>domain</emphasis> - Name of the routing domain to be used.
-            Additional to a string any pseudo-variable could
-            be used as input.
-  		    </para>
+          <para>
+            <emphasis>domain</emphasis> - Name of the routing domain to be used. it must be
+            string containing either domain id (nummeric) or domain name (arbitrary string).
+            It also accepts any pseudo-variable as input.
+          </para>
         </listitem>
         <listitem>
-		      <para><emphasis>prefix_matching</emphasis> - User name to be used for prefix matching
+          <para>
+            <emphasis>prefix_matching</emphasis> - User name to be used for prefix matching
             in the routing tree.
-            Additional to a string any pseudo-variable could
-            be used as input.
-  		    </para>
+            It also accepts any pseudo-variable as input
+          </para>
         </listitem>
         <listitem>
-		      <para><emphasis>rewrite_user</emphasis> - The user name to be used for applying the
-            rewriting rule. Usually this is the user part of the request
-            URI. Additional to a string any pseudo-variable could
-            be used as input.
-  		    </para>
+          <para>
+            <emphasis>rewrite_user</emphasis> - The user name to be used for applying the
+            rewriting rule. Usually this is the user part of the request URI.
+            It also accepts any pseudo-variable as input
+          </para>
         </listitem>
         <listitem>
-		      <para><emphasis>hash_source</emphasis> - The hash values of the destination set must
-            be a contiguous range starting at 1, limited by the
-            configuration parameter max_targets. Possible values for
-            hash_source are: call_id, from_uri, from_user, to_uri,
-            to_user and rand
-  		    </para>
+          <para>
+            <emphasis>hash_source</emphasis> - The hash values of the destination set, it must
+            be a contiguous range starting at 1, limited by the configuration parameter
+            <quote>max_targets</quote>. Possible values for hash_source are: <quote>call_id</quote>,
+            <quote>from_uri</quote>, <quote>from_user</quote>, <quote>to_uri</quote>,
+            <quote>to_user</quote> and <quote>rand</quote>.
+          </para>
         </listitem>
         <listitem>
-		      <para><emphasis>decsavp</emphasis> - AVP where to store the description.
-			This parameter is optional.
-  		    </para>
+          <para>
+            <emphasis>decsavp</emphasis> - AVP where to store the description.
+            This parameter is optional.
+          </para>
         </listitem>
-	    </itemizedlist>
-	</section>
-		<section>
-	    <title>
-		<function moreinfo="none">cr_nofallback_route(carrier, domain, prefix_matching, rewrite_user, hash_source, descavp)</function>
-	    </title>
-	    <para>
+      </itemizedlist>
+    </section>
+    <section>
+      <title>
+        <function moreinfo="none">cr_nofallback_route(carrier, domain, prefix_matching, rewrite_user, hash_source, descavp)</function>
+      </title>
+      <para>
         This function searches for the longest match for the user given
-        in prefix_matching at the given domain in the given carrier tree.
+        in prefix_matching with the given domain in the given carrier tree.
         The Request URI is rewritten using rewrite_user and the given
         hash source and algorithm. Returns -1 if there is no data found
         or an empty rewrite host on the longest match is found. On success
-        also the description is stored in the given AVP (if omitted, nothing
-        is stored in an AVP). This is useful if you need some additional
-        informations that belongs to each gw, like the destination or the
-        number of channels.
+        it also stores the carrier description in the given AVP (if present).
+        This is useful if you need some additional informations that belongs
+        to each gw, like the destination uri, force socket or any arbitrary info.
+      </para>
+      <para>
         This function is only usable with rewrite_user and prefix_matching
         containing a valid string. This string needs to be numerical if the match_mode
         parameter is set to 10.
-	    </para>
-	    <para>
-		It uses the standard CRC32 algorithm to calculate the hash values. In contrast
-		to the normal <emphasis>cr_route</emphasis> function the backup
-		rules of (now obsolete) cr_prime_route is used. This means not the configured
-		probabilities will be used, only a fixed hash distribution. This
-		makes sense to distribute incoming register requests e.g. to a bunch of
-		registrar servers. If one of the hash targets is not available and
-		backup rule is configured, the function will return -1.
-	    </para>
-	    <para>Meaning of the parameters is as follows:</para>
-	    <itemizedlist>
+      </para>
+      <para>
+        It uses the standard CRC32 algorithm to calculate the hash values. In contrast
+        to the normal <emphasis>cr_route</emphasis> function, the backup rules of
+        (now obsolete) cr_prime_route is used. This means none of the configured
+        probabilities will be used, only a fixed hash distribution is used. This
+        makes sense to distribute incoming register requests e.g. to a bunch of
+        registrar servers. If one of the hash targets is not available and backup
+        rule is configured, the function will return -1.
+      </para>
+      <para>Meaning of the parameters is as follows:</para>
+      <itemizedlist>
         <listitem>
-		      <para><emphasis>carrier</emphasis> - The routing tree to be used. Additional to a string
-            any pseudo-variable could be used as input.
-		      </para>
+          <para>
+            <emphasis>carrier</emphasis> - The routing tree to be used. It must be 
+            string containing either carrier id (nummeric) or carrier name (arbitrary string).
+            It also accepts any pseudo-variable as input.
+          </para>
         </listitem>
         <listitem>
-		      <para><emphasis>domain</emphasis> - Name of the routing domain to be used.
-            Additional to a string any pseudo-variable could
-            be used as input.
-		      </para>
+          <para>
+            <emphasis>domain</emphasis> - Name of the routing domain to be used. it must be
+            string containing either domain id (nummeric) or domain name (arbitrary string).
+            It also accepts any pseudo-variable as input
+          </para>
         </listitem>
         <listitem>
-		      <para><emphasis>prefix_matching</emphasis> - User name to be used for prefix matching
+          <para>
+            <emphasis>prefix_matching</emphasis> - User name to be used for prefix matching
             in the routing tree.
-            Additional to a string any pseudo-variable could
-            be used as input.
-		      </para>
+            It also accepts any pseudo-variable as input
+          </para>
         </listitem>
         <listitem>
-		      <para><emphasis>rewrite_user</emphasis> - The user name to be used for applying the
-            rewriting rule. Usually this is the user part of the request
-            URI. Additional to a string any pseudo-variable could
-            be used as input.
-		      </para>
+          <para>
+            <emphasis>rewrite_user</emphasis> - The user name to be used for applying the
+            rewriting rule. Usually this is the user part of the request URI.
+            It also accepts any pseudo-variable as input
+          </para>
         </listitem>
         <listitem>
-		      <para><emphasis>hash_source</emphasis> - The hash values of the destination set must
-            be a contiguous range starting at 1, limited by the
-            configuration parameter max_targets. Possible values for
-            hash_source are: call_id, from_uri, from_user, to_uri
-            and to_user.
-		      </para>
+          <para>
+            <emphasis>hash_source</emphasis> - The hash values of the destination set, it must
+            be a contiguous range starting at 1, limited by the configuration parameter
+            <quote>max_targets</quote>. Possible values for hash_source are: <quote>call_id</quote>,
+            <quote>from_uri</quote>, <quote>from_user</quote>, <quote>to_uri</quote>,
+            <quote>to_user</quote> and <quote>rand</quote>.
+          </para>
         </listitem>
         <listitem>
-		      <para><emphasis>descavp</emphasis> - Name of the AVP where to store the description.
-			This parameter is optional.
-		      </para>
+          <para>
+            <emphasis>decsavp</emphasis> - AVP where to store the description.
+            This parameter is optional.
+          </para>
         </listitem>
-	    </itemizedlist>
-	</section>
-
-	<section>
-	    <title>
-		<function moreinfo="none">cr_next_domain(carrier, domain, prefix_matching, host, reply_code, dstavp)</function>
-	    </title>
-	    <para>
-        This function searches for the longest match for the user given
-        in prefix_matching at the given domain in the given carrier
-        failure tree. It tries to find a next domain matching the given
-        host, reply_code and the message flags. The matching is done in this order:
-        host, reply_code and then flags. The more wildcards in reply_code
-        and the more bits used in flags, the lower the priority.
-        Returns -1 if there is no data found or an empty next_domain on
-        the longest match is found. Otherwise the next domain is stored
-        in the given AVP.
-        This function is only usable with rewrite_user and prefix_matching
-        containing a valid string. This string needs to be numerical if the match_mode
-		parameter is set to 10.
-	    </para>
-	    <para>Meaning of the parameters is as follows:</para>
-	    <itemizedlist>
-        <listitem>
-		      <para><emphasis>carrier</emphasis> - The routing tree to be used. Additional to a string
-            any pseudo-variable could be used as input.
-  		    </para>
-        </listitem>
-        <listitem>
-		      <para><emphasis>domain</emphasis> - Name of the routing domain to be used.
-            Additional to a string any pseudo-variable could
-            be used as input.
-  		    </para>
-        </listitem>
-        <listitem>
-		      <para><emphasis>prefix_matching</emphasis> - User name to be used for prefix matching
-            in the routing tree.
-            Additional to a string any pseudo-variable could
-            be used as input.
-  		    </para>
-        </listitem>
-        <listitem>
-		      <para><emphasis>host</emphasis> - The host name to be used for failure route rule
-            matching. Usually this is the last tried routing destination
-            stored in an avp by cr_route. Additional to a string any
-            pseudo-variable could be used as input.
-  		    </para>
-        </listitem>
-        <listitem>
-		      <para><emphasis>reply_code</emphasis> - The reply code to be used for failure route rule
-            matching. Additional to a string any pseudo-variable
-            could be used as input.
-  		    </para>
-        </listitem>
-        <listitem>
-		      <para><emphasis>dstavp</emphasis> - Name of the AVP where to store the next routing domain.
-  		    </para>
-        </listitem>
-	    </itemizedlist>
-	</section>
+      </itemizedlist>
     </section>
-
-<xi:include href="rpc.xml"/>
-
     <section>
-	<title>Configuration examples</title>
-	<example>
-		<title>Configuration example - Routing to default tree</title>
-		<programlisting format="linespecific">
+      <title>
+        <function moreinfo="none">cr_next_domain(carrier, domain, prefix_matching, host, reply_code, dstavp)</function>
+      </title>
+      <para>
+        This function searches for the longest match for the user given
+        in prefix_matching with the given domain in the given carrier
+        failure tree. It tries to find a next domain matching the given
+        host, reply_code and the message flags. The matching is done in
+        this order: <quote>host</quote> then <quote>reply_code</quote> and
+        then <quote>flags</quote>. The more wildcards in reply_code
+        and the more bits used in flags, the lower the priority will be.
+        Returns -1, if there is no data found or if the next_domain on the
+        longest match is empty. Otherwise the next domain is stored in the
+        given variable.
+      </para>
+      <para>
+        This function is only usable if rewrite_user and prefix_matching
+        contains a valid string. This string must be numerical if the
+        match_mode parameter is set to 10.
+      </para>
+      <para>Meaning of the parameters is as follows:</para>
+      <itemizedlist>
+        <listitem>
+          <para>
+            <emphasis>carrier</emphasis> - The routing tree to be used. It must be 
+            string containing either carrier id (nummeric) or carrier name (arbitrary string).
+            It also accepts any pseudo-variable as input.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <emphasis>domain</emphasis> - Name of the routing domain to be used. it must be
+            string containing either domain id (nummeric) or domain name (arbitrary string).
+            It also accepts any pseudo-variable as input.
+          </para>
+        </listitem>
+        <listitem>
+          <para><emphasis>prefix_matching</emphasis> - User name to be used for prefix matching
+            in the routing tree. 
+            It also accepts any pseudo-variable as input.
+          </para>
+        </listitem>
+        <listitem>
+          <para><emphasis>host</emphasis> - The host name to be used for failure route rule
+            matching. Usually this is the last tried routing destination
+            stored in an avp by cr_route.
+            It also accepts any pseudo-variable as input
+          </para>
+        </listitem>
+        <listitem>
+          <para><emphasis>reply_code</emphasis> - The reply code to be used for failure route rule
+            matching.
+            It also accepts any pseudo-variable as input
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <emphasis>dstavp</emphasis> - Name of the AVP where to store the next
+            routing domain.
+          </para>
+        </listitem>
+      </itemizedlist>
+    </section>
+  </section>
+  <xi:include href="rpc.xml"/>
+  <section>
+    <title>Configuration examples</title>
+    <example>
+      <title>Configuration example - Routing to default tree</title>
+      <programlisting format="linespecific">
 ...
 route {
-	# route calls based on hash over callid
-	# choose route domain 0 of the default carrier
-	
-	if(!cr_route("default", "0", "$rU", "$rU", "call_id")){
-		sl_send_reply("403", "Not allowed");
-	} else {
-		# In case of failure, re-route the request
-		t_on_failure("1");
-		# Relay the request to the gateway
-		t_relay();
-	}
+    # route calls based on hash over callid
+    # choose route domain 0 of the default carrier
+    
+    if(!cr_route("default", "0", "$rU", "$rU", "call_id")){
+        sl_send_reply("403", "Not allowed");
+    } else {
+        # In case of failure, re-route the request
+        t_on_failure("1");
+        # Relay the request to the gateway
+        t_relay();
+    }
 }
 
 failure_route[1] {
-	revert_uri();
-	# In case of failure, send it to an alternative route:
-	if (t_check_status("408|5[0-9][0-9]")) {
-	#choose route domain 1 of the default carrier
-	if(!cr_route("default", "1", "$rU", "$rU", "call_id")){
-			t_reply("403", "Not allowed");
-		} else {
-			t_on_failure("2");
-			t_relay();
-		}
-	}
+    revert_uri();
+    # In case of failure, send it to an alternative route:
+    if (t_check_status("408|5[0-9][0-9]")) {
+    #choose route domain 1 of the default carrier
+    if(!cr_route("default", "1", "$rU", "$rU", "call_id")){
+            t_reply("403", "Not allowed");
+        } else {
+            t_on_failure("2");
+            t_relay();
+        }
+    }
 }
 
 failure_route[2] {
-	# further processing
+    # further processing
 }
 
-		</programlisting>
-	</example>
-	
-	<example>
-		<title>Configuration example - Routing to user tree</title>
-		<programlisting format="linespecific">
+      </programlisting>
+    </example>
+    <example>
+      <title>Configuration example - Routing to user tree</title>
+      <programlisting format="linespecific">
 ...
 route[1] {
-	cr_user_carrier("$fU", "$fd", "$avp(s:carrier)");
+    cr_user_carrier("$fU", "$fd", "$avp(s:carrier)");
 
-	# just an example domain
-	$avp(s:domain)="start";
-	if (!cr_route("$avp(s:carrier)", "$avp(s:domain)", "$rU", "$rU",
-			"call_id")) {
-		xlog("L_ERR", "cr_route failed\n");
-		exit;
-	}
-	# if you store also the port as part of the rewrite host,
-	# otherwise you can just use $rd later
-	$avp(s:host)= $rd+":"+$rp;
-	t_on_failure("1");
-		if (!t_relay()) {
-			sl_reply_error();
-	};
+    # just an example domain
+    $avp(s:domain)="start";
+    if (!cr_route("$avp(s:carrier)", "$avp(s:domain)", "$rU", "$rU",
+            "call_id")) {
+        xlog("L_ERR", "cr_route failed\n");
+        exit;
+    }
+    # if you store also the port as part of the rewrite host,
+    # otherwise you can just use $rd later
+    $avp(s:host)= $rd+":"+$rp;
+    t_on_failure("1");
+        if (!t_relay()) {
+            sl_reply_error();
+    };
 }
 
 failure_route[1] {
-	revert_uri();
-	if (!cr_next_domain("$avp(s:carrier)", "$avp(s:domain)", "$rU",
-			"$avp(s:host)", "$T_reply_code", "$avp(s:domain)")) {
-		xlog("L_ERR", "cr_next_domain failed\n");
-		exit;
-	}
-	if (!cr_route("$avp(s:carrier)", "$avp(s:domain)", "$rU", "$rU",
-			"call_id")) {
-		xlog("L_ERR", "cr_route failed\n");
-		exit;
-	}
-	$avp(s:host)= $rd+":"+$rp;
-	t_on_failure("1");
-	if (!t_relay()) {
-		xlog("L_ERR", "t_relay failed\n");
-		exit;
-	};
+    revert_uri();
+    if (!cr_next_domain("$avp(s:carrier)", "$avp(s:domain)", "$rU",
+            "$avp(s:host)", "$T_reply_code", "$avp(s:domain)")) {
+        xlog("L_ERR", "cr_next_domain failed\n");
+        exit;
+    }
+    if (!cr_route("$avp(s:carrier)", "$avp(s:domain)", "$rU", "$rU",
+            "call_id")) {
+        xlog("L_ERR", "cr_route failed\n");
+        exit;
+    }
+    $avp(s:host)= $rd+":"+$rp;
+    t_on_failure("1");
+    if (!t_relay()) {
+        xlog("L_ERR", "t_relay failed\n");
+        exit;
+    };
 }
 ...
-		</programlisting>
-	</example>
-
-			
-	<example>
-		<title>Configuration example - module configuration</title>
-		<para>
-			The following config file specifies within the default carrier two
-			domains, each with a prefix that contains two hosts. It is not possible
-			to specify another carrier if you use the config file as data source.
-		</para>
-		<para>
-			All traffic will be equally distributed between the hosts, both are
-			active. The hash algorithm will working over the [1,2] set, messages
-			hashed to one will go to the first host, the other to the second one.
-			Don't use a hash index value of zero. If you omit the hash completely,
-			the module gives them an autogenerated value, starting from one.
-		</para>
-		<para>
-			Use the <quote>NULL</quote> prefix to specify an empty prefix in the config file.
-			Please note that the prefix is matched against the request URI (or to URI),
-			if they did not contain a valid (numerical) URI, no match is possible. So
-			for load-balancing purposes e.g. for your registrars, you should use an empty
-			prefix.
-		</para>
-		<programlisting format="linespecific">
+      </programlisting>
+    </example>
+    <example>
+      <title>Configuration example - module configuration</title>
+      <para>
+        The following config file specifies within the default carrier two
+        domains, each with a prefix that contains two hosts. It is not possible
+        to specify another carrier if you use the config file as data source.
+      </para>
+      <para>
+        All traffic will be equally distributed between the hosts, both are
+        active. The hash algorithm will working over the [1,2] set, messages
+        hashed to one will go to the first host, the other to the second one.
+        Don't use a hash index value of zero. If you omit the hash completely,
+        the module gives them an autogenerated value, starting from one.
+      </para>
+      <para>
+        Use the <quote>NULL</quote> prefix to specify an empty prefix in the config file.
+        Please note that the prefix is matched against the request URI (or to URI),
+        if they did not contain a valid (numerical) URI, no match is possible. So
+        for load-balancing purposes e.g. for your registrars, you should use an empty
+        prefix.
+      </para>
+      <programlisting format="linespecific">
 ...
 domain proxy {
    prefix 49 {
@@ -800,41 +798,39 @@ domain register {
    }
 }
 ...
-		</programlisting>
-	</example>
-    </section>
-
+      </programlisting>
+    </example>
+  </section>
+  <section>
+    <title>Installation and Running</title>
     <section>
-	<title>Installation and Running</title>
-	<section>
-		<title>Database setup</title>
-		<para>
-			Before running &kamailio; with carrierroute, you have to setup the database 
-			table where the module will store the routing data. For that, if 
-			the table was not created by the installation script or you choose
-			to install everything by yourself you can use the carrierroute-create.sql
-			<acronym>SQL</acronym> script in the database directories in the 
-			kamailio/scripts folder as template. 
-			Database and table name can be set with module parameters so they 
-			can be changed, but the name of the columns must be as they are 
-			in the <acronym>SQL</acronym> script.
-			You can also find the complete database documentation on the
-			project webpage, &kamailiodbdocs;.
-			The flags and mask columns have the same function as in the
-			carrierfailureroute table. A zero value in the flags and mask
-			column means that any message flags will match this rule.
-		</para>
-		<para>
-			For a minimal configuration either use the config file given above, or
-			insert some data into the tables of the module.
-		</para>
-	</section>
-	
-	<section>
-		<title>Database examples</title>
-	<example>
-		<title>Example database content - carrierroute table</title>
-		<programlisting format="linespecific">
+      <title>Database setup</title>
+      <para>
+        Before running &kamailio; with carrierroute, you have to setup the database 
+        table where the module will store the routing data. For that, if 
+        the table was not created by the installation script or you choose
+        to install everything by yourself you can use the carrierroute-create.sql
+        <acronym>SQL</acronym> script in the database directories in the 
+        kamailio/scripts folder as template. 
+        Database and table name can be set with module parameters so they 
+        can be changed, but the name of the columns must be as they are 
+        in the <acronym>SQL</acronym> script.
+        You can also find the complete database documentation on the
+        project webpage, &kamailiodbdocs;.
+        The flags and mask columns have the same function as in the
+        carrierfailureroute table. A zero value in the flags and mask
+        column means that any message flags will match this rule.
+      </para>
+      <para>
+        For a minimal configuration either use the config file given above, or
+        insert some data into the tables of the module.
+      </para>
+    </section>
+    <section>
+      <title>Database examples</title>
+      <example>
+        <title>Example database content - carrierroute table</title>
+        <programlisting format="linespecific">
 ...
 +----+---------+--------+-------------+-------+------+---------------+
 | id | carrier | domain | scan_prefix | flags | prob | rewrite_host  |
@@ -854,28 +850,28 @@ domain register {
 | 13 |       3 |      8 |             |     0 |    1 | gw.default    |
 +----+---------+--------+-------------+-------+------+---------------+
 ...
-		</programlisting>
-	</example>
-		<para>
-			This table contains three routes to two gateways for the <quote>49</quote> prefix,
-			and a default route for other prefixes over carrier 2 and carrier 1. The
-			gateways for the default carrier will be used for functions that don't
-			support the user specific carrier lookup. The routing rules for carrier 1
-			and carrier 2 for the <quote>49</quote> prefix contains an additional rule
-			with the domain 2, that can be used for example as fallback if the gateways
-			in domain 1 are not reachable. Two more fallback rules (domain 3 and 4) for 
-			carrier 1 are also supplied to support the functionality of the carrierfailureroute
-			table example that is provided in the next section.
-		</para>
-		<para>
-			This table provides also a <quote>carrier 1</quote> routing rule for the
-			<quote>49</quote> prefix, that is only chosen if some message flags are set.
-			If this flags are not set, the other two rules are used. The <quote>strip</quote>,
-			<quote>mask</quote> and <quote>comment</quote> columns are omitted for brevity.
-		</para>
-	<example>
-		<title>Example database content - simple carrierfailureroute table</title>
-		<programlisting format="linespecific">
+        </programlisting>
+      </example>
+      <para>
+        This table contains three routes to two gateways for the <quote>49</quote> prefix,
+        and a default route for other prefixes over carrier 2 and carrier 1. The
+        gateways for the default carrier will be used for functions that don't
+        support the user specific carrier lookup. The routing rules for carrier 1
+        and carrier 2 for the <quote>49</quote> prefix contains an additional rule
+        with the domain 2, that can be used for example as fallback if the gateways
+        in domain 1 are not reachable. Two more fallback rules (domain 3 and 4) for 
+        carrier 1 are also supplied to support the functionality of the carrierfailureroute
+        table example that is provided in the next section.
+      </para>
+      <para>
+        This table provides also a <quote>carrier 1</quote> routing rule for the
+        <quote>49</quote> prefix, that is only chosen if some message flags are set.
+        If this flags are not set, the other two rules are used. The <quote>strip</quote>,
+        <quote>mask</quote> and <quote>comment</quote> columns are omitted for brevity.
+      </para>
+      <example>
+        <title>Example database content - simple carrierfailureroute table</title>
+        <programlisting format="linespecific">
 ...
 +----+---------+--------+---------------+------------+-------------+
 | id | carrier | domain | host_name     | reply_code | next_domain |
@@ -884,24 +880,23 @@ domain register {
 |  2 |       1 | 1      | gw.carrier1-3 | ...        | 2           |
 +----+---------+--------+---------------+------------+-------------+
 ...
-</programlisting>
-	</example>
-		<para>
-			This table contains two failure routes for the <quote>gw.carrier1-1</quote> and
-			<quote>-2</quote> gateways. For any (failure) reply code the respective next
-			domain is chosen. After that no more failure routes are available, an error will
-			be returned from the <quote>cr_next_domain</quote> function. Not all table
-			columns are show here for brevity.
-		</para>
-		<para>
-			For each failure route domain and carrier that is added to the carrierfailureroute
-			table there must be at least one corresponding entry in the carrierroute table,
-			otherwise the module will not load the routing data.
-		</para>
-
-	<example>
-		<title>Example database content - more complex carrierfailureroute table</title>
-		<programlisting format="linespecific">
+        </programlisting>
+      </example>
+      <para>
+        This table contains two failure routes for the <quote>gw.carrier1-1</quote> and
+        <quote>-2</quote> gateways. For any (failure) reply code the respective next
+        domain is chosen. After that no more failure routes are available, an error will
+        be returned from the <quote>cr_next_domain</quote> function. Not all table
+        columns are show here for brevity.
+      </para>
+      <para>
+        For each failure route domain and carrier that is added to the carrierfailureroute
+        table there must be at least one corresponding entry in the carrierroute table,
+        otherwise the module will not load the routing data.
+      </para>
+      <example>
+        <title>Example database content - more complex carrierfailureroute table</title>
+        <programlisting format="linespecific">
 ...
 +----+---------+-----------+------------+--------+-----+-------------+
 | id | domain  | host_name | reply_code | flags | mask | next_domain |
@@ -941,14 +936,14 @@ domain register {
 |  3 | default  |
 +----+----------+
 ...
-		</programlisting>
-		</example>
-		<para>
-			This table contains the mapping of the carrier id to actual names.
-		</para>
-		<example>
-		<title>Example database content - domain_name table</title>
-		<programlisting format="linespecific">
+        </programlisting>
+      </example>
+      <para>
+        This table contains the mapping of the carrier id to actual names.
+      </para>
+      <example>
+        <title>Example database content - domain_name table</title>
+        <programlisting format="linespecific">
 ...
 +----+----------+
 | id | domain   |
@@ -958,30 +953,28 @@ domain register {
 |  3 | domain3  |
 +----+----------+
 ...
-		</programlisting>
-		</example>
-		<para>
-			This table contains the mapping of the domain id to actual names.
-		</para>
-
-	</section>
-	<section>
-		<title>User specific routing</title>
-		<para>
-			For a functional routing the <quote>cr_preferred_carrier</quote> column must
-			be added to the subscriber table (or to the table and column that you specified
-			as module parameter) to choose the actual carrier for the users.
-		</para>
-	<example>
-		<title>Necessary extensions for the user table</title>
-		<para>Suggested changes:</para>
-		<programlisting format="linespecific">
+        </programlisting>
+      </example>
+      <para>
+        This table contains the mapping of the domain id to actual names.
+      </para>
+    </section>
+    <section>
+      <title>User specific routing</title>
+      <para>
+        For a functional routing the <quote>cr_preferred_carrier</quote> column must
+        be added to the subscriber table (or to the table and column that you specified
+        as module parameter) to choose the actual carrier for the users.
+      </para>
+      <example>
+        <title>Necessary extensions for the user table</title>
+        <para>Suggested changes:</para>
+        <programlisting format="linespecific">
 ...
 ALTER TABLE subscriber ADD cr_preferred_carrier int(10) default NULL; 
 ...
-		</programlisting>
-	</example>
-		</section>
+        </programlisting>
+      </example>
     </section>
+  </section>
 </chapter>
-


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Following carrierroute module functions are exported to KEMI API.

- cr_load_next_domain ( )
- cr_route ( )
- cr_nofallback_route ( )

Additionally various fix-up free functions added for better memory management. The documentation has been updated to correctly explain various parameters and use cases.

#### Example 1: Proxy Routing
```python3

    def route_proxy(self, msg):
        KSR.info("==================== route_proxy\n")
        rU = KSR.kx.get_ruser()

        if rU == None:
           return -255

        if KSR.carrierroute.cr_route("default", "proxy", rU, rU, "call_id") < 0:
            KSR.sl.sl_send_reply(400, "Bad Request")
            return -255

```

#### Example 2: Registrar Routing
```python3

    def route_registrar(self, msg):
        KSR.info("==================== route_registrar\n")
        rU = KSR.kx.get_ruser()

        if rU == None:
           rU = ""

        if KSR.carrierroute.cr_nofallback_route("default", "register", rU, rU, "from_user") < 0:
            KSR.sl.sl_send_reply(400, "Bad Request")
            return -255

```