### PR TITLE
statsd: Add labels to metrics.

### DIFF
--- a/src/modules/statsd/lib_statsd.c
+++ b/src/modules/statsd/lib_statsd.c
@@ -11,7 +11,25 @@
 #include "../../core/sr_module.h"
 #include "lib_statsd.h"
 
+bool isNumber(char *str);
+
 static StatsConnection statsd_connection = {"127.0.0.1", "8125", -1};
+
+enum actions
+{
+	GAUGE = 0,
+	COUNTER,
+	SET,
+	HISTOGRAM,
+	TIMMING
+};
+
+static const char *const actions_val[] = {[GAUGE] = "g",
+		[COUNTER] = "c",
+		[SET] = "s",
+		[HISTOGRAM] = "h",
+		[TIMMING] = "ms"};
+
 
 bool statsd_connect(void)
 {
@@ -69,55 +87,66 @@ bool send_command(char *command)
 	return true;
 }
 
-bool statsd_set(char *key, char *value)
+bool statsd_send_command(
+		char *key, char *value, enum actions action, char *labels)
 {
-	char *end = 0;
-	char command[254];
-	int val;
-	val = strtol(value, &end, 0);
-	if(*end) {
+	size_t labels_len = 0;
+	if(labels != NULL) {
+		labels_len = strlen(labels);
+	}
+	const char *action_str = actions_val[action];
+	size_t command_len =
+			strlen(key) + strlen(value) + labels_len + strlen(action_str) + 6;
+	char command[command_len];
+
+	if(labels_len == 0) {
+		snprintf(command, command_len, "%s:%s|%s\n", key, value, action_str);
+	} else {
+		snprintf(command, sizeof command, "%s:%s|%s|#%s\n", key, value,
+				action_str, labels);
+	}
+	return send_command(command);
+}
+
+
+bool statsd_set(char *key, char *value, char *labels)
+{
+	if(!isNumber(value)) {
+		LM_ERR("statsd_set could not  use the provide value(%s)\n", value);
+		return false;
+	}
+	return statsd_send_command(key, value, SET, labels);
+}
+
+
+bool statsd_gauge(char *key, char *value, char *labels)
+{
+	return statsd_send_command(key, value, GAUGE, labels);
+}
+
+bool statsd_histogram(char *key, char *value, char *labels)
+{
+	return statsd_send_command(key, value, HISTOGRAM, labels);
+}
+
+bool statsd_count(char *key, char *value, char *labels)
+{
+	if(!isNumber(value)) {
 		LM_ERR("statsd_count could not  use the provide value(%s)\n", value);
 		return false;
 	}
-	snprintf(command, sizeof command, "%s:%i|s\n", key, val);
-	return send_command(command);
+	return statsd_send_command(key, value, COUNTER, labels);
 }
 
-
-bool statsd_gauge(char *key, char *value)
+bool statsd_timing(char *key, int value, char *labels)
 {
-	char command[254];
-	snprintf(command, sizeof command, "%s:%s|g\n", key, value);
-	return send_command(command);
-}
-
-bool statsd_histogram(char *key, char *value)
-{
-	char command[254];
-	snprintf(command, sizeof command, "%s:%s|h\n", key, value);
-	return send_command(command);
-}
-
-bool statsd_count(char *key, char *value)
-{
-	char *end = 0;
-	char command[254];
-	int val;
-
-	val = strtol(value, &end, 0);
-	if(*end) {
-		LM_ERR("statsd_count could not  use the provide value(%s)\n", value);
-		return false;
+	int value_len = 1;
+	if(value > 0) {
+		value_len = (int)((ceil(log10(value)) + 1) * sizeof(char));
 	}
-	snprintf(command, sizeof command, "%s:%i|c\n", key, val);
-	return send_command(command);
-}
-
-bool statsd_timing(char *key, int value)
-{
-	char command[254];
-	snprintf(command, sizeof command, "%s:%i|ms\n", key, value);
-	return send_command(command);
+	char val[value_len];
+	sprintf(val, "%i", value);
+	return statsd_send_command(key, val, TIMMING, labels);
 }
 
 bool statsd_init(char *ip, char *port)
@@ -136,4 +165,11 @@ bool statsd_destroy(void)
 {
 	statsd_connection.sock = 0;
 	return true;
+}
+
+bool isNumber(char *s)
+{
+	char *e = NULL;
+	(void)strtol(s, &e, 0);
+	return e != NULL && *e == (char)0;
 }

--- a/src/modules/statsd/lib_statsd.h
+++ b/src/modules/statsd/lib_statsd.h
@@ -11,10 +11,10 @@ typedef struct StatsConnection
 
 bool statsd_connect(void);
 bool send_command(char *command);
-bool statsd_set(char *key, char *value);
-bool statsd_gauge(char *key, char *value);
-bool statsd_histogram(char *key, char *value);
-bool statsd_count(char *key, char *value);
-bool statsd_timing(char *key, int value);
+bool statsd_set(char *key, char *value, char *labels);
+bool statsd_gauge(char *key, char *value, char *labels);
+bool statsd_histogram(char *key, char *value, char *labels);
+bool statsd_count(char *key, char *value, char *labels);
+bool statsd_timing(char *key, int value, char *labels);
 bool statsd_init(char *ip, char *port);
 bool statsd_destroy(void);

--- a/src/modules/statsd/statsd.c
+++ b/src/modules/statsd/statsd.c
@@ -34,12 +34,22 @@ MODULE_VERSION
 static int mod_init(void);
 void mod_destroy(void);
 static int func_gauge(struct sip_msg *msg, char *key, char *val);
+static int func_gauge_with_labels(
+		struct sip_msg *msg, char *key, char *val, char *labels);
 static int func_histogram(struct sip_msg *msg, char *key, char *val);
+static int func_histogram_with_labels(
+		struct sip_msg *msg, char *key, char *val, char *labels);
 static int func_set(struct sip_msg *msg, char *key, char *val);
+static int func_set_with_labels(
+		struct sip_msg *msg, char *key, char *val, char *labels);
 static int func_time_start(struct sip_msg *msg, char *key);
 static int func_time_end(struct sip_msg *msg, char *key);
+static int func_time_end_with_labels(
+		struct sip_msg *msg, char *key, char *labels);
 static int func_incr(struct sip_msg *msg, char *key);
+static int func_incr_with_labels(struct sip_msg *msg, char *key, char *labels);
 static int func_decr(struct sip_msg *msg, char *key);
+static int func_decr_with_labels(struct sip_msg *msg, char *key, char *labels);
 static char *get_milliseconds(char *dst);
 
 typedef struct StatsdParams
@@ -52,12 +62,18 @@ static StatsdParams statsd_params = {};
 /* clang-format off */
 static cmd_export_t commands[] = {
 	{"statsd_gauge", (cmd_function)func_gauge, 2, 0, 0, ANY_ROUTE},
+	{"statsd_gauge", (cmd_function)func_gauge_with_labels, 3, 0, 0, ANY_ROUTE},
 	{"statsd_histogram", (cmd_function)func_histogram, 2, 0, 0, ANY_ROUTE},
+	{"statsd_histogram", (cmd_function)func_histogram_with_labels, 3, 0, 0, ANY_ROUTE},
 	{"statsd_start", (cmd_function)func_time_start, 1, 0, 0, ANY_ROUTE},
 	{"statsd_stop", (cmd_function)func_time_end, 1, 0, 0, ANY_ROUTE},
+	{"statsd_stop", (cmd_function)func_time_end_with_labels, 2, 0, 0, ANY_ROUTE},
 	{"statsd_incr", (cmd_function)func_incr, 1, 0, 0, ANY_ROUTE},
+	{"statsd_incr", (cmd_function)func_incr_with_labels, 2, 0, 0, ANY_ROUTE},
 	{"statsd_decr", (cmd_function)func_decr, 1, 0, 0, ANY_ROUTE},
+	{"statsd_decr", (cmd_function)func_decr_with_labels, 2, 0, 0, ANY_ROUTE},
 	{"statsd_set", (cmd_function)func_set, 2, 0, 0, ANY_ROUTE},
+	{"statsd_set", (cmd_function)func_set_with_labels, 3, 0, 0, ANY_ROUTE},
     {0, 0, 0, 0, 0, 0}
 };
 
@@ -117,32 +133,69 @@ void mod_destroy(void)
 
 static int func_gauge(struct sip_msg *msg, char *key, char *val)
 {
-	return statsd_gauge(key, val);
+	return statsd_gauge(key, val, NULL);
 }
 
-static int func_histogram(struct sip_msg *msg, char *key, char *val)
+static int func_gauge_with_labels(
+		struct sip_msg *msg, char *key, char *val, char *labels)
 {
-	return statsd_histogram(key, val);
+	return statsd_gauge(key, val, labels);
 }
 
 static int ki_statsd_gauge(sip_msg_t *msg, str *key, str *val)
 {
-	return statsd_gauge(key->s, val->s);
+	return statsd_gauge(key->s, val->s, NULL);
 }
+
+static int ki_statsd_gauge_with_labels(
+		sip_msg_t *msg, str *key, str *val, str *labels)
+{
+	return statsd_gauge(key->s, val->s, labels->s);
+}
+
+static int func_histogram(struct sip_msg *msg, char *key, char *val)
+{
+	return statsd_histogram(key, val, NULL);
+}
+
+static int func_histogram_with_labels(
+		struct sip_msg *msg, char *key, char *val, char *labels)
+{
+	return statsd_histogram(key, val, labels);
+}
+
 
 static int ki_statsd_histogram(sip_msg_t *msg, str *key, str *val)
 {
-	return statsd_histogram(key->s, val->s);
+	return statsd_histogram(key->s, val->s, NULL);
+}
+
+static int ki_statsd_histogram_with_labels(
+		sip_msg_t *msg, str *key, str *val, str *labels)
+{
+	return statsd_histogram(key->s, val->s, labels->s);
 }
 
 static int func_set(struct sip_msg *msg, char *key, char *val)
 {
-	return statsd_set(key, val);
+	return statsd_set(key, val, NULL);
+}
+
+static int func_set_with_labels(
+		struct sip_msg *msg, char *key, char *val, char *labels)
+{
+	return statsd_set(key, val, labels);
 }
 
 static int ki_statsd_set(sip_msg_t *msg, str *key, str *val)
 {
-	return statsd_set(key->s, val->s);
+	return statsd_set(key->s, val->s, NULL);
+}
+
+static int ki_statsd_set_with_labels(
+		sip_msg_t *msg, str *key, str *val, str *labels)
+{
+	return statsd_set(key->s, val->s, labels->s);
 }
 
 static int func_time_start(struct sip_msg *msg, char *key)
@@ -168,7 +221,13 @@ static int ki_statsd_start(sip_msg_t *msg, str *key)
 	return func_time_start(msg, key->s);
 }
 
+
 static int func_time_end(struct sip_msg *msg, char *key)
+{
+	return func_time_end_with_labels(msg, key, NULL);
+}
+
+int func_time_end_with_labels(struct sip_msg *msg, char *key, char *labels)
 {
 	char unix_time[24];
 	char *endptr;
@@ -204,7 +263,7 @@ static int func_time_end(struct sip_msg *msg, char *key)
 	LM_DBG("Statsd: statsd_stop Start_time=%ld unix_time=%ld (%i)\n",
 			start_time, atol(unix_time), result);
 	destroy_avp(prev_avp);
-	return statsd_timing(key, result);
+	return statsd_timing(key, result, labels);
 }
 
 static int ki_statsd_stop(sip_msg_t *msg, str *key)
@@ -212,24 +271,49 @@ static int ki_statsd_stop(sip_msg_t *msg, str *key)
 	return func_time_end(msg, key->s);
 }
 
