### PR TITLE
tcpops: added tcp_get_conid() for kemi

### DIFF
--- a/src/modules/tcpops/tcpops_mod.c
+++ b/src/modules/tcpops/tcpops_mod.c
@@ -604,6 +604,26 @@ setvalue:
 /**
  *
  */
+static int ki_tcp_get_conid(sip_msg_t* msg, str *saddr, str *pvs)
+{
+    pv_spec_t *dst;
+    dst = pv_cache_get(pvs);
+
+    if(dst==NULL) {
+        LM_ERR("failed to get pv spec for: %.*s\n", pvs->len, pvs->s);
+        return -1;
+    }
+    if(dst->setf==NULL) {
+        LM_ERR("target pv is not writable: %.*s\n", pvs->len, pvs->s);
+        return -1;
+    }
+
+    return ki_tcp_get_conid_helper(msg, saddr, dst);
+}
+
+/**
+ *
+ */
 static int w_tcp_get_conid(sip_msg_t* msg, char *paddr, char *pvn)
 {
 	str saddr;
@@ -853,6 +873,11 @@ static sr_kemi_t sr_kemi_tcpops_exports[] = {
 	{ str_init("tcpops"), str_init("tcp_conid_state"),
 		SR_KEMIP_INT, ki_tcp_conid_state,
 		{ SR_KEMIP_INT, SR_KEMIP_NONE, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("tcpops"), str_init("tcp_get_conid"),
+		SR_KEMIP_INT, ki_tcp_get_conid,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
 	{ str_init("tcpops"), str_init("tcp_set_otcpid"),


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
In `tcpops` module, the method `tcp_get_conid()` was missing which may be needed to trace, track and log TCP connections, especially for UDP to TCP reply route in KEMI. The patch is tested to work with `master` and `5.6` and above branches.