### PR TITLE
Make timeout mechanism useful by adding support for supplying timeout tag

### DIFF
--- a/src/modules/rtpproxy/doc/rtpproxy.xml
+++ b/src/modules/rtpproxy/doc/rtpproxy.xml
@@ -67,7 +67,7 @@
 		</editor>
 	</authorgroup>
 	<copyright>
-		<year>2003-2008</year>
+		<year>2003-2023</year>
 		<holder>Sippy Software, Inc.</holder>
 	</copyright>
 	<copyright>

--- a/src/modules/rtpproxy/doc/rtpproxy_admin.xml
+++ b/src/modules/rtpproxy/doc/rtpproxy_admin.xml
@@ -18,11 +18,7 @@
 	<title>Overview</title>
 	<para>
 		This is a module that enables media streams to be proxied
-		via an rtpproxy.  Rtpproxies know to work with this module
-		are Sippy RTPproxy <ulink url="http://www.rtpproxy.org"></ulink>
-		and ngcp-rtpproxy-ng
-		<ulink url="http://deb.sipwise.com/spce/2.6/pool/main/n/ngcp-mediaproxy-ng"></ulink>.
-		Some features of the rtpproxy module apply only to one of the two rtpproxies.
+		via the Sippy RTPproxy <ulink url="http://www.rtpproxy.org"></ulink>.
 	</para>
 	</section>
 
@@ -235,7 +231,37 @@ modparam("rtpproxy", "nortpproxy_str", "a=sdpmangled:yes\r\n")
 		<title>Set <varname>timeout_socket</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("rtpproxy", "timeout_socket", "xmlrpc:http://127.0.0.1:8000/RPC2")
+modparam("rtpproxy", "timeout_socket", "tcp:127.0.0.1:8000")
+...
+</programlisting>
+		</example>
+	</section>
+	<section id="rtpproxy.p.timeout_tag_pv">
+		<title><varname>timeout_tag_pv</varname> (string)</title>
+		<para>
+		The parameter devines the AVP of the string to be provided to the
+		RTP-Proxy.
+		</para>
+		<para>
+		The content of the AVP must be a valid URL-encoded string with
+		no spaces.
+		It will be decoded and send by the RTP proxy to the timeout socket if the
+		media timeout has happened.
+		</para>
+		<para>
+		This parameter is required in order for the timeout notification
+		mechanism to work properly.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote></quote> (nothing).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>timeout_tag_pv</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("rtpproxy", "timeout_tag_pv", "$avp(rtpp_ntag)")
 ...
 </programlisting>
 		</example>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
The timeout_socket feature has been added in 2010, but from the look of it it has been designed for the "ngcp-mediaproxy-ng" and never worked with the real RTPProxy. As such both the documentation and the code needs to be adjusted to make it actually useful with the RTPProxy.