### PR TITLE
core: fixed wrong network interface selection.

### DIFF
--- a/src/core/forward.c
+++ b/src/core/forward.c
@@ -168,6 +168,9 @@ retry:
 	}
 	su2ip_addr(&ip, &from);
 	si = find_si(&ip, 0, proto);
+	if(si == 0) {
+		si = find_sock_info_by_address_family(proto, ip.af);
+	}
 	if(si == 0)
 		goto error;
 	LM_DBG("socket determined: %p\n", si);

--- a/src/core/socket_info.c
+++ b/src/core/socket_info.c
@@ -2591,3 +2591,35 @@ struct socket_info *lookup_local_socket(str *phostp)
 	return grep_sock_info(
 			&r.host, (unsigned short)r.port, (unsigned short)r.proto);
 }
+
+struct socket_info *find_sock_info_by_address_family(
+		int proto, int address_family)
+{
+	struct addr_info *ai = NULL;
+	int found = 0;
+	struct socket_info *si = NULL;
+	struct socket_info **si_list = get_sock_info_list(proto);
+
+	for(si = si_list ? *si_list : NULL; si; si = si->next) {
+		if(si->flags & (SI_IS_LO | SI_IS_MCAST)) {
+			continue;
+		}
+
+		if(si->address.af == address_family) {
+			break;
+		}
+
+		for(ai = si->addr_info_lst; ai; ai = ai->next) {
+			if(ai->address.af == address_family) {
+				found = 1;
+				break;
+			}
+		}
+
+		if(found) {
+			break;
+		}
+	}
+
+	return si;
+}

--- a/src/core/socket_info.h
+++ b/src/core/socket_info.h
@@ -171,4 +171,7 @@ unsigned int ipv6_get_netif_scope(char *ipval);
 int ksr_sockets_no_get(void);
 void ksr_sockets_index(void);
 
+struct socket_info *find_sock_info_by_address_family(
+		int proto, int address_family);
+
 #endif


### PR DESCRIPTION
fixed incorrect source IP address selection for the SIP messages sending procedure when TCP transport is used or for UDP with the 'mhomed' setting set as 'mhomed=1'.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3486(replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
The current service behavior is as follows: if OS contains several network interfaces and the service has a listening TCP socket (or UDP with 'mhomed=1' setting) on the second (third, fourth and so  on) interface, then the outbound SIP messages will be always sent from the first (default) interface.
These changes make the outbound SIP messages always going through the network_interface/address, which is taken for listening by service.
