### PR TITLE
nats: nats_publish set reply parameter to be optional

### DIFF
--- a/src/modules/nats/nats_mod.c
+++ b/src/modules/nats/nats_mod.c
@@ -59,7 +59,9 @@ static param_export_t params[] = {
 
 static cmd_export_t cmds[] = {
 	{"nats_publish", (cmd_function)w_nats_publish_f,
-		  3, fixup_publish_get_value, fixup_publish_get_value_free, ANY_ROUTE},
+		  2, fixup_publish_get_value, fixup_publish_get_value_free, ANY_ROUTE},
+	{"nats_publish", (cmd_function)w_nats_publish_reply_f,
+		  3, fixup_publish_reply_get_value, fixup_publish_reply_get_value_free, ANY_ROUTE},
 	{0, 0, 0, 0, 0, 0}
 };
 

--- a/src/modules/nats/nats_mod.h
+++ b/src/modules/nats/nats_mod.h
@@ -35,10 +35,13 @@ static int mod_init(void);
 static int mod_child_init(int);
 static void mod_destroy(void);
 
-extern int w_nats_publish_f(
+extern int w_nats_publish_f(sip_msg_t *msg, char *subj, char *payload);
+extern int w_nats_publish_reply_f(
 		sip_msg_t *msg, char *subj, char *payload, char *reply);
 extern int fixup_publish_get_value(void **param, int param_no);
 extern int fixup_publish_get_value_free(void **param, int param_no);
+extern int fixup_publish_reply_get_value(void **param, int param_no);
+extern int fixup_publish_reply_get_value_free(void **param, int param_no);
 extern void _nats_pub_worker_cb(uv_poll_t *handle, int status, int events);
 
 int nats_run_cfg_route(int rt, str *evname);

--- a/src/modules/nats/nats_pub.c
+++ b/src/modules/nats/nats_pub.c
@@ -32,7 +32,7 @@ int pub_worker = 0;
 
 int fixup_publish_get_value(void **param, int param_no)
 {
-	if(param_no == 1 || param_no == 2 || param_no == 3) {
+	if(param_no == 1 || param_no == 2) {
 		return fixup_spve_null(param, 1);
 	}
 	LM_ERR("invalid parameter number <%d>\n", param_no);
@@ -40,6 +40,25 @@ int fixup_publish_get_value(void **param, int param_no)
 }
 
 int fixup_publish_get_value_free(void **param, int param_no)
+{
+	if(param_no == 1 || param_no == 2) {
+		fixup_free_spve_null(param, 1);
+		return 0;
+	}
+	LM_ERR("invalid parameter number <%d>\n", param_no);
+	return -1;
+}
+
+int fixup_publish_reply_get_value(void **param, int param_no)
+{
+	if(param_no == 1 || param_no == 2 || param_no == 3) {
+		return fixup_spve_null(param, 1);
+	}
+	LM_ERR("invalid parameter number <%d>\n", param_no);
+	return -1;
+}
+
+int fixup_publish_reply_get_value_free(void **param, int param_no)
 {
 	if(param_no == 1 || param_no == 2 || param_no == 3) {
 		fixup_free_spve_null(param, 1);
@@ -84,7 +103,24 @@ static int _w_nats_publish_f(str subj, str payload, str reply, int worker)
 	return 1;
 }
 
-int w_nats_publish_f(sip_msg_t *msg, char *subj, char *payload, char *reply)
+int w_nats_publish_f(sip_msg_t *msg, char *subj, char *payload)
+{
+	str subj_s = STR_NULL;
+	str payload_s = STR_NULL;
+	str reply_s = STR_NULL;
+	if(fixup_get_svalue(msg, (gparam_t *)subj, &subj_s) < 0) {
+		LM_ERR("failed to get subj value\n");
+		return -1;
+	}
+	if(fixup_get_svalue(msg, (gparam_t *)payload, &payload_s) < 0) {
+		LM_ERR("failed to get subj value\n");
+		return -1;
+	}
+	return w_nats_publish(msg, subj_s, payload_s, reply_s);
+}
+
+int w_nats_publish_reply_f(
+		sip_msg_t *msg, char *subj, char *payload, char *reply)
 {
 	str subj_s = STR_NULL;
 	str payload_s = STR_NULL;

--- a/src/modules/nats/nats_pub.h
+++ b/src/modules/nats/nats_pub.h
@@ -39,9 +39,13 @@ typedef struct _nats_pub_delivery
 nats_pub_delivery_ptr _nats_pub_delivery_new(
 		str subject, str payload, str reply);
 void nats_pub_free_delivery_ptr(nats_pub_delivery_ptr ptr);
-int w_nats_publish_f(sip_msg_t *msg, char *subj, char *payload, char *reply);
+int w_nats_publish_f(sip_msg_t *msg, char *subj, char *payload);
+int w_nats_publish_reply_f(
+		sip_msg_t *msg, char *subj, char *payload, char *reply);
 int w_nats_publish(sip_msg_t *msg, str subj_s, str payload_s, str reply_s);
 int fixup_publish_get_value(void **param, int param_no);
 int fixup_publish_get_value_free(void **param, int param_no);
+int fixup_publish_reply_get_value(void **param, int param_no);
+int fixup_publish_reply_get_value_free(void **param, int param_no);
 
 #endif


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
commit a725b4fd224c27d84a9f5623faa5af3c3873a2e5 seems to make the `nats_publish` function require the `reply.topic` parameter required. The change from that commit breaks backward compatibility and forces the configuration to pass a reply.topic. This PR makes the `reply.topic` optional.  
