### PR TITLE
utils/kamctl: allow the definition of a specific startup file at star…

### DIFF
--- a/utils/kamctl/kamctl
+++ b/utils/kamctl/kamctl
@@ -73,6 +73,10 @@ if [ -z "$MYLIBDIR" ] ; then
 	fi
 fi
 
+if [ -z "$STARTUP_CONFIG_FILE" ]; then
+	STARTUP_CONFIG_FILE="kamailio.cfg"
+fi
+
 ##### ------------------------------------------------ #####
 ### load base functions
 #
@@ -2007,9 +2011,9 @@ kamailio_start() {
 		exit 1
 	fi
 	if [ $SYSLOG = 1 ] ; then
-		$KAMBIN -P $PID_FILE  -f $ETCDIR/kamailio.cfg $STARTOPTIONS 1>/dev/null 2>/dev/null
+		$KAMBIN -P $PID_FILE  -f $ETCDIR/$STARTUP_CONFIG_FILE $STARTOPTIONS 1>/dev/null 2>/dev/null
 	else
-		$KAMBIN -P $PID_FILE -E  -f $ETCDIR/kamailio.cfg $STARTOPTIONS
+		$KAMBIN -P $PID_FILE -E  -f $ETCDIR/$STARTUP_CONFIG_FILE $STARTOPTIONS
 	fi
 	sleep 3
 	if [ ! -s $PID_FILE ] ; then

--- a/utils/kamctl/kamctlrc
+++ b/utils/kamctl/kamctlrc
@@ -159,6 +159,10 @@
 ## PID file path - default is: /run/kamailio/kamailio.pid
 # PID_FILE=/run/kamailio/kamailio.pid
 
+## Kamailio Startup Configuration File
+## Default is: kamailio.cfg
+# STARTUP_CONFIG_FILE=kamailio.cfg
+
 ## Extra start options - default is: not set
 ## example: start Kamailio with 64MB shared memory: STARTOPTIONS="-m 64"
 # STARTOPTIONS=


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Added the possibility to specify an alternative file different from the default: `kamailio.cfg`, when starting `kamailio`, using the `kamctl` tool.
This makes it possible to start `kamailio` by passing a startup file located in a specific folder (via `ETCDIR` env variable) and with a specific name, instead of using the default name: `kamailio.cfg`.

Several local tests have been performed and it has been verified that it is now possible to perform the basic start/stop/restart operations of `kamailio` via `kamctl`, considering the use of a startup file other than the default: `kamailio.cfg`.

Example of `.kamctlrc` used:

```sh
ETCDIR="/etc/my-component/confs"
RPCFIFOPATH="/run/my-component/my-component_rpc.fifo"
PID_FILE="/run/my-component/my-component.pid"
STARTUP_CONFIG_FILE="starter.cfg"
STARTOPTIONS="-m 512 -M 64 -u user -g group"
```

Tested on `CentOS Linux release 7.9.2009 (Core)`.

I think this change will be interesting for many users.

Thanks
