### PR TITLE
kamctl: hide errors raised by "which"

### DIFF
--- a/utils/kamctl/kamctl.base
+++ b/utils/kamctl/kamctl.base
@@ -10,7 +10,7 @@ locate_tool() {
 	while [ -n "$1" ]
 	do
 		if [ -x /usr/bin/which ] ; then
-			TOOLPATH=`which $1`
+			TOOLPATH=`which $1 2> /dev/null`
 			if [ -n "$TOOLPATH" ]; then
 				return
 			fi


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Hide error messages from "which" to avoid polluting kamctl's output (e.g. when a JSON document is returned) in environments where STDOUT and STDERR may be combined into a single stream (e.g. containers).

Without this change, kamctl's output may end up containing error messages, resulting in invalid/unparsable data. This is caused by the stdout & stderr streams being combined into a single stream in some environments, which may be outside the end-user's control (e.g. external cloud provider).