+static int ki_statsd_stop_with_labels(sip_msg_t *msg, str *key, str *labels)
+{
+	return func_time_end_with_labels(msg, key->s, labels->s);
+}
+
 static int func_incr(struct sip_msg *msg, char *key)
 {
-	return statsd_count(key, "+1");
+	return statsd_count(key, "+1", NULL);
+}
+
+static int func_incr_with_labels(struct sip_msg *msg, char *key, char *labels)
+{
+	return statsd_count(key, "+1", labels);
 }
 
 static int ki_statsd_incr(sip_msg_t *msg, str *key)
 {
-	return statsd_count(key->s, "+1");
+	return statsd_count(key->s, "+1", NULL);
+}
+
+static int ki_statsd_incr_with_labels(sip_msg_t *msg, str *key, str *labels)
+{
+	return statsd_count(key->s, "+1", labels->s);
 }
 
 static int func_decr(struct sip_msg *msg, char *key)
 {
-	return statsd_count(key, "-1");
+	return statsd_count(key, "-1", NULL);
+}
+
+static int func_decr_with_labels(struct sip_msg *msg, char *key, char *labels)
+{
+	return statsd_count(key, "-1", labels);
 }
 
 static int ki_statsd_decr(sip_msg_t *msg, str *key)
 {
-	return statsd_count(key->s, "-1");
+	return statsd_count(key->s, "-1", NULL);
+}
+
+static int ki_statsd_decr_with_labels(sip_msg_t *msg, str *key, str *labels)
+{
+	return statsd_count(key->s, "-1", labels->s);
 }
 
 char *get_milliseconds(char *dst)
