### PR TITLE
New record-route is not updating when the device network is broken/power-off & on (sca_subscribe.c).

### DIFF
--- a/src/modules/sca/sca_subscribe.c
+++ b/src/modules/sca/sca_subscribe.c
@@ -906,6 +906,10 @@ static int sca_subscription_update_unsafe(sca_mod *scam,
 
 		SCA_STR_COPY(&update_sub->rr, &saved_sub->rr);
 	}
+	else{
+     
+         SCA_STR_COPY(&saved_sub->rr, &update_sub->rr);
+     }
 
 	rc = 1;
 


### PR DESCRIPTION
After initial subscription by the SCA device, if we power off and on again, we won't get an unsubscribe notification and we are getting a new record-route with sca-subscription. In this case kamailio not updating the new record-route for the SCA Device.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ *] Commits are split per component (core, individual modules, libs, utils, ...)
- [ *] Each component has a single commit (if not, squash them into one commit)
- [ *] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [* ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ *] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
When we initially subscribe to the SCA (Shared call appearance) device, we receive a new subscription notification. However, if we subsequently power off and then power on the SCA device, we will no longer receive an unsubscribe notification; instead, we are receiving a new subscription notification with a new record-route. In this scenario, kamailio is not updating the new record-route and sca notification is working after the device is powered on. In two different scenario this issue is occuring(1.Device power off & on 2. Device network broken).
