### PR TITLE
core: pv_cache_dump

### DIFF
--- a/src/core/cfg_core.c
+++ b/src/core/cfg_core.c
@@ -55,6 +55,7 @@
 #include "sock_ut.h"
 #include "cfg/cfg.h"
 #include "cfg_core.h"
+#include "pvapi.h"
 
 struct cfg_group_core default_core_cfg = {
 		L_WARN,		/*!<  print only msg. < L_WARN */
@@ -121,6 +122,7 @@ struct cfg_group_core default_core_cfg = {
 		0,	   /*!< latency limit db */
 		0,	   /*!< latency limit action */
 		0,	   /*!< latency limit cfg */
+		0,	   /*!< pv_cache_dump */
 		2048,  /*!< pv_cache_limit */
 		0	   /*!< pv_cache_action */
 };
@@ -336,6 +338,8 @@ cfg_def_t core_cfg_def[] = {
 				"limit in ms for alerting on time consuming config actions"},
 		{"latency_limit_cfg", CFG_VAR_INT | CFG_ATOMIC, 0, 0, 0, 0,
 				"limit in ms for alerting on time consuming config execution"},
+		{"pv_cache_dump", CFG_VAR_INT, 0, 0, 0, pv_cache_dump_cb,
+				"dump process pv cache, parameter: pid_number"},
 		{"pv_cache_limit", CFG_VAR_INT | CFG_ATOMIC, 0, 0, 0, 0,
 				"limit to alert if too many vars in pv cache"},
 		{"pv_cache_action", CFG_VAR_INT | CFG_ATOMIC, 0, 0, 0, 0,

--- a/src/core/cfg_core.h
+++ b/src/core/cfg_core.h
@@ -112,6 +112,7 @@ struct cfg_group_core
 	int latency_limit_db;	  /*!< alert limit of running db commands */
 	int latency_limit_action; /*!< alert limit of running cfg actions */
 	int latency_limit_cfg;	  /*!< alert limit of running cfg routing script */
+	int pv_cache_dump;	 /*!< dump process pv cache, parameter: pid_number */
 	int pv_cache_limit;	 /*!< alert limit of having too many vars in pv cache */
 	int pv_cache_action; /*!< action to be taken on pv cache limit */
 };

--- a/src/core/pvapi.c
+++ b/src/core/pvapi.c
@@ -90,6 +90,38 @@ pv_cache_t **pv_cache_get_table(void)
 	return NULL;
 }
 
+static void pv_cache_dump(int level)
+{
+	int i;
+	pv_cache_t *pvi = NULL;
+
+	if(_pv_cache_set == 0) {
+		LM_DBG("PV cache not initialized\n");
+		return;
+	}
+
+	for(i = 0; i < PV_CACHE_SIZE; i++) {
+		pvi = _pv_cache[i];
+		while(pvi) {
+			LOG(level, "pvar [%.*s] found in cache[%d]\n", pvi->pvname.len,
+					pvi->pvname.s, i);
+			pvi = pvi->next;
+		}
+	}
+}
+
+/* Dumps pv cache.
+ * Per-child process callback that is called
+ * when pv_cache_dump cfg var is changed.
+ */
+void pv_cache_dump_cb(str *gname, str *name)
+{
+	if(cfg_get(core, core_cfg, pv_cache_dump) == my_pid()) {
+		pv_cache_dump(cfg_get(core, core_cfg, memlog));
+		cfg_get(core, core_cfg, pv_cache_dump) = 0;
+	}
+}
+
 /**
  * @brief Check if a char is valid according to the PV syntax
  * @param c checked char

--- a/src/core/pvapi.h
+++ b/src/core/pvapi.h
@@ -22,6 +22,7 @@
 
 #ifndef __pvapi_h__
 #define __pvapi_h__
+#include "str.h"
 
 int pv_init_api(void);
 void pv_destroy_api(void);
@@ -34,6 +35,7 @@ int pv_get_buffer_size(void);
 int pv_get_buffer_slots(void);
 void pv_set_buffer_size(int n);
 void pv_set_buffer_slots(int n);
+void pv_cache_dump_cb(str *gname, str *name);
 
 #endif /*__pvapi_h__*/
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3440

#### Description

implemented a way to dump the names of the variables stored in pv_cache this helped me to find out what was filling the pv_cache
