### PR TITLE
core: fix a seg while t_continue with nats module

### DIFF
--- a/src/core/cfg/cfg_struct.h
+++ b/src/core/cfg/cfg_struct.h
@@ -361,7 +361,7 @@ static inline void cfg_update_local(int no_cbs)
 	if (unlikely(cfg_child_cb==CFG_NO_CHILD_CBS || no_cbs))
 		return;
 	/* call the per-process callbacks */
-	while (cfg_child_cb != last_cb) {
+	while (cfg_child_cb && cfg_child_cb != last_cb) {
 		prev_cb = cfg_child_cb;
 		cfg_child_cb = cfg_child_cb->next;
 		atomic_inc(&cfg_child_cb->refcnt);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

segfault

```
#0  0x0000ffffb9934840 in cfg_update_local (no_cbs=0) at ../../core/cfg/cfg_struct.h:366
366			cfg_child_cb = cfg_child_cb->next;
(gdb) print cfg_child_cb
$1 = (cfg_child_cb_t *) 0x0
```

example lua:

```
function ksr_route_nats()
	KSR.tm.t_newtran()
	local tindex = KSR.pv.gete("$T(id_index)")
	local tlabel = KSR.pv.gete("$T(id_label)")
	KSR.tmx.t_suspend()

	local req = {
		jsonrpc = "2.0", method = "route",
		id = tindex .. ':' .. tlabel,
		params = {
			from = KSR.pv.gete("$fu"),
			to = KSR.pv.gete("$tu"),
		}
	}
	local rpc = cjson.encode(req)
	KSR.info("rpc: " .. rpc .. "\n")
	KSR.nats.publish("cn.xswitch.ctrl.route", rpc)
	KSR.x.exit();
end

function handle_nats_response(data)
	msg = cjson.decode(data)
	if (not msg) or (not msg.id) then return end
	KSR.info("========= msg.id: " .. msg.id .. "\n")

	if not msg.result then
		KSR.error("response has no result\n")
		return
	end

	tindex, tlabel = msg.id:match("(.+):(.+)")
	if tindex and tlabel then
		KSR.pv.sets('$var(nats_response)', data)
		KSR.tmx.t_continue(tindex, tlabel, 'ksr_nats_continue')
	end
end
```

I'm not sure if it's the proper fix, but this pr fixed the seg. Thanks.