@@ -253,9 +337,19 @@ static sr_kemi_t sr_kemi_statsd_exports[] = {
 		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
+	{ str_init("statsd"), str_init("statsd_gauge"),
+		SR_KEMIP_INT, ki_statsd_gauge_with_labels,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
 	{ str_init("statsd"), str_init("statsd_histogram"),
 		SR_KEMIP_INT, ki_statsd_histogram,
 		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("statsd"), str_init("statsd_histogram"),
+		SR_KEMIP_INT, ki_statsd_histogram_with_labels,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
 	{ str_init("statsd"), str_init("statsd_start"),
@@ -268,9 +362,19 @@ static sr_kemi_t sr_kemi_statsd_exports[] = {
 		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
+	{ str_init("statsd"), str_init("statsd_stop"),
+		SR_KEMIP_INT, ki_statsd_stop_with_labels,
+		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_STR,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
 	{ str_init("statsd"), str_init("statsd_incr"),
 		SR_KEMIP_INT, ki_statsd_incr,
 		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("statsd"), str_init("statsd_incr"),
+		SR_KEMIP_INT, ki_statsd_incr_with_labels,
+		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_STR,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
 	{ str_init("statsd"), str_init("statsd_decr"),
@@ -278,9 +382,19 @@ static sr_kemi_t sr_kemi_statsd_exports[] = {
 		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
+	{ str_init("statsd"), str_init("statsd_decr"),
+		SR_KEMIP_INT, ki_statsd_decr_with_labels,
+		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_STR,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
 	{ str_init("statsd"), str_init("statsd_set"),
 		SR_KEMIP_INT, ki_statsd_set,
 		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("statsd"), str_init("statsd_set"),
+		SR_KEMIP_INT, ki_statsd_set_with_labels,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
 


### PR DESCRIPTION
A user reached me to add a way to add the custom labels into the statsd
module, so a better way to report metrics to the observability platform.

I keep the same old functions and add a new parameter to the statsd
modules to both interfaces cfg and kemi.

The full documentation can be found here:
https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics

So, each function can be used like this: ``` statsd_set("fooo", 1,
"inbound"); statsd_gauge("NotFound", "+1", "outbound,carrierFoo");
statsd_gauge("AuthFailed", "+1", "carrier=foo,priority=10"); ```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>
Tested-by: Alex Antonevych <alex.antonevych@replicant.ai>


<!-- Kamailio Pull Request Template -->




#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally

I'm waiting until first review on function arguments to create the docs
changes.
