### PR TITLE
core: Add TCP_USER_TIMEOUT socket option on listening socket.

### DIFF
--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -3172,6 +3172,18 @@ int tcp_init(struct socket_info *sock_info)
 	}
 #endif
 	init_sock_keepalive(sock_info->socket);
+#ifdef HAVE_TCP_USER_TIMEOUT
+	if((optval = TICKS_TO_S(cfg_get(tcp, tcp_cfg, send_timeout)))) {
+		optval *= 1000;
+		if(setsockopt(sock_info->socket, IPPROTO_TCP, TCP_USER_TIMEOUT, &optval,
+				   sizeof(optval))
+				< 0) {
+			LM_WARN("failed to set TCP_USER_TIMEOUT: %s\n", strerror(errno));
+		} else {
+			LM_INFO("Set TCP_USER_TIMEOUT=%d ms\n", optval);
+		}
+	}
+#endif
 	if(bind(sock_info->socket, &addr->s, sockaddru_len(*addr)) == -1) {
 		LM_ERR("bind(%x, %p, %d) on %s:%d : %s\n", sock_info->socket, &addr->s,
 				(unsigned)sockaddru_len(*addr), sock_info->address_str.s,

--- a/src/core/tcp_options.h
+++ b/src/core/tcp_options.h
@@ -68,6 +68,13 @@
 #endif /* __OS_ */
 #endif /* NO_TCP_LINGER2 */
 
+/* tcp user_timeout */
+#ifndef NO_TCP_USER_TIMEOUT
+#ifdef __OS_linux
+#define HAVE_TCP_USER_TIMEOUT
+#endif /* __OS_ */
+#endif /* NO_TCP_LINGER2 */
+
 /* keepalive */
 #ifndef NO_TCP_KEEPALIVE
 #define HAVE_SO_KEEPALIVE


### PR DESCRIPTION
Use tcp_send_timeout config option also on listening socket to timeout outbound messages sent on passive inbound connections.

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3443

#### Description
Based on the description of core parameter "tcp_send_timeout" the timeout should also work for sending on forked incoming tcp connections. But sending on a broken connection causes the kernel to use the default values of `tcp_retries1` and `tcp_retries2` , leading to try to send a SIP message for 15 minutes. This makes absolutely no sense in a real time kamailio application.

Following man 7 tcp TCP_USER_TIMEOUT can be used on recent Linux kernels to utilize tcp_send_timeout:

       TCP_USER_TIMEOUT (since Linux 2.6.37)
              This  option  takes  an  unsigned  int as an argument.  When the value is greater than 0, it specifies the maximum
              amount of time in milliseconds that transmitted data may remain unacknowledged before TCP will forcibly close  the
              corresponding connection and return ETIMEDOUT to the application.  If the option value is specified as 0, TCP will
              use the system default.

              Increasing user timeouts allows a TCP connection to survive extended periods without end-to-end connectivity.  De‐
              creasing  user  timeouts  allows applications to "fail fast", if so desired.  Otherwise, failure may take up to 20
              minutes with the current system defaults in a normal WAN environment.

              This option can be set during any state of a TCP connection, but is effective only during the synchronized  states
              of  a  connection  (ESTABLISHED,  FIN-WAIT-1, FIN-WAIT-2, CLOSE-WAIT, CLOSING, and LAST-ACK).  Moreover, when used
              with the TCP keepalive (SO_KEEPALIVE) option, TCP_USER_TIMEOUT will override keepalive to determine when to  close
              a connection due to keepalive failure.

              The option has no effect on when TCP retransmits a packet, nor when a keepalive probe is sent.

              This option, like many others, will be inherited by the socket returned by accept(2), if it was set on the listen‐
              ing socket.

              Further details on the user timeout feature can be found in RFC 793 and RFC 5482 ("TCP User Timeout Option").

Having a tcp connection break by firewall or network breakdown the retransmits to this destination are now aborted after `tcp_send_timeout` seconds with a 

    NOTICE: <core> [core/tcp_read.c:267]: tcp_read_data(): error reading: Connection timed out (110) ([1.2.3.4]:51151 ->



