### PR TITLE
rr: doc — replace enable_username with add_username

### DIFF
--- a/src/modules/rr/doc/rr_admin.xml
+++ b/src/modules/rr/doc/rr_admin.xml
@@ -12,7 +12,7 @@
   <section>
     <title>Overview</title>
 
-    <para>The module contains record routing logic</para>
+    <para>The module contains record routing logic.</para>
   </section>
 
   <section id="RR-dialog-id">
@@ -20,7 +20,7 @@
 
     <para>&kamailio; is basically <emphasis>only</emphasis> a transaction
     stateful proxy, without any dialog support build in. There are many
-    features/services which actually requires a dialog awareness, like storing
+    features/services which actually require a dialog awareness, like storing
     the information in the dialog creation stage, information which will be
     used during the whole dialog existence.</para>
 
@@ -246,7 +246,7 @@ modparam("rr", "enable_socket_mismatch_warning", 0)
     <section id="rr.p.custom_user_avp">
       <title><varname>custom_user_avp</varname> (avp string)</title>
 
-      <para>When enable_username is enabled, a call to record_route will add
+      <para>When add_username is enabled, a call to record_route will add
       the username of the RequestURI to the Record-Route URI. This parameter
       allows you to setup an AVP with which you can customise the username to
       be added in the Record-Route URI.</para>
@@ -664,7 +664,7 @@ add_rr_param(";nat=yes");
 
       <para>The function checks if the URI parameters of the local Route
       header (corresponding to the local server) matches the given regular
