### PR TITLE
tm: clarify t_relay() can create a transaction

### DIFF
--- a/src/modules/tm/config.h
+++ b/src/modules/tm/config.h
@@ -39,7 +39,7 @@
 #include "../../core/cfg/cfg.h"
 #include "../../core/str.h"
 
-/* maximum length of localy generated acknowledgment */
+/* maximum length of locally generated acknowledgment */
 #define MAX_ACK_LEN 1024
 
 /* FINAL_RESPONSE_TIMER ... tells how long should the transaction engine

--- a/src/modules/tm/dlg.c
+++ b/src/modules/tm/dlg.c
@@ -368,7 +368,7 @@ int new_dlg_uac(str *_cid, str *_ltag, unsigned int _lseq, str *_luri,
  * @brief Store display names into a dialog
  * @param _d - dialog structure
  * @param _ldname - local party display name
- * @param _rdname - remote party dispaly name
+ * @param _rdname - remote party display name
  * @return 0 on success; negative on error
  */
 

--- a/src/modules/tm/doc/event_routes.xml
+++ b/src/modules/tm/doc/event_routes.xml
@@ -19,7 +19,7 @@
 	    <function moreinfo="none">event_route[tm:branch-failure:id]</function>
 	</title>
 	<para>
-		Named branch failure routes can be defined to run when when a failure
+		Named branch failure routes can be defined to run when a failure
 		response is received. This allows handling failures on individual
 		branches, for example, retrying an alternative outbound flow.
 	</para>

--- a/src/modules/tm/doc/functions.xml
+++ b/src/modules/tm/doc/functions.xml
@@ -16,7 +16,8 @@
 	    Relay a message statefully either to the destination indicated in the
 		current URI (if called without any parameters) or to the specified 
 		host and port. In the later case (host and port specified) the protocol
-		used is the same protocol on which the message was received.
+		used is the same protocol on which the message was received. It creates
+		a transaction.
 	</para>
 	<para>
 		<function>t_relay()</function> is the stateful version for 
