### PR TITLE
sca: update rr if necessary for subscriptions

### DIFF
--- a/src/modules/sca/sca_subscribe.c
+++ b/src/modules/sca/sca_subscribe.c
@@ -905,6 +905,17 @@ static int sca_subscription_update_unsafe(sca_mod *scam,
 		}
 
 		SCA_STR_COPY(&update_sub->rr, &saved_sub->rr);
+	} else if(!SCA_STR_EMPTY(&update_sub->rr)
+			  && !STR_EQ(update_sub->rr, saved_sub->rr)) {
+		if(!SCA_STR_EMPTY(&saved_sub->rr)) {
+			shm_free(saved_sub->rr.s);
+			saved_sub->rr.len = 0;
+		}
+		if((saved_sub->rr.s = (char *)shm_malloc(update_sub->rr.len)) == NULL) {
+			SHM_MEM_ERROR;
+			goto done;
+		}
+		SCA_STR_COPY(&saved_sub->rr, &update_sub->rr);
 	}
 
 	rc = 1;


### PR DESCRIPTION
<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [ ] Tested changes locally

#### Description
From https://github.com/kamailio/kamailio/pull/3569

After initial subscription by the SCA device, if we power off and on again, we won't get an unsubscribe notification and we are getting a new record-route with sca-subscription. In this case kamailio not updating the new record-route for the SCA Device.
