### PR TITLE
examples/kamailio-basic-kemi-lua.lua: Add example for rtpengine

### DIFF
--- a/misc/examples/kemi/kamailio-basic-kemi-lua.lua
+++ b/misc/examples/kemi/kamailio-basic-kemi-lua.lua
@@ -340,7 +340,7 @@ end
 
 -- RTPProxy control
 function ksr_route_natmanage()
-	if not KSR.rtpproxy then
+	if not KSR.rtpproxy and not KSR.rtpengine then
 		return 1;
 	end
 	if KSR.siputils.is_request()>0 then
@@ -354,7 +354,19 @@ function ksr_route_natmanage()
 		return 1;
 	end
 
-	KSR.rtpproxy.rtpproxy_manage("co");
+	if KSR.kx.ifdef('WITH_RTPENGINE') then
+		if KSR.nathelper.nat_uac_test(8)>0 then
+			KSR.rtpengine.rtpengine_manage("replace-origin replace-session-connection SIP-source-address");
+		else
+			KSR.rtpengine.rtpengine_manage("replace-origin replace-session-connection");
+		end
+	elseif KSR.kx.ifdef('WITH_RTPPROXY') then
+		if KSR.nathelper.nat_uac_test(8)>0 then
+			KSR.rtpproxy.rtpproxy_manage("co");
+		else
+			KSR.rtpproxy.rtpproxy_manage("cor");
+		end
+	end
 
 	if KSR.siputils.is_request()>0 then
 		if KSR.siputils.has_totag()<0 then


### PR DESCRIPTION
A while ago I wanted to adjust my Lua configuration to work with rtpengine and I have adjusted this example accordingly.  I have not tried the example, but if there are no obvious bugs with it, I think it will be useful.
