### PR TITLE
 usrloc: correct AOR value on usrloc:contact-expired

### DIFF
--- a/src/modules/usrloc/udomain.c
+++ b/src/modules/usrloc/udomain.c
@@ -955,7 +955,7 @@ int udomain_contact_expired_cb(db1_con_t* _c, udomain_t* _d)
 	db_val_t query_vals[3];
 	int key_num = 2;
 	db1_res_t* res = NULL;
-	str user, contact;
+	str user, contact, domain;
 	int i;
 	int n;
 	urecord_t r;
@@ -963,6 +963,9 @@ int udomain_contact_expired_cb(db1_con_t* _c, udomain_t* _d)
 #define RUIDBUF_SIZE 128
 	char ruidbuf[RUIDBUF_SIZE];
 	str ruid;
+#define AORBUF_SIZE 512
+	char aorbuf[AORBUF_SIZE];
+	str aor;
 
 	if (ul_db_mode!=DB_ONLY) {
 		return 0;
@@ -1057,6 +1060,14 @@ int udomain_contact_expired_cb(db1_con_t* _c, udomain_t* _d)
 				continue;
 			}
 			user.len = strlen(user.s);
+			if(user.len < AORBUF_SIZE ) {
+				memcpy(aorbuf, user.s, user.len);
+				aor.s = aorbuf;
+				aor.len = user.len;
+			} else {
+				LM_ERR("user is too long %d\n", user.len);
+				continue;
+			}
 
 			ci = dbrow2info(ROW_VALUES(row)+1, &contact, 0);
 			if (ci==0) {
@@ -1065,18 +1076,30 @@ int udomain_contact_expired_cb(db1_con_t* _c, udomain_t* _d)
 				continue;
 			}
 
-			lock_udomain(_d, &user);
+			if(ul_use_domain) {
+				domain.s = (char*)VAL_STRING(ROW_VALUES(row)+20);
+				domain.len = strlen(domain.s);
+				if(domain.len + aor.len < AORBUF_SIZE) {
+					aorbuf[aor.len] = '@';
+					memcpy(aorbuf+aor.len+1, domain.s, domain.len);
+					aor.len += domain.len + 1;
+				} else {
+					LM_ERR("aor too long, using user part only\n");
+				}
+			}
+
+			lock_udomain(_d, &aor);
 			/* don't use the same static value from get_static_urecord() */
 			memset( &r, 0, sizeof(struct urecord) );
-			r.aor = user;
-			r.aorhash = ul_get_aorhash(&user);
+			r.aor = aor;
+			r.aorhash = ul_get_aorhash(&aor);
 			r.domain = _d->name;
 
 			if ( (c=mem_insert_ucontact(&r, &contact, ci)) == 0) {
 				LM_ERR("inserting temporary contact failed for %.*s\n",
-						user.len, user.s);
+						aor.len, aor.s);
 				release_urecord(&r);
-				unlock_udomain(_d, &user);
+				unlock_udomain(_d, &aor);
 				goto error;
 			}
 
@@ -1095,11 +1118,11 @@ int udomain_contact_expired_cb(db1_con_t* _c, udomain_t* _d)
 					ruid.len = c->ruid.len;
 				} else {
 					LM_ERR("ruid is too long %d for %.*s\n", c->ruid.len,
-							user.len, user.s);
+							aor.len, aor.s);
 				}
 			}
 			release_urecord(&r);
-			unlock_udomain(_d, &user);
+			unlock_udomain(_d, &aor);
 			if(ruid.len > 0 && ul_xavp_contact_name.s != NULL) {
 				/* delete attributes by ruid */
 				uldb_delete_attrs_ruid(_d->name, &ruid);


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3365

#### Description
previously $ulc(x=>aor) had only the user part even with use_domain set

output after applied the fix
```
│Feb  9 16:47:58.089067 spce proxy[30268]: DEBUG: usrloc [udomain.c:1053]: udomain_contact_expired_cb(): calling contact expired records - cycle [1]
│Feb  9 16:47:58.089100 spce proxy[30268]: DEBUG: usrloc [ul_callback.h:83]: run_ul_callbacks(): contact=0x7f8859ed4f50, callback type 8/8, id 0 entered
│Feb  9 16:47:58.089197 spce proxy[30268]: DEBUG: registrar [regpv.c:734]: reg_ul_expired_contact(): saved contact for <43991002@ce-trunk.lab> in [exp]
│Feb  9 16:47:58.089220 spce proxy[30268]: NOTICE: usrloc:contact-expired <script>: Contact ruid uloc-63e5131a-7639-1 to sip:43991002@192.168.2.177:5160 for user 43991002@ce-trunk.lab expired
```