@@ -298,13 +299,12 @@ branch_route[1] {
 	    <function>t_newtran()</function>
 	</title>
 	<para>
-	    Creates a new transaction, returns a negative value on error. This
-	    is the only way a script can add a new transaction in an atomic
-	    way. Typically, it is used to deploy a UAS.
+	    Creates a new transaction, returns a negative value on error. Typically,
+	    it is used to deploy a UAS.
 	</para>
 	<para>
 		Note: once the t_newtran() is executed, the new message flag operations
-		(i.e., setflag() and resetflag()) are not syncronized to the transaction,
+		(i.e., setflag() and resetflag()) are not synchronized to the transaction,
 		being stored only in the private memory SIP message structure. Use the
 		tmx module function t_flush_flags() to synchronize the modified message
 		flags to the already created transaction.
@@ -546,6 +546,8 @@ t_forward_nonack("1.2.3.4", "5060");
 			(in milliseconds) for INVITEs. See also 
 			<varname>fr_inv_timer</varname>.
 		</para>
+	    </listitem>
+	    <listitem>
 		<para><emphasis>fr_timeout</emphasis> - new final response timeout
 		 	(in milliseconds) for non-INVITE transaction, or INVITEs which 
 			haven't received yet a provisional response. See also
@@ -635,6 +637,8 @@ route {
 			lifetime (in milliseconds). See also 
 			<varname>max_inv_lifetime</varname>.
 		</para>
+	    </listitem>
+	    <listitem>
 		<para><emphasis>noninv_lifetime</emphasis> - maximum non-INVITE 
 			transaction lifetime (in milliseconds).
 			See also <varname>max_noninv_lifetime</varname>.
@@ -703,7 +707,7 @@ route {
 		Sets the retr_t1_interval and retr_t2_interval for the current
 		transaction or for transactions created during the same script 
 		invocation, after calling this function.
-		If one of the parameters is 0, it's value won't be changed.
+		If one of the parameters is 0, its value won't be changed.
 		If the transaction is already created (e.g called after
 		 <function>t_relay()</function> or in an onreply_route) all the
 		 existing branches will have their retransmissions intervals updated 
@@ -728,6 +732,8 @@ route {
 			interval (in milliseconds). See also
 			<varname>retr_t1_timeout</varname>.
 		</para>
+	    </listitem>
+	    <listitem>
 		<para><emphasis>retr_t2_interval</emphasis> - new T2 (or maximum) 
 			retransmission interval (in milliseconds). See also
 			<varname>retr_t2_timeout</varname>.
@@ -966,7 +972,7 @@ failure_route[0]{
 	    <function>t_is_expired()</function>
 	</title>
 	<para>
-		Returns true if the current transaction has already been expired,
+		Returns true if the current transaction has already expired,
 		i.e. the max_inv_lifetime/max_noninv_lifetime interval has already
 		elapsed.
 	</para>
@@ -1179,7 +1185,7 @@ failure_route[1] {
 		<para>
 		  If the current destination set contains more than one branch,
 		  the function sorts them according to the algorithm selected
-		  with the 'mode' paramenter and then stores the branches in
+		  with the 'mode' parameter and then stores the branches in
 		  reverse order into the XAVP.
 		</para>
 		<para>
@@ -1913,7 +1919,7 @@ t_clean();
 	    <function>t_exists()</function>
 	</title>
 	<para>
-		Return true of the transaction for current message exists, without
+		Return true if a transaction for the current message exists, without
 		setting the global references.
 	</para>
 	<example>

--- a/src/modules/tm/doc/params.xml
+++ b/src/modules/tm/doc/params.xml
@@ -144,7 +144,7 @@ modparam("tm", "max_inv_lifetime", 150000)
 		<varname>fr_timer</varname> is that the 
 		<varname>fr_timer</varname> is per branch, while 
 		<varname>max_noninv_lifetime</varname> is per the whole transaction.
-		An example when a transaction can live substantially more then its
+		An example when a transaction can live substantially more than its
 		<varname>fr_timer</varname> and where
 		<varname>max_noninv_lifetime</varname> will help is when DNS failover
 		is used (each failed DNS SRV destination can introduce a new branch).
@@ -372,7 +372,7 @@ modparam("tm", "unix_tx_timeout", 250)
         <section id="tm.p.aggregate_challenges">
 	<title><varname>aggregate_challenges</varname> (integer)</title>
 	<para>
-		If set (default) and the final response is a 401 or a 407 and more than
+		If set (default), the final response is a 401 or a 407 and more than
 		one branch received a 401 or 407, then all the WWW-Authenticate and 
 		Proxy-Authenticate headers from all the 401 and 407 replies will 
 		be aggregated in a new final response. If only one branch received the
@@ -801,7 +801,7 @@ modparam("tm", "contact_flows_avp", "tm_contact_flows")
 	<section id="tm.p.fr_timer_avp" >
 		<title><varname>fr_timer_avp</varname> (string)</title>
 		<para>
-			The value of fr_timer timer can be overriden on per-transaction
+			The value of fr_timer timer can be overridden on per-transaction
 			basis. The administrator can provide a value to be used for a
 			particular transaction in an AVP. This parameter contains the name
 			of the AVP that will be checked. If the AVP exists then its value
@@ -846,7 +846,7 @@ modparam("tm", "fr_timer_avp", "i:708")
 	<section id="tm.p.fr_inv_timer_avp">
 		<title><varname>fr_inv_timer_avp</varname> (string)</title>
 		<para>
-			The value of fr_inv_timer timer can be overriden on
+			The value of fr_inv_timer timer can be overridden on
 			per-transaction basis. The administrator can provide a value to be
 			used for a particular transaction in an AVP. This parameter
 			contains the name of the AVP that will be checked. If the AVP
@@ -1177,7 +1177,7 @@ modparam("tm", "disable_6xx_block", 1)
 		</para></listitem>
 	</itemizedlist>
 	<note><para>
-	Mode 1 and 2 does not follow RFC 3261, but are useful to deal with some simple UAs
+	Modes 1 and 2 do not follow RFC 3261, but are useful to deal with some simple UAs
 	behind a NAT (no different routing for the ACK and the contact 
 	contains an address behind the NAT).
 	</para></note>
@@ -1274,8 +1274,8 @@ modparam("tm", "failure_reply_mode", 0)
 		</para></listitem>
 		<listitem><para>
 		<emphasis>&gt; 0</emphasis> - priority is decreased by given amount.
-		Do not make it higer than 10000 or faked replies will even loose
-		from 1xx clsss replies.
+		Do not make it higher than 10000 or faked replies will even loose
+		from 1xx class replies.
 		</para></listitem>
 	</itemizedlist>
 	<para>
@@ -1595,10 +1595,10 @@ modparam("tm", "exec_time_check", 0)
 	<section id="tm.p.reply_relay_mode">
 		<title><varname>reply_relay_mode</varname> (int)</title>
 		<para>
-			If set to 1, a received 200 OK response that was suspeneded is no
+			If set to 1, a received 200 OK response that was suspended is no
 			longer forwarded in the transactional context if another final
-			response was forward while 200 OK was suspended. Forwarding the 200 OK,
-			even it was received first, results in overwritting the transaction
+			response was forwarded while 200 OK was suspended. Forwarding the 200 OK,
+			even it was received first, results in overwriting the transaction
 			response buffer that can impact matching of incoming ACKs.
 		</para>
 		<para>
@@ -1626,6 +1626,7 @@ modparam("tm", "reply_relay_mode", 0)
 		<para>
 			Enable failure route trigger, for uac. This will copy the tm uac into uas.
 			Thus, failure route can be triggered even for uac messages.
+			The default is 0 (disabled).
 		</para>
 		<example>
 			<title>enable_uac_fr example</title>

--- a/src/modules/tm/doc/tm.xml
+++ b/src/modules/tm/doc/tm.xml
@@ -248,7 +248,7 @@ request_route {
 	  </para>
 	  <para>
 		Function <function>t_next_contacts()</function> takes the AVP created
-		by the previous function and extract the branches with highest q
+		by the previous function and extracts the branches with highest q
 		values from it. In our example it is branch D. That branch is then put
 		back into the destination set and when the script finally
 		reaches <function>t_relay()</function>, the destination set only
@@ -301,7 +301,7 @@ failure_route["serial"]
 		we have more new branches to try and we need to setup the
 		failure_route again and call <function>t_relay()</function>. In our
 		example the request will now be forwarded to branches B and C in
-		paralell, because they were both added to the destination set
+		parallel, because they were both added to the destination set
 		by <function>t_next_contacts()</function> at the same time.
 	  </para>
 	  <para>

--- a/src/modules/tm/h_table.c
+++ b/src/modules/tm/h_table.c
@@ -329,7 +329,7 @@ struct cell *build_cell(struct sip_msg *p_msg)
 
 	/* allocs a new cell, add space for:
 	 * md5 (MD5_LEN - sizeof(struct cell.md5))
-	 * uac (sr_dst_max_banches * sizeof(struct ua_client) ) */
+	 * uac (sr_dst_max_branches * sizeof(struct ua_client) ) */
 	cell_size = sizeof(struct cell) + MD5_LEN - sizeof(((struct cell *)0)->md5)
 				+ (sr_dst_max_branches * sizeof(struct ua_client));
 
@@ -516,7 +516,7 @@ error0:
  * backup xdata from/to msg context to local var and use T lists
  * - mode = 0 - from msg context to _txdata and use T lists
  * - mode = 1 - restore to msg context from _txdata
- * the function can be also used to restore the core context from transacation data
+ * the function can be also used to restore the core context from transaction data
  */
 void tm_xdata_swap(tm_cell_t *t, tm_xlinks_t *xd, int mode)
 {

--- a/src/modules/tm/h_table.h
+++ b/src/modules/tm/h_table.h
@@ -101,7 +101,7 @@ void unlock_hash(int i);
  * REQ_EXIST means that this request is a retransmission which does not
  *     affect transactional state
  * REQ_ERR_DELAYED mean that tm wants to send  reply(ser_error) but it
- *     delayed it to end-of-script to allow it to be overriden.
+ *     delayed it to end-of-script to allow it to be overridden.
  *     If this is set and all of the above flag are not => send reply
  *     on end of script. If any of the above flags is set, do not
  *     send (especially REQ_RPLD and REQ_RLSD).

--- a/src/modules/tm/select.c
+++ b/src/modules/tm/select.c
@@ -42,8 +42,8 @@ inline static int select_tm_get_cell(
 {
 
 	/* make sure we know the associated transaction ... */
-	if(t_check(msg, branch) == -1) /* it's not necessary whan calling
-										* from script because already done */
+	if(t_check(msg, branch) == -1) /* it's not necessary when calling
+					* from script because already done */
 		return -1;
 
 	/*... if there is none, tell the core router to fwd statelessly */

--- a/src/modules/tm/sip_msg.c
+++ b/src/modules/tm/sip_msg.c
@@ -72,7 +72,7 @@ struct sip_msg *sip_msg_cloner(struct sip_msg *org_msg, int *sip_msg_len)
 }
 
 /**
- * @brief Indicates wheter we have already cloned the msg lumps or not
+ * @brief Indicates whether we have already cloned the msg lumps or not
  */
 unsigned char lumps_are_cloned = 0;
 

--- a/src/modules/tm/sip_msg.h
+++ b/src/modules/tm/sip_msg.h
@@ -97,7 +97,7 @@
 struct sip_msg *sip_msg_cloner(struct sip_msg *org_msg, int *sip_msg_len);
 
 /**
- * @brief Indicates wheter we have already cloned the msg lumps or not
+ * @brief Indicates whether we have already cloned the msg lumps or not
  */
 extern unsigned char lumps_are_cloned;
 

--- a/src/modules/tm/t_fifo.c
+++ b/src/modules/tm/t_fifo.c
@@ -280,7 +280,7 @@ int parse_tw_append(modparam_t type, void *val)
 				goto parse_error;
 			foo.len = s - foo.s;
 		}
-		/* foo containes the elemet type */
+		/* foo contains the element type */
 		if(foo.len == ELEM_TYPE_AVP_LEN
 				&& !strncasecmp(foo.s, ELEM_TYPE_AVP, foo.len)) {
 			ha->type = ELEM_IS_AVP;
@@ -339,7 +339,7 @@ int parse_tw_append(modparam_t type, void *val)
 				}
 			}
 		} else if(ha->type == ELEM_IS_HDR) {
-			/* element is HDR -  try to get it's coded type if defined */
+			/* element is HDR -  try to get its coded type if defined */
 			bar = foo.s[foo.len];
 			foo.s[foo.len] = ':';
 			/* parse header name */

--- a/src/modules/tm/t_funcs.c
+++ b/src/modules/tm/t_funcs.c
@@ -40,7 +40,7 @@
 #include "t_stats.h"
 
 /* if defined t_relay* error reply generation will be delayed till script
- * end (this allows the script writter to send its own error reply) */
+ * end (this allows the script writer to send its own error reply) */
 #define TM_DELAYED_REPLY
 
 #ifdef USE_DNS_FAILOVER

--- a/src/modules/tm/t_funcs.h
+++ b/src/modules/tm/t_funcs.h
@@ -71,7 +71,7 @@ extern str contact_flows_avp;
 */
 
 
-/* send a buffer -- 'PR' means private, i.e., it is assumed noone
+/* send a buffer -- 'PR' means private, i.e., it is assumed no one
    else can affect the buffer during sending time
 */
 #ifdef EXTRA_DEBUG

--- a/src/modules/tm/t_fwd.c
+++ b/src/modules/tm/t_fwd.c
@@ -333,7 +333,7 @@ static int prepare_new_uac(struct cell *t, struct sip_msg *i_req, int branch,
 				rpl_snd_flags_bak = i_req->rpl_send_flags;
 				force_send_socket_bak = i_req->force_send_socket;
 				/* set the new values */
-				i_req->fwd_send_flags = snd_flags /* intial value  */;
+				i_req->fwd_send_flags = snd_flags /* initial value  */;
 				set_force_socket(i_req, fsocket);
 				keng = sr_kemi_eng_get();
 				if(unlikely(keng != NULL)) {
@@ -1107,7 +1107,7 @@ int e2e_cancel_branch(struct sip_msg *cancel_msg, struct cell *t_cancel,
 	t_cancel->uac[branch].request.dst = t_invite->uac[branch].request.dst;
 	/* print */
 	if(cfg_get(tm, tm_cfg, reparse_invite)) {
-		/* buffer is built localy from the INVITE which was sent out */
+		/* buffer is built locally from the INVITE which was sent out */
 		/* lumps can be set outside of the lock, make sure that we read
 		 * the up-to-date values */
 		membar_depends();
@@ -1383,7 +1383,7 @@ void e2e_cancel(struct sip_msg *cancel_msg, struct cell *t_cancel,
 			if(t_invite->uac[i].last_received >= 100) {
 				/* Provisional reply received on this branch, send CANCEL */
 				/* we do need to stop the retr. timers if the request is not
-				 * an invite and since the stop_rb_retr() cost is lower then
+				 * an invite and since the stop_rb_retr() cost is lower than
 				 * the invite check we do it always --andrei */
 				stop_rb_retr(&t_invite->uac[i].request);
 				if(SEND_BUFFER(&t_cancel->uac[i].request) == -1) {
@@ -1761,7 +1761,7 @@ int t_forward_nonack(
 		return lowest_ret;
 	}
 
-	/* mark the fist branch in this fwd step */
+	/* mark the first branch in this fwd step */
 	t->uac[first_branch].flags |= TM_UAC_FLAG_FB;
 
 	ser_error = 0; /* clear branch adding errors */
@@ -1871,7 +1871,7 @@ int t_forward_cancel(struct sip_msg *p_msg, struct proxy_l *proxy, int proto,
 		UNREF(t_invite);
 		ret = 1;
 		goto end;
-	} else /* no coresponding INVITE transaction */
+	} else /* no corresponding INVITE transaction */
 		if(cfg_get(tm, tm_cfg, unmatched_cancel) == UM_CANCEL_DROP) {
 			LM_DBG("non matching cancel dropped\n");
 			ret = 1; /* do nothing -> drop */
@@ -1918,8 +1918,8 @@ end:
  * return value:
  *    0: the CANCEL was successfully relayed
  *       (or error occurred but reply cannot be sent) => DROP
- *    1: no corresponding INVITE transaction exisis
- *   <0: corresponding INVITE transaction exisis but error occurred
+ *    1: no corresponding INVITE transaction exists
+ *   <0: corresponding INVITE transaction exists but error occurred
  */
 int t_relay_cancel(struct sip_msg *p_msg)
 {
@@ -1950,7 +1950,7 @@ int t_relay_cancel(struct sip_msg *p_msg)
 		goto end;
 
 	} else {
-		/* no corresponding INVITE trasaction found */
+		/* no corresponding INVITE transaction found */
 		ret = 1;
 	}
 end:

--- a/src/modules/tm/t_hooks.c
+++ b/src/modules/tm/t_hooks.c
@@ -184,14 +184,14 @@ int register_tmcb(struct sip_msg *p_msg, struct cell *t, int types,
 	if((types != TMCB_MAX) && (types & TMCB_REQUEST_IN)) {
 		if(types != TMCB_REQUEST_IN) {
 			LM_CRIT("BUG: callback type TMCB_REQUEST_IN"
-					" can't be register along with types\n");
+					" can't be registered along with types\n");
 			return E_BUG;
 		}
 		cb_list = req_in_tmcb_hl;
 	} else if((types != TMCB_MAX) && (types & TMCB_LOCAL_REQUEST_IN)) {
 		if(types != TMCB_LOCAL_REQUEST_IN) {
 			LM_CRIT("BUG: callback type"
-					" TMCB_LOCAL_REQUEST_IN can't be register along with"
+					" TMCB_LOCAL_REQUEST_IN can't be registered along with"
 					" other types\n");
 			return E_BUG;
 		}

--- a/src/modules/tm/t_hooks.h
+++ b/src/modules/tm/t_hooks.h
@@ -229,11 +229,11 @@ struct cell;
  *  Note: if the send fails or via cannot be resolved, this callback is
  *  _not_ called.
  *
- *  TMCB_LOCAL_COMPLETED -- final reply for localy initiated
+ *  TMCB_LOCAL_COMPLETED -- final reply for locally initiated
  *  transaction arrived. Message may be FAKED_REPLY. Can be called multiple
  *  times, no lock is held.
  *
- *  TMCB_LOCAL_RESPONSE_OUT -- provisional reply for localy initiated
+ *  TMCB_LOCAL_RESPONSE_OUT -- provisional reply for locally initiated
  *  transaction. The message may be a FAKED_REPLY and the callback might be
  *  called multiple time quasi-simultaneously. No lock is held.
  *  Note: depends on tm.pass_provisional_replies.
@@ -307,7 +307,7 @@ struct cell;
  * TMCB_RESPONSE_READY -- a reply is ready to be sent out. Callback is
  *  is executed just before writing the reply content to network.
  *
- * TMCB_DONT_ACK (requires AS support) -- for localy generated INVITEs, TM
+ * TMCB_DONT_ACK (requires AS support) -- for locally generated INVITEs, TM
  * automatically generates an ACK for the received 2xx replies. But, if this
  * flag is passed to TM when creating the initial UAC request, this won't
  * happen anymore: the ACK generation must be triggered from outside, using

--- a/src/modules/tm/t_lookup.c
+++ b/src/modules/tm/t_lookup.c
@@ -114,7 +114,7 @@ static struct cell *T = NULL;
  * for the transaction currently processed.
  * It has a valid value only if T is valid (tm_global_ctx_id.{msgid, pid}==msg->{id, pid}
  * -- see above, and T!=0 and T!=T_UNDEFINED).
- * For a request it's value is T_BR_UNDEFINED (it can have valid values only
+ * For a request its value is T_BR_UNDEFINED (it can have valid values only
  * for replies).
  */
 static int T_branch = 0;
@@ -400,14 +400,14 @@ static int matching_3261(struct sip_msg *p_msg, struct cell **trans,
 		 * purpose of accounting. We think it is a bad place here, among
 		 * other things because it is not reliable. If a transaction loops
 		 * via server the ACK can't be matched to proper INVITE transaction
-		 * (it is a separate transactino with its own branch ID) and it
+		 * (it is a separate transaction with its own branch ID) and it
 		 * matches all transaction instances in the loop dialog-wise.
 		 * Eventually, regardless to which transaction in the loop the
 		 * ACK belongs, only the first one will match.
 		 */
 
 		/* dialog matching needs to be applied for ACK/200s but only if
-		 * this is a local transaction or its a proxied transaction interested
+		 * this is a local transaction or it is a proxied transaction interested
 		 *  in e2e ACKs (has E2EACK* callbacks installed) */
 		if(unlikely(is_ack && p_cell->uas.status < 300)) {
 			if(unlikely(has_tran_tmcbs(
@@ -584,7 +584,7 @@ int t_request_search(struct sip_msg *p_msg, struct cell **r_cell)
 			if(!t_msg)
 				continue; /* skip UAC transactions */
 			/* for non-ACKs we want same method matching, we
-			 * make an exception for pre-exisiting CANCELs because we
+			 * make an exception for pre-existing CANCELs because we
 			 * want to set *cancel */
 			if((t_msg->REQ_METHOD != p_msg->REQ_METHOD)
 					&& (t_msg->REQ_METHOD != METHOD_CANCEL))
@@ -831,7 +831,7 @@ int t_lookup_request(struct sip_msg *p_msg, int leave_new_locked, int *cancel)
 			if(!t_msg)
 				continue; /* skip UAC transactions */
 			/* for non-ACKs we want same method matching, we
-			 * make an exception for pre-exisiting CANCELs because we
+			 * make an exception for pre-existing CANCELs because we
 			 * want to set *cancel */
 			if((t_msg->REQ_METHOD != p_msg->REQ_METHOD)
 					&& (t_msg->REQ_METHOD != METHOD_CANCEL))

--- a/src/modules/tm/t_msgbuilder.c
+++ b/src/modules/tm/t_msgbuilder.c
@@ -401,7 +401,7 @@ char *build_local_reparse(tm_cell_t *Trans, unsigned int branch,
 					/* copy hf */
 					append_str(d, s1, s - s1);
 					first_via = 0;
-				} /* else skip this line, we need olny the first via */
+				} /* else skip this line, we need only the first via */
 				break;
 
 			case HDR_TO_T:
@@ -1059,7 +1059,7 @@ static int eval_uac_routing(sip_msg_t *rpl, const struct retr_buf *inv_rb,
 				} else {
 					/* trash last entry and replace with new remote target */
 					free_rte_list(t);
-					/* compact the rr_t struct along with rte. this way, free'ing
+					/* compact the rr_t struct along with rte. This way, free'ing
 				 * it can be done along with rte chunk, independent of Route
 				 * header parser's allocator (using pkg/shm) */
 					chklen = sizeof(struct rte) + sizeof(rr_t);
@@ -1117,7 +1117,7 @@ error:
 /*
  * The function creates an ACK to 200 OK. Route set will be created
  * and parsed and the dst parameter will contain the destination to which
- * the request should be send. The function is used by tm when it
+ * the request should be sent. The function is used by tm when it
  * generates local ACK to 200 OK (on behalf of applications using uac)
  */
 char *build_dlg_ack(struct sip_msg *rpl, struct cell *Trans,
@@ -1860,7 +1860,7 @@ void t_uas_request_clean_parsed(tm_cell_t *t)
 		if(hdr->parsed && hdr_allocs_parse(hdr)
 				&& (hdr->parsed < mstart || hdr->parsed >= mend)) {
 			/* header parsed filed doesn't point inside fake memory
-			 * chunck -> it was added by failure funcs.-> free it as pkg */
+			 * chunk -> it was added by failure funcs.-> free it as pkg */
 			LM_DBG("removing hdr->parsed %d\n", hdr->type);
 			clean_hdr_field(hdr);
 			hdr->parsed = 0;

--- a/src/modules/tm/t_msgbuilder.h
+++ b/src/modules/tm/t_msgbuilder.h
@@ -48,7 +48,7 @@ char *build_uac_cancel(str *headers, str *body, struct cell *cancelledT,
 /*
  * The function creates an ACK to 200 OK. Route set will be created
  * and parsed and the dst parameter will contain the destination to which the
- * request should be send. The function is used by tm when it generates
+ * request should be sent. The function is used by tm when it generates
  * local ACK to 200 OK (on behalf of applications using uac
  */
 char *build_dlg_ack(struct sip_msg *rpl, struct cell *Trans,

--- a/src/modules/tm/t_reply.c
+++ b/src/modules/tm/t_reply.c
@@ -121,7 +121,7 @@ extern int tm_reply_relay_mode;
  * Values:
  * - 0 - all branches are kept (default, and default ser 2.1.x behaviour)
  * - 1 - all branches are discarded
- * - 2 - braches of last step of serial forking are discarded
+ * - 2 - branches of last step of serial forking are discarded
  * - 3 - all branches are discarded if a new leg of serial forking
  *       is started (default kamailio 1.5.x behaviour)
  */
@@ -730,7 +730,7 @@ static int _tm_faked_env_idx = -1;
 /** create or restore a "fake environment" for running a failure_route,
  * OR an "async environment" depending on is_async_value (0=std failure-faked, 1=async)
  * if msg is set -> it will fake the env. vars conforming with the msg; if NULL
- * the env. will be restore to original.
+ * the env. will be restored to original.
  * Side-effect: mark_ruri_consumed() for faked env only.
  */
 int faked_env(struct cell *t, struct sip_msg *msg, int is_async_env)
@@ -961,7 +961,7 @@ void free_faked_req(struct sip_msg *faked_req, int len)
 		if(hdr->parsed && hdr_allocs_parse(hdr)
 				&& (hdr->parsed < mstart || hdr->parsed >= mend)) {
 			/* header parsed filed doesn't point inside fake memory
-			 * chunck -> it was added by failure funcs.-> free it as pkg */
+			 * chunk -> it was added by failure funcs.-> free it as pkg */
 			LM_DBG("removing hdr->parsed %d\n", hdr->type);
 			clean_hdr_field(hdr);
 			hdr->parsed = 0;
@@ -1525,7 +1525,7 @@ static enum rps t_should_relay_response(struct cell *Trans, int new_code,
 			Trans->uac[branch].reply = 0;
 
 		/* look if the callback perhaps replied transaction; it also
-		 * covers the case in which a transaction is replied localy
+		 * covers the case in which a transaction is replied locally
 		 * on CANCEL -- then it would make no sense to proceed to
 		 * new branches below
 		*/
@@ -1592,7 +1592,7 @@ static enum rps t_should_relay_response(struct cell *Trans, int new_code,
 		/* really no more pending branches -- return lowest code */
 		*should_store = 0;
 		*should_relay = picked_branch;
-		/* we dont need 'prepare_to_cancel' here -- all branches
+		/* we don't need 'prepare_to_cancel' here -- all branches
 		 * known to have completed */
 		/* prepare_to_cancel( Trans, cancel_bitmap, 0 ); */
 		LM_DBG("rps completed - uas status: %d branch: %d\n", Trans->uas.status,
@@ -1821,7 +1821,7 @@ inline static int auth_reply_count(struct cell *t, struct sip_msg *crt_reply)
 }
 
 
-/* must be called with the REPY_LOCK held */
+/* must be called with the REPLY_LOCK held */
 inline static char *reply_aggregate_auth(int code, char *txt, str *new_tag,
 		struct cell *t, unsigned int *res_len, struct bookmark *bm)
 {
@@ -2177,7 +2177,7 @@ enum rps relay_reply(struct cell *t, struct sip_msg *p_msg, int branch,
 		* failure_route  or from a callback and the timer has been already
 		* started. (Miklos)
 		*
-		* put_on_wait() should always be called after we finished dealling
+		* put_on_wait() should always be called after we finished dealing
 		* with t, because otherwise the wait timer might fire before we
 		*  finish with t, and by the time we want to use t it could
 		*  be already deleted. This could happen only if this function is
@@ -2574,7 +2574,7 @@ int reply_received(struct sip_msg *p_msg)
 			sr_event_exec(SREV_SIP_REPLY_OUT, &evp);
 		}
 
-		/* restore brach last_received as before executing onreply_route */
+		/* restore branch last_received as before executing onreply_route */
 		uac->last_received = last_uac_status;
 		/* transfer current message context back to t */
 		if(t->uas.request) {
@@ -2596,7 +2596,7 @@ int reply_received(struct sip_msg *p_msg)
 		xavi_set_list(backup_xavis);
 		/* handle a possible DROP in the script, but only if this
 		 * is not a final reply (final replies already stop the timers
-		 * and droping them might leave a transaction living forever) */
+		 * and dropping them might leave a transaction living forever) */
 #ifdef TM_ONREPLY_FINAL_DROP_OK
 		if(unlikely(ctx.run_flags & DROP_R_F))
 #else
@@ -2608,7 +2608,7 @@ int reply_received(struct sip_msg *p_msg)
 #ifdef TM_ONREPLY_FINAL_DROP_OK
 		if(msg_status >= 200) {
 			/* stop final reply timers, now that we executed the onreply route
-			 * and the reply was not DROPed */
+			 * and the reply was not DROPped */
 			stop_rb_timers(&uac->request);
 		}
 #endif	/* TM_ONREPLY_FINAL_DROP_OK */
@@ -2764,7 +2764,7 @@ done:
 	/* don't try to relay statelessly neither on success
 	 * (we forwarded statefully) nor on error; on troubles,
 	 * simply do nothing; that will make the other party to
-	 * retransmit; hopefuly, we'll then be better off */
+	 * retransmit; hopefully, we'll then be better off */
 	return 0;
 
 trans_not_found:
@@ -2776,7 +2776,7 @@ trans_not_found:
 				/* The script writer has a chance to decide whether to
 				 * forward the reply or not.
 				 * Pre- and post-script callbacks have already
-				 * been execueted by the core. (Miklos)
+				 * been executed by the core. (Miklos)
 			 */
 				return run_top_route(
 						onreply_rt.rlist[goto_on_sl_reply], p_msg, 0);

--- a/src/modules/tm/t_stats.h
+++ b/src/modules/tm/t_stats.h
@@ -67,19 +67,19 @@ extern union t_stats *tm_stats;
 #ifdef TM_MORE_STATS
 inline void static t_stats_created(void)
 {
-	/* keep it in process's piece of shmem */
+	/* keep it in process' piece of shmem */
 	tm_stats[process_no].s.t_created++;
 }
 
 inline void static t_stats_freed(void)
 {
-	/* keep it in process's piece of shmem */
+	/* keep it in process' piece of shmem */
 	tm_stats[process_no].s.t_freed++;
 }
 
 inline void static t_stats_delayed_free(void)
 {
-	/* keep it in process's piece of shmem */
+	/* keep it in process' piece of shmem */
 	tm_stats[process_no].s.delayed_free++;
 }
 #else /* TM_MORE_STATS  */
@@ -98,7 +98,7 @@ inline void static t_stats_delayed_free(void)
 
 inline void static t_stats_new(int local)
 {
-	/* keep it in process's piece of shmem */
+	/* keep it in process' piece of shmem */
 	tm_stats[process_no].s.transactions++;
 	if(local)
 		tm_stats[process_no].s.client_transactions++;
@@ -106,7 +106,7 @@ inline void static t_stats_new(int local)
 
 inline void static t_stats_wait(void)
 {
-	/* keep it in process's piece of shmem */
+	/* keep it in process' piece of shmem */
 	tm_stats[process_no].s.waiting++;
 }
 

--- a/src/modules/tm/t_suspend.c
+++ b/src/modules/tm/t_suspend.c
@@ -72,7 +72,7 @@ int t_suspend(
 		return 1;
 	}
 	if(t->uas.status >= 200) {
-		LM_DBG("trasaction sent out a final response already - %d\n",
+		LM_DBG("transaction sent out a final response already - %d\n",
 				t->uas.status);
 		return -3;
 	}

--- a/src/modules/tm/timer.c
+++ b/src/modules/tm/timer.c
@@ -400,7 +400,7 @@ inline static void final_response_handler(
 			&& is_invite(t)
 			/* parallel forking does not allow silent state discarding */
 			&& t->nr_of_outgoings == 1
-			/* on_negativ reply handler not installed -- serial forking
+			/* on_negative reply handler not installed -- serial forking
 		 * could occur otherwise */
 			&& t->on_failure == 0
 			/* the same for FAILURE callbacks */

--- a/src/modules/tm/timer.h
+++ b/src/modules/tm/timer.h
@@ -218,7 +218,7 @@ inline static int _set_fr_retr(struct retr_buf *rb, unsigned retr_ms)
 #endif
 	if(ret == 0)
 		rb->t_active = 1;
-	membar_write_atomic_op(); /* make sure t_active will be commited to mem.
+	membar_write_atomic_op(); /* make sure t_active will be committed to mem.
 								 before the transaction would be deref. by the
 								 current process */
 	return ret;

--- a/src/modules/tm/tm.c
+++ b/src/modules/tm/tm.c
@@ -948,7 +948,7 @@ static int ki_t_get_status_code(sip_msg_t *msg)
 			/* use the status of the winning reply */
 			ret = t_pick_branch(-1, 0, t, &scode);
 			if(ret == -1) {
-				/* t_pick_branch() retuns error also when there are only
+				/* t_pick_branch() returns error also when there are only
 				 * blind UACs. Let us give it another chance including the
 				 * blind branches. */
 				LM_DBG("t_pick_branch returned error,"
@@ -1103,7 +1103,7 @@ static int t_check_status(struct sip_msg *msg, char *p1, char *foo)
 			/* use the status of the winning reply */
 			ret = t_pick_branch(-1, 0, t, &lowest_status);
 			if(ret == -1) {
-				/* t_pick_branch() retuns error also when there are only
+				/* t_pick_branch() returns error also when there are only
 				 * blind UACs. Let us give it another chance including the
 				 * blind branches. */
 				LM_DBG("t_pick_branch returned error,"
@@ -1208,7 +1208,7 @@ static int ki_t_check_status(sip_msg_t *msg, str *sexp)
 			/* use the status of the winning reply */
 			ret = t_pick_branch(-1, 0, t, &lowest_status);
 			if(ret == -1) {
-				/* t_pick_branch() retuns error also when there are only
+				/* t_pick_branch() returns error also when there are only
 				 * blind UACs. Let us give it another chance including the
 				 * blind branches. */
 				LM_DBG("t_pick_branch returned error,"
@@ -3127,7 +3127,7 @@ static int w_t_exists(struct sip_msg *msg, char *p1, char *p2)
 }
 
 #ifdef USE_DNS_FAILOVER
-/* parse reply codes for failover given in module paraleter */
+/* parse reply codes for failover given in module parameter */
 static int t_failover_parse_reply_codes()
 {
 	param_t *params_list = NULL;

--- a/src/modules/tm/uac.c
+++ b/src/modules/tm/uac.c
@@ -829,8 +829,8 @@ struct retr_buf *local_ack_rb(sip_msg_t *rpl_2xx, struct cell *trans,
 	}
 	/* 'buffer' now points into a contiguous chunk of memory with enough
 	 * room to hold both the retr. buffer and the string raw buffer: it
-	 * points to the begining of the string buffer; we iterate back to get
-	 * the begining of the space for the retr. buffer. */
+	 * points to the beginning of the string buffer; we iterate back to get
+	 * the beginning of the space for the retr. buffer. */
 	lack = &((struct retr_buf *)buffer)[-1];
 	lack->buffer = buffer;
 	lack->buffer_len = buf_len;


### PR DESCRIPTION
I removed the word atomic before transaction, since it implies that there are in addition non-atomic ways to create a transaction.

Per https://lists.kamailio.org/mailman3/hyperkitty/list/sr-users@lists.kamailio.org/message/V7ZJEQZMXH7BNGRDI32BTYX742GVAWDB/ t_relay() creates a transaction.

- typos