### PR TITLE
websocket: ignoring keepalive for socket in the removing state

### DIFF
--- a/src/modules/websocket/ws_frame.c
+++ b/src/modules/websocket/ws_frame.c
@@ -810,7 +810,10 @@ void ws_keepalive(unsigned int ticks, void *param)
 				wsconn_close_now(wsc);
 			} else if (ws_keepalive_mechanism == KEEPALIVE_MECHANISM_CONCHECK) {
 				tcp_connection_t *con = tcpconn_get(wsc->id, 0, 0, 0, 0);
-				if(con==NULL) {
+				if(wsc->state == WS_S_REMOVING) {
+					LM_DBG("ws (id: %d wsc: %p) in removing state ignoring keepalive\n",
+							wsc->id, wsc);
+				} else if(con==NULL) {
 					LM_INFO("tcp connection has been lost (id: %d wsc: %p)\n",
 							wsc->id, wsc);
 					wsc->state = WS_S_CLOSING;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3278

#### Description
When websocket is closed, then possible race condition websocket removal and websocket keepalive functions.

[ws_frame.c:816](https://github.com/kamailio/kamailio/blob/ac4c2d4579f121395876de2cc6f7649f3cb2fba7/src/modules/websocket/ws_frame.c#L816) - setting socked state `WS_S_CLOSING`
[ws_conn.c:703](https://github.com/kamailio/kamailio/blob/master/src/modules/websocket/ws_conn.c#L703-L704) - setting socket state `WS_S_REMOVING` and updates `rmticks` value.
 