### PR TITLE
crypto: SHA1_Init deprecated at openssl 3.0

### DIFF
--- a/src/modules/crypto/crypto_uuid.c
+++ b/src/modules/crypto/crypto_uuid.c
@@ -177,14 +177,33 @@ static inline int crypto_format_rfc4122_uuid(
  */
 void crypto_generate_callid(str *callid)
 {
+#if OPENSSL_VERSION_NUMBER > 0x030000000L
+	EVP_MD_CTX *crypto_ctx = NULL;
+#else
 	static SHA_CTX crypto_ctx = {0};
+#endif
 	static unsigned char crypto_buf[SHA_DIGEST_LENGTH] = {0};
 	static char crypto_sbuf[UUID_LEN] = {0};
 	crypto_inc_counter(crypto_callid_counter, CTR_LEN);
+
+#if OPENSSL_VERSION_NUMBER > 0x030000000L
+	if((crypto_ctx = EVP_MD_CTX_new()) == NULL) {
+		LM_ERR("can't get new context\n");
+		callid->s = NULL;
+		callid->len = 0;
+		return;
+	}
+	EVP_DigestInit_ex(crypto_ctx, EVP_sha1(), NULL);
+	EVP_DigestUpdate(crypto_ctx, crypto_callid_seed, SEED_LEN);
+	EVP_DigestUpdate(crypto_ctx, crypto_callid_counter, CTR_LEN);
+	EVP_DigestFinal_ex(crypto_ctx, crypto_buf, NULL);
+	EVP_MD_CTX_free(crypto_ctx);
+#else
 	SHA1_Init(&crypto_ctx);
 	SHA1_Update(&crypto_ctx, crypto_callid_seed, SEED_LEN);
 	SHA1_Update(&crypto_ctx, crypto_callid_counter, CTR_LEN);
 	SHA1_Final(crypto_buf, &crypto_ctx);
+#endif
 	crypto_format_rfc4122_uuid(
 			crypto_sbuf, sizeof(crypto_sbuf), crypto_buf, sizeof(crypto_buf));
 	callid->s = crypto_sbuf;


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [x] Related to issue #3502

#### Description
From https://www.openssl.org/docs/man3.0/man7/migration_guide.html

> Use of low-level digest functions such as SHA1_Init(3) have been informally
> discouraged from use for a long time. Applications should instead use the
> high level EVP APIs EVP_DigestInit_ex(3), EVP_DigestUpdate(3) and
> EVP_DigestFinal_ex(3), or the quick one-shot EVP_Q_digest(3).
