### PR TITLE
[app_lua] clarify the file scripts can be in source or bytecode

### DIFF
--- a/src/modules/app_lua/doc/app_lua_admin.xml
+++ b/src/modules/app_lua/doc/app_lua_admin.xml
@@ -117,7 +117,7 @@
 	    <para>
 			Set the path to the Lua script to be loaded at startup. Then you
 			can use lua_run(function, params) to execute a function from the
-			script at runtime.
+			script at runtime.  The script can be in Lua-source or bytecode.
 	    </para>
 	    <para>
 		<emphasis>


### PR DESCRIPTION
This is valid both for Lua.org and LuaJIT.