### PR TITLE
core: msg_translator.c put new line after «parsing failed» error message

### DIFF
--- a/src/core/msg_translator.c
+++ b/src/core/msg_translator.c
@@ -53,7 +53,7 @@
  *    lookup is performed on the host part and the reply is sent to the
  *    resulting ip. If a port is present or the host part is an ip address
  *    the dns lookup will be a "normal" one (A or AAAA).
- *  - if rport is present, it's value will be used as the destination port
+ *  - if rport is present, its value will be used as the destination port
  *   (and this will also disable srv lookups)
  *  - if no port is present the destination port will be taken from the srv
  *    lookup. If the srv lookup fails or is not performed (e.g. ip address
@@ -1459,7 +1459,7 @@ skip_nop_before:
                     /* skip len bytes from orig msg */
                     s_offset+=t->len;
                 } else if (t->op==LUMP_DEL && flag == FLAG_MSG_LUMPS_ONLY) {
-                    /* copy lump value and indent as necessarely */
+                    /* copy lump value and indent as necessarily */
                     memcpy(new_buf+offset, orig + t->u.offset, t->len);
                     offset+=t->len;
                     if (new_buf[offset-1] != '\n') {
@@ -1592,7 +1592,7 @@ static inline int adjust_clen(struct sip_msg* msg, int body_delta, int proto)
 		/* The body has been changed, try to find
 		 * existing Content-Length
 		 */
-		/* no need for Content-Length if it's and UDP packet and
+		/* no need for Content-Length if it's an UDP packet and
 		 * it hasn't Content-Length already */
 		if (msg->content_length==0){
 		    /* content-length doesn't exist, append it */
@@ -1938,7 +1938,7 @@ clean:
 /** builds a request in memory from another sip request.
   *
   * Side-effects: - it adds lumps to the msg which are _not_ cleaned.
-  * The added lumps are HDR_VIA_T (almost always added), HDR_CONTENLENGTH_T
+  * The added lumps are HDR_VIA_T (almost always added), HDR_CONTENTLENGTH_T
   * and HDR_ROUTE_T (when a Route: header is added as a result of a non-null
   * msg->path_vec).
   *               - it might change send_info->proto and send_info->send_socket
@@ -2109,7 +2109,7 @@ after_local_via:
 		}
 		received_buf = NULL;
 	}
-	/* if rport needs to be updated, delete it if present and add it's value */
+	/* if rport needs to be updated, delete it if present and add its value */
 	if (rport_buf){
 		if (msg->via1->rport){ /* rport already present */
 			via_insert_param=del_lump(msg,
@@ -3075,7 +3075,7 @@ char* create_via_hf(unsigned int *len,
 
 /* builds a char* buffer from message headers without body
  * first line is excluded in case of skip_first_line=1
- * error is set -1 if the memory allocation failes
+ * error is set -1 if the memory allocation fails
  */
 char * build_only_headers( struct sip_msg* msg, int skip_first_line,
 				unsigned int *returned_len,
@@ -3127,7 +3127,7 @@ char * build_only_headers( struct sip_msg* msg, int skip_first_line,
 }
 
 /* builds a char* buffer from message body
- * error is set -1 if the memory allocation failes
+ * error is set -1 if the memory allocation fails
  */
 char * build_body( struct sip_msg* msg,
 			unsigned int *returned_len,
@@ -3253,7 +3253,7 @@ int build_sip_msg_from_buf(struct sip_msg *msg, char *buf, int len,
 	msg->buf = buf;
 	msg->len = len;
 	if (parse_msg(buf, len, msg)!=0) {
-		LM_ERR("parsing failed");
+		LM_ERR("parsing failed\n");
 		return -1;
 	}
 	msg->set_global_address=default_global_address;


### PR DESCRIPTION
I use Kamailio with `log_stderror=yes`.  When Kamailio receives confirmation from the Websocket reverse proxy, it logs on stderr
```
23(24) ERROR: <core> [core/parser/parse_fline.c:271]: parse_first_line(): parse_first_line: bad message (offset: 22)
23(24) ERROR: <core> [core/parser/msg_parser.c:749]: parse_msg(): ERROR: parse_msg: message=<HTTP/1.1 101 Switching Protocols
Sia: SIP/2.0/TCP 111.11.111.11:47418
Sec-WebSocket-Protocol: sip
Upgrade: websocket
Connection: upgrade
Sec-WebSocket-Accept: Ak3/c/aw3iyHnFkDDHabw1iXcqY=
Content-Length: 0

>
23(24) ERROR: <core> [core/msg_translator.c:3256]: build_sip_msg_from_buf(): parsing failed
```
Without the included `\n` here the subsequent messages are logged on the same line as `parsing failed`.

For the record, I use this NGINX configuration:
```
location /sip {
    proxy_http_version 1.1;
    proxy_set_header "Accept-Encoding" "";  # delete header before sending it to Kamailio
    proxy_set_header "Pragma" "";
    proxy_set_header "Cache-control" "";
    proxy_set_header "User-Agent" "";
    proxy_set_header Host $host;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection $http_connection;
    proxy_pass http://123.12.123.12:5060;
    proxy_read_timeout 86400;
}
```
and it leads to that unparsable message above.