### PR TITLE
tls: get san entries by index

### DIFF
--- a/src/modules/tls/tls_select.c
+++ b/src/modules/tls/tls_select.c
@@ -318,7 +318,7 @@ static int get_version(str* res, sip_msg_t* msg)
 	res->s = buf;
 	res->len = version.len;
 	tcpconn_put(c);
-		return 0;
+	return 0;
 
  err:
 	if (c) tcpconn_put(c);
@@ -1894,7 +1894,3 @@ sr_kemi_xval_t* ki_tls_cget_attr(sip_msg_t* msg, str *aname)
 	sr_kemi_xval_null(&_ksr_kemi_tls_xval, SR_KEMI_XVAL_NULL_EMPTY);
 	return &_ksr_kemi_tls_xval;
 }
-
-
-
-


### PR DESCRIPTION
- adds count pv and sel for DNS, EMAIL, IP, URI
- adds ability to access SAN entries by index

fix #3400

<!-- Kamailio Pull Request Template -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3400 

#### Description
Fix issue #3400 that describes that tls module cannot properly handle certificates with multiple SAN entries.

Add ability to access SAN entries by index.

Add ability to get count of supported SAN entries by type of entry.

If index is not provided will return first entry (current behavior to remain backwards compatible.

Tested by creating a self signed SAN cert with 3 DNS entries and confirmed expected results for:

$(tls_peer_san_hostname[2])
$(tls_peer_san_hostname);
$tls_peer_san_count(DNS)
$tls_peer_san_count(URI)
$tls_peer_san_count(EMAIL)
$tls_peer_san_count(IP)
$sel(tls.peer.dns[1])
$sel(tls.peer.dns)
$sel(tls.peer.count[\"DNS\"])
$(tls_peer_san_ip[0])
$(tls_peer_san_uri)
$sel(tls.peer.ip[0])
$sel(tls.peer.count[\"EMAIL\"])
$(tls_my_san_hostname[2])
$(tls_my_san_hostname)
$tls_my_san_count(DNS)
$tls_my_san_count(URI)
$tls_my_san_count(EMAIL)
$tls_my_san_count(IP)
$sel(tls.my.dns[1])
$sel(tls.my.dns)
$sel(tls.my.count[\"DNS\"]
$(tls_my_san_ip[0])]
$(tls_my_san_uri)
$sel(tls.my.ip[0])
$sel(tls.my.count[\"EMAIL\"])

Also repeated the test with a self signed cert with 3 DNS entries, 1 IP entry, 1 EMAIL entry and 1 URI entry