-      expression. It must be call after loose_route() (see <xref
+      expression. It must be called after loose_route() (see <xref
       linkend="rr.f.loose_route"/>).</para>
 
       <para>Meaning of the parameters is as follows:</para>

--- a/src/modules/rr/doc/rr_devel.xml
+++ b/src/modules/rr/doc/rr_devel.xml
@@ -128,7 +128,7 @@ record_route_advertised_address("1.2.3.4:5090");
 		The function checks for the request <quote>msg</quote> if the URI 
 		parameters of the local Route header (corresponding to the local 
 		server) matches the given regular expression <quote>re</quote>. 
-		It must be call after the loose_route was done.
+		It must be called after the loose_route was done.
 		</para>
 		<para>
 		The function returns 0 on success. Otherwise, -1 is returned.
@@ -157,7 +157,7 @@ record_route_advertised_address("1.2.3.4:5090");
 		<quote>msg</quote>. As for checking it's used the <quote>ftag</quote> 
 		Route header parameter, the append_fromtag (see 
 		<xref linkend="append-fromtag-id"/> module parameter 
-		must be enables. Also this must be call only after the loose_route is 
+		must be enables. Also this must be called only after the loose_route is 
 		done.
 		</para>
 		<para>
@@ -185,9 +185,9 @@ record_route_advertised_address("1.2.3.4:5090");
 		<function moreinfo="none">get_route_param(msg, name, val)</function>
 		</title>
 		<para>
-		The function search in to the <quote>msg</quote>'s Route header 
+		The function searches in the <quote>msg</quote>'s Route header 
 		parameters the parameter called <quote>name</quote> and returns its
-		value into <quote>val</quote>. It must be call only after the 
+		value into <quote>val</quote>. It must be called only after the 
 		loose_route is done.
 		</para>
 		<para>
@@ -220,7 +220,7 @@ record_route_advertised_address("1.2.3.4:5090");
 		<function moreinfo="none">register_rrcb(callback, param)</function>
 		</title>
 		<para>
-		The function register a new callback (along with its parameter). The
+		The function registers a new callback (along with its parameter). The
 		callback will be called when a loose route will be performed for the
 		local address.
 		</para>

--- a/src/modules/rr/loose.c
+++ b/src/modules/rr/loose.c
@@ -595,7 +595,7 @@ static inline int after_strict(struct sip_msg* _m)
 	}
 
 	if ( enable_double_rr && is_2rr(&puri.params) && is_myself(&puri)) {
-		/* double route may occure due different IP and port, so force as
+		/* double route may occur due different IP and port, so force as
 		 * send interface the one advertise in second Route */
 		si = grep_sock_info( &puri.host, puri.port_no, puri.proto);
 		if (si) {
@@ -891,7 +891,7 @@ static inline int after_loose(struct sip_msg* _m, int preloaded)
 		} else rt = rt->next;
 
 		if (enable_double_rr && is_2rr(&puri.params)) {
-			/* double route may occure due different IP and port, so force as
+			/* double route may occur due different IP and port, so force as
 			 * send interface the one advertise in second Route */
 			if (parse_uri(rt->nameaddr.uri.s,rt->nameaddr.uri.len,&puri)<0) {
 				LM_ERR("failed to parse the double route URI (%.*s)\n",
@@ -1118,7 +1118,7 @@ int redo_route_params(sip_msg_t *msg)
  *
  * The function checks for the request "msg" if the URI parameters
  * of the local Route header (corresponding to the local server)
- * matches the given regular expression "re". It must be call
+ * matches the given regular expression "re". It must be called
  * after the loose_route was done.
  *
  * \param msg SIP message request that will has the Route header parameters checked
@@ -1170,7 +1170,7 @@ int check_route_param(sip_msg_t * msg, regex_t* re)
  *
  * The function search in to the "msg"'s Route header parameters
  * the parameter called "name" and returns its value into "val".
- * It must be call only after the loose_route is done.
+ * It must be called only after the loose_route is done.
  *
  * \param msg - request that will have the Route header parameter searched
  * \param name - contains the Route header parameter to be serached
@@ -1265,7 +1265,7 @@ found:
  * The function checks the flow direction of the request "msg". As
  * for checking it's used the "ftag" Route header parameter, the
  * append_fromtag module parameter must be enables.
- * Also this must be call only after the loose_route is done.
+ * Also this must be called only after the loose_route is done.
 
  * \param msg SIP message request that will have the direction checked
  * \param dir direction to be checked against. It may be RR_FLOW_UPSTREAM or RR_FLOW_DOWNSTREAM

--- a/src/modules/rr/loose.h
+++ b/src/modules/rr/loose.h
@@ -66,7 +66,7 @@ int loose_route(struct sip_msg* _m);
  *
  * The function checks for the request "msg" if the URI parameters
  * of the local Route header (corresponding to the local server)
- * matches the given regular expression "re". It must be call
+ * matches the given regular expression "re". It must be called
  * after the loose_route was done.
  *
  * \param msg SIP message request that will has the Route header parameters checked
@@ -82,7 +82,7 @@ int check_route_param(struct sip_msg *msg, regex_t* re);
  * The function checks the flow direction of the request "msg". As
  * for checking it's used the "ftag" Route header parameter, the
  * append_fromtag module parameter must be enables.
- * Also this must be call only after the loose_route is done.
+ * Also this must be called only after the loose_route is done.
 
  * \param msg SIP message request that will have the direction checked
  * \param dir direction to be checked against. It may be RR_FLOW_UPSTREAM or RR_FLOW_DOWNSTREAM
@@ -96,7 +96,7 @@ int is_direction(struct sip_msg *msg, int dir);
  *
  * The function search in to the "msg"'s Route header parameters
  * the parameter called "name" and returns its value into "val".
- * It must be call only after the loose_route is done.
+ * It must be called only after the loose_route is done.
  *
  * \param msg - request that will have the Route header parameter searched
  * \param name - contains the Route header parameter to be serached

--- a/src/modules/rr/rr_mod.c
+++ b/src/modules/rr/rr_mod.c
@@ -622,7 +622,7 @@ static void free_rr_lump(struct lump **list)
 			/* if (lump->flags & (LUMPFLAG_DUPED|LUMPFLAG_SHMEM)){
 				LOG(L_CRIT, "BUG: free_rr_lmp: lump %p, flags %x\n",
 						lump, lump->flags);
-			*/	/* ty to continue */
+			*/	/* try to continue */
 			/*}*/
 			a=lump->before;
 			while(a) {


### PR DESCRIPTION
The documentation of rr.custom_user_avp speaks about option `enable_username`, but there is no such option.

I assume the documentation means `add_username`.