### PR TITLE
Initial support for devcontainers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,7 @@
 ---
+Language: Json
+BasedOnStyle: llvm
+---
 Language:        Cpp
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -4
@@ -87,4 +90,3 @@ Standard:        Cpp11
 TabWidth:        4
 UseTab:          Always
 ...
-

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+# utils packages
+RUN apt-get update && \
+  export DEBIAN_FRONTEND=noninteractive && \
+  apt-get -y install --no-install-recommends \
+    apt-utils dialog clang-format clang pbuilder
+
+# bookworm packaging
+RUN mkdir -p /usr/local/src/pkg
+COPY bookworm /usr/local/src/pkg/debian
+
+# get build dependences
+RUN cd /usr/local/src/pkg/ && \
+  /usr/lib/pbuilder/pbuilder-satisfydepends-experimental
+
+# clean
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  /* For format details, see https://aka.ms/devcontainer.json. For config options, see the
+   * README at: https://github.com/devcontainers/templates/tree/main/src/debian
+   */
+  "name": "Debian",
+  "build": {
+    "context": "../pkg/kamailio/deb",
+    "dockerfile": "Dockerfile"
+  },
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/wxw-matt/devcontainer-features/command_runner:0": {}
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [
+    5060
+  ],
+
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "ms-vscode.cpptools-extension-pack",
+        "xaver.clang-format"
+      ]
+    }
+  },
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  "remoteUser": "root"
+}


### PR DESCRIPTION
#### Description
Initial support of [devcontainers](https://containers.dev/)

Allows to develop inside a container using [vscode](https://code.visualstudio.com/docs/devcontainers/containers)

Next steps:
* configure github actions to build and publish the image in our github repository
   https://github.com/devcontainers/ci/blob/main/docs/github-action.md
* include configurations for vscode to build and run kamailio
* investigate how to debug inside vscode
