### PR TITLE
websocket: example must listen on ports 80 and 443

### DIFF
--- a/src/modules/websocket/doc/websocket_admin.xml
+++ b/src/modules/websocket/doc/websocket_admin.xml
@@ -44,6 +44,8 @@
 	<programlisting><![CDATA[
 ...
 tcp_accept_no_cl=yes
+listen=tcp:127.0.0.17:80
+listen=tls:127.0.0.17:443
 ...
 loadmodule "sl.so"
 loadmodule "xhttp.so"
@@ -135,6 +137,7 @@ event_route[xhttp:request] {
 ...
 loadmodule "sl.so"
 loadmodule "tm.so"
+loadmodule "xhttp.so"
 ...
 loadmodule "websocket.so"
 ...


### PR DESCRIPTION
otherwise the code below always matches:
```
   if ($Rp != 80 && $Rp != 443) {
```