### PR TITLE
registrar: adding tcpconn_id to xavp_cfg

### DIFF
--- a/src/modules/registrar/doc/registrar_admin.xml
+++ b/src/modules/registrar/doc/registrar_admin.xml
@@ -798,6 +798,13 @@ modparam("registrar", "reg_callid_avp", "$avp(s:avp)")
 				Used in save().
 			</para>
 		</listitem>
+		<listitem>
+			<para>
+				<emphasis>tcpconn_id</emphasis> This can be set with $conid, the TCP connection ID of the connection the current message.
+				This is useful when calling save() on a reply route to set the connecion of the original request.
+				Used in save().
+			</para>
+		</listitem>
 		</itemizedlist>
 		<para>
 			For example. if this parameter is set to 'reg', then the number

--- a/src/modules/registrar/regpv.c
+++ b/src/modules/registrar/regpv.c
@@ -275,6 +275,8 @@ int pv_get_ulc(struct sip_msg *msg,  pv_param_t *param,
 				return  pv_get_strval(msg, param, res, &c->instance);
 		break;
 		case 21: /* conid */
+			if (c->tcpconn_id > 0)
+				return pv_get_sintval(msg, param, res, c->tcpconn_id);
 			if (c->sock && (c->sock->proto == PROTO_TCP || c->sock->proto == PROTO_TLS || c->sock->proto == PROTO_WS || c->sock->proto == PROTO_WSS))
 				return pv_get_sintval(msg, param, res, c->tcpconn_id);
 		break;
@@ -662,6 +664,10 @@ int pv_fetch_contacts_helper(sip_msg_t* msg, udomain_t* dt, str* uri,
 				|| ptr->sock->proto == PROTO_TLS || ptr->sock->proto == PROTO_WS
 				|| ptr->sock->proto == PROTO_WSS))
 		{
+			c0->tcpconn_id = ptr->tcpconn_id;
+		}
+		if (ptr->tcpconn_id > 0) {
+			LM_DBG("preset tcpconn_id : %d\n", ptr->tcpconn_id);
 			c0->tcpconn_id = ptr->tcpconn_id;
 		}
 

--- a/src/modules/registrar/save.c
+++ b/src/modules/registrar/save.c
@@ -71,6 +71,27 @@ extern sruid_t _reg_sruid;
 static int q_override_msg_id;
 static qvalue_t q_override_value;
 
+int reg_get_cfg_tcpconnid(void)
+{
+       int n;
+       sr_xavp_t *vavp=NULL;
+       str vname = {"tcpconn_id", 10};
+
+       n = 0;
+
+       if(reg_xavp_cfg.s!=NULL)
+       {
+               vavp = xavp_get_child_with_ival(&reg_xavp_cfg, &vname);
+               if(vavp!=NULL)
+               {
+                       n = vavp->val.v.i;
+                       LM_DBG("using tcpconn_id value from xavp: %d\n", n);
+               }
+       }
+
+       return n;
+}
+
 /*! \brief
  * Process request that contained a star (*) as a contact, in that case,
  * we will remove all bindings with the given username
@@ -277,6 +298,9 @@ static inline ucontact_info_t* pack_ci( struct sip_msg* _m, contact_t* _c,
 		} else {
 			ci.tcpconn_id = -1;
 		}
+		/* if a tcp connectionid is set, use it */
+		if (reg_get_cfg_tcpconnid())
+			ci.tcpconn_id = reg_get_cfg_tcpconnid();
 
 		/* additional info from message */
 		if (parse_headers(_m, HDR_USERAGENT_F, 0) != -1 && _m->user_agent &&

--- a/src/modules/registrar/save.c
+++ b/src/modules/registrar/save.c
@@ -84,7 +84,7 @@ int reg_get_cfg_tcpconnid(void)
                vavp = xavp_get_child_with_ival(&reg_xavp_cfg, &vname);
                if(vavp!=NULL)
                {
-                       n = vavp->val.v.i;
+                       n = (int)vavp->val.v.l;
                        LM_DBG("using tcpconn_id value from xavp: %d\n", n);
                }
        }


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] New feature (non-breaking change which adds new functionality)

#### Checklist:
- [x] Tested changes locally

#### Description

This is adding the variable `tcpconn_id` to `xavp_cfg`

When using Kamailio as a "mid registrar", we need to save the contact in the reply-route (once we have the confirmation from the registrar), one problem I faced was that the tcpconid was the one of the response message coming from the registrar.
I needed a way to save the one of the original request message.

## mid registrar config example where we need/use the tcpconnid

```
modparam("registrar", "xavp_cfg", "reg")

route[REGISTER] {
    ...
    t_on_reply("ON_REPLY_REGISTER");
    $xavp(reg=>tcpconn_id) = $conid; // set the TCP connection id to be saved on the reply
   ....
}

onreply_route[ON_REPLY_REGISTER] {
        if (t_check_status("200")) {
                if (is_present_hf("Expires") && $hdr(Expires) == "0") {
                        xinfo("[ON_REPLY_REGISTER][$rm][$ci] registrar remove[$var(ret)]\n");
                        $var(ret) = unregister("location", "$tu");
                } else {
                        xinfo("[ON_REPLY_REGISTER][$rm][$ci] registrar save[$var(ret)]\n");
                        $var(ret) = save("location", "0x02");
                }
        }
}

route[INVITE] {
    ...
    if(reg_fetch_contacts("location", "$ru", "caller"))  {
         if(!tcp_conid_alive("$var(conid)")) {
                 xinfo("[RELAY][$ci] using tcp connection inactive [$var(conid)] suspend/push\n");
                 route(PUSH_SUSPEND);
         } else {
                  xinfo("[RELAY][$ci] using tcp connection [$var(conid)]\n");
         }
     }
     ...
}
```