### PR TITLE
core: typos

### DIFF
--- a/src/core/action.c
+++ b/src/core/action.c
@@ -257,7 +257,7 @@ char *get_cfg_crt_route_name(void)
  * @param msg
  * @param src - source action_u_t array (e.g. action->val)
  * @param dst - temporary action_u_t array used for conversions. It can be
- *              used for the function parameters. It's contents it's not
+ *              used for the function parameters. Its contents is not
  *              valid after the call.
  * @param params... - variable list of parameters, passed to the module
  *               function
@@ -1371,7 +1371,7 @@ match_cleanup:
 					i++;
 
 				if (unlikely(i > cfg_get(core, core_cfg, max_while_loops))){
-					LM_ERR("runaway while (%d, %d): more then %d loops\n",
+					LM_ERR("runaway while (%d, %d): more than %d loops\n",
 								rve->fpos.s_line, rve->fpos.s_col,
 								cfg_get(core, core_cfg, max_while_loops));
 					ret=-1;

--- a/src/core/atomic/atomic_alpha.h
+++ b/src/core/atomic/atomic_alpha.h
@@ -84,7 +84,7 @@
 
 
 /* main asm block 
- * if store failes, jump _forward_ (optimization, because back jumps are
+ * if store fails, jump _forward_ (optimization, because back jumps are
  *  always predicted to happen on alpha )*/
 #define ATOMIC_ASM_OP00_int(op) \
 			"1:   ldl_l %0, %2 \n\t" \

--- a/src/core/atomic/atomic_ppc.h
+++ b/src/core/atomic/atomic_ppc.h
@@ -71,7 +71,7 @@
 #define membar_write() asm volatile ("eieio \n\t" : : : "memory") 
 #define membar_depends()  do {} while(0) /* really empty, not even a cc bar. */
 #define membar_enter_lock() asm volatile("lwsync \n\t" : : : "memory")
-/* for unlock lwsync will work too and is faster then sync
+/* for unlock lwsync will work too and is faster than sync
  *  [IBM Prgramming Environments Manual, D.4.2.2] */
 #define membar_leave_lock() asm volatile("lwsync \n\t" : : : "memory")
 /* membars after or before atomic_ops or atomic_setget -> use these or

--- a/src/core/atomic/atomic_sparc64.h
+++ b/src/core/atomic/atomic_sparc64.h
@@ -57,7 +57,7 @@
  *  functions that use atomic ops (and both of them use at least a store to
  *  the lock). membar_enter_lock() is at most a StoreStore|StoreLoad barrier
  *   and membar_leave_lock() is at most a LoadStore|StoreStore barries
- *  (if the atomic ops on the specific arhitecture imply these barriers
+ *  (if the atomic ops on the specific architecture imply these barriers
  *   => these macros will be empty)
  *   Warning: these barriers don't force LoadLoad ordering between code
  *    before the lock/membar_enter_lock() and code 
@@ -192,7 +192,7 @@ ATOMIC_FUNC_DECL1(and,     "and  %0, %4, %1", int, void, /* no return */ )
 ATOMIC_FUNC_DECL1(or,      "or   %0, %4, %1", int, void, /* no return */ )
 ATOMIC_FUNC_DECL(inc_and_test, "add   %0, 1, %1", int, int, ((ret+1)==0) )
 ATOMIC_FUNC_DECL(dec_and_test, "sub   %0, 1, %1", int, int, ((ret-1)==0) )
-/* deprecated but probably better then CAS for futexes */
+/* deprecated but probably better than CAS for futexes */
 ATOMIC_FUNC_DECL1_RAW(get_and_set, "swap [%2], %0", int, int, ret)
 /*ATOMIC_FUNC_DECL1(get_and_set, "mov %4, %1" , int, int,  ret)*/
 ATOMIC_FUNC_DECL1(add,     "add  %0, %4, %1", int, int,  ret+v)

--- a/src/core/atomic/atomic_unknown.h
+++ b/src/core/atomic/atomic_unknown.h
@@ -46,7 +46,7 @@
 #else /* SMP */
 
 #warning no native memory barrier implementations, falling back to slow lock \
-	       based workarround
+	       based workaround
 
 #define MEMBAR_USES_LOCK
 
@@ -238,7 +238,7 @@ ATOMIC_FUNC_DECL1_RET(add, *var+=v;ret=*var, long, long, ret )
  */
 
 /* mb_atomic_{set,get} use membar() : if we're lucky we have membars
- * for the arch. (e.g. sparc32) => membar() might be cheaper then lock/unlock */
+ * for the arch. (e.g. sparc32) => membar() might be cheaper than lock/unlock */
 #define mb_atomic_set_int(v, i) \
 	do{ \
 		membar(); \

--- a/src/core/atomic_ops.h
+++ b/src/core/atomic_ops.h
@@ -47,7 +47,7 @@
  *                             operation on the lock var.). It is at most
  *                             a StoreStore|StoreLoad barrier, but could also
  *                             be empty if an atomic op implies a memory 
- *                             barrier on the specific arhitecture.
+ *                             barrier on the specific architecture.
  *                             Example usage: 
  *                               raw_lock(l); membar_enter_lock(); ...
  *  void membar_leave_lock() - memory barrier function that should be called 

--- a/src/core/atomic_ops_init.h
+++ b/src/core/atomic_ops_init.h
@@ -27,7 +27,7 @@
  * \ingroup core
  * Module: \ref core
  *
- * Needed for lock intializing if no native asm locks are available
+ * Needed for lock initializing if no native asm locks are available
  *  for the current arch./compiler combination, see \ref atomic_ops.c
  */
 

--- a/src/core/basex.c
+++ b/src/core/basex.c
@@ -221,7 +221,7 @@ int init_basex()
 #elif defined __IS_BIG_ENDIAN /* __IS_LITTLE_ENDIAN */
 		_bx_b64_12[r]=(b64_enc_char(r>>6)<<8)|b64_enc_char(r&0x3f);
 #else /* __IS_LITTLE_ENDIAN */
-#error Neither __IS_LITTE_ENDIAN nor __IS_BIG_ENDIAN  defined
+#error Neither __IS_LITTLE_ENDIAN nor __IS_BIG_ENDIAN  defined
 #endif
 	/* decode */
 	for (r=0; r<256; r++)

--- a/src/core/basex.h
+++ b/src/core/basex.h
@@ -664,7 +664,7 @@ inline static int base64_dec(unsigned char* src, int slen,
 	unsigned char* end;
 	int osize;
 	register unsigned a, b, c, d; /* more registers used, but allows for
-									 paralles execution */
+									 parallel execution */
 	
 	if (unlikely((slen<4) || (slen%4) || 
 				(src[slen-2]=='=' && src[slen-1]!='=')))
@@ -784,7 +784,7 @@ inline static int q_base64_dec(unsigned char* src, int slen,
 	register unsigned u;
 #else
 	register unsigned a, b, c, d; /* more registers used, but allows for
-									 paralles execution */
+									 parallel execution */
 #endif
 	
 	if (unlikely((slen<4) || (slen%4) || 

--- a/src/core/bit_count.h
+++ b/src/core/bit_count.h
@@ -82,7 +82,7 @@ static inline int bit_count(unsigned int i)
 
 #if 0
 /* number of bits in a byte.
- * (Only slightly faster then the above version,
+ * (Only slightly faster than the above version,
  * It is not worth the extra memory usage.)
  */
 extern int	bits_in_char[256];

--- a/src/core/bit_scan.h
+++ b/src/core/bit_scan.h
@@ -95,7 +95,7 @@
 #elif defined __CPU_sparc64
 /* no asm yet => use branch for everything in 64 bit mode
  *               and debruijn + branch in 32 bit mode
- *  (in 64bit mode the branch method is slightly faster then debruijn,
+ *  (in 64bit mode the branch method is slightly faster than debruijn,
  *   however note that in 32 bit mode the roles are reversed for _forward)*/
 #ifndef BIT_SCAN_BRANCH
 #define BIT_SCAN_BRANCH

--- a/src/core/ccopts.sh
+++ b/src/core/ccopts.sh
@@ -95,9 +95,9 @@ icc)
 			CFLAGS="$CFLAGS -tpp6 -xK"
 			#-openmp  #optimize for PIII 
 			# -prefetch doesn't seem to work
-			#( ty to inline acroos files, unroll loops,prefetch,
+			#( try to inline acroos files, unroll loops,prefetch,
 			# optimize for PIII, use PIII instructions & vect.,
-			# mutlithread loops)
+			# multithread loops)
 		;;
 		*)
 			echo "$WARN_ARCH" 1>&2

--- a/src/core/cfg.y
+++ b/src/core/cfg.y
@@ -130,7 +130,7 @@
 
 
 extern int yylex();
-/* safer then using yytext which can be array or pointer */
+/* safer than using yytext which can be array or pointer */
 extern char* yy_number_str;
 
 static void yyerror(char* s, ...);
@@ -3264,7 +3264,7 @@ rval_expr: rval						{ $$=$1;
 				rve_tmp=mk_rve2(RVE_SELVALOPT_OP, $5, $7);
 				if(rve_tmp == NULL) {
 					$$=0;
-					yyerror("faild to create tenary target expression");
+					yyerror("failed to create tenary target expression");
 				}
 				$$=mk_rve2(RVE_SELVALEXP_OP, $3, rve_tmp);
 		}
@@ -4308,7 +4308,7 @@ static int mod_f_params_pre_fixup(struct action* a)
 			cmd_exp->fixup_flags  |= FIXUP_F_FPARAM_RVE;
 		else if (!(cmd_exp->fixup_flags & FIXUP_F_FPARAM_RVE) &&
 				 cmd_exp->free_fixup == 0) {
-			/* v0 or v1 functions that have fixups and no coresp. fixup_free
+			/* v0 or v1 functions that have fixups and no corresp. fixup_free
 			   functions, need constant, string params.*/
 			for (r=0; r < param_no; r++) {
 				rve=params[r].u.data;

--- a/src/core/cfg/cfg.c
+++ b/src/core/cfg/cfg.c
@@ -225,7 +225,7 @@ int cfg_declare_str(char *group_name, char *var_name, char *val, char *descr)
 	return 0;
 }
 
-/* Add a varibale to a group instance with integer type.
+/* Add a variable to a group instance with integer type.
  * The group instance is created if it does not exist.
  * wrapper function for new_add_var()
  */
@@ -243,7 +243,7 @@ int cfg_ginst_var_int(char *group_name, unsigned int group_id, char *var_name,
 			(void *)(long)val, CFG_VAR_INT);
 }
 
-/* Add a varibale to a group instance with string type.
+/* Add a variable to a group instance with string type.
  * The group instance is created if it does not exist.
  * wrapper function for new_add_var()
  */

--- a/src/core/cfg/cfg_ctx.c
+++ b/src/core/cfg/cfg_ctx.c
@@ -254,7 +254,7 @@ static int cfg_var_size(cfg_mapping_t *var)
 	}
 }
 
-/* Update the varibales of the array within the meta structure
+/* Update the variables of the array within the meta structure
  * with the new default value.
  * The array is cloned before a change if clone is set to 1.
  */
@@ -364,7 +364,7 @@ int cfg_set_now(cfg_ctx_t *ctx, str *group_name, unsigned int *group_id, str *va
 	if (group_id
 			&& var->def->on_set_child_cb
 			&& var->def->type & CFG_CB_ONLY_ONCE ) {
-		LM_ERR("This variable does not support muliple values.\n");
+		LM_ERR("This variable does not support multiple values.\n");
 		goto error0;
 	}
 
@@ -388,7 +388,7 @@ int cfg_set_now(cfg_ctx_t *ctx, str *group_name, unsigned int *group_id, str *va
 			&& var->def->on_change_cb) {
 		/* Call the fixup function.
 		 * There is no need to set a temporary cfg handle,
-		 * becaue a single variable is changed */
+		 * because a single variable is changed */
 		if (!group_id) {
 			var_block = *(group->handle);
 		} else {
@@ -734,7 +734,7 @@ int cfg_set_delayed(cfg_ctx_t *ctx, str *group_name, unsigned int *group_id,
 	if (group_id
 			&& var->def->on_set_child_cb
 			&& var->def->type & CFG_CB_ONLY_ONCE) {
-		LM_ERR("This variable does not support muliple values.\n");
+		LM_ERR("This variable does not support multiple values.\n");
 		goto error0;
 	}
 
@@ -1798,7 +1798,7 @@ error:
 	return -1;
 }
 
-/* Check the existance of a group instance.
+/* Check the existence of a group instance.
  * return value:
  *	1: exists
  *	0: does not exist
@@ -1896,7 +1896,7 @@ int cfg_apply_list(cfg_group_inst_t *ginst, cfg_group_t *group,
 		if (var->def->on_set_child_cb
 				&& var->def->type & CFG_CB_ONLY_ONCE
 				) {
-			LM_ERR("This variable does not support muliple values.\n");
+			LM_ERR("This variable does not support multiple values.\n");
 			goto error;
 		}
 

--- a/src/core/cfg/cfg_ctx.h
+++ b/src/core/cfg/cfg_ctx.h
@@ -205,7 +205,7 @@ int cfg_add_group_inst(cfg_ctx_t *ctx, str *group_name, unsigned int group_id);
 /* Delete an instance of a group */
 int cfg_del_group_inst(cfg_ctx_t *ctx, str *group_name, unsigned int group_id);
 
-/* Check the existance of a group instance.
+/* Check the existence of a group instance.
  * return value:
  *	1: exists
  *	0: does not exist

--- a/src/core/cfg/cfg_struct.c
+++ b/src/core/cfg/cfg_struct.c
@@ -747,7 +747,7 @@ cfg_group_inst_t *cfg_find_group(cfg_group_meta_t *meta, int group_size, unsigne
 	if (!meta)
 		return NULL;
 
-	/* For now, search lineray. TODO: improve */
+	/* For now, search lineary. TODO: improve */
 	for (i = 0; i < meta->num; i++) {
 		ginst = (cfg_group_inst_t *)((char *)meta->array
 				+ (sizeof(cfg_group_inst_t) + group_size - 1) * i);
@@ -1141,7 +1141,7 @@ void cfg_move_handle(cfg_group_t *group, cfg_group_inst_t *src_ginst, cfg_group_
 			}
 		}
 	}
-	/* keep track of how many group instences are set in the child process */
+	/* keep track of how many group instances are set in the child process */
 	if (!src_ginst && dst_ginst)
 		cfg_ginst_count++;
 	else if (!dst_ginst)

--- a/src/core/cfg/cfg_struct.h
+++ b/src/core/cfg/cfg_struct.h
@@ -130,7 +130,7 @@ typedef struct _cfg_group_meta {
 	cfg_group_inst_t	*array;	/*!< Array of cfg groups with num number of items */
 } cfg_group_meta_t;
 
-/*! \brief single memoy block that contains all the cfg values */
+/*! \brief single memory block that contains all the cfg values */
 #pragma pack(push, 1)
 typedef struct _cfg_block {
 	atomic_t	refcnt;		/*!< reference counter,

--- a/src/core/counters.c
+++ b/src/core/counters.c
@@ -33,7 +33,7 @@
 #define GRP_HASH_SIZE	16
 /* initial sorted groups array size (rpc use) */
 #define GRP_SORTED_SIZE	16
-/* intial counter id 2 record array size */
+/* initial counter id 2 record array size */
 #define CNT_ID2RECORD_SIZE	64
 
 #define CACHELINE_PAD 128
@@ -69,7 +69,7 @@ struct grp_record {
 
 /** hash table mapping a counter name to an id */
 static struct str_hash_table cnts_hash_table;
-/** array maping id 2 record */
+/** array mapping id 2 record */
 struct counter_record** cnt_id2record;
 static int cnt_id2record_size;
 /** hash table for groups (maps a group name to a counter list) */
@@ -186,7 +186,7 @@ void destroy_counters()
 
 
 
-/** complete counter intialization, when the number of processes is known.
+/** complete counter initialization, when the number of processes is known.
  * shm must be available.
  * @return 0 on success, < 0 on error
  */

--- a/src/core/daemonize.c
+++ b/src/core/daemonize.c
@@ -31,8 +31,8 @@
 #define _XOPEN_SOURCE_EXTENDED /*!< same as \ref _XOPEN_SOURCE */
 #define __USE_XOPEN_EXTENDED /*!< same as \ref _XOPEN_SOURCE, overrides features.h */
 #define __EXTENSIONS__ /*!< needed on solaris: if XOPEN_SOURCE is defined
-                          struct timeval defintion from <sys/time.h> won't
-                          be included => workarround define _EXTENSIONS_
+                          struct timeval definition from <sys/time.h> won't
+                          be included => workaround define _EXTENSIONS_
                            -andrei */
 #include <signal.h>
 #include <syslog.h>

--- a/src/core/dns_cache.c
+++ b/src/core/dns_cache.c
@@ -68,7 +68,7 @@
 
 #define DNS_HASH_SIZE	1024 /* must be <= 65535 */
 #define DEFAULT_DNS_TIMER_INTERVAL 120  /* 2 min. */
-#define DNS_HE_MAX_ADDR 10  /* maxium addresses returne in a hostent struct */
+#define DNS_HE_MAX_ADDR 10  /* maximum addresses returned in a hostent struct */
 #define MAX_CNAME_CHAIN  10
 #define SPACE_FORMAT "    " /* format of view output */
 #define DNS_SRV_ZERO_W_CHANCE	1000 /* one in a 1000*weight_sum chance for
@@ -159,7 +159,7 @@ inline static void dns_destroy_entry(struct dns_hash_entry* e)
 }
 
 
-/* "internal" only, same as above, asumes shm_lock() held (tm optimization) */
+/* "internal" only, same as above, assumes shm_lock() held (tm optimization) */
 inline static void dns_destroy_entry_shm_unsafe(struct dns_hash_entry* e)
 {
 	memset(e, 0, e->total_size);
@@ -479,7 +479,7 @@ int init_dns_cache_stats(int iproc_num)
 
 
 /* must be called with the DNS_LOCK hold
- * remove and entry from the hash, dec. its refcnt and if not referenced
+ * removes an entry from the hash, dec. its refcnt and if not referenced
  * anymore deletes it */
 inline static void _dns_hash_remove(struct dns_hash_entry* e)
 {
@@ -796,7 +796,7 @@ inline static struct dns_hash_entry* dns_cache_mk_ip_entry(str* name,
 	ticks_t now;
 
 	/* everything is allocated in one block: dns_hash_entry + name +
-	 * + dns_rr + rdata;  dns_rr must start at an aligned adress,
+	 * + dns_rr + rdata;  dns_rr must start at an aligned address,
 	 * hence we need to round dns_hash_entry+name size to a sizeof(long)
 	 * multiple.
 	 * Memory image:
@@ -844,7 +844,7 @@ static struct dns_hash_entry* dns_cache_mk_srv_entry(str* name,
 	ticks_t now;
 
 	/* everything is allocated in one block: dns_hash_entry + name +
-	 * + dns_rr + rdata;  dns_rr must start at an aligned adress,
+	 * + dns_rr + rdata;  dns_rr must start at an aligned address,
 	 * hence we need to round dns_hash_entry+name size to a sizeof(long),
 	 * and similarly, dns_rr must be rounded to sizeof(short).
 	 * multiple.
@@ -917,7 +917,7 @@ inline static struct dns_hash_entry* dns_cache_mk_rd_entry(str* name, int type,
 
 
 	/* everything is allocated in one block: dns_hash_entry + name +
-	 * + dns_rr + rdata_raw+ ....;  dns_rr must start at an aligned adress,
+	 * + dns_rr + rdata_raw+ ....;  dns_rr must start at an aligned address,
 	 * hence we need to round dns_hash_entry+name size to a sizeof(long)
 	 * multiple. If rdata type requires it, rdata_raw might need to be also
 	 * aligned.
@@ -927,10 +927,10 @@ inline static struct dns_hash_entry* dns_cache_mk_rd_entry(str* name, int type,
 	 * padding to multiple of sizeof(char*)
 	 * dns_rr1 (e->rr_lst)
 	 * possible padding: no padding for a_rdata or aaaa_rdata,
-	 *                   multipe of sizeof(short) for srv_rdata,
+	 *                   multiple of sizeof(short) for srv_rdata,
 	 *                   multiple of sizeof(long) for naptr_rdata and others
 	 * dns_rr1->rdata  (e->rr_lst->rdata)
-	 * padding to multipe of sizeof long
+	 * padding to multiple of sizeof long
 	 * dns_rr2 (e->rr_lst->next)
 	 * ....
 	 *
@@ -1327,7 +1327,7 @@ inline static struct dns_hash_entry* dns_cache_mk_rd_entry2(struct rdata* rd)
 	no_records=0;
 	rec[0].e=0;
 	/* everything is allocated in one block: dns_hash_entry + name +
-	 * + dns_rr + rdata_raw+ ....;  dns_rr must start at an aligned adress,
+	 * + dns_rr + rdata_raw+ ....;  dns_rr must start at an aligned address,
 	 * hence we need to round dns_hash_entry+name size to a sizeof(long)
 	 * multiple. If rdata type requires it, rdata_raw might need to be also
 	 * aligned.
@@ -1337,10 +1337,10 @@ inline static struct dns_hash_entry* dns_cache_mk_rd_entry2(struct rdata* rd)
 	 * padding to multiple of sizeof(char*)
 	 * dns_rr1 (e->rr_lst)
 	 * possible padding: no padding for a_rdata or aaaa_rdata,
-	 *                   multipe of sizeof(short) for srv_rdata,
+	 *                   multiple of sizeof(short) for srv_rdata,
 	 *                   multiple of sizeof(long) for naptr_rdata and others
 	 * dns_rr1->rdata  (e->rr_lst->rdata)
-	 * padding to multipe of sizeof long
+	 * padding to multiple of sizeof long
 	 * dns_rr2 (e->rr_lst->next)
 	 * ....
 	 *
@@ -2579,7 +2579,7 @@ struct hostent* dns_srv_sip_resolvehost(str* name, unsigned short* port,
  * params:
  *         naptr_head - naptr dns_rr list head
  *         tried      - bitmap used to keep track of the already tried records
- *                      (no more then sizeof(tried)*8 valid records are
+ *                      (no more than sizeof(tried)*8 valid records are
  *                      ever walked
  *         srv_name   - if successful, it will be set to the selected record
  *                      srv name (naptr repl.)
@@ -4379,7 +4379,7 @@ int dns_cache_add_record(unsigned short type,
 
 			if (type == T_SRV) {
 				/* SRV records must be ordered by their priority and weight.
-				 * With modifying an exising rr, or adding new rr to the DNS entry,
+				 * With modifying an existing rr, or adding new rr to the DNS entry,
 				 * the ordered list might got broken which needs to be fixed.
 				 */
 				rr_p = NULL;

--- a/src/core/dns_cache.h
+++ b/src/core/dns_cache.h
@@ -311,7 +311,7 @@ struct hostent* dns_get_he(str* name, int flags);
 int dns_sip_resolve(struct dns_srv_handle* h,  str* name, struct ip_addr* ip,
 					unsigned short* port, char* proto, int flags);
 
-/** @brief same as above, but fills su intead of changing port and filling an ip */
+/** @brief same as above, but fills su instead of changing port and filling an ip */
 inline static int dns_sip_resolve2su(struct dns_srv_handle* h,
 									 union sockaddr_union* su,
 									 str* name, unsigned short port,

--- a/src/core/dprint.c
+++ b/src/core/dprint.c
@@ -322,7 +322,7 @@ void dprint_term_color(char f, char b, str *obuf)
 	p = term_color;
 	end = p + TERM_COLOR_SIZE;
 
-	/* excape sequence */
+	/* escape sequence */
 	dprint_termc_add(p, end, "\033[");
 
 	if(f!='_')

--- a/src/core/dprint.h
+++ b/src/core/dprint.h
@@ -100,7 +100,7 @@
                         (e.g. fixup_dbg_sip_msg) */
 
 /** @brief This is the facility value used to indicate that the caller of the macro
- * did not override the facility. Value 0 (the defaul) is LOG_KERN on Linux
+ * did not override the facility. Value 0 (the default) is LOG_KERN on Linux
  */
 #define DEFAULT_FACILITY 0
 

--- a/src/core/dst_blocklist.c
+++ b/src/core/dst_blocklist.c
@@ -240,7 +240,7 @@ int register_blocklist_hook(struct blocklist_hook *h, int type)
 			goto error;
 	}
 	if (cb_lst==0 || cb_lst->hooks==0 || cb_lst->max_hooks==0){
-		BUG("register_blocklist_hook: intialization error\n");
+		BUG("register_blocklist_hook: initialization error\n");
 		goto error;
 	}
 
@@ -621,8 +621,8 @@ inline static int _dst_blocklist_del(
 
 /* frees all the expired entries until either there are no more of them
  *  or the total memory used is <= target (to free all of them use -1 for
- *  targer)
- *  params:   target  - free expired entries until no more then taget memory
+ *  target)
+ *  params:   target  - free expired entries until no more than target memory
  *                      is used  (use 0 to free all of them)
  *            delta   - consider an entry expired if it expires after delta
  *                      ticks from now
@@ -697,7 +697,7 @@ static ticks_t blst_timer(ticks_t ticks, struct timer_ln* tl, void* data)
 
 
 /* adds a proto ip:port combination to the blocklist
- * returns 0 on success, -1 on error (blocklist full -- would use more then
+ * returns 0 on success, -1 on error (blocklist full -- would use more than
  *  blst:_max_mem, or out of shm. mem.)
  */
 inline static int dst_blocklist_add_ip(unsigned char err_flags,
@@ -735,7 +735,7 @@ inline static int dst_blocklist_add_ip(unsigned char err_flags,
 #endif
 				UNLOCK_BLST(hash);
 				/* first try to free some memory  (~ 12%), but don't
-				 * spend more then 250 ms*/
+				 * spend more than 250 ms*/
 				dst_blocklist_clean_expired(*blst_mem_used/16*14, 0,
 															MS_TO_TICKS(250));
 				if (unlikely(*blst_mem_used+size >=

--- a/src/core/endianness.h
+++ b/src/core/endianness.h
@@ -73,7 +73,7 @@ extern int _endian_test_int;
 
 extern int endianness_sanity_check(void);
 
-/* detect compile time endianess */
+/* detect compile time endianness */
 #if defined __BYTE_ORDER && defined __LITTLE_ENDIAN && defined __BIG_ENDIAN
 /* linux */
 #if __BYTE_ORDER == __LITTLE_ENDIAN && ! defined __IS_LITTLE_ENDIAN
@@ -121,11 +121,11 @@ extern int endianness_sanity_check(void);
 #endif
 
 #else
-#error could not detect endianess
+#error could not detect endianness
 #endif
 
 #if !defined __IS_LITTLE_ENDIAN && !defined __IS_BIG_ENDIAN
-#error BUG: could not detect endianess
+#error BUG: could not detect endianness
 #endif
 
 #if defined __IS_LITTLE_ENDIAN && defined __IS_BIG_ENDIAN

--- a/src/core/error.c
+++ b/src/core/error.c
@@ -108,7 +108,7 @@ int err2reason_phrase(
 			break;
 
 		case E_OUT_OF_MEM:
-		/* dont disclose lack of mem in release mode */
+		/* don't disclose lack of mem in release mode */
 #ifdef EXTRA_DEBUG
 			error_txt="Excuse me I ran out of memory";
 			*sip_error=500;

--- a/src/core/fix_lumps.h
+++ b/src/core/fix_lumps.h
@@ -68,7 +68,7 @@ inline static void free_via_clen_lump( struct lump **list )
 			if (lump->flags & (LUMPFLAG_DUPED|LUMPFLAG_SHMEM)){
 				LM_CRIT("free_via_clen_lmp: lump %p, flags %x\n",
 						lump, lump->flags);
-				/* ty to continue */
+				/* try to continue */
 			}
 			a=lump->before;
 			while(a) {

--- a/src/core/forward.c
+++ b/src/core/forward.c
@@ -628,7 +628,7 @@ int forward_request(struct sip_msg* msg, str* dst, unsigned short port,
 		}else{
 			p_onsend=0;
 			ret=ser_error=E_OK;
-			/* exit succcesfully */
+			/* exit succesfully */
 			goto end;
 		}
 #ifdef USE_DNS_FAILOVER

--- a/src/core/hashes.h
+++ b/src/core/hashes.h
@@ -249,7 +249,7 @@ inline static unsigned int get_hash2_case_raw2(const str* key1,
 
 
 /*
- * generic hashing - from the intial origins of ser
+ * generic hashing - from the initial origins of ser
  */
 #define ch_h_inc h+=v^(v>>3)
 #define ch_icase(_c) (((_c)>='A'&&(_c)<='Z')?((_c)|0x20):(_c))

--- a/src/core/io_wait.h
+++ b/src/core/io_wait.h
@@ -26,7 +26,7 @@
  * You also have to define:
  *     int handle_io(struct fd_map* fm, short events, int idx) (see below)
  *     (this could be trivially replaced by a callback pointer entry attached
- *      to the io_wait handler if more flexibility rather then performance
+ *      to the io_wait handler if more flexibility rather than performance
  *      is needed)
  *      fd_type - define to some enum of you choice and define also
  *                FD_TYPE_DEFINED (if you don't do it fd_type will be defined
@@ -89,7 +89,7 @@
 #endif /* HAVE_EPOLL */
 
 
-extern int _os_ver; /* os version number, needed to select bugs workarrounds */
+extern int _os_ver; /* os version number, needed to select bugs workarounds */
 
 
 #if 0
@@ -204,7 +204,7 @@ static inline struct fd_map* hash_fd_map(	io_wait_h* h,
 
 #ifdef HANDLE_IO_INLINE
 /* generic handle io routine, this must be defined in the including file
- * (faster then registering a callback pointer)
+ * (faster than registering a callback pointer)
  *
  * params:  fm     - pointer to a fd hash entry
  *          events - combinations of POLLIN, POLLOUT, POLLERR & POLLHUP
@@ -212,7 +212,7 @@ static inline struct fd_map* hash_fd_map(	io_wait_h* h,
  * return: -1 on error
  *          0 on EAGAIN or when by some other way it is known that no more
  *            io events are queued on the fd (the receive buffer is empty).
- *            Usefull to detect when there are no more io events queued for
+ *            Useful to detect when there are no more io events queued for
  *            sigio_rt, epoll_et, kqueue.
  *         >0 on successfull read from the fd (when there might be more io
  *            queued -- the receive buffer might still be non-empty)
@@ -387,7 +387,7 @@ inline static int io_watch_add(	io_wait_h* h,
 		LM_ERR("failed to hash the fd %d\n", fd);
 		goto error;
 	}
-	switch(h->poll_method){ /* faster then pointer to functions */
+	switch(h->poll_method){ /* faster than pointer to functions */
 		case POLL_POLL:
 #ifdef POLLRDHUP
 			/* listen to POLLRDHUP by default (if POLLIN) */
@@ -1154,7 +1154,7 @@ again:
 					constructive we can do if we get an error we don't know
 					how to handle), but apart from that we ignore it in the
 					idea that it is better apply the rest of the changes,
-					rather then dropping all of them.
+					rather than dropping all of them.
 				*/
 				/*
 					example EV_ERROR for trying to delete a read watched fd,
@@ -1295,7 +1295,7 @@ again:
 					(unsigned)sigio_band,
 					sigio_fd);
 #endif
-			/* on some errors (e.g. when receving TCP RST), sigio_band will
+			/* on some errors (e.g. when receiving TCP RST), sigio_band will
 			 * be set to 0x08 (POLLERR) or 0x18 (POLLERR|POLLHUP - on stream
 			 *  unix socket close) , so better catch all events --andrei */
 			if (likely(sigio_band)){

--- a/src/core/ip_addr.c
+++ b/src/core/ip_addr.c
@@ -505,7 +505,7 @@ int mk_net_bitlen(struct net* n, struct ip_addr* ip, unsigned int bitlen)
 /** initializes a net structure from a string.
  * @param dst - net structure that will be filled
  * @param s - string of the form "ip", "ip/mask_len" or "ip/ip_mak".
- * @return -1 on error, 0 on succes
+ * @return -1 on error, 0 on success
  */
 int mk_net_str(struct net* dst, str* s)
 {

--- a/src/core/kemi.c
+++ b/src/core/kemi.c
@@ -1549,7 +1549,7 @@ static int sr_kemi_core_to_proto_helper(sip_msg_t *msg)
 		return -1;
 	}
 	if(msg->first_line.type == SIP_REPLY) {
-		/* REPLY doesnt have r/d-uri - use second Via */
+		/* REPLY doesn't have r/d-uri - use second Via */
 		if(parse_headers( msg, HDR_VIA2_F, 0)==-1) {
 			LM_DBG("no 2nd via parsed\n");
 			return -1;
@@ -1667,7 +1667,7 @@ static int sr_kemi_core_to_af_helper(sip_msg_t *msg)
 		return -1;
 	}
 	if(msg->first_line.type == SIP_REPLY) {
-		/* REPLY doesnt have r/d-uri - use second Via */
+		/* REPLY doesn't have r/d-uri - use second Via */
 		if(parse_headers( msg, HDR_VIA2_F, 0)==-1) {
 			LM_DBG("no 2nd via parsed\n");
 			return -1;

--- a/src/core/local_timer.c
+++ b/src/core/local_timer.c
@@ -114,7 +114,7 @@ static inline void local_timer_redist(struct local_timer* l,
 /** local timer add function (no lock, not multithread or multiprocess safe,
  * designed for local process use only)
  * t = current ticks
- * tl must be filled (the intial_timeout and flags must be set)
+ * tl must be filled (the initial_timeout and flags must be set)
  * returns -1 on error, 0 on success */
 static inline int _local_timer_add(struct local_timer *h, ticks_t t,
 									struct timer_ln* tl)

--- a/src/core/lock_ops.h
+++ b/src/core/lock_ops.h
@@ -53,14 +53,14 @@ Implements:
 	GEN_LOCK_T_PREFERRED - defined if using  arrays of gen_lock_t is as good as
 	                      using a lock set (gen_lock_set_t). 
 						  In general is better to have the locks "close" or 
-						  inside the protected data structure rather then 
+						  inside the protected data structure rather than 
 						  having a separate array or lock set. However in some
 						  case (e.g. SYSV_LOCKS) is better to use lock sets,
 						  either due to lock number limitations, excesive 
 						  performance or memory overhead. In this cases
 						  GEN_LOCK_T_PREFERRED will not be defined.
 	GEN_LOCK_T_UNLIMITED - defined if there is no system imposed limit on
-	                       the number of locks (other then the memory).
+	                       the number of locks (other than the memory).
 	GEN_LOCK_SET_T_UNLIMITED
 	                      - like above but for the size of a lock set.
 

--- a/src/core/mem/dl_malloc.c
+++ b/src/core/mem/dl_malloc.c
@@ -1366,7 +1366,7 @@ static int win32munmap(void* ptr, size_t size) {
 #define CALL_MORECORE(S)     MFAIL
 #endif /* HAVE_MORECORE */
 
-/* mstate bit set if continguous morecore disabled or failed */
+/* mstate bit set if contiguous morecore disabled or failed */
 #define USE_NONCONTIGUOUS_BIT (4U)
 
 /* segment bit set in create_mspace_with_base */
@@ -4158,7 +4158,7 @@ void* dlmalloc(size_t bytes) {
 
 void dlfree(void* mem) {
   /*
-     Consolidate freed chunks with preceeding or succeeding bordering
+     Consolidate freed chunks with preceding or succeeding bordering
      free chunks, if they exist, and then place in a bin.  Intermixed
      with special cases for top, dv, mmapped chunks, and usage errors.
   */
@@ -4999,7 +4999,7 @@ History:
       * Use ordered bins instead of best-fit threshhold
       * Eliminate block-local decls to simplify tracing and debugging.
       * Support another case of realloc via move into top
-      * Fix error occuring when initial sbrk_base not word-aligned.
+      * Fix error occurring when initial sbrk_base not word-aligned.
       * Rely on page size for units instead of SBRK_UNIT to
         avoid surprises about sbrk alignment conventions.
       * Add mallinfo, mallopt. Thanks to Raymond Nijssen

--- a/src/core/mem/ll_malloc.c
+++ b/src/core/mem/ll_malloc.c
@@ -1078,7 +1078,7 @@ void sfm_info(struct sfm_block* qm, struct mem_info* info)
  * on error (not compiled with bookkeeping code) returns (unsigned long)(-1) */
 unsigned long sfm_available(struct sfm_block* qm)
 {
-	/* we don't know how much free memory we have and it's to expensive
+	/* we don't know how much free memory we have and it's too expensive
 	 * to compute it */
 	return ((unsigned long)-1);
 }

--- a/src/core/mem/sf_malloc.c
+++ b/src/core/mem/sf_malloc.c
@@ -1101,7 +1101,7 @@ void sfm_info(struct sfm_block *qm, struct mem_info *info)
 			 * on error (not compiled with bookkeeping code) returns (unsigned long)(-1) */
 unsigned long sfm_available(struct sfm_block *qm)
 {
-	/* we don't know how much free memory we have and it's to expensive
+	/* we don't know how much free memory we have and it's too expensive
 				 * to compute it */
 	return ((unsigned long)-1);
 }

--- a/src/core/mod_fix.c
+++ b/src/core/mod_fix.c
@@ -116,7 +116,7 @@ int fixup_regexpNL_none(void** param, int param_no); /* textops */
   *
   * @see FIXUP_F2FP for the parameters with the exception
   * that only the first no1 parameters are converted to 
-  * fparamt_t and the rest directly to the correponding type
+  * fparamt_t and the rest directly to the corresponding type
   *
   * Side effect: declares also some _fpt_helper functions
   */
@@ -143,7 +143,7 @@ int fixup_regexpNL_none(void** param, int param_no); /* textops */
 	}
 
 
-/** macro for declaring a fixup which fixes all the paremeters to the same
+/** macro for declaring a fixup which fixes all the parameters to the same
   * type.
   *
   * @see FIXUP_F2T.

--- a/src/core/msg_translator.h
+++ b/src/core/msg_translator.h
@@ -144,7 +144,7 @@ char * build_only_headers( struct sip_msg* msg, int skip_first_line,
 				struct dest_info* send_info);
 
 /* builds a char* buffer from message body
- * error is set -1 if the memory allocation failes
+ * error is set -1 if the memory allocation fails
  */
 char * build_body( struct sip_msg* msg,
 			unsigned int *returned_len,

--- a/src/core/onsend.c
+++ b/src/core/onsend.c
@@ -68,7 +68,7 @@ int run_onsend(sip_msg_t* orig_msg, dest_info_t* dst, char* buf, int len)
 			/* backup orig_msg send flags */
 			fwd_snd_flags_bak=orig_msg->fwd_send_flags;
 			rpl_snd_flags_bak=orig_msg->rpl_send_flags;
-			orig_msg->fwd_send_flags=dst->send_flags; /* intial value */
+			orig_msg->fwd_send_flags=dst->send_flags; /* initial value */
 			init_run_actions_ctx(&ra_ctx);
 
 			if(keng) {
@@ -135,7 +135,7 @@ int run_onsend_evroute(onsend_info_t *sndinfo, int evrt, str *evcb, str *evname)
 	/* backup orig_msg send flags */
 	fwd_snd_flags_bak=sndinfo->msg->fwd_send_flags;
 	rpl_snd_flags_bak=sndinfo->msg->rpl_send_flags;
-	sndinfo->msg->fwd_send_flags=sndinfo->dst->send_flags; /* intial value */
+	sndinfo->msg->fwd_send_flags=sndinfo->dst->send_flags; /* initial value */
 	init_run_actions_ctx(&ra_ctx);
 
 	if(keng) {

--- a/src/core/parser/digest/digest_parser.c
+++ b/src/core/parser/digest/digest_parser.c
@@ -110,7 +110,7 @@ static inline int parse_token(str* _s, str* _r)
 {
 	int i;
 
-	     /* Save the begining of the
+	     /* Save the beginning of the
 	      * token in _r->s
 	      */
 	_r->s = _s->s;
@@ -173,7 +173,7 @@ static inline int parse_digest_param(str* _s, dig_cred_t* _c)
 	_s->s++;  /* skip = */
 	_s->len--;
 
-	     /* Find the begining of body */
+	     /* Find the beginning of body */
 	trim_leading(_s);
 
 	if (_s->len == 0) {

--- a/src/core/parser/digest/digest_parser.h
+++ b/src/core/parser/digest/digest_parser.h
@@ -99,7 +99,7 @@ typedef struct dig_cred {
  * Macro to obtain the value of realm. The macro would first
  * check if there is any @domain part in the username and if
  * so, it will be returned as the value of realm. This hack is
- * ofter used to protect realm using the digest (username parameter
+ * often used to protect realm using the digest (username parameter
  * is protected by the response hash) and also to allow subscribers
  * to specify a different domain part than the one in realm parameter
  */

--- a/src/core/parser/hf.c
+++ b/src/core/parser/hf.c
@@ -55,7 +55,7 @@ void clean_hdr_field(struct hdr_field* const hf)
 	void** h_parsed;
 
 	if (hf->parsed){
-		h_parsed=&hf->parsed; /* strict aliasing warnings workarround */
+		h_parsed=&hf->parsed; /* strict aliasing warnings workaround */
 		switch(hf->type){
 		/* headers with pkg alloc for parsed structure (alphabetic order) */
 		case HDR_ACCEPT_T:

--- a/src/core/parser/hf.h
+++ b/src/core/parser/hf.h
@@ -83,7 +83,7 @@ enum _hdr_types_t {
 	HDR_CONTENTDISPOSITION_T	= 30   /*!< Content-Disposition hdr field */,
 	HDR_DIVERSION_T				= 31   /*!< Diversion header field */,
 	HDR_RPID_T					= 32   /*!< Remote-Party-ID header field */,
-	HDR_REFER_TO_T				= 33   /*!< Refer-To header fiels */,
+	HDR_REFER_TO_T				= 33   /*!< Refer-To header fields */,
 	HDR_SIPIFMATCH_T			= 34   /*!< SIP-If-Match header field */,
 	HDR_SESSIONEXPIRES_T		= 35   /*!< Session-Expires header */,
 	HDR_MIN_SE_T				= 36   /*!< Min-SE */,

--- a/src/core/parser/msg_parser.c
+++ b/src/core/parser/msg_parser.c
@@ -1372,7 +1372,7 @@ int get_rcv_socket_uri(sip_msg_t *m, int tmode, str *uri, int atype)
 }
 
 
-/*! \brief returns a pointer to the begining of the msg's body
+/*! \brief returns a pointer to the beginning of the msg's body
  */
 char* get_body(sip_msg_t* const msg)
 {

--- a/src/core/parser/msg_parser.h
+++ b/src/core/parser/msg_parser.h
@@ -383,7 +383,7 @@ typedef struct sip_msg {
 
 	struct lump* add_rm;       /*!< used for all the forwarded requests/replies */
 	struct lump* body_lumps;     /*!< Lumps that update Content-Length */
-	struct lump_rpl *reply_lump; /*!< only for localy generated replies !!!*/
+	struct lump_rpl *reply_lump; /*!< only for locally generated replies !!!*/
 
 	/*! \brief str add_to_branch;
 		whatever whoever want to append to Via branch comes here */
@@ -444,7 +444,7 @@ void free_sip_msg(struct sip_msg* const msg);
 */
 int check_transaction_quadruple(sip_msg_t* const msg);
 
-/*! \brief returns a pointer to the begining of the msg's body
+/*! \brief returns a pointer to the beginning of the msg's body
  */
 char* get_body(sip_msg_t* const msg);
 

--- a/src/core/parser/parse_body.c
+++ b/src/core/parser/parse_body.c
@@ -34,7 +34,7 @@
 #include "keys.h"
 #include "parse_body.h"
 
-/*! \brief returns the value of boundary parameter from the Contect-Type HF */
+/*! \brief returns the value of boundary parameter from the Content-Type HF */
 static inline int get_boundary_param(struct sip_msg *msg, str *boundary)
 {
 	str	s;
@@ -127,7 +127,7 @@ inline static char *get_multipart_body(char *buf,
 		if (beg >= buf_end)
 			goto error;
 	}
-	/* CRLF delimeter found, the body begins right after it */
+	/* CRLF delimiter found, the body begins right after it */
 	while ((beg < buf_end) && (*beg != '\n'))
 		beg++;
 	beg++;
@@ -196,7 +196,7 @@ char *get_body_part(	struct sip_msg *msg,
 			return NULL;
 		buf_end = msg->buf+msg->len;
 
-		/* check all the body parts delimated by the boundary value,
+		/* check all the body parts delimited by the boundary value,
 		and search for the Content-Type HF with the given 
 		type/subtype */
 next_part:
@@ -237,7 +237,7 @@ next_part:
 						return NULL;
 
 					if (*c != ':')
-						/* not realy a Content-Type HF */
+						/* not really a Content-Type HF */
 						goto next_hf;
 					c++;
 
@@ -281,7 +281,7 @@ next_hf:
 				while ((c < buf_end) && (*c != '\n')) c++;
 				c++;
 			}
-			/* CRLF delimeter reached,
+			/* CRLF delimiter reached,
 			no Content-Type HF was found */
 		}
 	}
@@ -343,7 +343,7 @@ char *trim_leading_e_r (char *buffer, char *end_buffer)
  * -- Content-Type   that matches content_type / content_subtype. (if Content-Type enabled) &&
  * -- Content-ID     that matches content_id. (if Content-ID enabled) &&
  * -- Content-Length that matches content_length. (if Content-Length enabled)
- * - false, if any of them doesnt match.
+ * - false, if any of them doesn't match.
  */
 int part_multipart_headers_cmp (char *buffer,
 				char *end_buffer,
@@ -463,14 +463,14 @@ int part_multipart_headers_cmp (char *buffer,
 							error_msg = "Failed to perform trim_leading_hts || trim_leading_e_r";
 						}
 					} else {
-						/* Next characters dont match "Type:" or "ID:" or "Length:" OR
+						/* Next characters don't match "Type:" or "ID:" or "Length:" OR
 					     * header already parsed (maybe duplicates?) and founded OR
-					     * header initially set as disabled and it doesnt need to be treated.
+					     * header initially set as disabled and it doesn't need to be treated.
 					     * This is NOT an error. */
 						;
 					}
 				} else {
-					/* First 8 characters dont match "Content-"
+					/* First 8 characters don't match "Content-"
 					 * This is NOT an error. */
 					;
 				}

--- a/src/core/parser/parse_content.c
+++ b/src/core/parser/parse_content.c
@@ -223,7 +223,7 @@ char* parse_content_length(char* const buffer, const char* const end,
 		LM_ERR("empty input buffer: %p - %p\n", buffer, end);
 		goto error;
 	}
-	/* search the begining of the number */
+	/* search the beginning of the number */
 	while ( p<end && (*p==' ' || *p=='\t'
 				|| (*p=='\n' && p+1<end && (*(p+1)==' ' || *(p+1)=='\t')) ) )
 		p++;
@@ -234,7 +234,7 @@ char* parse_content_length(char* const buffer, const char* const end,
 	number = 0;
 	while (p<end && *p>='0' && *p<='9') {
 		if(number >= INT_MAX/10) {
-			LM_ERR("content lenght value is too large\n");
+			LM_ERR("content length value is too large\n");
 			goto error;
 		}
 		number = number*10 + ((*p) - '0');
@@ -292,7 +292,7 @@ char* decode_mime_type(char* const start, const char* const end,
 
 	p = start;
 
-	/* search the begining of the type */
+	/* search the beginning of the type */
 	while ( p<end && (*p==' ' || *p=='\t' ||
 	(*p=='\n' && (*(p+1)==' '||*(p+1)=='\t')) ))
 		p++;
@@ -337,7 +337,7 @@ char* decode_mime_type(char* const start, const char* const end,
 	if ( p==end || *(p++)!='/')
 		goto error;
 
-	/* search the begining of the sub-type */
+	/* search the beginning of the sub-type */
 	while ( p<end && (*p==' ' || *p=='\t' ||
 	(*p=='\n' && (*(p+1)==' '||*(p+1)=='\t')) ))
 		p++;
@@ -436,7 +436,7 @@ int parse_content_type_hdr(struct sip_msg* const msg)
 	if (ret==0)
 		goto error;
 	if (ret!=end) {
-		LM_ERR("Content-Type hdr contains more then one mime type!\n");
+		LM_ERR("Content-Type hdr contains more than one mime type!\n");
 		goto error;
 	}
 	if ((mime&0x00ff)==SUBTYPE_ALL || (mime>>16)==TYPE_ALL) {

--- a/src/core/parser/parse_content.h
+++ b/src/core/parser/parse_content.h
@@ -97,7 +97,7 @@ struct mime_type {
 #define get_accept(_msg_) ((int*)((_msg_)->accept->parsed))
 
 /*! \brief
- * parse the body of the Content-Type header. It's value is also converted
+ * parse the body of the Content-Type header. Its value is also converted
  * as int.
  * Returns:   n (n>0)  : the found type
  *            0        : hdr not found
@@ -108,7 +108,7 @@ int parse_content_type_hdr(struct sip_msg* const msg);
 int parse_accept_body(struct hdr_field* const hdr);
 
 /*! \brief
- * parse the body of the Accept header. It's values are also converted
+ * parse the body of the Accept header. Its values are also converted
  * as a null-terminated array of ints.
  * Returns:   1 : OK
  *            0 : hdr not found

--- a/src/core/parser/parse_diversion.c
+++ b/src/core/parser/parse_diversion.c
@@ -42,7 +42,7 @@
  * returns 0 on success,
  *        -1 on failure.
  *
- * limitations: it parses only the first occurence
+ * limitations: it parses only the first occurrence
  */
 int parse_diversion_header(struct sip_msg *msg)
 {

--- a/src/core/parser/parse_expires.c
+++ b/src/core/parser/parse_expires.c
@@ -58,7 +58,7 @@ static inline int expires_parser(char* _s, int _l, exp_body_t* _e)
 	_e->text.s = tmp.s;
 	_e->text.len = tmp.len;
 
-	/* more then 32bit/maxuint cant be valid */
+	/* more than 32bit/maxuint can't be valid */
 	if (tmp.len > 10) {
 		_e->valid = 0;
 		return 0;

--- a/src/core/parser/parse_param.c
+++ b/src/core/parser/parse_param.c
@@ -342,7 +342,7 @@ static inline int parse_token_param(str *_s, str *_r, char separator)
 		return -1;
 	}
 
-	/* Save the begining of the
+	/* Save the beginning of the
 	 * token in _r->s
 	 */
 	_r->s = _s->s;

--- a/src/core/parser/parse_uri.c
+++ b/src/core/parser/parse_uri.c
@@ -58,7 +58,7 @@ int uri_host_char_allowed(char c)
 	return 0;
 }
 
-/* buf= pointer to begining of uri (sip:x@foo.bar:5060;a=b?h=i)
+/* buf= pointer to beginning of uri (sip:x@foo.bar:5060;a=b?h=i)
  * len= len of uri
  * returns: fills uri & returns <0 on error or 0 if ok
  */

--- a/src/core/parser/parse_uri.h
+++ b/src/core/parser/parse_uri.h
@@ -37,7 +37,7 @@
 
 extern str	s_sip, s_sips, s_tel, s_tels, s_urn;
 
-/* buf= pointer to begining of uri (sip:x@foo.bar:5060;a=b?h=i)
+/* buf= pointer to beginning of uri (sip:x@foo.bar:5060;a=b?h=i)
  * len= len of uri
  * returns: fills uri & returns <0 on error or 0 if ok
  */

--- a/src/core/parser/parse_via.c
+++ b/src/core/parser/parse_via.c
@@ -1124,7 +1124,7 @@ find_value:
 #ifdef USE_COMP
 					case L_COMP_VALUE:
 						comp_unexpected_char;
-						/* we want to contine with no comp */
+						/* we want to continue with no comp */
 						state = F_PARAM;
 						param->value.len = 0;
 						param->value.s = 0;
@@ -1174,7 +1174,7 @@ find_value:
 #ifdef USE_COMP
 					case L_COMP_VALUE:
 						comp_unexpected_char;
-						/* we want to contine with no comp */
+						/* we want to continue with no comp */
 						state = F_VIA;
 						param->value.len = 0;
 						param->value.s = 0;
@@ -1346,7 +1346,7 @@ char *parse_via(
 	struct via_body *vb;
 	struct via_param *param;
 
-	vb = vbody; /* keep orignal vbody value, needed to set the error member
+	vb = vbody; /* keep original vbody value, needed to set the error member
 				* in case of multiple via bodies in the same header */
 parse_again:
 	vb->error = PARSE_ERROR;

--- a/src/core/parser/sdp/sdp.c
+++ b/src/core/parser/sdp/sdp.c
@@ -59,7 +59,7 @@ static inline int new_sdp(struct sip_msg* _m)
 }
 
 /**
- * Alocate a new session cell.
+ * Allocate a new session cell.
  */
 static inline sdp_session_cell_t *add_sdp_session(sdp_info_t* _sdp, int session_num, str* cnt_disp)
 {
@@ -374,7 +374,7 @@ static int parse_sdp_session(str *sdp_body, int session_num, str *cnt_disp, sdp_
 	str remote_candidates = {"a:remote-candidates:", 20};
 
 	/* hook the start and length of sdp body inside structure
-	 * - shorcut useful for multi-part bodies and sdp operations
+	 * - shortcut useful for multi-part bodies and sdp operations
 	 */
 	_sdp->text = *sdp_body;
 	pf = AF_INET;
@@ -712,7 +712,7 @@ static int parse_mixed_content(str *mixed_body, str delimiter, sdp_info_t* _sdp)
 					return -1;
 				if (ret!=end) {
 					LM_ERR("the header CONTENT_TYPE contains "
-						"more then one mime type :-(!\n");
+						"more than one mime type :-(!\n");
 					return -1;
 				}
 				if ((mime&0x00ff)==SUBTYPE_ALL || (mime>>16)==TYPE_ALL) {

--- a/src/core/parser/sdp/sdp_helpr_funcs.c
+++ b/src/core/parser/sdp/sdp_helpr_funcs.c
@@ -749,7 +749,7 @@ char *find_sdp_line(char* p, char* plimit, char linechar)
 		/*
 		 * Having such data, but not at line beginning.
 		 * Skip them and reiterate. ser_memmem() will find next
-		 * occurence.
+		 * occurrence.
 		 */
 		if (plimit - cp1 < 2)
 			return NULL;

--- a/src/core/pass_fd.c
+++ b/src/core/pass_fd.c
@@ -49,7 +49,7 @@
  *         data_len -
  *         flags    - recv flags for the first recv (see recv(2)), only
  *                    0, MSG_WAITALL and MSG_DONTWAIT make sense
- * if flags is set to MSG_DONWAIT (or to 0 and the socket fd is non-blocking),
+ * if flags is set to MSG_DONTWAIT (or to 0 and the socket fd is non-blocking),
  * and if no data is queued on the fd, recv_all will not wait (it will
  * return error and set errno to EAGAIN/EWOULDBLOCK). However if even 1 byte
  *  is queued, the call will block until the whole data_len was read or an

--- a/src/core/rand/fortuna/fortuna.c
+++ b/src/core/rand/fortuna/fortuna.c
@@ -185,7 +185,7 @@ init_state(FState *st)
 }
 
 /*
- * Endianess does not matter.
+ * Endianness does not matter.
  * It just needs to change without repeating.
  */
 static void

--- a/src/core/raw_sock.c
+++ b/src/core/raw_sock.c
@@ -204,7 +204,7 @@ int raw_udp4_socket(struct ip_addr* ip, str* iface, int iphdr_incl)
  * from and to are filled (only the ip part the ports are 0 since this
  * function doesn't try to look beyond the IP level).
  * @param sock - raw socket
- * @param buf - detination buffer.
+ * @param buf - destination buffer.
  * @param len - buffer len (should be enough for receiving a packet +
  *               IP header).
  * @param from - result parameter, the IP address part of it will be filled
@@ -282,7 +282,7 @@ end:
  * The packet is copied in *buf and *buf is advanced to point to the
  * payload.  Fills from and to.
  * @param rsock - raw socket
- * @param buf - the packet will be written to where *buf points intially and
+ * @param buf - the packet will be written to where *buf points initially and
  *              then *buf will be advanced to point to the udp payload.
  * @param len - buffer length (should be enough to hold at least the
  *               ip and udp headers + 1 byte).

--- a/src/core/resolve.c
+++ b/src/core/resolve.c
@@ -596,8 +596,8 @@ error:
  *  (see http://tools.ietf.org/html/draft-ietf-enum-branch-location-record-03)
  * one or several character strings:
  *  01234567
- * +--------+
- * | postion|
+ * +---------+
+ * | position|
  * +-----------+
  * / separator /
  * +-----------+
@@ -1386,7 +1386,7 @@ end:
  * params:
  *         naptr_head - naptr rr list head
  *         tried      - bitmap used to keep track of the already tried records
- *                      (no more then sizeof(tried)*8 valid records are
+ *                      (no more than sizeof(tried)*8 valid records are
  *                      ever walked
  *         srv_name   - if successful, it will be set to the selected record
  *                      srv name (naptr repl.)
@@ -1493,7 +1493,7 @@ size_t create_srv_pref_list(char *proto, struct dns_srv_proto *list) {
 		list_len=1;
 	} else {
 		list_len = 0;
-		/*get protocols and preference scores, and add availble protocol(s) and score(s) to the list*/
+		/*get protocols and preference scores, and add available protocol(s) and score(s) to the list*/
 		for (i=PROTO_UDP; i<PROTO_LAST;i++) {
 			tmp.proto_pref = srv_proto_pref_score(i);
 			/* if -1 so disabled continue with next protocol*/
@@ -1506,7 +1506,7 @@ size_t create_srv_pref_list(char *proto, struct dns_srv_proto *list) {
 			}
 		};
 
-		/* if all protocol prefence scores equal, then set the perference to default values: udp,tcp,tls,sctp */
+		/* if all protocol preference scores equal, then set the preference to default values: udp,tcp,tls,sctp */
 		for (i=1; i<list_len;i++) {
 			if(list[0].proto_pref!=list[i].proto_pref){
 				default_order=0;

--- a/src/core/rpc.h
+++ b/src/core/rpc.h
@@ -54,7 +54,7 @@ typedef int (*rpc_send_f)(void* ctx);                                      /*!< 
 typedef void (*rpc_fault_f)(void* ctx, int code, char* fmt, ...);          /*!< Signal a failure to the client */
 typedef int (*rpc_add_f)(void* ctx, char* fmt, ...);                       /*!< Add a new piece of data to the result */
 typedef int (*rpc_scan_f)(void* ctx, char* fmt, ...);                      /*!< Retrieve request parameters */
-typedef int (*rpc_rpl_printf_f)(void* ctx, char* fmt, ...);                /*!< Add printf-like formated data to the result set */
+typedef int (*rpc_rpl_printf_f)(void* ctx, char* fmt, ...);                /*!< Add printf-like formatted data to the result set */
 typedef int (*rpc_struct_add_f)(void* ctx, char* fmt, ...);                /*!< Add fields in a structure */
 typedef int (*rpc_array_add_f)(void* ctx, char* fmt, ...);                 /*!< Add values in an array */
 typedef int (*rpc_struct_scan_f)(void* ctx, char* fmt, ...);               /*!< Scan attributes of a structure */

--- a/src/core/rvalue.c
+++ b/src/core/rvalue.c
@@ -72,7 +72,7 @@
  */
 #define RVAL_GET_INT_ERR_IGN
 
-/* minimum size alloc'ed for STR RVs (to accomodate
+/* minimum size alloc'ed for STR RVs (to accommodate
  * strops without reallocs) */
 #define RV_STR_EXTRA 80
 
@@ -390,7 +390,7 @@ struct rvalue* rval_new(enum rval_type t, union rval_val* v, int extra_size)
 /**
  * @brief get rvalue basic type (RV_LONG or RV_STR)
  *
- * Given a rvalue it tries to determinte its basic type.
+ * Given a rvalue it tries to determine its basic type.
  * Fills val_cache if non-null and empty (can be used in other rval*
  * function calls, to avoid re-resolving avps or pvars). It must be
  * rval_cache_clean()'en when no longer needed.
@@ -651,7 +651,7 @@ int rve_has_side_effects(struct rval_expr* rve)
 static int rve_op_unary(enum rval_expr_op op)
 {
 	switch(op){
-		case RVE_RVAL_OP: /* not realy an operator */
+		case RVE_RVAL_OP: /* not really an operator */
 			return -1;
 		case RVE_UMINUS_OP:
 		case RVE_BOOL_OP:
@@ -2489,7 +2489,7 @@ error:
 
 /** evals a rval expr and always returns a new rval.
  * like rval_expr_eval, but always returns a new rvalue (never a reference
- * to an exisiting one).
+ * to an existing one).
  * WARNING: result must be rval_destroy()'ed if non-null (it might be
  * a reference to another rval). The result can be modified only
  * if rv_chg_in_place() returns true.
@@ -3008,7 +3008,7 @@ error:
 
 /** optimize op($v, 0) or op($v, 1).
  * Note: internal use only from rve_optimize
- * It should be called after ct optimization, for non-contant
+ * It should be called after ct optimization, for non-constant
  *  expressions (the left or right side is not constant).
  * @return 1 on success (rve was changed), 0 on failure and -1 on error
  */
@@ -3325,7 +3325,7 @@ static int rve_opt_01(struct rval_expr* rve, enum rval_type rve_type)
 		}
 	/* no optimization for generic RVE_PLUS_OP for now, only for RVE_CONCAT_OP
 	 * (RVE_PLUS_OP should be converted to RVE_CONCAT_OP if it's supposed
-	 * to work on strings. If it's not converted/optimized it means it's type
+	 * to work on strings. If it's not converted/optimized it means its type
 	 * can be determined only at runtime => we cannot optimize */
 		/* debugging messages */
 		if (ret==1 && dbg){

--- a/src/core/rvalue.h
+++ b/src/core/rvalue.h
@@ -77,7 +77,7 @@ enum rval_expr_op{
 	RVE_STRDIFF_OP,/**< 2 members, string != , returns left != right (bool)*/
 	RVE_MATCH_OP,  /**< 2 members, string ~),  returns left matches re(right) */
 	/* tenary expression - (x)?y:z */
-	RVE_SELVALEXP_OP,  /**< selval expresion - selval(exp, ...)*/
+	RVE_SELVALEXP_OP,  /**< selval expression - selval(exp, ...)*/
 	RVE_SELVALOPT_OP,  /**< selval options - selval(exp, opt1, opt2)*/
 	/* avp, pvars a.s.o */
 	RVE_DEFINED_OP, /**< one member, returns is_defined(val) (bool) */

--- a/src/core/select.c
+++ b/src/core/select.c
@@ -52,7 +52,7 @@ int select_level = 0;
 
 /** pointer to the SIP uri being processed.
  * Nested function calls can pass information to each
- * other using this pointer. Only for performace reasons.
+ * other using this pointer. Only for performance reasons.
  * (Miklos)
  */
 struct sip_uri	*select_uri_p = NULL;

--- a/src/core/select.h
+++ b/src/core/select.h
@@ -36,7 +36,7 @@
 #define MAX_SELECT_PARAMS 32
 #define MAX_NESTED_CALLS  4
 
-/* Flags for parser table FLAG bitfiels
+/* Flags for parser table FLAG bitfields
  */
 #define DIVERSION_MASK   0x00FF
 
@@ -147,7 +147,7 @@ extern int select_level;
 
 /* pointer to the SIP uri being processed.
  * Nested function calls can pass information to each
- * other using this pointer. Only for performace reasons.
+ * other using this pointer. Only for performance reasons.
  * (Miklos)
  */
 extern struct sip_uri	*select_uri_p;

--- a/src/core/select_core.c
+++ b/src/core/select_core.c
@@ -328,7 +328,7 @@ int select_via_name(str* res, select_t* s, struct sip_msg* msg)
 {
 	struct via_body *p = NULL;
 	
-	// it's not neccessary to test if (s->n > 1)
+	// it's not necessary to test if (s->n > 1)
 	if (s->params[1].type == SEL_PARAM_STR) {
 		if(parse_via_header(msg, 1, &p)<0) return -1;
 	} else if (parse_via_header(msg, s->params[1].v.i, &p)<0) return -1;
@@ -340,7 +340,7 @@ int select_via_version(str* res, select_t* s, struct sip_msg* msg)
 {
 	struct via_body *p = NULL;
 	
-	// it's not neccessary to test if (s->n > 1)
+	// it's not necessary to test if (s->n > 1)
 	if (s->params[1].type == SEL_PARAM_STR) {
 		if (parse_via_header(msg, 1, &p)<0) return -1;
 	} else if (parse_via_header(msg, s->params[1].v.i, &p)<0) return -1;
@@ -352,7 +352,7 @@ int select_via_transport(str* res, select_t* s, struct sip_msg* msg)
 {
 	struct via_body *p = NULL;
 	
-	// it's not neccessary to test if (s->n > 1)
+	// it's not necessary to test if (s->n > 1)
 	if (s->params[1].type == SEL_PARAM_STR) {
 		if(parse_via_header(msg, 1, &p)<0) return -1;
 	} else if (parse_via_header(msg, s->params[1].v.i, &p)<0) return -1;
@@ -364,7 +364,7 @@ int select_via_host(str* res, select_t* s, struct sip_msg* msg)
 {
 	struct via_body *p = NULL;
 	
-	// it's not neccessary to test if (s->n > 1)
+	// it's not necessary to test if (s->n > 1)
 	if (s->params[1].type == SEL_PARAM_STR) {
 		if (parse_via_header(msg, 1, &p)<0) return -1;
 	} else if (parse_via_header(msg, s->params[1].v.i, &p)<0) return -1;
@@ -376,7 +376,7 @@ int select_via_port(str* res, select_t* s, struct sip_msg* msg)
 {
 	struct via_body *p = NULL;
 	
-	// it's not neccessary to test if (s->n > 1)
+	// it's not necessary to test if (s->n > 1)
 	if (s->params[1].type == SEL_PARAM_STR) {
 		if (parse_via_header(msg, 1, &p)<0) return -1;
 	} else if (parse_via_header(msg, s->params[1].v.i, &p)<0) return -1;
@@ -388,7 +388,7 @@ int select_via_comment(str* res, select_t* s, struct sip_msg* msg)
 {
 	struct via_body *p = NULL;
 	
-	// it's not neccessary to test if (s->n > 1)
+	// it's not necessary to test if (s->n > 1)
 	if (s->params[1].type == SEL_PARAM_STR) {
 		if(parse_via_header(msg, 1, &p)<0) return -1;
 	} else if (parse_via_header(msg, s->params[1].v.i, &p)<0) return -1;
@@ -401,7 +401,7 @@ int select_via_params(str* res, select_t* s, struct sip_msg* msg)
 	struct via_body *p = NULL;
 	struct via_param *q;
 
-	// it's not neccessary to test if (s->n > 1)
+	// it's not necessary to test if (s->n > 1)
 	if (s->params[1].type == SEL_PARAM_STR) {
 		if (parse_via_header(msg, 1, &p)<0) return -1;
 	} else if (parse_via_header(msg, s->params[1].v.i, &p)<0) return -1;
@@ -425,7 +425,7 @@ int select_via_params_spec(str* res, select_t* s, struct sip_msg* msg)
 		return -1;
 	}
 	
-	// it's not neccessary to test if (s->n > 1)
+	// it's not necessary to test if (s->n > 1)
 	if (s->params[1].type != SEL_PARAM_INT) {
 		if(parse_via_header(msg, 1, &p)<0) return -1;
 	} else if (parse_via_header(msg, s->params[1].v.i, &p)<0) return -1;

--- a/src/core/ser_time.h
+++ b/src/core/ser_time.h
@@ -29,7 +29,7 @@
 #include <sys/time.h>
 #include <time.h>
 
-/* time(2) equivalent, using ser internal timers (faster then a syscall) */
+/* time(2) equivalent, using ser internal timers (faster than a syscall) */
 time_t ser_time(time_t* t);
 
 /* gettimeofday(2) equivalent, faster but much more imprecise

--- a/src/core/signals.c
+++ b/src/core/signals.c
@@ -43,7 +43,7 @@ void (*set_sig_h(int sig, void (*handler) (int) ))(int)
 	sigemptyset(&act.sa_mask);
 	act.sa_flags=0;
 	*/
-	/* sa_sigaction not set, we use sa_hanlder instead */
+	/* sa_sigaction not set, we use sa_handler instead */
 	return (sigaction (sig, &act, &old)==-1)?SIG_ERR:old.sa_handler;
 }
 #endif

--- a/src/core/sip_msg_clone.c
+++ b/src/core/sip_msg_clone.c
@@ -698,7 +698,7 @@ struct sip_msg *sip_msg_shm_clone(
 					/*alloc*/
 					new_to_prm = (struct to_param *)p;
 					p += ROUND4(sizeof(struct to_param));
-					/*coping*/
+					/*copying*/
 					memcpy(new_to_prm, to_prm, sizeof(struct to_param));
 					((struct to_body *)new_hdr->parsed)->param_lst = 0;
 					new_to_prm->name.s = translate_pointer(

--- a/src/core/socket_info.c
+++ b/src/core/socket_info.c
@@ -2496,7 +2496,7 @@ int parse_protohostport(str* ins, sr_phostp_t *r)
 		r->host.s=first+1;
 		r->host.len=(int)(p-r->host.s);
 	}else{
-		/* valid port => its host:port */
+		/* valid port => it is host:port */
 		r->sport = tmp;
 		r->host.s=ins->s;
 		r->host.len=(int)(first-r->host.s);

--- a/src/core/sr_module.c
+++ b/src/core/sr_module.c
@@ -1717,7 +1717,7 @@ int get_str_fparam(str* dst, struct sip_msg* msg, fparam_t* param)
 			dst->s=pv_get_buffer();
 			dst->len=pv_get_buffer_size();
 			if (unlikely(pv_printf(msg, param->v.pve, dst->s, &dst->len)!=0)){
-				LM_ERR("Could not convert the PV-formated string to str\n");
+				LM_ERR("Could not convert the PV-formatted string to str\n");
 				dst->len=0;
 				return -1;
 			};
@@ -1727,7 +1727,7 @@ int get_str_fparam(str* dst, struct sip_msg* msg, fparam_t* param)
 }
 
 
-/** Get the function parameter value as string cpoied in the dst->s buffer.
+/** Get the function parameter value as string copied in the dst->s buffer.
  *  - dst->len has to provide size of dst->s buffer and it is updated to the
  *  size of the value
  *  @return  0 - Success
@@ -1789,7 +1789,7 @@ int get_strbuf_fparam(str* dst, struct sip_msg* msg, fparam_t* param)
 			break;
 		case FPARAM_PVE:
 			if (unlikely(pv_printf(msg, param->v.pve, dst->s, &dst->len)!=0)){
-				LM_ERR("Could not convert the PV-formated string to str\n");
+				LM_ERR("Could not convert the PV-formatted string to str\n");
 				dst->len=0;
 				return -1;
 			};
@@ -1956,7 +1956,7 @@ int get_is_fparam(int* i_dst, str* s_dst, struct sip_msg* msg, fparam_t* param, 
 			s_dst->s=pv_get_buffer();
 			s_dst->len=pv_get_buffer_size();
 			if (unlikely(pv_printf(msg, param->v.pve, s_dst->s, &s_dst->len)!=0)){
-				LM_ERR("Could not convert the PV-formated string to str\n");
+				LM_ERR("Could not convert the PV-formatted string to str\n");
 				s_dst->len=0;
 				return -1;
 			}
@@ -2037,7 +2037,7 @@ int fixup_free_fparam_2(void** param, int param_no)
 
 /** returns true if a fixup is a fparam_t* one.
  * Used to automatically detect "pure" fparam fixups that can be used with non
- * contant RVEs.
+ * constant RVEs.
  * @param f - function pointer
  * @return 1 for fparam fixups, 0 for others.
  */

--- a/src/core/strutils.c
+++ b/src/core/strutils.c
@@ -380,7 +380,7 @@ int escape_param(str *sin, str *sout)
 
 /*! \brief
  * escapes a string to use as a CSV field, as specified in RFC4180:
- * - enclose sting in double quotes
+ * - enclose string in double quotes
  * - escape double quotes with a second double quote
  */
 int escape_csv(str *sin, str *sout)

--- a/src/core/switch.c
+++ b/src/core/switch.c
@@ -214,7 +214,7 @@ int fix_switch(struct action* t)
 			n++; /* count only non-default cases */
 		}else{
 			if (default_found){
-				LM_ERR("more then one \"default\"");
+				LM_ERR("more than one \"default\"");
 				return E_UNSPEC;
 			}
 			default_found=1;
@@ -322,10 +322,10 @@ int fix_switch(struct action* t)
 	}
 	/* try to create a jumptable */
 	/* cost: 2 cmp & table lookup
-	   => makes sense for more then 3 cases
+	   => makes sense for more than 3 cases
 	   & if size< MAX_JT_SIZE
 	*/
-	best_hits=3; /* more then 3 hits needed */
+	best_hits=3; /* more than 3 hits needed */
 	start=end=0;
 	for (i=0; i<n; i++){
 		last=first=cond[i];
@@ -529,7 +529,7 @@ static int fix_match(struct action* t)
 			}
 		}else{
 			if (default_found){
-				LM_ERR("more then one \"default\" label found (%d, %d)\n",
+				LM_ERR("more than one \"default\" label found (%d, %d)\n",
 						(c->ct_rve)?c->ct_rve->fpos.s_line:0,
 						(c->ct_rve)?c->ct_rve->fpos.s_col:0);
 				ret=E_UNSPEC;

--- a/src/core/tcp_conn.h
+++ b/src/core/tcp_conn.h
@@ -288,7 +288,7 @@ typedef struct tcp_connection {
 /* list head, new element, next member, prev member */
 #define tcpconn_listadd(head, c, next, prev) \
 	do{ \
-		/* add it at the begining of the list*/ \
+		/* add it at the beginning of the list*/ \
 		(c)->next=(head); \
 		(c)->prev=0; \
 		if ((head)) (head)->prev=(c); \

--- a/src/core/tcp_init.h
+++ b/src/core/tcp_init.h
@@ -26,7 +26,7 @@
 /* maximum accepted lifetime in ticks (maximum possible is  ~ MAXINT/2) */
 #define MAX_TCP_CON_LIFETIME	((1U<<(sizeof(ticks_t)*8-1))-1)
 
-#define DEFAULT_TCP_SEND_TIMEOUT 10 /* if a send can't write for more then 10s,
+#define DEFAULT_TCP_SEND_TIMEOUT 10 /* if a send can't write for more than 10s,
 									   timeout */
 #define DEFAULT_TCP_CONNECT_TIMEOUT 10 /* if a connect doesn't complete in this
 										  time, timeout */

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1474,7 +1474,7 @@ int tcpconn_finish_connect( struct tcp_connection* c,
 		new_conn_alias_flags=cfg_get(tcp, tcp_cfg, new_conn_alias_flags);
 		TCPCONN_LOCK;
 			/* remove all the aliases except the first one and re-add them
-			 * (there shouldn't be more then the 3 default aliases at this
+			 * (there shouldn't be more than the 3 default aliases at this
 			 * stage) */
 			if (c->aliases > 1) {
 				for (r=1; r<c->aliases; r++){
@@ -1512,13 +1512,13 @@ inline static struct tcp_connection*  tcpconn_add(struct tcp_connection *c)
 		new_conn_alias_flags=cfg_get(tcp, tcp_cfg, new_conn_alias_flags);
 		TCPCONN_LOCK;
 		c->flags|=F_CONN_HASHED;
-		/* add it at the begining of the list*/
+		/* add it at the beginning of the list*/
 		tcpconn_listadd(tcpconn_id_hash[c->id_hash], c, id_next, id_prev);
 		/* set the aliases */
 		/* first alias is for (peer_ip, peer_port, 0 ,0) -- for finding
 		 *  any connection to peer_ip, peer_port
 		 * the second alias is for (peer_ip, peer_port, local_addr, 0) -- for
-		 *  finding any conenction to peer_ip, peer_port from local_addr 
+		 *  finding any connection to peer_ip, peer_port from local_addr 
 		 * the third alias is for (peer_ip, peer_port, local_addr, local_port) 
 		 *   -- for finding if a fully specified connection exists 
 		 * the fourth alias is for (peer_ip, peer_port, cinfo_addr, 0) -- for
@@ -2563,7 +2563,7 @@ static int tcpconn_send_put(struct tcp_connection* c, const char* buf,
 			}
 			/* handle fd closed or bad connection/error
 				(it's possible that this happened in the time between
-				we found the intial connection and the time when we get
+				we found the initial connection and the time when we get
 				the fd)
 			 */
 			if (unlikely(c!=tmp || fd==-1 || c->state==S_CONN_BAD)){
@@ -3946,7 +3946,7 @@ inline static int handle_ser_child(struct process_table* p, int fd_i)
 			} else if (unlikely(send_fd(p->unix_sock, &tcpconn,
 										sizeof(tcpconn), tcpconn->s)<=0)){
 				LM_ERR("CONN_GET_FD: send_fd failed\n");
-				/* try sending error (better then not sending anything) */
+				/* try sending error (better than not sending anything) */
 				tmp = 0;
 				if (unlikely(send_all(p->unix_sock, &tmp, sizeof(tmp)) <= 0))
 					BUG("handle_ser_child: CONN_GET_FD:"
@@ -4600,7 +4600,7 @@ error:
  * return: -1 on error
  *          0 on EAGAIN or when by some other way it is known that no more 
  *            io events are queued on the fd (the receive buffer is empty).
- *            Usefull to detect when there are no more io events queued for
+ *            Useful to detect when there are no more io events queued for
  *            sigio_rt, epoll_et, kqueue.
  *         >0 on successfull read from the fd (when there might be more io
  *            queued -- the receive buffer might still be non-empty)
@@ -4859,7 +4859,7 @@ void tcp_main_loop()
 					goto error;
 			}
 	}
-	/* add all the unix sokets used for communication with the tcp childs */
+	/* add all the unix sockets used for communication with the tcp childs */
 	for (r=0; r<tcp_children_no; r++){
 		if (tcp_children[r].unix_sock>0)/*we can't have 0, we never close it!*/
 			if (io_watch_add(&io_h, tcp_children[r].unix_sock, POLLIN,

--- a/src/core/tcp_options.c
+++ b/src/core/tcp_options.c
@@ -109,7 +109,7 @@ static cfg_def_t tcp_cfg_def[] = {
 	{ "reuse_port",   CFG_VAR_INT | CFG_ATOMIC,   0,        1,  0,         0,
 		"reuse TCP ports "},
 	{ "wait_data_ms",  CFG_VAR_INT | CFG_ATOMIC,      0, 7200000, 0,        0,
-		"wait for data on new tcp connetions (milliseconds)"},
+		"wait for data on new tcp connections (milliseconds)"},
 	{ "close_rst",     CFG_VAR_INT | CFG_READONLY,    0,   1,      0,         0,
 			"trigger an RST on connection close"},
 	/* internal and/or "fixed" versions of some vars

--- a/src/core/tcp_read.c
+++ b/src/core/tcp_read.c
@@ -548,7 +548,7 @@ int tcp_read_headers(struct tcp_connection *c, rd_conn_flags_t* read_flags)
 #ifdef READ_MSRP
 						/* catch end of MSRP frame without body
 						 *     '-------sessid$\r\n'
-						 * follows headers wihtout extra CRLF */
+						 * follows headers without extra CRLF */
 						if(r->flags&F_TCP_REQ_MSRP_FRAME) {
 							p--;
 							r->state=H_MSRP_BODY_END;
@@ -880,7 +880,7 @@ int tcp_read_headers(struct tcp_connection *c, rd_conn_flags_t* read_flags)
 				r->chunk_size = 0;
 				r->state = H_HTTP11_CHUNK_SIZE;
 				break;
-			case H_HTTP11_CHUNK_BODY: /* content of chunnk */
+			case H_HTTP11_CHUNK_BODY: /* content of chunk */
 				remaining=r->pos-p;
 				if (remaining>r->bytes_to_go) remaining=r->bytes_to_go;
 				r->bytes_to_go-=remaining;
@@ -1379,7 +1379,7 @@ int receive_tcp_msg(char* tcpbuf, unsigned int len,
 
 	/* allocate buffer when needed
 	 * - no buffer yet
-	 * - existing buffer too small (min size is BUF_SIZE - to accomodate most
+	 * - existing buffer too small (min size is BUF_SIZE - to accommodate most
 	 *   of SIP messages; expected larger for HTTP/XCAP)
 	 * - existing buffer too large (e.g., we got a too big message in the past,
 	 *   let's free it)
@@ -1709,7 +1709,7 @@ static ticks_t tcpconn_read_timeout(ticks_t t, struct timer_ln* tl, void* data)
  *            from this fd (e.g.: we are closing it )
  *          0 on EAGAIN or when by some other way it is known that no more
  *            io events are queued on the fd (the receive buffer is empty).
- *            Usefull to detect when there are no more io events queued for
+ *            Useful to detect when there are no more io events queued for
  *            sigio_rt, epoll_et, kqueue.
  *         >0 on successfull read from the fd (when there might be more io
  *            queued -- the receive buffer might still be non-empty)

--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -306,7 +306,7 @@ again:
 #ifdef __OS_darwin
 	/* workaround for darwin sigwait bug, see slow_timer_main() for more
 	 * info (or grep __OS_darwin) */
-	/* keep in sync wih main.c: sig_usr() - signals we are interested in */
+	/* keep in sync with main.c: sig_usr() - signals we are interested in */
 	sigaddset(&slow_timer_sset, SIGINT);
 	sigaddset(&slow_timer_sset, SIGTERM);
 	sigaddset(&slow_timer_sset, SIGUSR1);
@@ -436,7 +436,7 @@ inline static void adjust_ticks(void)
 
 
 
-/* time(2) equivalent, using ser internal timers (faster then a syscall) */
+/* time(2) equivalent, using ser internal timers (faster than a syscall) */
 time_t ser_time(time_t *t)
 {
 	if (likely(t==0))
@@ -506,7 +506,7 @@ void timer_free(struct timer_ln* t)
 
 /* unsafe (no lock ) timer add function
  * t = current ticks
- * tl must be filled (the intial_timeout and flags must be set)
+ * tl must be filled (the initial_timeout and flags must be set)
  * returns -1 on error, 0 on success */
 static inline int _timer_add(ticks_t t, struct timer_ln* tl)
 {
@@ -1077,7 +1077,7 @@ void slow_timer_main()
 		/* on darwin sigwait is buggy: it will cause extreme slow down
 		 *  on signal delivery for the signals it doesn't wait on
 		 *  (on darwin 8.8.0, g4 1.5Ghz I've measured a 36s delay!).
-		 * To work arround this bug, we sigwait() on all the signals we
+		 * To work around this bug, we sigwait() on all the signals we
 		 * are interested in kamailio and manually call the main signal handler
 		 * if the signal!= slow timer signal -- andrei */
 		sig_usr(sig);

--- a/src/core/timer.h
+++ b/src/core/timer.h
@@ -69,7 +69,7 @@ typedef void (timer_function_w)(unsigned int ticks, int worker, void* param);
 	timer_ticks.h (.e.g TICKS_TO_S(tick) to convert to s or ms )*/
 #define TIMER_TICK 1 /* 1 s, kept for compatibility */
 
-/*function prototype to execute on mili-second based basic timers */
+/*function prototype to execute on millisecond based basic timers */
 typedef void (utimer_function)(unsigned int uticks, void* param);
 typedef void (utimer_function_w)(unsigned int uticks, int worker, void* param);
 

--- a/src/core/timer_funcs.h
+++ b/src/core/timer_funcs.h
@@ -51,7 +51,7 @@ struct timer_head{
  *
  * Uses ~280K on a 64 bits system and ~140K on a 32 bit system; for TICKS_HZ=10
  * holds ~ 30 min in the first hash/wheel and ~233h in the first two.
- * More perfomant arrangement: 16, 8, 8 (but eats 1 MB on a 64 bit system, and
+ * More performant arrangement: 16, 8, 8 (but eats 1 MB on a 64 bit system, and
  *  512K on a 32 bit one). For TICKS_HZ=10 it holds almost 2h in the
  *  first hash/wheel and ~460h in the first two.
  */

--- a/src/core/timer_proc.c
+++ b/src/core/timer_proc.c
@@ -137,7 +137,7 @@ int fork_basic_utimer(int child_id, char* desc, int make_sock,
 			sleep_us(uinterval);
 			cfg_update();
 			ts = get_ticks_raw();
-			f(TICKS_TO_MS(ts), param); /* ticks in mili-seconds */
+			f(TICKS_TO_MS(ts), param); /* ticks in milliseconds */
 		}
 	}
 	/* parent */
@@ -159,7 +159,7 @@ int fork_basic_utimer_w(int child_id, char* desc, int make_sock,
 			sleep_us(uinterval);
 			cfg_update();
 			ts = get_ticks_raw();
-			f(TICKS_TO_MS(ts), worker, param); /* ticks in mili-seconds */
+			f(TICKS_TO_MS(ts), worker, param); /* ticks in milliseconds */
 		}
 	}
 	/* parent */
@@ -254,12 +254,12 @@ int fork_sync_timer(int child_id, char* desc, int make_sock,
 	if (pid<0) return -1;
 	if (pid==0){
 		/* child */
-		interval *= 1000;  /* miliseconds */
+		interval *= 1000;  /* milliseconds */
 		ts2 = interval;
 		if (cfg_child_init()) return -1;
 		for(;;){
 			if (ts2>interval)
-				sleep_us(1000);    /* 1 milisecond sleep to catch up */
+				sleep_us(1000);    /* 1 millisecond sleep to catch up */
 			else
 				sleep_us(ts2*1000); /* microseconds sleep */
 			ts1 = get_ticks_raw();
@@ -312,7 +312,7 @@ int fork_sync_utimer(int child_id, char* desc, int make_sock,
 				sleep_us(ts2);
 			ts1 = get_ticks_raw();
 			cfg_update();
-			f(TICKS_TO_MS(ts1), param); /* ticks in mili-seconds */
+			f(TICKS_TO_MS(ts1), param); /* ticks in milliseconds */
 			ts2 = uinterval - get_ticks_raw() + ts1;
 		}
 	}

--- a/src/core/timer_proc.h
+++ b/src/core/timer_proc.h
@@ -64,7 +64,7 @@ int fork_basic_timer_w(int child_id, char* desc, int make_sock,
 #define fork_dummy_timer fork_basic_timer
 
 /**
- * \brief Forks a separate simple milisecond-sleep() periodic timer
+ * \brief Forks a separate simple millisecond-sleep() periodic timer
  *
  * Forks a very basic periodic timer process, that just ms-sleep()s for
  * the specified interval and then calls the timer function.
@@ -76,7 +76,7 @@ int fork_basic_timer_w(int child_id, char* desc, int make_sock,
  * @param make_sock @see fork_process()
  * @param f         timer function/callback
  * @param param     parameter passed to the timer function
- * @param uinterval  interval in mili-seconds.
+ * @param uinterval  interval in milliseconds.
  * @return pid of the new process on success, -1 on error
  * (doesn't return anything in the child process)
  */

--- a/src/core/timer_ticks.h
+++ b/src/core/timer_ticks.h
@@ -30,7 +30,7 @@
 #define _timer_ticks_h
 
 /** @brief how many ticks per second (must >1 and < 100 (on linux x86))
- * recomended values >=8, <=32 (a 2^k value is better/faster)*/
+ * recommended values >=8, <=32 (a 2^k value is better/faster)*/
 #define TIMER_TICKS_HZ	16U
 
 /** @brief how many ticks per m milliseconds? (rounded up) */

--- a/src/core/usr_avp.c
+++ b/src/core/usr_avp.c
@@ -861,7 +861,7 @@ int parse_avp_name( str *name, int *type, numstr_ut *avp_name, int *index)
  *                    (uri, user, domain or global)
  *          \<index\> = \<number\> | '-' \<number\> | ''
  *                    (the avp index, if missing it means AVP_INDEX_ALL, but
- *                     it's use is deprecated)
+ *                     its use is deprecated)
  * More examples:
  *       "fr.bar[1]"  - from track, uri class, avp "bar", the value 1.
  *       "tu./^foo/"  - to track,  user class, all avps for which the name

--- a/src/core/ut.c
+++ b/src/core/ut.c
@@ -199,7 +199,7 @@ char* as_asciiz(str* s)
 /* return system version (major.minor.minor2) as
  *  (major<<16)|(minor)<<8|(minor2)
  * (if some of them are missing, they are set to 0)
- * if the parameters are not null they are set to the coresp. part
+ * if the parameters are not null they are set to the corresp. part
  */
 unsigned int get_sys_version(int* major, int* minor, int* minor2)
 {

--- a/src/core/ut.h
+++ b/src/core/ut.h
@@ -399,7 +399,7 @@ static inline int ushort2sbuf(unsigned short u, char* buf, int len)
 
 #define USHORT2STR_MAX_LEN  (USHORT2SBUF_MAX_LEN+1) /* 65535\0*/
 /* converts an unsigned short (16 bits) to asciiz
- * (optimized for port conversiob (4 or 5 digits most of the time)*/
+ * (optimized for port conversion (4 or 5 digits most of the time)*/
 static inline char* ushort2str(unsigned short u)
 {
 	static char buf[USHORT2STR_MAX_LEN];
@@ -1116,7 +1116,7 @@ char* as_asciiz(str* s);
 /* return system version (major.minor.minor2) as
  *  (major<<16)|(minor)<<8|(minor2)
  * (if some of them are missing, they are set to 0)
- * if the parameters are not null they are set to the coresp. part */
+ * if the parameters are not null they are set to the corresp. part */
 unsigned int get_sys_version(int* major, int* minor, int* minor2);
 
 /** Converts relative pathnames to absolute pathnames. This function returns

--- a/src/core/utils/srjson.c
+++ b/src/core/utils/srjson.c
@@ -392,7 +392,7 @@ static char *print_string_ptr(srjson_doc_t *doc, const char *str)
 	*ptr2++ = 0;
 	return out;
 }
-/* Invote print_string_ptr (which is useful) on an item. */
+/* Invoke print_string_ptr (which is useful) on an item. */
 static char *print_string(srjson_doc_t *doc, srjson_t *item) {
 	return print_string_ptr(doc, item->valuestring);
 }

--- a/src/core/utils/tmrec.c
+++ b/src/core/utils/tmrec.c
@@ -20,7 +20,7 @@
  */
 
 /**
- * Time Recurence Library according to iCalendar (RFC 2445)
+ * Time Recurrence Library according to iCalendar (RFC 2445)
  * - implemented at FhG Fokus, 2003 - external link:
  *   https://github.com/miconda/tmrec
  * \brief core/utils :: <description of this file>

--- a/src/core/ver.c
+++ b/src/core/ver.c
@@ -46,7 +46,7 @@ const char ver_flags[] = SER_COMPILE_FLAGS;
 const char repo_ver[] = REPO_VER;
 /** git hash. */
 const char repo_hash[] = REPO_HASH;
-/** state of the repository: dirty (uncommited changes) or "" */
+/** state of the repository: dirty (uncommitted changes) or "" */
 const char repo_state[] = REPO_STATE;
 
 /* vi: set ts=4 sw=4 tw=79:ai:cindent: */


### PR DESCRIPTION
In src/core/ccopts.sh:98 there is “acroos”.  This could be macros or across.

Likewise in 2× src/Makefile.defs 

In src/core/dst_blocklist.c:625 `taget` could be `target` or `tagged`.