### PR TITLE
No warning generated when UDP and no Content-Length header

### DIFF
--- a/src/modules/sanity/doc/sanity_admin.xml
+++ b/src/modules/sanity/doc/sanity_admin.xml
@@ -252,6 +252,27 @@ modparam("sanity", "noreply", 1)
 	    </programlisting>
 	</example>
 	</section>
+
+	<section id="sanity.p.always_log_missed_content_length">
+	<title><varname>always_log_missed_content_length</varname> (integer)</title>
+	<para>
+		If the value is 1 then the SIP message with no 'Content-Length' header
+		will cause warning message in the logs. If the value is 0 then the warning
+		message is not generated for cases when SIP message with no 'Content-Length'
+		header is sent over UDP or SCTP.
+	</para>
+	<para>
+		Default value is 1.
+	</para>
+	<example>
+	    <title>Set <varname>always_log_missed_content_length</varname> parameter</title>
+	    <programlisting>
+...
+modparam("sanity", "always_log_missed_content_length", 0)
+...
+	    </programlisting>
+	</example>
+	</section>
 </section>
 
    <section id="sanity.functions" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/src/modules/sanity/sanity.c
+++ b/src/modules/sanity/sanity.c
@@ -39,6 +39,7 @@
 #define UNSUPPORTED_HEADER_LEN (sizeof(UNSUPPORTED_HEADER)-1)
 
 extern int ksr_sanity_noreply;
+extern int always_log_missed_content_length;
 
 #define KSR_SANITY_REASON_SIZE 128
 typedef struct ksr_sanity_info {
@@ -608,7 +609,8 @@ int check_cl(sip_msg_t* msg) {
 			return SANITY_CHECK_FAILED;
 		}
 		LM_DBG("check_cl passed\n");
-	} else {
+	} else if (SANITY_LOG_MISSED_CONTENT_LEN == always_log_missed_content_length ||
+				(msg->rcv.proto != PROTO_UDP && msg->rcv.proto != PROTO_SCTP)) {
 		LM_WARN("content length header missing in request\n");
 	}
 

--- a/src/modules/sanity/sanity_mod.c
+++ b/src/modules/sanity/sanity_mod.c
@@ -40,6 +40,7 @@ int default_msg_checks = SANITY_DEFAULT_CHECKS;
 int default_uri_checks = SANITY_DEFAULT_URI_CHECKS;
 int _sanity_drop = 1;
 int ksr_sanity_noreply = 0;
+int always_log_missed_content_length = SANITY_LOG_MISSED_CONTENT_LEN;
 
 str_list_t* proxyrequire_list = NULL;
 
@@ -70,11 +71,12 @@ static cmd_export_t cmds[] = {
  * Exported parameters
  */
 static param_export_t params[] = {
-	{"default_checks",	PARAM_INT,	&default_msg_checks	},
-	{"uri_checks",		PARAM_INT,	&default_uri_checks	},
-	{"proxy_require",	PARAM_STR,	&pr_str			},
-	{"autodrop",		PARAM_INT,	&_sanity_drop	},
-	{"noreply",			PARAM_INT,	&ksr_sanity_noreply	},
+	{"default_checks",			PARAM_INT,	&default_msg_checks	},
+	{"uri_checks",				PARAM_INT,	&default_uri_checks	},
+	{"proxy_require",			PARAM_STR,	&pr_str			},
+	{"autodrop",				PARAM_INT,	&_sanity_drop	},
+	{"noreply",				PARAM_INT,	&ksr_sanity_noreply	},
+	{"always_log_missed_content_length",	PARAM_INT,	&always_log_missed_content_length	},
 	{0, 0, 0}
 };
 

--- a/src/modules/sanity/sanity_mod.h
+++ b/src/modules/sanity/sanity_mod.h
@@ -74,6 +74,9 @@
 #define SANITY_CHECK_ERROR -1
 #define SANITY_CHECK_NOT_APPLICABLE -2
 
+#define SANITY_DONT_LOG_MISSED_CONTENT_LEN 0
+#define SANITY_LOG_MISSED_CONTENT_LEN 1
+
 extern int default_checks;
 extern str_list_t* proxyrequire_list;
 


### PR DESCRIPTION
GH #

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #3210

#### Description

Added 'always_log_missed_content_length' mode for sanity module.
If 'always_log_missed_content_length' is 1 then the SIP message
with no 'Content-Length' header will cause warning message in
the logs. Otherwise warning message is not generated for cases
when SIP message with no 'Content-Length' header is sent over UDP.
