### PR TITLE
Adding TLS support to db_redis (also password support) and ndb_redis

### DIFF
--- a/src/modules/db_redis/Makefile
+++ b/src/modules/db_redis/Makefile
@@ -20,10 +20,19 @@ endif
 
 ifeq ($(HIREDIS_BUILDER),)
 	HIREDISDEFS=-I$(LOCALBASE)/include -I$(LOCALBASE)/include/hiredis -I/usr/include/hiredis
-	HIREDISLIBS=-L$(LOCALBASE)/lib -lhiredis
+	HIREDISLIBS=-L$(LOCALBASE)/lib -lhiredis_ssl -lhiredis
+	ifneq ($(shell ls $(LOCALBASE) | grep libhiredis_ssl.so),)
+		HIREDISDEFS += -DWITH_SSL
+		HIREDISLIBS += -lhiredis_ssl
+	endif
 else
 	HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags)
-	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs)
+	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs) -lhiredis_ssl
+	HIREDISLIBSPATH = $(shell $(HIREDIS_BUILDER) --libs-only-L | cut -c 3-)
+	ifneq ($(shell ls $(HIREDISLIBSPATH) | grep libhiredis_ssl.so),)
+		HIREDISDEFS += -DWITH_SSL
+		HIREDISLIBS += -lhiredis_ssl
+	endif
 
 ifeq (,$(findstring hiredis,$(HIREDISDEFS)))
 	DEFS+=-DWITH_HIREDIS_PATH
@@ -31,7 +40,11 @@ endif
 
 ifeq ($(HIREDISLIBS),-L -lhiredis)
 		HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags) /opt/local/include
-		HIREDISLIBS = -L/opt/local/lib -lhiredis
+		HIREDISLIBS = -L/opt/local/lib -lhiredis -lhiredis_ssl
+		ifneq ($(shell ls /opt/local/lib | grep libhiredis_ssl.so),)
+			HIREDISDEFS += -DWITH_SSL
+			HIREDISLIBS += -lhiredis_ssl
+		endif
 endif
 
 endif
@@ -42,6 +55,11 @@ LIBS=$(HIREDISLIBS)
 ifneq ($(HIREDIS_CLUSTER_BUILDER),)
 	HIREDISCLUSTERDEFS = $(shell $(HIREDIS_CLUSTER_BUILDER) --cflags)
 	HIREDISCLUSTERLIBS = $(shell $(HIREDIS_CLUSTER_BUILDER) --libs)
+	HIREDISCLUSTERLIBSPATH = $(shell $(HIREDIS_CLUSTER_BUILDER) --libs-only-L | cut -c 3-)
+	ifneq ($(shell ls $(HIREDISCLUSTERLIBSPATH) | grep libhiredis_ssl.so),)
+		HIREDISCLUSTERDEFS += -DWITH_SSL
+		HIREDISCLUSTERLIBS += -lhiredis_ssl
+	endif
 	DEFS+=-DWITH_HIREDIS_CLUSTER
 	DEFS+=$(HIREDISCLUSTERDEFS)
 	LIBS+=$(HIREDISCLUSTERLIBS)

--- a/src/modules/db_redis/Makefile
+++ b/src/modules/db_redis/Makefile
@@ -29,10 +29,18 @@ else
 	HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags)
 	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs)
 	HIREDISLIBSPATH = $(shell $(HIREDIS_BUILDER) --libs-only-L | cut -c 3-)
-	ifneq ($(shell ls $(HIREDISLIBSPATH) | grep libhiredis_ssl.so),)
+    ifeq ($(HIREDISLIBSPATH),)
+        GCCSEARCHDIRS = $(shell $(CC) -print-search-dirs | grep -Po '^.*libraries: =.*' | cut -d "=" -f2- | tr : ' ')
+        ifneq ($(shell find $(GCCSEARCHDIRS) libhiredis_ssl.so),)
+		    HIREDISDEFS += -DWITH_SSL
+		    HIREDISLIBS += -lhiredis_ssl
+        endif
+    else
+        ifneq ($(shell ls $(HIREDISLIBSPATH) | grep libhiredis_ssl.so),)
 		HIREDISDEFS += -DWITH_SSL
 		HIREDISLIBS += -lhiredis_ssl
-	endif
+        endif
+    endif
 
 ifeq (,$(findstring hiredis,$(HIREDISDEFS)))
 	DEFS+=-DWITH_HIREDIS_PATH

--- a/src/modules/db_redis/Makefile
+++ b/src/modules/db_redis/Makefile
@@ -20,14 +20,14 @@ endif
 
 ifeq ($(HIREDIS_BUILDER),)
 	HIREDISDEFS=-I$(LOCALBASE)/include -I$(LOCALBASE)/include/hiredis -I/usr/include/hiredis
-	HIREDISLIBS=-L$(LOCALBASE)/lib -lhiredis_ssl -lhiredis
+	HIREDISLIBS=-L$(LOCALBASE)/lib -lhiredis
 	ifneq ($(shell ls $(LOCALBASE) | grep libhiredis_ssl.so),)
 		HIREDISDEFS += -DWITH_SSL
 		HIREDISLIBS += -lhiredis_ssl
 	endif
 else
 	HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags)
-	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs) -lhiredis_ssl
+	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs)
 	HIREDISLIBSPATH = $(shell $(HIREDIS_BUILDER) --libs-only-L | cut -c 3-)
 	ifneq ($(shell ls $(HIREDISLIBSPATH) | grep libhiredis_ssl.so),)
 		HIREDISDEFS += -DWITH_SSL
@@ -40,7 +40,7 @@ endif
 
 ifeq ($(HIREDISLIBS),-L -lhiredis)
 		HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags) /opt/local/include
-		HIREDISLIBS = -L/opt/local/lib -lhiredis -lhiredis_ssl
+		HIREDISLIBS = -L/opt/local/lib -lhiredis
 		ifneq ($(shell ls /opt/local/lib | grep libhiredis_ssl.so),)
 			HIREDISDEFS += -DWITH_SSL
 			HIREDISLIBS += -lhiredis_ssl

--- a/src/modules/db_redis/db_redis_mod.c
+++ b/src/modules/db_redis/db_redis_mod.c
@@ -31,9 +31,9 @@
 
 #ifdef WITH_SSL
 int db_redis_opt_tls = 0;
-char *ca_path = 0;
+char *db_redis_ca_path = 0;
 #endif
-char *db_pass = 0;
+char *db_redis_db_pass = 0;
 
 MODULE_VERSION
 
