### PR TITLE
core: add socket timestamp of received packets and keep track of receive delay

### DIFF
--- a/src/core/ip_addr.h
+++ b/src/core/ip_addr.h
@@ -174,6 +174,7 @@ typedef struct receive_info {
 	struct socket_info* bind_address; /* sock_info structure on which
 										* the msg was received */
 	recv_flags_t rflags; /* flags */
+	struct timespec ts; /* network timestamp of incoming packet (using CLOCK_REALTIME) */
 	char proto;
 #ifdef USE_COMP
 	char proto_pad0;  /* padding field */

--- a/src/core/parser/msg_parser.h
+++ b/src/core/parser/msg_parser.h
@@ -296,6 +296,7 @@ typedef struct sip_msg {
 	unsigned int id;               /*!< message id, unique/process*/
 	int pid;                       /*!< process id */
 	struct timeval tval;           /*!< time value associated to message */
+	struct timespec ts_recv_delay; /*!< time difference between network receiving the message and Kamailio reading it */
 	snd_flags_t fwd_send_flags;    /*!< send flags for forwarding */
 	snd_flags_t rpl_send_flags;    /*!< send flags for replies */
 	struct msg_start first_line;   /*!< Message first line */

--- a/src/core/receive.c
+++ b/src/core/receive.c
@@ -362,6 +362,14 @@ int receive_msg(char *buf, unsigned int len, receive_info_t *rcv_info)
 	if(likely(sr_msg_time == 1))
 		msg_set_time(msg);
 
+	/* If the timestamp of network reception is available,
+	 * compute and store the time difference between network receiving the message and Kamailio reading it. */
+	if (timespec_isset(&rcv_info->ts)) {
+		struct timespec ts_recvmsg;
+		clock_gettime(CLOCK_REALTIME, &ts_recvmsg); // same clock as used to set SO_TIMESTAMPNS (CLOCK_REALTIME)
+		timespec_sub(&ts_recvmsg, &rcv_info->ts, &msg->ts_recv_delay);
+	}
+
 	if(parse_msg(buf, len, msg) != 0) {
 		errsipmsg = 1;
 		evp.data = (void *)msg;

--- a/src/core/ut.h
+++ b/src/core/ut.h
@@ -46,6 +46,20 @@
 
 
 
+/* Macros for manipulation of struct timespec
+ * Similar to the macros defined for struct timeval in <sys/time.h> (timersub, ...)
+ */
+#define timespec_isset(tsp) ((tsp)->tv_sec || (tsp)->tv_nsec)
+#define timespec_sub(a, b, result) \
+	do { \
+		(result)->tv_sec = (a)->tv_sec - (b)->tv_sec; \
+		(result)->tv_nsec = (a)->tv_nsec - (b)->tv_nsec; \
+		if ((result)->tv_nsec < 0) { \
+			--(result)->tv_sec; \
+			(result)->tv_nsec += 1000000000; \
+		} \
+	} while (0)
+
 /* zero-string wrapper */
 #define ZSW(_c) ((_c)?(_c):"")
 
@@ -133,7 +147,7 @@
 		(_dest) += (_len) ;						\
 	}while(0);									\
 
-	
+
 /*! append _c char to _dest string */
 #define append_chr(_dest,_c) \
 	*((_dest)++) = _c;
@@ -222,11 +236,11 @@ static inline int btostr( char *p,  unsigned char val)
 #define INT2STR_MAX_LEN  (19+1+1+1) /* 2^64~= 16*10^18 =>
 									   19+1 digits + sign + \0 */
 
-/* 
- * returns a pointer to a static buffer containing l in asciiz (with base "base") & sets len 
+/*
+ * returns a pointer to a static buffer containing l in asciiz (with base "base") & sets len
  * left padded with 0 to "size"
  */
-static inline char* int2str_base_0pad(unsigned int l, int* len, int base, 
+static inline char* int2str_base_0pad(unsigned int l, int* len, int base,
 											int size)
 {
 	static char r[INT2STR_MAX_LEN];
@@ -379,7 +393,7 @@ static inline int ushort2sbuf(unsigned short u, char* buf, int len)
 {
 	int offs;
 	unsigned char a, b, c, d;
-	
+
 	if (unlikely(len<USHORT2SBUF_MAX_LEN))
 		return 0;
 	offs=0;
@@ -478,7 +492,7 @@ inline static int int2reverse_hex( char **c, int *size, unsigned int nr )
 }
 
 /* double output length assumed ; does NOT zero-terminate */
-inline static int string2hex( 
+inline static int string2hex(
 	/* input */ unsigned char *str, int len,
 	/* output */ char *hex )
 {
@@ -555,7 +569,7 @@ inline static int hex2int(char hex_digit)
 	<0 is returned on an unescaping error, length of the
 	unescaped string otherwise
 */
-inline static int un_escape(str *user, str *new_user ) 
+inline static int un_escape(str *user, str *new_user )
 {
  	int i, j, value;
 	int hi, lo;
@@ -608,7 +622,7 @@ inline static int un_escape(str *user, str *new_user )
 error:
 	new_user->len = j;
 	return -1;
-} 
+}
 
 
 /*
@@ -1027,7 +1041,7 @@ static inline int str_strcasecmp(const str *str1, const str *str2)
 #endif
 
 
-/* INTeger-TO-Buffer-STRing : convers an unsigned long to a string 
+/* INTeger-TO-Buffer-STRing : convers an unsigned long to a string
  * IMPORTANT: the provided buffer must be at least INT2STR_MAX_LEN size !! */
 static inline char* int2bstr(unsigned long l, char *s, int* len)
 {
@@ -1092,7 +1106,7 @@ int group2gid(int* gid, char* group);
 
 /*
  * Replacement of timegm (does not exists on all platforms
- * Taken from 
+ * Taken from
  * http://lists.samba.org/archive/samba-technical/2002-November/025737.html
  */
 time_t _timegm(struct tm* t);

--- a/src/modules/pv/pv_time.c
+++ b/src/modules/pv/pv_time.c
@@ -376,6 +376,18 @@ int pv_get_timeval(struct sip_msg *msg, pv_param_t *param,
 				LM_ERR("unable to get monotonic clock value\n");
 				return pv_get_null(msg, param, res);
 			}
+		case 7:
+			/* recv delay timespec (converted to nanoseconds returned as string) */
+			if (!timespec_isset(&msg->ts_recv_delay)) {
+				LM_ERR("Timer receive delay is not set\n");
+				return pv_get_null(msg, param, res);
+			}
+			s.len = snprintf(_timeval_ts_buf, 64, "%" PRIu64,
+				(u_int64_t)msg->ts_recv_delay.tv_sec * 1000000000 + (u_int64_t)msg->ts_recv_delay.tv_nsec);
+			if (s.len < 0)
+				return pv_get_null(msg, param, res);
+			s.s = _timeval_ts_buf;
+			return pv_get_strval(msg, param, res, &s);
 		default:
 			msg_set_time(msg);
 			return pv_get_uintval(msg, param, res, (unsigned int)msg->tval.tv_sec);
@@ -407,6 +419,9 @@ int pv_parse_timeval_name(pv_spec_p sp, str *in)
 				sp->pvp.pvn.u.isname.name.n = 5;
 			else if(strncmp(in->s, "Sm", 2)==0)
 				sp->pvp.pvn.u.isname.name.n = 6;
+			else if(strncmp(in->s, "RD", 2)==0)
+				/* recv delay timespec (converted to nanoseconds returned as string) */
+				sp->pvp.pvn.u.isname.name.n = 7;
 			else goto error;
 		break;
 		default:


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

This is a proposed evolution that adds socket timestamping of received UDP packets (using SO_TIMESTAMPNS).
It computes the delay between this timestamp and the time at which the packet is read by Kamailio.
This can then be accessed using pv "$TV(RD)" (RD for "receive relay").

Rationale :
The Kamailio server is handling traffic that is irregular and can temporarily spike to a point where all children are still busy when new packets are incoming on the network interface.
Consequently, these packets have to wait until a worker is available. The client will see a higher response time, that currently cannot be monitored by Kamailio itself.
This evolution allows to make this wait time observable by Kamailio, allowing to log or write the information to CDR for example.

If this is possible, I'd like to merge this feature in Kamailio.
Of course, I'm ready to discuss the PR and make any necessary changes.
All comments and reviews are most welcome.

I've tested this locally on Linux (3.10.0-957.10.1.el7.x86_64) with the latest Kamailio master as of 2023/03/23.


Thanks!