### PR TITLE
tm: memory leak in case dropping messages in local-request event route

### DIFF
--- a/src/modules/tm/uac.c
+++ b/src/modules/tm/uac.c
@@ -540,6 +540,7 @@ static inline int t_uac_prepare(uac_req_t *uac_r,
 	if (unlikely(goto_on_local_req>=0 || tm_event_callback.len>0)) {
 		refresh_shortcuts = t_run_local_req(&buf, &buf_len, uac_r, new_cell, request);
 		if (unlikely(refresh_shortcuts==E_DROP)) {
+			shm_free(buf);
 			ret=E_DROP;
 			goto error1;
 		}
@@ -653,6 +654,10 @@ int prepare_req_within(uac_req_t *uac_r,
 	
 	if (unlikely(ret < 0 && ret == E_DROP)) {
 		ret = 0;
+		if(uac_r->cbp) {
+			shm_free(uac_r->cbp);
+		}
+
 	}
 
  err:
@@ -749,6 +754,9 @@ int t_uac_with_ids(uac_req_t *uac_r,
 	if (ret < 0) {
 		if (unlikely(ret == E_DROP)) {
 			ret = 0;
+			if(uac_r->cbp) {
+				shm_free(uac_r->cbp);
+			}
 		}
 		return ret;
 	}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
I faced an issue with memory leak in case drop NOTIFY messages in the "local-request" event route in `mem_copy_subs` and `build_uac_req`

analysis of mem leak:
kamcmd corex.shm_summary
<code>...
Mar 23 12:00:28 pbx kamailio[72308]: NOTICE: fm_status: fm_sums():  count=    11 size=      7520 bytes from presence: hash.c: mem_copy_subs(141)<br>             
Mar 23 12:00:28 pbx kamailio[72308]: NOTICE: fm_status: fm_sums():  count=    23 size=     22536 bytes from tm: t_msgbuilder.c: build_uac_req(1618)
...</code>

a lot of dropped messages in local-request event route

<code>...
Mar 23 12:01:09 pbx kamailio[72308]: NOTICE: fm_status: fm_sums():  count=    83 size=     51256 bytes from presence: hash.c: mem_copy_subs(141)
Mar 23 12:01:09 pbx kamailio[72308]: NOTICE: fm_status: fm_sums():  count=    98 size=    116864 bytes from tm: t_msgbuilder.c: build_uac_req(1618)
...</code>

no messages, no activities

<code>...
Mar 23 12:02:34 pbx kamailio[72308]: NOTICE: fm_status: fm_sums():  count=    83 size=     51256 bytes from presence: hash.c: mem_copy_subs(141)
Mar 23 12:02:34 pbx kamailio[72308]: NOTICE: fm_status: fm_sums():  count=    96 size=    115432 bytes from tm: t_msgbuilder.c: build_uac_req(1618)
...</code>

In the code, we have a comment like "never free cbp here because if t_uac_prepare fails, cbp is not freed and thus caller has no chance to discover if it is freed or not", but we'll free the cbp in two cases:
1. in case of error, but we have if (ret == E_DROP) then ret = 0; (so, no error result)
2. in case call insert_tmcb for cbp, but we don't do it for E_DROP