### PR TITLE
tm:t_lookup_callid use only trans Call-ID header value to match with …

### DIFF
--- a/src/modules/tm/t_lookup.c
+++ b/src/modules/tm/t_lookup.c
@@ -1767,7 +1767,7 @@ int t_lookup_callid(struct cell ** trans, str callid, str cseq) {
 	}
 
 	/* create header fields the same way tm does itself, then compare headers */
-	endpos = print_callid_mini(callid_header, callid);
+	endpos = print_callid_mini_value(callid_header, callid);
 	LM_DBG("created comparable call_id header field: >%.*s<\n",
 			(int)(endpos - callid_header), callid_header);
 
@@ -1784,8 +1784,14 @@ int t_lookup_callid(struct cell ** trans, str callid, str cseq) {
 	clist_foreach(hash_bucket, p_cell, next_c){
 
 		prefetch_loc_r(p_cell->next_c, 1);
+		int callid_value_len = strlen(callid_header);
+		int cid_value_len = p_cell->callid.len - 8;
+		char* cid_value = (char*)malloc(sizeof(char) * (cid_value_len + 1));
+		char* only_callid = strncpy(cid_value, (p_cell->callid.s + 8), cid_value_len);
+		while(isspace((unsigned char)*only_callid)) only_callid++;
 		/* compare complete header fields, casecmp to make sure invite=INVITE*/
-		if ((strncmp(callid_header, p_cell->callid.s, p_cell->callid.len) == 0)
+		if ((strncmp(callid_header, only_callid, callid_value_len) == 0)
+		/*if ((strncmp(callid_header, p_cell->callid.s, p_cell->callid.len) == 0)*/
 				&& (strncasecmp(cseq_header, p_cell->cseq_n.s, p_cell->cseq_n.len)
 					== 0)) {
 			LM_DBG("we have a match: callid=>>%.*s<< cseq=>>%.*s<<\n",

--- a/src/modules/tm/t_msgbuilder.c
+++ b/src/modules/tm/t_msgbuilder.c
@@ -1491,6 +1491,15 @@ char* print_callid_mini(char* target, str callid) {
 	return target;
 }
 
+/*
+ * Print Call-ID header field value
+ */
+char* print_callid_mini_value(char* target, str callid) {
+       memapp(target, callid.s, callid.len);
+       memapp(target, CRLF, CRLF_LEN);
+       return target;
+}
+
 static inline char* print_callid(char* w, dlg_t* dialog, struct cell* t)
 {
 	/* begins with CRLF, not included in t->callid, don`t know why...?!? */

--- a/src/modules/tm/t_msgbuilder.h
+++ b/src/modules/tm/t_msgbuilder.h
@@ -90,6 +90,7 @@ int t_calc_branch(struct cell *t,
 
 /* exported minimum functions for use in t_cancel */
 char* print_callid_mini(char* target, str callid);
+char* print_callid_mini_value(char* target, str callid);
 char* print_cseq_mini(char* target, str* cseq, str* method);
 
 #endif


### PR DESCRIPTION
…callid param

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x ] PR should be backported to stable branches
- [x ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Using kamailio 5.4 version, we have had an issue with a carrier that sent a CANCEL with to-tag. To be able to process that request, we used the function t_cancel_callid, to convert that abnormal CANCEL to a regular one cancelling the current transaction for that call. 
But we saw that it was not working since they sent the callid header named as CALL-ID.
Seems the matching between the stored callid header in memory and the param passed for the callid lookup matching, is being done in case sensitive way with a generated Call-ID: XXXXXXXX based on the called param of the function.

we have tested a wasy to do the comparision only with the callid header value, so we strip from the callid header stored at memory the Call-ID: (or CALL-ID:) part.

maybe there is another way to do that in other part of the code, but seems at least this worked for the tests

thanks a lot and regards
david
