### PR TITLE
rtpengine: doc add codec-accept with an example

### DIFF
--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -2630,6 +2630,15 @@ rtpengine_offer();
 				and used for transcoding on the offering side. Useful only in combination with codec-transcode. <emphasis>all</emphasis> keyword
 				can be used to mask all offered codecs
 				</para></listitem>
+
+				<listitem><para>
+				<emphasis>codec-accept=...</emphasis> - Similar to `mask` and `consume` but doesn't remove the codec from the list of
+				offered codecs. This means that a codec listed under `accept` will still be offered
+				to the remote peer, but if the remote peer rejects it, it will still be accepted
+				towards the original offerer and then used for transcoding. It is a more selective
+				version of what the `always transcode` flag does.
+				</para></listitem>
+
 				<listitem><para>
 				<emphasis>T.38=decode</emphasis> - If the offered &sdp; contains a media section
 				advertising T.38 over UDPTL, translate it to a regular audio media section
@@ -2696,6 +2705,30 @@ if (has_body("application/sdp")) {
 				t_on_reply("1");
 }
 
+...
+</programlisting>
+                </example>
+		<example>
+			<title><function>rtpengine_offer</function> usage to force transcoding from opus to PCMU</title>
+		<programlisting format="linespecific">
+route {
+...
+    if (is_method("INVITE")) {
+        if (has_body("application/sdp")) {
+            if (rtpengine_offer("codec-mask=opus codec-accept-opus codec-strip=PCMU codec-transcode=PCMU"))
+                t_on_reply("1");
+        }
+    }
+...
+}
+
+onreply_route[1]
+{
+...
+    if (has_body("application/sdp"))
+        rtpengine_answer("codec-strip=PCMU codec-strip=PCMA");
+...
+}
 ...
 </programlisting>
                 </example>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x]  Documentation.

#### Description
A) offers OPUS + PCMU

B) answers PCMU

I do not want PCMU to be selected, I would like to endup transcoding : 
```
A <-opus-> rtpengine <-pcmu-> B
```
If I understand correctly, this is what I have to set on the rtpengine_offer
```
codec-mask=opus codec-strip=PCMU codec-transcode=PCMU
```
rtpengine is removing opus from the offer before sending it.

The answer sent by rtpengine is as follows:
```
m=audio 10884 UDP/TLS/RTP/SAVPF 0 126
a=maxptime:150
a=mid:0
a=rtpmap:0 PCMU/8000
a=rtpmap:126 telephone-event/8000
```
 for this to work, I would expect rtpengine to insert opus and remove pcmu ?
 
 Answer :
 ```
 That's what 'codec-accept` is for 

Try with `codec-accept-opus` and/or `opus-accept-opus/48000` in the offer.  That should be all that's needed (assuming reasonably recent version).

```
 