@@ -60,9 +60,9 @@ static param_export_t params[] = {
 		{"verbosity", PARAM_INT, &db_redis_verbosity},
 #ifdef WITH_SSL
 		{"opt_tls", PARAM_INT, &db_redis_opt_tls},
-		{"ca_path", PARAM_STRING, &ca_path},
+		{"ca_path", PARAM_STRING, &db_redis_ca_path},
 #endif
-		{"db_pass", PARAM_STRING, &db_pass}, {0, 0, 0}};
+		{"db_pass", PARAM_STRING, &db_redis_db_pass}, {0, 0, 0}};
 
 
 struct module_exports exports = {

--- a/src/modules/db_redis/db_redis_mod.c
+++ b/src/modules/db_redis/db_redis_mod.c
@@ -59,10 +59,10 @@ static param_export_t params[] = {
 		{"schema_path", PARAM_STR, &redis_schema_path},
 		{"verbosity", PARAM_INT, &db_redis_verbosity},
 #ifdef WITH_SSL
-		{"opt_tls",	PARAM_INT, &db_redis_opt_tls},
-		{"ca_path", PARAM_STRING, &ca_path },
+		{"opt_tls", PARAM_INT, &db_redis_opt_tls},
+		{"ca_path", PARAM_STRING, &ca_path},
 #endif
-		{"db_pass", PARAM_STRING, &db_pass},{0, 0, 0}};
+		{"db_pass", PARAM_STRING, &db_pass}, {0, 0, 0}};
 
 
 struct module_exports exports = {

--- a/src/modules/db_redis/db_redis_mod.c
+++ b/src/modules/db_redis/db_redis_mod.c
@@ -29,6 +29,12 @@
 #include "redis_dbase.h"
 #include "redis_table.h"
 
+#ifdef WITH_SSL
+int db_redis_opt_tls = 0;
+char *ca_path = 0;
+#endif
+char *db_pass = 0;
+
 MODULE_VERSION
 
 str redis_keys = str_init("");
@@ -51,7 +57,12 @@ static cmd_export_t cmds[] = {
 static param_export_t params[] = {
 		{"keys", PARAM_STRING | USE_FUNC_PARAM, (void *)keys_param},
 		{"schema_path", PARAM_STR, &redis_schema_path},
-		{"verbosity", PARAM_INT, &db_redis_verbosity}, {0, 0, 0}};
+		{"verbosity", PARAM_INT, &db_redis_verbosity},
+#ifdef WITH_SSL
+		{"opt_tls",	PARAM_INT, &db_redis_opt_tls},
+		{"ca_path", PARAM_STRING, &ca_path },
+#endif
+		{"db_pass", PARAM_STRING, &db_pass},{0, 0, 0}};
 
 
 struct module_exports exports = {

--- a/src/modules/db_redis/doc/db_redis.xml
+++ b/src/modules/db_redis/doc/db_redis.xml
@@ -27,6 +27,11 @@
 		<surname>Balashov</surname>
 		<email>abalashov@evaristesys.com</email>
 	    </editor>
+	    <editor>
+		<firstname>Joel</firstname>
+		<surname>Centelles Martin</surname>
+		<email>joel_centellesmartin@baxter.com</email>
+	    </editor>
 	</authorgroup>
 	<copyright>
 	    <year>2018</year>

--- a/src/modules/db_redis/doc/db_redis_admin.xml
+++ b/src/modules/db_redis/doc/db_redis_admin.xml
@@ -218,6 +218,61 @@ modparam("db_redis", "verbosity", 0)
 			</example>
 		</section>
 
+		<section id="db_redis.p.opt_tls">
+			<title><varname>opt_tls</varname> (int)</title>
+			<para>
+				Controls TLS usage while connecting to a remote DB.
+				If set to 1, TLS is used to connect to the DB.
+			</para>
+			<para>
+				Default value: 0.
+			</para>
+			<example>
+				<title>Enabling TLS connection</title>
+				<programlisting format="linespecific">
+...
+modparam("db_redis", "opt_tls", 1)
+...
+				</programlisting>
+			</example>
+		</section>
+
+		<section id="db_redis.p.db_pass">
+			<title><varname>db_pass</varname> (string)</title>
+			<para>
+				Sets the password to connect to the DB.
+			</para>
+			<para>
+				Default value: "" (empty).
+			</para>
+			<example>
+				<title>Setting a password</title>
+				<programlisting format="linespecific">
+...
+modparam("db_redis", "db_pass", "r3d1sPass")
+...
+				</programlisting>
+			</example>
+		</section>
+
+		<section id="db_redis.p.ca_path">
+			<title><varname>ac_path</varname> (string)</title>
+			<para>
+				Sets the path where Certificates Authorities certs are stored.
+			</para>
+			<para>
+				Default value: "" (empty).
+			</para>
+			<example>
+				<title>Setting CA path</title>
+				<programlisting format="linespecific">
+...
+modparam("db_redis", "ca_path", "/etc/ssl/certs")
+...
+				</programlisting>
+			</example>
+		</section>
+
 	</section>
 
 	<section id="db_redis.sec.usage">
@@ -230,6 +285,10 @@ modparam("db_redis", "verbosity", 0)
 		<para>
 			For cluster support you need to set the "db_url" modparam with a comma separated list of cluster hosts:
 			'redis://host1:port1,host2:port2/'. The database portion is not supported in cluster mode.
+		</para>
+		<para>
+			If accessed DB requires TLS connections, you need to enable TLS support setting the "opt_tls" parameter to 1.
+			In case the DB requires a password, that should be set using the "db_pass" parameter.
 		</para>
 		<example>
 			<title>Usage</title>

--- a/src/modules/db_redis/redis_connection.c
+++ b/src/modules/db_redis/redis_connection.c
@@ -150,7 +150,7 @@ int db_redis_connect(km_redis_con_t *con)
 	char hosts[MAX_URL_LENGTH];
 	char *host_begin;
 	char *host_end;
-	LM_DBG("connecting to redis cluster at %.*s\n", con->id->url.len, 
+	LM_DBG("connecting to redis cluster at %.*s\n", con->id->url.len,
 			con->id->url.s);
 	host_begin = strstr(con->id->url.s, "redis://");
 	if(host_begin) {
@@ -164,7 +164,8 @@ int db_redis_connect(km_redis_con_t *con)
 	if(db_redis_opt_tls != 0) {
 		/* Create SSL context*/
 		redisInitOpenSSL();
-		ssl = redisCreateSSLContext(NULL, db_redis_ca_path, NULL, NULL, NULL, NULL);
+		ssl = redisCreateSSLContext(
+				NULL, db_redis_ca_path, NULL, NULL, NULL, NULL);
 		if(ssl == NULL) {
 			LM_ERR("Unable to create Redis SSL Context.\n");
 			goto err;
@@ -197,7 +198,7 @@ int db_redis_connect(km_redis_con_t *con)
 #endif
 	status = redisClusterConnect2(con->con);
 	if(status != REDIS_OK) {
-		LM_ERR("cannot open connection to cluster with hosts: %s, error: %s\n", 
+		LM_ERR("cannot open connection to cluster with hosts: %s, error: %s\n",
 				hosts, con->con->errstr);
 		goto err;
 	}
@@ -208,7 +209,8 @@ int db_redis_connect(km_redis_con_t *con)
 	if(db_redis_opt_tls != 0) {
 		/* Create SSL context*/
 		redisInitOpenSSL();
-		ssl = redisCreateSSLContext(NULL, db_redis_ca_path, NULL, NULL, NULL, NULL);
+		ssl = redisCreateSSLContext(
+				NULL, db_redis_ca_path, NULL, NULL, NULL, NULL);
 		if(ssl == NULL) {
 			LM_ERR("Unable to create Redis SSL Context.\n");
 			goto err;
@@ -218,7 +220,7 @@ int db_redis_connect(km_redis_con_t *con)
 
 	con->con = redisConnectWithTimeout(con->id->host, con->id->port, tv);
 	if(!con->con) {
-		LM_ERR("cannot open connection: %.*s\n", con->id->url.len, 
+		LM_ERR("cannot open connection: %.*s\n", con->id->url.len,
 				con->id->url.s);
 		goto err;
 	}

--- a/src/modules/db_redis/redis_connection.c
+++ b/src/modules/db_redis/redis_connection.c
@@ -35,6 +35,11 @@ static unsigned int MAX_URL_LENGTH = 1023;
 #endif
 
 extern int db_redis_verbosity;
+#ifdef WITH_SSL
+extern int db_redis_opt_tls;
+extern char *ca_path;
+#endif
+extern char *db_pass;
 
 static void print_query(redis_key_t *query)
 {
@@ -120,12 +125,17 @@ int db_redis_connect(km_redis_con_t *con)
 #ifndef WITH_HIREDIS_CLUSTER
 	int db;
 #endif
+#ifdef WITH_SSL
+	redisSSLContext *ssl = NULL;
+#endif
+	char* password = NULL;
 
 	tv.tv_sec = 1;
 	tv.tv_usec = 0;
 #ifndef WITH_HIREDIS_CLUSTER
 	db = atoi(con->id->database);
 #endif
+	redisSSLContext *ssl = NULL;
 	reply = NULL;
 
 	if(con->con) {
@@ -139,69 +149,109 @@ int db_redis_connect(km_redis_con_t *con)
 #ifdef WITH_HIREDIS_CLUSTER
 	int status;
 	char hosts[MAX_URL_LENGTH];
-	char *host_begin;
-	char *host_end;
-	LM_DBG("connecting to redis cluster at %.*s\n", con->id->url.len,
+	char* host_begin;
+	char* host_end;
+	LM_DBG("connecting to redis cluster at %.*s\n", con->id->url.len, 
 			con->id->url.s);
 	host_begin = strstr(con->id->url.s, "redis://");
-	if(host_begin) {
+	if (host_begin) {
 		host_begin += 8;
 	} else {
 		LM_ERR("invalid url scheme\n");
 		goto err;
 	}
+
+#ifdef WITH_SSL
+	if (db_redis_opt_tls != 0) {
+		/* Create SSL context*/
+		redisInitOpenSSL();
+		ssl = redisCreateSSLContext(NULL, ca_path, NULL, NULL, NULL, NULL);
+		if (ssl == NULL) {
+			LM_ERR("Unable to create Redis SSL Context.\n");
+			goto err;
+		}
+	} 
+#endif
+
 	host_end = strstr(host_begin, "/");
-	if(!host_end) {
+	if (! host_end) {
 		LM_ERR("invalid url: cannot find end of host part\n");
 		goto err;
 	}
-	if((host_end - host_begin) > (MAX_URL_LENGTH - 1)) {
+	if ((host_end - host_begin) > (MAX_URL_LENGTH-1)) {
 		LM_ERR("url too long\n");
 		goto err;
 	}
 	strncpy(hosts, host_begin, (host_end - host_begin));
-	hosts[MAX_URL_LENGTH - 1] = '\0';
+	hosts[MAX_URL_LENGTH-1] = '\0';
 	con->con = redisClusterContextInit();
-	if(!con->con) {
+	if (! con->con) {
 		LM_ERR("no private memory left\n");
 		goto err;
 	}
 	redisClusterSetOptionAddNodes(con->con, hosts);
 	redisClusterSetOptionConnectTimeout(con->con, tv);
+#ifdef WITH_SSL
+	if (ssl) {
+		redisClusterSetOptionEnableSSL(con->con, ssl);
+	}
+#endif
 	status = redisClusterConnect2(con->con);
-	if(status != REDIS_OK) {
-		LM_ERR("cannot open connection to cluster with hosts: %s, error: %s\n",
+	if (status != REDIS_OK) {
+		LM_ERR("cannot open connection to cluster with hosts: %s, error: %s\n", 
 				hosts, con->con->errstr);
 		goto err;
 	}
 #else
 	LM_DBG("connecting to redis at %s:%d\n", con->id->host, con->id->port);
+
+#ifdef WITH_SSL
+	if (db_redis_opt_tls != 0) {
+		/* Create SSL context*/
+		redisInitOpenSSL();
+		ssl = redisCreateSSLContext(NULL, ca_path, NULL, NULL, NULL, NULL);
+		if (ssl == NULL) {
+			LM_ERR("Unable to create Redis SSL Context.\n");
+			goto err;
+		}
+	} 
+#endif
+
 	con->con = redisConnectWithTimeout(con->id->host, con->id->port, tv);
-	if(!con->con) {
-		LM_ERR("cannot open connection: %.*s\n", con->id->url.len,
+	if (!con->con) {
+		LM_ERR("cannot open connection: %.*s\n", con->id->url.len, 
 				con->id->url.s);
 		goto err;
 	}
-	if(con->con->err) {
-		LM_ERR("cannot open connection to %.*s: %s\n", con->id->url.len,
+	if (con->con->err) {
+		LM_ERR("cannot open connection to %.*s: %s\n", con->id->url.len, 
 				con->id->url.s, con->con->errstr);
 		goto err;
 	}
+#ifdef WITH_SSL
+	if (ssl) {
+		redisInitiateSSLWithContext(con->con, ssl);
+	}
+#endif
 #endif
 
-	if(con->id->password) {
-		reply = redisCommand(con->con, "AUTH %s", con->id->password);
-		if(!reply) {
+	password = con->id->password;
+	if (!password) {
+		password = db_pass;
+	}
+	if (password) {
+		reply = redisCommand(con->con, "AUTH %s", password);
+		if (!reply) {
 			LM_ERR("cannot authenticate connection %.*s: %s\n",
 					con->id->url.len, con->id->url.s, con->con->errstr);
 			goto err;
 		}
-		if(reply->type == REDIS_REPLY_ERROR) {
+		if (reply->type == REDIS_REPLY_ERROR) {
 			LM_ERR("cannot authenticate connection %.*s: %s\n",
 					con->id->url.len, con->id->url.s, reply->str);
 			goto err;
 		}
-		freeReplyObject(reply);
+		freeReplyObject(reply); 
 		reply = NULL;
 	}
 
@@ -299,11 +349,11 @@ km_redis_con_t *db_redis_new_connection(const struct db_id *id)
 	ptr->id = (struct db_id *)id;
 
 	/*
-    LM_DBG("trying to initialize connection to '%.*s' with schema path '%.*s' and keys '%.*s'\n",
-            id->url.len, id->url.s,
-            redis_schema_path.len, redis_schema_path.s,
-            redis_keys.len, redis_keys.s);
-    */
+	LM_DBG("trying to initialize connection to '%.*s' with schema path '%.*s' and keys '%.*s'\n",
+			id->url.len, id->url.s,
+			redis_schema_path.len, redis_schema_path.s,
+			redis_keys.len, redis_keys.s);
+	*/
 	LM_DBG("trying to initialize connection to '%.*s'\n", id->url.len,
 			id->url.s);
 	if(db_redis_parse_schema(ptr) != 0) {

--- a/src/modules/db_redis/redis_connection.c
+++ b/src/modules/db_redis/redis_connection.c
@@ -37,9 +37,9 @@ static unsigned int MAX_URL_LENGTH = 1023;
 extern int db_redis_verbosity;
 #ifdef WITH_SSL
 extern int db_redis_opt_tls;
-extern char *ca_path;
+extern char *db_redis_ca_path;
 #endif
-extern char *db_pass;
+extern char *db_redis_db_pass;
 
 static void print_query(redis_key_t *query)
 {
@@ -164,7 +164,7 @@ int db_redis_connect(km_redis_con_t *con)
 	if(db_redis_opt_tls != 0) {
 		/* Create SSL context*/
 		redisInitOpenSSL();
-		ssl = redisCreateSSLContext(NULL, ca_path, NULL, NULL, NULL, NULL);
+		ssl = redisCreateSSLContext(NULL, db_redis_ca_path, NULL, NULL, NULL, NULL);
 		if(ssl == NULL) {
 			LM_ERR("Unable to create Redis SSL Context.\n");
 			goto err;
@@ -208,7 +208,7 @@ int db_redis_connect(km_redis_con_t *con)
 	if(db_redis_opt_tls != 0) {
 		/* Create SSL context*/
 		redisInitOpenSSL();
-		ssl = redisCreateSSLContext(NULL, ca_path, NULL, NULL, NULL, NULL);
+		ssl = redisCreateSSLContext(NULL, db_redis_ca_path, NULL, NULL, NULL, NULL);
 		if(ssl == NULL) {
 			LM_ERR("Unable to create Redis SSL Context.\n");
 			goto err;
@@ -236,7 +236,7 @@ int db_redis_connect(km_redis_con_t *con)
 
 	password = con->id->password;
 	if(!password) {
-		password = db_pass;
+		password = db_redis_db_pass;
 	}
 	if(password) {
 		reply = redisCommand(con->con, "AUTH %s", password);

--- a/src/modules/db_redis/redis_connection.c
+++ b/src/modules/db_redis/redis_connection.c
@@ -170,7 +170,7 @@ int db_redis_connect(km_redis_con_t *con)
 			LM_ERR("Unable to create Redis SSL Context.\n");
 			goto err;
 		}
-	} 
+	}
 #endif
 
 	host_end = strstr(host_begin, "/");
@@ -214,7 +214,7 @@ int db_redis_connect(km_redis_con_t *con)
 			LM_ERR("Unable to create Redis SSL Context.\n");
 			goto err;
 		}
-	} 
+	}
 #endif
 
 	con->con = redisConnectWithTimeout(con->id->host, con->id->port, tv);

--- a/src/modules/db_redis/redis_connection.c
+++ b/src/modules/db_redis/redis_connection.c
@@ -135,7 +135,6 @@ int db_redis_connect(km_redis_con_t *con)
 #ifndef WITH_HIREDIS_CLUSTER
 	db = atoi(con->id->database);
 #endif
-	redisSSLContext *ssl = NULL;
 	reply = NULL;
 
 	if(con->con) {

--- a/src/modules/db_redis/redis_connection.c
+++ b/src/modules/db_redis/redis_connection.c
@@ -128,7 +128,7 @@ int db_redis_connect(km_redis_con_t *con)
 #ifdef WITH_SSL
 	redisSSLContext *ssl = NULL;
 #endif
-	char* password = NULL;
+	char *password = NULL;
 
 	tv.tv_sec = 1;
 	tv.tv_usec = 0;
@@ -149,12 +149,12 @@ int db_redis_connect(km_redis_con_t *con)
 #ifdef WITH_HIREDIS_CLUSTER
 	int status;
 	char hosts[MAX_URL_LENGTH];
-	char* host_begin;
-	char* host_end;
+	char *host_begin;
+	char *host_end;
 	LM_DBG("connecting to redis cluster at %.*s\n", con->id->url.len, 
 			con->id->url.s);
 	host_begin = strstr(con->id->url.s, "redis://");
-	if (host_begin) {
+	if(host_begin) {
 		host_begin += 8;
 	} else {
 		LM_ERR("invalid url scheme\n");
@@ -162,11 +162,11 @@ int db_redis_connect(km_redis_con_t *con)
 	}
 
 #ifdef WITH_SSL
-	if (db_redis_opt_tls != 0) {
+	if(db_redis_opt_tls != 0) {
 		/* Create SSL context*/
 		redisInitOpenSSL();
 		ssl = redisCreateSSLContext(NULL, ca_path, NULL, NULL, NULL, NULL);
-		if (ssl == NULL) {
+		if(ssl == NULL) {
 			LM_ERR("Unable to create Redis SSL Context.\n");
 			goto err;
 		}
@@ -174,30 +174,30 @@ int db_redis_connect(km_redis_con_t *con)
 #endif
 
 	host_end = strstr(host_begin, "/");
-	if (! host_end) {
+	if(!host_end) {
 		LM_ERR("invalid url: cannot find end of host part\n");
 		goto err;
 	}
-	if ((host_end - host_begin) > (MAX_URL_LENGTH-1)) {
+	if((host_end - host_begin) > (MAX_URL_LENGTH - 1)) {
 		LM_ERR("url too long\n");
 		goto err;
 	}
 	strncpy(hosts, host_begin, (host_end - host_begin));
-	hosts[MAX_URL_LENGTH-1] = '\0';
+	hosts[MAX_URL_LENGTH - 1] = '\0';
 	con->con = redisClusterContextInit();
-	if (! con->con) {
+	if(!con->con) {
 		LM_ERR("no private memory left\n");
 		goto err;
 	}
 	redisClusterSetOptionAddNodes(con->con, hosts);
 	redisClusterSetOptionConnectTimeout(con->con, tv);
 #ifdef WITH_SSL
-	if (ssl) {
+	if(ssl) {
 		redisClusterSetOptionEnableSSL(con->con, ssl);
 	}
 #endif
 	status = redisClusterConnect2(con->con);
-	if (status != REDIS_OK) {
+	if(status != REDIS_OK) {
 		LM_ERR("cannot open connection to cluster with hosts: %s, error: %s\n", 
 				hosts, con->con->errstr);
 		goto err;
@@ -206,11 +206,11 @@ int db_redis_connect(km_redis_con_t *con)
 	LM_DBG("connecting to redis at %s:%d\n", con->id->host, con->id->port);
 
 #ifdef WITH_SSL
-	if (db_redis_opt_tls != 0) {
+	if(db_redis_opt_tls != 0) {
 		/* Create SSL context*/
 		redisInitOpenSSL();
 		ssl = redisCreateSSLContext(NULL, ca_path, NULL, NULL, NULL, NULL);
-		if (ssl == NULL) {
+		if(ssl == NULL) {
 			LM_ERR("Unable to create Redis SSL Context.\n");
 			goto err;
 		}
@@ -218,40 +218,40 @@ int db_redis_connect(km_redis_con_t *con)
 #endif
 
 	con->con = redisConnectWithTimeout(con->id->host, con->id->port, tv);
-	if (!con->con) {
+	if(!con->con) {
 		LM_ERR("cannot open connection: %.*s\n", con->id->url.len, 
 				con->id->url.s);
 		goto err;
 	}
-	if (con->con->err) {
-		LM_ERR("cannot open connection to %.*s: %s\n", con->id->url.len, 
+	if(con->con->err) {
+		LM_ERR("cannot open connection to %.*s: %s\n", con->id->url.len,
 				con->id->url.s, con->con->errstr);
 		goto err;
 	}
 #ifdef WITH_SSL
-	if (ssl) {
+	if(ssl) {
 		redisInitiateSSLWithContext(con->con, ssl);
 	}
 #endif
 #endif
 
 	password = con->id->password;
-	if (!password) {
+	if(!password) {
 		password = db_pass;
 	}
-	if (password) {
+	if(password) {
 		reply = redisCommand(con->con, "AUTH %s", password);
-		if (!reply) {
+		if(!reply) {
 			LM_ERR("cannot authenticate connection %.*s: %s\n",
 					con->id->url.len, con->id->url.s, con->con->errstr);
 			goto err;
 		}
-		if (reply->type == REDIS_REPLY_ERROR) {
+		if(reply->type == REDIS_REPLY_ERROR) {
 			LM_ERR("cannot authenticate connection %.*s: %s\n",
 					con->id->url.len, con->id->url.s, reply->str);
 			goto err;
 		}
-		freeReplyObject(reply); 
+		freeReplyObject(reply);
 		reply = NULL;
 	}
 

--- a/src/modules/db_redis/redis_connection.h
+++ b/src/modules/db_redis/redis_connection.h
@@ -28,8 +28,14 @@
 #else
 #ifdef WITH_HIREDIS_PATH
 #include <hiredis/hiredis.h>
+#ifdef WITH_SSL
+#include <hiredis/hiredis_ssl.h>
+#endif
 #else
 #include <hiredis.h>
+#ifdef WITH_SSL
+#include <hiredis_ssl.h>
+#endif
 #endif
 #endif
 

--- a/src/modules/ndb_redis/Makefile
+++ b/src/modules/ndb_redis/Makefile
@@ -23,10 +23,18 @@ else
 	HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags)
 	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs)
 	HIREDISLIBSPATH = $(shell $(HIREDIS_BUILDER) --libs-only-L | cut -c 3-)
-	ifneq ($(shell ls $(HIREDISLIBSPATH) | grep libhiredis_ssl.so),)
-		HIREDISDEFS += -DWITH_SSL
-		HIREDISLIBS += -lhiredis_ssl
-	endif
+    ifeq ($(HIREDISLIBSPATH),)
+        GCCSEARCHDIRS = $(shell $(CC) -print-search-dirs | grep -Po '^.*libraries: =.*' | cut -d "=" -f2- | tr : ' ')
+        ifneq ($(shell find $(GCCSEARCHDIRS) libhiredis_ssl.so),)
+            HIREDISDEFS += -DWITH_SSL
+            HIREDISLIBS += -lhiredis_ssl
+        endif
+    else
+        ifneq ($(shell ls $(HIREDISLIBSPATH) | grep libhiredis_ssl.so),)
+            HIREDISDEFS += -DWITH_SSL
+            HIREDISLIBS += -lhiredis_ssl
+        endif
+    endif
 
 ifeq (,$(findstring hiredis,$(HIREDISDEFS)))
 	DEFS+=-DWITH_HIREDIS_PATH

--- a/src/modules/ndb_redis/Makefile
+++ b/src/modules/ndb_redis/Makefile
@@ -14,10 +14,19 @@ endif
 
 ifeq ($(HIREDIS_BUILDER),)
 	HIREDISDEFS=-I$(LOCALBASE)/include -I$(LOCALBASE)/include/hiredis  -I/usr/include/hiredis
-	HIREDISLIBS=-L$(LOCALBASE)/lib -lhiredis
+	HIREDISLIBS=-L$(LOCALBASE)/lib
+	ifneq ($(shell ls $(LOCALBASE) | grep libhiredis_ssl.so),)
+		HIREDISDEFS += -DWITH_SSL
+		HIREDISLIBS += -lhiredis_ssl
+	endif
 else
 	HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags)
 	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs)
+	HIREDISLIBSPATH = $(shell $(HIREDIS_BUILDER) --libs-only-L | cut -c 3-)
+	ifneq ($(shell ls $(HIREDISLIBSPATH) | grep libhiredis_ssl.so),)
+		HIREDISDEFS += -DWITH_SSL
+		HIREDISLIBS += -lhiredis_ssl
+	endif
 
 ifeq (,$(findstring hiredis,$(HIREDISDEFS)))
 	DEFS+=-DWITH_HIREDIS_PATH
@@ -26,6 +35,10 @@ endif
 ifeq ($(HIREDISLIBS),-L -lhiredis)
 		HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags) /opt/local/include
 		HIREDISLIBS = -L/opt/local/lib -lhiredis
+		ifneq ($(shell ls /opt/local/lib | grep libhiredis_ssl.so),)
+			HIREDISDEFS += -DWITH_SSL
+			HIREDISLIBS += -lhiredis_ssl
+		endif
 endif
 
 endif

--- a/src/modules/ndb_redis/doc/ndb_redis.xml
+++ b/src/modules/ndb_redis/doc/ndb_redis.xml
@@ -38,6 +38,11 @@
 				<surname>Bock</surname>
 				<email>carsten@ng-voice.com</email>
 			</author>
+			<author>
+				<firstname>Joel</firstname>
+				<surname>Centelles Martin</surname>
+				<email>joel_centellesmartin@baxter.com</email>
+			</author>
 		</authorgroup>
 		<copyright>
 			<year>2011</year>

--- a/src/modules/ndb_redis/doc/ndb_redis_admin.xml
+++ b/src/modules/ndb_redis/doc/ndb_redis_admin.xml
@@ -63,12 +63,12 @@
 		<title><varname>server</varname> (str)</title>
 		<para>
 			Specify the details to connect to REDIS server. It takes a list of attribute=value
-			separated by semicolon, the attributes can be name, unix, addr, port, db and pass. Name
+			separated by semicolon, the attributes can be name, unix, addr, port, db, pass and tls. Name
 			is a generic identifier to be used with module functions. unix is the path to the unix
 			domain socket provided by redis server. addr and port are the IP address and the port to
-			connect to REDIS server. pass is the server password. unix and (addr, port) are mutually
-			exclusive.  If both appear in same server settings unix domain socket is configured.  db
-			is the DB number to use (defaults to 0 if not specified).
+			connect to REDIS server. pass is the server password. tls is to enable TLS connectivity.
+            unix and (addr, port) are mutually exclusive.  If both appear in same server settings unix 
+            domain socket is configured.  db is the DB number to use (defaults to 0 if not specified).
 		</para>
 		<para>
 			You can set this parameter many times, in case you want to connect to
@@ -86,6 +86,7 @@
 ...
 modparam("ndb_redis", "server", "name=srvN;addr=127.0.0.1;port=6379;db=1")
 modparam("ndb_redis", "server", "name=srvX;addr=127.0.0.2;port=6379;db=4;pass=mypassword")
+modparam("ndb_redis", "server", "name=srvY;addr=127.0.0.3;port=6379;db=5;pass=mypassword;tls=1")
 
 # Unix domain socket
 modparam("ndb_redis", "server", "name=srvY;unix=/tmp/redis.sock;db=3")
@@ -324,6 +325,23 @@ modparam("ndb_redis", "allow_dynamic_nodes", 1)
 			<programlisting format="linespecific">
 ...
 modparam("ndb_redis", "debug", 1)
+...
+			</programlisting>
+		</example>
+	</section>
+	<section id="ndb_redis.p.ca_path">
+		<title><varname>ac_path</varname> (string)</title>
+		<para>
+			Sets the path where Certificates Authorities certs are stored.
+		</para>
+		<para>
+			Default value: "" (empty).
+		</para>
+		<example>
+			<title>Setting CA path</title>
+			<programlisting format="linespecific">
+...
+modparam("db_redis", "ca_path", "/etc/ssl/certs")
 ...
 			</programlisting>
 		</example>

--- a/src/modules/ndb_redis/ndb_redis_mod.c
+++ b/src/modules/ndb_redis/ndb_redis_mod.c
@@ -54,6 +54,9 @@ int redis_allowed_timeouts_param = -1;
 int redis_flush_on_reconnect_param = 0;
 int redis_allow_dynamic_nodes_param = 0;
 int ndb_redis_debug = L_DBG;
+#ifdef WITH_SSL
+char *ca_path = 0;
+#endif
 
 static int w_redis_cmd3(
 		struct sip_msg *msg, char *ssrv, char *scmd, char *sres);
@@ -131,7 +134,12 @@ static param_export_t params[] = {
 		{"allowed_timeouts", INT_PARAM, &redis_allowed_timeouts_param},
 		{"flush_on_reconnect", INT_PARAM, &redis_flush_on_reconnect_param},
 		{"allow_dynamic_nodes", INT_PARAM, &redis_allow_dynamic_nodes_param},
-		{"debug", PARAM_INT, &ndb_redis_debug}, {0, 0, 0}};
+		{"debug", PARAM_INT, &ndb_redis_debug}, 
+#ifdef WITH_SSL
+		{"ca_path", PARAM_STRING, &ca_path},
+#endif
+		{0, 0, 0}
+};
 
 struct module_exports exports = {
 		"ndb_redis", DEFAULT_DLFLAGS, /* dlopen flags */

--- a/src/modules/ndb_redis/ndb_redis_mod.c
+++ b/src/modules/ndb_redis/ndb_redis_mod.c
@@ -134,7 +134,7 @@ static param_export_t params[] = {
 		{"allowed_timeouts", INT_PARAM, &redis_allowed_timeouts_param},
 		{"flush_on_reconnect", INT_PARAM, &redis_flush_on_reconnect_param},
 		{"allow_dynamic_nodes", INT_PARAM, &redis_allow_dynamic_nodes_param},
-		{"debug", PARAM_INT, &ndb_redis_debug}, 
+		{"debug", PARAM_INT, &ndb_redis_debug},
 #ifdef WITH_SSL
 		{"ca_path", PARAM_STRING, &ndb_redis_ca_path},
 #endif

--- a/src/modules/ndb_redis/ndb_redis_mod.c
+++ b/src/modules/ndb_redis/ndb_redis_mod.c
@@ -138,8 +138,7 @@ static param_export_t params[] = {
 #ifdef WITH_SSL
 		{"ca_path", PARAM_STRING, &ca_path},
 #endif
-		{0, 0, 0}
-};
+		{0, 0, 0}};
 
 struct module_exports exports = {
 		"ndb_redis", DEFAULT_DLFLAGS, /* dlopen flags */

--- a/src/modules/ndb_redis/ndb_redis_mod.c
+++ b/src/modules/ndb_redis/ndb_redis_mod.c
@@ -55,7 +55,7 @@ int redis_flush_on_reconnect_param = 0;
 int redis_allow_dynamic_nodes_param = 0;
 int ndb_redis_debug = L_DBG;
 #ifdef WITH_SSL
-char *ca_path = 0;
+char *ndb_redis_ca_path = 0;
 #endif
 
 static int w_redis_cmd3(
@@ -136,7 +136,7 @@ static param_export_t params[] = {
 		{"allow_dynamic_nodes", INT_PARAM, &redis_allow_dynamic_nodes_param},
 		{"debug", PARAM_INT, &ndb_redis_debug}, 
 #ifdef WITH_SSL
-		{"ca_path", PARAM_STRING, &ca_path},
+		{"ca_path", PARAM_STRING, &ndb_redis_ca_path},
 #endif
 		{0, 0, 0}};
 

--- a/src/modules/ndb_redis/redis_client.c
+++ b/src/modules/ndb_redis/redis_client.c
@@ -140,14 +140,14 @@ int redisc_init(void)
 						pit->body.s);
 				haspass = 1;
 #ifdef WITH_SSL
-			} else if(pit->name.len==3 
-					&& strncmp(pit->name.s, "tls", 3) == 0) {
+			} else if(pit->name.len == 3 
+					  && strncmp(pit->name.s, "tls", 3) == 0) {
 				snprintf(pass, sizeof(pass) - 1, "%.*s", pit->body.len, 
 						pit->body.s);
 				if(str2int(&pit->body, &enable_ssl) < 0)
 					enable_ssl = 0;
 #endif
-			} else if(pit->name.len == 14 
+			} else if(pit->name.len == 14
 					  && strncmp(pit->name.s, "sentinel_group", 14) == 0) {
 				snprintf(sentinel_group, sizeof(sentinel_group) - 1, "%.*s",
 						pit->body.len, pit->body.s);
@@ -236,8 +236,8 @@ int redisc_init(void)
  		if(enable_ssl) {
  			/* Create SSL context*/
  			redisInitOpenSSL();
- 			rsrv->sslCtxRedis = 
-					redisCreateSSLContext(NULL, ndb_redis_ca_path, NULL, NULL, NULL, NULL);
+ 			rsrv->sslCtxRedis = redisCreateSSLContext(
+					NULL, ndb_redis_ca_path, NULL, NULL, NULL, NULL);
  			if(rsrv->sslCtxRedis == NULL) {
 				LM_ERR("Unable to create Redis TLS Context.\n");
  			}
@@ -251,8 +251,8 @@ int redisc_init(void)
 					redisConnectUnixWithTimeout(unix_sock_path, tv_conn);
 		} else {
 #ifdef WITH_SSL
-			LOG(ndb_redis_debug, "Connecting to %s %s:%d\n", 
-					(enable_ssl) ?"TLS" :"UDP", addr, port);
+			LOG(ndb_redis_debug, "Connecting to %s %s:%d\n",
+					(enable_ssl) ? "TLS" : "UDP", addr, port);
 #else
 			LOG(ndb_redis_debug, "Connecting to %s:%d\n", addr, port);
 #endif
@@ -500,7 +500,7 @@ int redisc_reconnect_server(redisc_server_t *rsrv)
 #ifdef WITH_SSL
  		} else if(pit->name.len == 3 && strncmp(pit->name.s, "tls", 3) == 0) {
 			snprintf(
-					pass, sizeof(pass)-1, "%.*s", pit->body.len, pit->body.s);
+					pass, sizeof(pass) - 1, "%.*s", pit->body.len, pit->body.s);
  			if(str2int(&pit->body, &enable_ssl) < 0)
 				enable_ssl = 0;
 #endif
@@ -598,8 +598,8 @@ int redisc_reconnect_server(redisc_server_t *rsrv)
 	if(enable_ssl) {
 		/* Create SSL context*/
 		redisInitOpenSSL();
-		rsrv->sslCtxRedis =
-				redisCreateSSLContext(NULL, ndb_redis_ca_path, NULL, NULL, NULL, NULL);
+		rsrv->sslCtxRedis = redisCreateSSLContext(
+				NULL, ndb_redis_ca_path, NULL, NULL, NULL, NULL);
 		if(rsrv->sslCtxRedis == NULL) {
 			LM_ERR("Unable to create Redis TLS Context.\n");
 		}

--- a/src/modules/ndb_redis/redis_client.c
+++ b/src/modules/ndb_redis/redis_client.c
@@ -63,7 +63,7 @@ extern int redis_flush_on_reconnect_param;
 extern int redis_allow_dynamic_nodes_param;
 extern int ndb_redis_debug;
 #ifdef WITH_SSL
-extern char *ca_path;
+extern char *ndb_redis_ca_path;
 #endif
 
 /* backwards compatibility with hiredis < 0.12 */
@@ -237,7 +237,7 @@ int redisc_init(void)
  			/* Create SSL context*/
  			redisInitOpenSSL();
  			rsrv->sslCtxRedis = 
-					redisCreateSSLContext(NULL, NULL, NULL, NULL, NULL, NULL);
+					redisCreateSSLContext(NULL, ndb_redis_ca_path, NULL, NULL, NULL, NULL);
  			if(rsrv->sslCtxRedis == NULL) {
 				LM_ERR("Unable to create Redis TLS Context.\n");
  			}
@@ -599,7 +599,7 @@ int redisc_reconnect_server(redisc_server_t *rsrv)
 		/* Create SSL context*/
 		redisInitOpenSSL();
 		rsrv->sslCtxRedis =
-				redisCreateSSLContext(NULL, NULL, NULL, NULL, NULL, NULL);
+				redisCreateSSLContext(NULL, ndb_redis_ca_path, NULL, NULL, NULL, NULL);
 		if(rsrv->sslCtxRedis == NULL) {
 			LM_ERR("Unable to create Redis TLS Context.\n");
 		}

--- a/src/modules/ndb_redis/redis_client.c
+++ b/src/modules/ndb_redis/redis_client.c
@@ -140,13 +140,14 @@ int redisc_init(void)
 						pit->body.s);
 				haspass = 1;
 #ifdef WITH_SSL
-			} else if(pit->name.len==3 && strncmp(pit->name.s, "tls", 3)==0) {
-				snprintf(pass, sizeof(pass)-1, "%.*s",
-						pit->body.len, pit->body.s);
-				if (str2int(&pit->body, &enable_ssl) < 0)
+			} else if(pit->name.len==3 
+					&& strncmp(pit->name.s, "tls", 3) == 0) {
+				snprintf(pass, sizeof(pass) - 1, "%.*s", pit->body.len, 
+						pit->body.s);
+				if(str2int(&pit->body, &enable_ssl) < 0)
 					enable_ssl = 0;
 #endif
-			} else if(pit->name.len==14 
+			} else if(pit->name.len == 14 
 					  && strncmp(pit->name.s, "sentinel_group", 14) == 0) {
 				snprintf(sentinel_group, sizeof(sentinel_group) - 1, "%.*s",
 						pit->body.len, pit->body.s);
@@ -232,11 +233,12 @@ int redisc_init(void)
 		}
 
 #ifdef WITH_SSL
- 		if (enable_ssl) {
+ 		if(enable_ssl) {
  			/* Create SSL context*/
  			redisInitOpenSSL();
- 			rsrv->sslCtxRedis = redisCreateSSLContext(NULL, NULL, NULL, NULL, NULL, NULL);
- 			if (rsrv->sslCtxRedis == NULL) {
+ 			rsrv->sslCtxRedis = 
+					redisCreateSSLContext(NULL, NULL, NULL, NULL, NULL, NULL);
+ 			if(rsrv->sslCtxRedis == NULL) {
 				LM_ERR("Unable to create Redis TLS Context.\n");
  			}
   		}
@@ -249,7 +251,8 @@ int redisc_init(void)
 					redisConnectUnixWithTimeout(unix_sock_path, tv_conn);
 		} else {
 #ifdef WITH_SSL
-			LOG(ndb_redis_debug, "Connecting to %s %s:%d\n", (enable_ssl) ?"TLS" :"UDP", addr, port);
+			LOG(ndb_redis_debug, "Connecting to %s %s:%d\n", 
+					(enable_ssl) ?"TLS" :"UDP", addr, port);
 #else
 			LOG(ndb_redis_debug, "Connecting to %s:%d\n", addr, port);
 #endif
@@ -257,7 +260,7 @@ int redisc_init(void)
 		}
 
 #ifdef WITH_SSL
- 		if (enable_ssl) {
+ 		if(enable_ssl) {
  			/* Negotiate SSL/TLS handshake*/
  			redisInitiateSSLWithContext(rsrv->ctxRedis, rsrv->sslCtxRedis);
  		}
@@ -495,12 +498,13 @@ int redisc_reconnect_server(redisc_server_t *rsrv)
 					pass, sizeof(pass) - 1, "%.*s", pit->body.len, pit->body.s);
 			haspass = 1;
 #ifdef WITH_SSL
- 		} else if(pit->name.len==3 && strncmp(pit->name.s, "tls", 3)==0) {
-			snprintf(pass, sizeof(pass)-1, "%.*s", pit->body.len, pit->body.s);
- 			if (str2int(&pit->body, &enable_ssl) < 0)
+ 		} else if(pit->name.len == 3 && strncmp(pit->name.s, "tls", 3) == 0) {
+			snprintf(
+					pass, sizeof(pass)-1, "%.*s", pit->body.len, pit->body.s);
+ 			if(str2int(&pit->body, &enable_ssl) < 0)
 				enable_ssl = 0;
 #endif
-		} else if(pit->name.len == 14 
+		} else if(pit->name.len == 14
 				  && strncmp(pit->name.s, "sentinel_group", 14) == 0) {
 			snprintf(sentinel_group, sizeof(sentinel_group) - 1, "%.*s",
 					pit->body.len, pit->body.s);
@@ -586,16 +590,17 @@ int redisc_reconnect_server(redisc_server_t *rsrv)
 		rsrv->ctxRedis = NULL;
 	}
 #ifdef WITH_SSL
-	if(rsrv->sslCtxRedis!=NULL) {
-	    redisFreeSSLContext(rsrv->sslCtxRedis);
-	    rsrv->sslCtxRedis = NULL;
+	if(rsrv->sslCtxRedis != NULL) {
+		redisFreeSSLContext(rsrv->sslCtxRedis);
+		rsrv->sslCtxRedis = NULL;
 	}
 
-	if (enable_ssl) {
+	if(enable_ssl) {
 		/* Create SSL context*/
 		redisInitOpenSSL();
-		rsrv->sslCtxRedis = redisCreateSSLContext(NULL, NULL, NULL, NULL, NULL, NULL);
-		if (rsrv->sslCtxRedis == NULL) {
+		rsrv->sslCtxRedis =
+				redisCreateSSLContext(NULL, NULL, NULL, NULL, NULL, NULL);
+		if(rsrv->sslCtxRedis == NULL) {
 			LM_ERR("Unable to create Redis TLS Context.\n");
 		}
 	}
@@ -607,7 +612,7 @@ int redisc_reconnect_server(redisc_server_t *rsrv)
 		rsrv->ctxRedis = redisConnectWithTimeout(addr, port, tv_conn);
 	}
 #ifdef WITH_SSL
-	if (enable_ssl) {
+	if(enable_ssl) {
 		/* Negotiate SSL/TLS handshake*/
 		redisInitiateSSLWithContext(rsrv->ctxRedis, rsrv->sslCtxRedis);
 	}

--- a/src/modules/ndb_redis/redis_client.c
+++ b/src/modules/ndb_redis/redis_client.c
@@ -62,6 +62,9 @@ extern int redis_allowed_timeouts_param;
 extern int redis_flush_on_reconnect_param;
 extern int redis_allow_dynamic_nodes_param;
 extern int ndb_redis_debug;
+#ifdef WITH_SSL
+extern char *ca_path;
+#endif
 
 /* backwards compatibility with hiredis < 0.12 */
 #if(HIREDIS_MAJOR == 0) && (HIREDIS_MINOR < 12)
@@ -81,6 +84,9 @@ int redisc_init(void)
 	char addr[256], pass[256], unix_sock_path[256], sentinel_group[256];
 
 	unsigned int port, db, sock = 0, haspass = 0, sentinel_master = 1;
+#ifdef WITH_SSL
+	unsigned int enable_ssl = 0;
+#endif
 	int i, row;
 	redisc_server_t *rsrv = NULL;
 	param_t *pit = NULL;
@@ -133,7 +139,14 @@ int redisc_init(void)
 				snprintf(pass, sizeof(pass) - 1, "%.*s", pit->body.len,
 						pit->body.s);
 				haspass = 1;
-			} else if(pit->name.len == 14
+#ifdef WITH_SSL
+			} else if(pit->name.len==3 && strncmp(pit->name.s, "tls", 3)==0) {
+				snprintf(pass, sizeof(pass)-1, "%.*s",
+						pit->body.len, pit->body.s);
+				if (str2int(&pit->body, &enable_ssl) < 0)
+					enable_ssl = 0;
+#endif
+			} else if(pit->name.len==14 
 					  && strncmp(pit->name.s, "sentinel_group", 14) == 0) {
 				snprintf(sentinel_group, sizeof(sentinel_group) - 1, "%.*s",
 						pit->body.len, pit->body.s);
@@ -218,15 +231,37 @@ int redisc_init(void)
 			}
 		}
 
+#ifdef WITH_SSL
+ 		if (enable_ssl) {
+ 			/* Create SSL context*/
+ 			redisInitOpenSSL();
+ 			rsrv->sslCtxRedis = redisCreateSSLContext(NULL, NULL, NULL, NULL, NULL, NULL);
+ 			if (rsrv->sslCtxRedis == NULL) {
+				LM_ERR("Unable to create Redis TLS Context.\n");
+ 			}
+  		}
+#endif
+
 		if(sock != 0) {
 			LOG(ndb_redis_debug, "Connecting to unix socket: %s\n",
 					unix_sock_path);
 			rsrv->ctxRedis =
 					redisConnectUnixWithTimeout(unix_sock_path, tv_conn);
 		} else {
+#ifdef WITH_SSL
+			LOG(ndb_redis_debug, "Connecting to %s %s:%d\n", (enable_ssl) ?"TLS" :"UDP", addr, port);
+#else
 			LOG(ndb_redis_debug, "Connecting to %s:%d\n", addr, port);
+#endif
 			rsrv->ctxRedis = redisConnectWithTimeout(addr, port, tv_conn);
 		}
+
+#ifdef WITH_SSL
+ 		if (enable_ssl) {
+ 			/* Negotiate SSL/TLS handshake*/
+ 			redisInitiateSSLWithContext(rsrv->ctxRedis, rsrv->sslCtxRedis);
+ 		}
+#endif
 
 		LOG(ndb_redis_debug, "rsrv->ctxRedis = %p\n", rsrv->ctxRedis);
 
@@ -420,6 +455,9 @@ int redisc_reconnect_server(redisc_server_t *rsrv)
 {
 	char addr[256], pass[256], unix_sock_path[256], sentinel_group[256];
 	unsigned int port, db, sock = 0, haspass = 0, sentinel_master = 1;
+#ifdef WITH_SSL
+	unsigned int enable_ssl = 0;
+#endif
 	char sentinels[MAXIMUM_SENTINELS][256];
 	uint8_t sentinels_count = 0;
 	int i, row;
@@ -456,7 +494,13 @@ int redisc_reconnect_server(redisc_server_t *rsrv)
 			snprintf(
 					pass, sizeof(pass) - 1, "%.*s", pit->body.len, pit->body.s);
 			haspass = 1;
-		} else if(pit->name.len == 14
+#ifdef WITH_SSL
+ 		} else if(pit->name.len==3 && strncmp(pit->name.s, "tls", 3)==0) {
+			snprintf(pass, sizeof(pass)-1, "%.*s", pit->body.len, pit->body.s);
+ 			if (str2int(&pit->body, &enable_ssl) < 0)
+				enable_ssl = 0;
+#endif
+		} else if(pit->name.len == 14 
 				  && strncmp(pit->name.s, "sentinel_group", 14) == 0) {
 			snprintf(sentinel_group, sizeof(sentinel_group) - 1, "%.*s",
 					pit->body.len, pit->body.s);
@@ -541,12 +585,33 @@ int redisc_reconnect_server(redisc_server_t *rsrv)
 		redisFree(rsrv->ctxRedis);
 		rsrv->ctxRedis = NULL;
 	}
+#ifdef WITH_SSL
+	if(rsrv->sslCtxRedis!=NULL) {
+	    redisFreeSSLContext(rsrv->sslCtxRedis);
+	    rsrv->sslCtxRedis = NULL;
+	}
+
+	if (enable_ssl) {
+		/* Create SSL context*/
+		redisInitOpenSSL();
+		rsrv->sslCtxRedis = redisCreateSSLContext(NULL, NULL, NULL, NULL, NULL, NULL);
+		if (rsrv->sslCtxRedis == NULL) {
+			LM_ERR("Unable to create Redis TLS Context.\n");
+		}
+	}
+#endif
 
 	if(sock != 0) {
 		rsrv->ctxRedis = redisConnectUnixWithTimeout(unix_sock_path, tv_conn);
 	} else {
 		rsrv->ctxRedis = redisConnectWithTimeout(addr, port, tv_conn);
 	}
+#ifdef WITH_SSL
+	if (enable_ssl) {
+		/* Negotiate SSL/TLS handshake*/
+		redisInitiateSSLWithContext(rsrv->ctxRedis, rsrv->sslCtxRedis);
+	}
+#endif
 	LM_DBG("rsrv->ctxRedis = %p\n", rsrv->ctxRedis);
 	if(!rsrv->ctxRedis)
 		goto err;

--- a/src/modules/ndb_redis/redis_client.h
+++ b/src/modules/ndb_redis/redis_client.h
@@ -30,8 +30,14 @@
 
 #ifdef WITH_HIREDIS_PATH
 #include <hiredis/hiredis.h>
+#ifdef WITH_SSL
+#include <hiredis/hiredis_ssl.h>
+#endif
 #else
 #include <hiredis.h>
+#ifdef WITH_SSL
+#include <hiredis_ssl.h>
+#endif
 #endif
 
 #include "../../core/str.h"
@@ -76,6 +82,7 @@ typedef struct redisc_server
 	param_t *attrs;
 	char *spec;
 	redisContext *ctxRedis;
+	redisSSLContext *sslCtxRedis;
 	struct redisc_server *next;
 	redisc_piped_cmds_t piped;
 	redisc_srv_disable_t disable;

--- a/src/modules/ndb_redis/redis_client.h
+++ b/src/modules/ndb_redis/redis_client.h
@@ -82,7 +82,9 @@ typedef struct redisc_server
 	param_t *attrs;
 	char *spec;
 	redisContext *ctxRedis;
+#ifdef WITH_SSL
 	redisSSLContext *sslCtxRedis;
+#endif
 	struct redisc_server *next;
 	redisc_piped_cmds_t piped;
 	redisc_srv_disable_t disable;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
A couple of commits into db_redis and ndb_redis adding TLS support and also password support to db_redis.

This mainly includes checking if proper parameter is provided (for ndb_redis is `tls` option in the DB URL and, for db_redis, a new `opt_tls` parameter) and creates a temporary SSL context that is used to initialise the redis context.

Also added `ca_path` parameter to both modules to be able to define a valid folder containing the root certificates used to validate TLS' certificate chain.

db_redis is also updated with a `db_pass` parameter to provide a DB access password.

TLS support is automatically enabled by checking libhiredis_ssl.so existence in each Makefile and defining a `WITH_SSL` flag that enables all the corresponding code lines. 
