### PR TITLE
Add 2 new options to dispatcher management in kamctl

### DIFF
--- a/utils/kamctl/kamctl
+++ b/utils/kamctl/kamctl
@@ -1756,6 +1756,40 @@ dispatcher() {
 			fi
 
 			;;
+	  rmip)
+			require_dbengine
+			shift
+			if [ $# -ne 2 ] ; then
+				merr "missing gateway ip address and/or setid to be removed"
+				exit 1
+			fi
+
+			QUERY="delete from $DISPATCHER_TABLE where $DISPATCHER_SETID_COLUMN='$2' and $DISPATCHER_DESTINATION_COLUMN like 'sip:$1:%';"
+			$DBCMD "$QUERY"
+
+			if [ $? -ne 0 ] ; then
+				merr "dispatcher - SQL Error"
+				exit 1
+			fi
+
+	    ;;
+	  rmset)
+			require_dbengine
+			shift
+			if [ $# -ne 2 ] ; then
+				merr "missing gateway setid to be removed"
+				exit 1
+			fi
+
+			QUERY="delete from $DISPATCHER_TABLE where $DISPATCHER_SETID_COLUMN='$1'' and $DISPATCHER_DESTINATION_COLUMN like 'sip:$1:%'';"
+			$DBCMD "$QUERY"
+
+			if [ $? -ne 0 ] ; then
+				merr "dispatcher - SQL Error"
+				exit 1
+			fi
+
+	    ;;
 		reload)
 			require_ctlengine
 			ctl_cmd_run dispatcher.reload

--- a/utils/kamctl/kamctl.base
+++ b/utils/kamctl/kamctl.base
@@ -512,6 +512,8 @@ cat <<EOF
  dispatcher add <setid> <destination> [flags] [priority] [attrs] [description]
             .......................... add gateway
  dispatcher rm <id> .................. delete gateway
+ dispatcher rmip <ip> <setid>.................. delete gateway <ip> in <setid>
+ dispatcher rmset <setid> .................. delete all gateways in <setid>
 EOF
 }
 USAGE_FUNCTIONS="$USAGE_FUNCTIONS usage_dispatcher"

--- a/utils/kamctl/kamctl.base
+++ b/utils/kamctl/kamctl.base
@@ -512,8 +512,8 @@ cat <<EOF
  dispatcher add <setid> <destination> [flags] [priority] [attrs] [description]
             .......................... add gateway
  dispatcher rm <id> .................. delete gateway
- dispatcher rmip <ip> <setid>.................. delete gateway <ip> in <setid>
- dispatcher rmset <setid> .................. delete all gateways in <setid>
+ dispatcher rmip <ip> <setid>......... delete gateway <ip> in <setid>
+ dispatcher rmset <setid> ............. delete all gateways in <setid>
 EOF
 }
 USAGE_FUNCTIONS="$USAGE_FUNCTIONS usage_dispatcher"


### PR DESCRIPTION
kamctl: added new options to dispatcher interface

- added a new `rmip` option to delete a specific gateway `ip` in a predefined `setid`
- added a new `rmset` option to delete a specific `setid` completely
