### PR TITLE
rtpengine: fix unaligned memory access

### DIFF
--- a/src/modules/rtpengine/bencode.c
+++ b/src/modules/rtpengine/bencode.c
@@ -12,6 +12,8 @@
 
 #define BENCODE_HASH_BUCKETS		31 /* prime numbers work best */
 
+#define BENCODE_ALLOC_ALIGN 8
+
 struct __bencode_buffer_piece {
 	char *tail;
 	unsigned int left;
@@ -76,7 +78,7 @@ static struct __bencode_buffer_piece *__bencode_piece_new(unsigned int size) {
 
 	if (size < BENCODE_MIN_BUFFER_PIECE_LEN)
 		size = BENCODE_MIN_BUFFER_PIECE_LEN;
-	ret = BENCODE_MALLOC(sizeof(*ret) + size);
+	ret = BENCODE_MALLOC(sizeof(*ret) + size + BENCODE_ALLOC_ALIGN);
 	if (!ret)
 		return NULL;
 
@@ -99,6 +101,7 @@ int bencode_buffer_init(bencode_buffer_t *buf) {
 static void *__bencode_alloc(bencode_buffer_t *buf, unsigned int size) {
 	struct __bencode_buffer_piece *piece;
 	void *ret;
+	unsigned int align_size = ((size + BENCODE_ALLOC_ALIGN - 1) / BENCODE_ALLOC_ALIGN) * BENCODE_ALLOC_ALIGN;
 
 	if (!buf)
 		return NULL;
@@ -121,9 +124,12 @@ static void *__bencode_alloc(bencode_buffer_t *buf, unsigned int size) {
 	assert(size <= piece->left);
 
 alloc:
-	piece->left -= size;
+	if (piece->left >= align_size)
+		piece->left -= align_size;
+	else
+		piece->left = 0;
 	ret = piece->tail;
-	piece->tail += size;
+	piece->tail += align_size;
 	return ret;
 }
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #3444

#### Description

Make sure the pointers we return from our continuous memory buffer is always 64-bit aligned as it's used not only for strings, but also for structs/objects, and such unaligned memory access is undefined on some archs and flagged as such by ASAN.

From https://github.com/sipwise/rtpengine/commit/ade8100d3b10308f1ff63f8cb06fdf292618edca
