### PR TITLE
pdt: make add_to_tree() idempotent

### DIFF
--- a/src/modules/pdt/pdtree.c
+++ b/src/modules/pdt/pdtree.c
@@ -117,9 +117,9 @@ int add_to_tree(pdt_tree_t *pt, str *sp, str *sd)
 
 	if(itn0[strpos(pdt_char_list.s, sp->s[l]) % PDT_NODE_SIZE].domain.s
 			!= NULL) {
-		LM_ERR("prefix already allocated [%.*s/[%.*s]\n", sp->len, sp->s,
+		LM_WARN("prefix already allocated [%.*s/[%.*s]\n", sp->len, sp->s,
 				sd->len, sd->s);
-		return -1;
+		return 0;
 	}
 
 	itn0[strpos(pdt_char_list.s, sp->s[l]) % PDT_NODE_SIZE].domain.s =


### PR DESCRIPTION
- the function call will suceed even if the prefix being inserted already exists in the tree

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
PDT module initialization currently fails if you try to insert a prefix multiple times. We use kamailio as a loadbalancer and have had this change out in the field for quite some time now as our database often contains a prefix multiple times (associated with the same domain). Would it make sense to change the behavior in this case ?

Thanks,
Vladimir. 


