### PR TITLE
websocket: typos

### DIFF
--- a/src/modules/websocket/doc/websocket_admin.xml
+++ b/src/modules/websocket/doc/websocket_admin.xml
@@ -488,7 +488,7 @@ end
 		</para>
 		<para><emphasis>Default value is 1.</emphasis></para>
 		<example>
-		<title>Set <varname>timer_interval</varname>parameter</title>
+		<title>Set <varname>timer_interval</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
 modparam("websocket", "timer_interval", 5)

--- a/src/modules/websocket/utf8_decode.h
+++ b/src/modules/websocket/utf8_decode.h
@@ -47,7 +47,7 @@ static const uint8_t utf8d[] = {
 	10,3,3,3,3,3,3,3,3,3,3,3,3,4,3,3, 11,6,6,6,5,8,8,8,8,8,8,8,8,8,8,8,
 
 	// The second part is a transition table that maps a combination
-	// of a state of the automaton and a character class to a state.
+	// of a state of the automation and a character class to a state.
 	0, 12,24,36,60,96,84,12,12,12,48,72, 12,12,12,12,12,12,12,12,12,12,12,12,
 	12, 0,12,12,12,12,12, 0,12, 0,12,12, 12,24,12,12,12,12,12,24,12,24,12,12,
 	12,12,12,12,12,12,12,24,12,12,12,12, 12,24,12,12,12,12,12,12,12,24,12,12,


### PR DESCRIPTION
I run Kamailio with
```
log_stderror=yes
/* LOG Levels: 3=DBG, 2=INFO, 1=NOTICE, 0=WARN, -1=ERR, ... */
debug=-1
```
and inspect the output.  Some messages from the websocket module are logged repeatedly at ERROR-level, but they are in no way errors.  This changes moves such periodially logged no-error messages to debug-level INFO.