### PR TITLE
nathelper: ping_nated_only=1 sends SIP-request-based pings

### DIFF
--- a/src/modules/nathelper/doc/nathelper_admin.xml
+++ b/src/modules/nathelper/doc/nathelper_admin.xml
@@ -27,12 +27,12 @@
 		header field with request's source address:port pair. The function
 		<function>fix_nated_sdp()</function> adds the active direction indication
 		to &sdp; (flag 0x01) and updates the source &ip; address too (flag 0x02). The function
-		<function>fix_nated_register()</function> exports exports the request's source
+		<function>fix_nated_register()</function> exports the request's source
 		address:port into an AVP to be used during <function>save()</function> and should
 		be used for <quote>REGISTER</quote> requests.
 	</para>
         <para>
-		Note: <function>fix_nated_contact</function> changes the <quote>Contact</quote>
+		Note: <function>fix_nated_contact()</function> changes the <quote>Contact</quote>
 		header, thus it breaks the RFC. Although usually this is not an issue, it may
 		cause problems with strict SIP clients.  An alternative is to use
 		<function>add_contact_alias()</function> that together with
@@ -62,7 +62,7 @@
 				<para><emphasis>Disadvantages:</emphasis> unidirectional 
 				traffic through NAT (inbound - from outside to inside); As 
 				many NATs do update the bind timeout only on outbound traffic,
-				the bind may expire and closed.
+				the bind may expire and get closed.
 				</para>
 				</listitem>
 			</itemizedlist>
@@ -174,7 +174,7 @@ modparam("nathelper", "natping_interval", 10)
 		<para>
 		If this parameter is set to 1 then only contacts that have
 		the behind NAT <quote>nat_bflag</quote> flag in user location
-		database set will get ping.
+		database set will get SIP-request-based ping.
 		</para>
 		<para>
 		If it is 0 and sipping_bflag is not set, then the 4-bytes UDP ping
@@ -650,7 +650,7 @@ if (search("User-Agent: Cisco ATA.*") {fix_nated_sdp("3");};
 		This function can be used from REQUEST_ROUTE.
 		</para>
 		<example>
-		<title><function>add_rcv_paramer</function> usage</title>
+		<title><function>add_rcv_param</function> usage</title>
 		<programlisting format="linespecific">
 ...
 add_rcv_param(); # add the parameter to the Contact header
@@ -1008,7 +1008,7 @@ $ &kamcmd; nathelper.enable_ping 1
 		<title>@nathelper.rewrite_contact[n]</title>
 		<para>
 			Get n-th Contact value with IP:Port rewritten to source ip:port. N is counted from 1.
-		    Only IP:port is rewritten, remaining part are left unchanged. Full nameaddr is supported.
+		    Only IP:port is rewritten, remaining parts are left unchanged. Full nameaddr is supported.
 		</para>
 		<example>
 			<title>@nathelper.rewrite_contact usage</title>

--- a/src/modules/nathelper/examples/4to6.cfg
+++ b/src/modules/nathelper/examples/4to6.cfg
@@ -38,7 +38,7 @@ modparam("nathelper", "natping_interval", 15)
 
 route {
 	# initial sanity checks -- messages with
-	# max_forwars == 0, or excessively long requests,
+	# max_forwards == 0, or excessively long requests,
 	# or those that don't addressed to us
 	if (!mf_process_maxfwd_header("10")) {
 		sl_send_reply("483", "Too Many Hops");

--- a/src/modules/nathelper/examples/alg.cfg
+++ b/src/modules/nathelper/examples/alg.cfg
@@ -35,7 +35,7 @@ modparam("nathelper", "natping_interval", 15)
 
 route {
 	# initial sanity checks -- messages with
-	# max_forwars == 0, or excessively long requests,
+	# max_forwards == 0, or excessively long requests,
 	# or those that don't addressed to us
 	if (!mf_process_maxfwd_header("10")) {
 		sl_send_reply("483", "Too Many Hops");

--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -2405,7 +2405,7 @@ done:
 
 /*
  * Create received SIP uri that will be either
- * passed to registrar in an AVP or apended
+ * passed to registrar in an AVP or appended
  * to Contact header field as a parameter
  */
 static int create_rcv_uri(str *uri, struct sip_msg *m)
@@ -2416,7 +2416,7 @@ static int create_rcv_uri(str *uri, struct sip_msg *m)
 
 /*
  * Add received parameter to Contacts for further
- * forwarding of the REGISTER requuest
+ * forwarding of the REGISTER request
  */
 static int ki_add_rcv_param(sip_msg_t *msg, int upos)
 {
@@ -2485,7 +2485,7 @@ static int ki_add_rcv_param(sip_msg_t *msg, int upos)
 
 /*
  * Add received parameter to Contacts for further
- * forwarding of the REGISTER requuest
+ * forwarding of the REGISTER request
  */
 static int add_rcv_param_f(struct sip_msg *msg, char *str1, char *str2)
 {

--- a/src/modules/nathelper/nhelpr_funcs.c
+++ b/src/modules/nathelper/nhelpr_funcs.c
@@ -176,8 +176,8 @@ int extract_body(struct sip_msg *msg, str *body)
 
 	/*
 	 * Better use the content-len value - no need of any explicit
-	 * parcing as get_body() parsed all headers and Conten-Length
-	 * body header is automaticaly parsed when found.
+	 * parsing as get_body() parsed all headers and Content-Length
+	 * body header is automatically parsed when found.
 	 */
 	if(msg->content_length == 0) {
 		LM_ERR("failed to get the content length in message\n");


### PR DESCRIPTION
My experiments show that with
```
modparam("nathelper", "ping_nated_only", 1)
modparam("nathelper", "sipping_bflag", FLB_NATSIPPING)
modparam("usrloc", "nat_bflag", FLB_NATB)
```
when both FLB_NATB and FLB_NATSIPPING branch flags are set, no OPTIONS from Kamailio to UAC is generated, so I assume that nathelper.ping_nated_only=1 does force 4-bytes UDP keepalive.

This change spells the above, as the behaviour currently is not specified. 