### PR TITLE
kamctl: Source only one kamctlrc

### DIFF
--- a/utils/kamctl/kamctl
+++ b/utils/kamctl/kamctl
@@ -18,6 +18,7 @@ else
 fi
 
 ### include config files
+RC_FILE_SOURCED="false"
 
 # check for rc file at same location with kamctl
 which greadlink >/dev/null 2>&1
@@ -39,11 +40,13 @@ if [ -n "$KAMCTLFULLPATH" ] ; then
 fi
 
 # check for rc file at standard locations
-if [ -f /etc/kamailio/kamctlrc -a -r /etc/kamailio/kamctlrc ]; then
+if [ $RC_FILE_SOURCED = "false" ] && [ -f /etc/kamailio/kamctlrc -a -r /etc/kamailio/kamctlrc ]; then
 	. /etc/kamailio/kamctlrc
+	RC_FILE_SOURCED="true"
 fi
-if [ -f /usr/local/etc/kamailio/kamctlrc -a -r /usr/local/etc/kamailio/kamctlrc ]; then
+if[ $RC_FILE_SOURCED = "false" ] &&  [ -f /usr/local/etc/kamailio/kamctlrc -a -r /usr/local/etc/kamailio/kamctlrc ]; then
 	. /usr/local/etc/kamailio/kamctlrc
+	RC_FILE_SOURCED="true"
 fi
 if [ -f ~/.kamctlrc -a -r ~/.kamctlrc ]; then
 	. ~/.kamctlrc
@@ -3255,4 +3258,3 @@ case $1 in
 		exit 1
 		;;
 esac
-


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)


#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

kamctl now sources the kamctlrc from only one location if available in this order: 

1. same folder as kamctl,
2. {intstall_prefix}/etc/kamailio/,
3. ~/.kamctlrc
4. /etc/kamailio/. 

If no kamctlrc is found, it continues just like before. Should it stop?

#### Issue description
`kamctl` uses env variables from all the config files above, and retains the env value of the latest config that declares it.

Let's say we have 3 kamctlrc files right now:

```
# first config file (same folder that kamctl resides)
# {prefix_install}/sbin/kamctlrc
...
SIP_DOMAIN=kamailio.org
DBENGINE is commented
...
```

```
# second config file 
# /etc/kamailio/kamctlrc
...
SIP_DOMAIN=kam0.XXXX.net
DBENGINE=MYSQL
...
```

```
# third config file 
# {prefix_install}/etc/kamailio/kamctlrc
...
SIP_DOMAIN is commented
DBENGINE=MYSQL
...
```

Running `{install_prefix}/sbin/kamctl` (before changes in order) it prints :

```
Loading config file /home/xenofon/kamailio-source-install/sbin/kamctlrc
Loading config file /etc/kamailio/kamctlrc
Loading config file /home/xenofon/kamailio-source-install/etc/kamailio//kamctlrc
SIP_DOMAIN env var is kam0.XXXX.net
DBENGINE env var is MYSQL
```
suggesting that env variables from multiple sources are gathered and overwritten in cases. 