### PR TITLE
presence: active_watcher cleanup timer

### DIFF
--- a/src/modules/presence/notify.c
+++ b/src/modules/presence/notify.c
@@ -3197,3 +3197,36 @@ void pres_timer_send_notify(unsigned int ticks, void *param)
 		return;
 	}
 }
+
+void ps_active_watchers_db_timer_clean(unsigned int ticks, void *param)
+{
+	db_key_t db_keys[2];
+	db_val_t db_vals[2];
+	db_op_t db_ops[2];
+
+	if(pa_db == NULL) {
+		return;
+	}
+
+	LM_DBG("cleaning expired active_watchers\n");
+
+	db_keys[0] = &str_expires_col;
+	db_ops[0] = OP_LT;
+	db_vals[0].type = DB1_INT;
+	db_vals[0].nul = 0;
+	db_vals[0].val.int_val = (int)time(NULL);
+
+	db_keys[1] = &str_expires_col;
+	db_ops[1] = OP_GT;
+	db_vals[1].type = DB1_INT;
+	db_vals[1].nul = 0;
+	db_vals[1].val.int_val = 0;
+
+	if(pa_dbf.use_table(pa_db, &active_watchers_table) < 0) {
+		LM_ERR("unsuccessful use table sql operation\n");
+		return;
+	}
+
+	if(pa_dbf.delete(pa_db, db_keys, db_ops, db_vals, 2) < 0)
+		LM_ERR("cleaning expired active_watchers\n");
+}

--- a/src/modules/presence/notify.h
+++ b/src/modules/presence/notify.h
@@ -129,4 +129,5 @@ char *get_status_str(int flag);
 str *get_p_notify_body(str pres_uri, pres_ev_t *event, str *etag, str *contact);
 void free_notify_body(str *body, pres_ev_t *ev);
 void pres_timer_send_notify(unsigned int ticks, void *param);
+void ps_active_watchers_db_timer_clean(unsigned int ticks, void *param);
 #endif

--- a/src/modules/presence/presence.c
+++ b/src/modules/presence/presence.c
@@ -453,12 +453,16 @@ static int mod_init(void)
 		if(pres_timer_mode == 0) {
 			register_timer(ps_presentity_db_timer_clean, 0, pres_clean_period);
 			register_timer(ps_watchers_db_timer_clean, 0, pres_clean_period);
+			register_timer(
+					ps_active_watchers_db_timer_clean, 0, pres_clean_period);
 			if(publ_cache_mode == PS_PCACHE_RECORD) {
 				register_timer(ps_ptable_timer_clean, 0, pres_clean_period);
 			}
 		} else {
 			sr_wtimer_add(ps_presentity_db_timer_clean, 0, pres_clean_period);
 			sr_wtimer_add(ps_watchers_db_timer_clean, 0, pres_clean_period);
+			sr_wtimer_add(
+					ps_active_watchers_db_timer_clean, 0, pres_clean_period);
 			if(publ_cache_mode == PS_PCACHE_RECORD) {
 				sr_wtimer_add(ps_ptable_timer_clean, 0, pres_clean_period);
 			}
@@ -1842,6 +1846,7 @@ void rpc_presence_cleanup(rpc_t *rpc, void *c)
 
 	(void)ps_watchers_db_timer_clean(0, 0);
 	(void)ps_presentity_db_timer_clean(0, 0);
+	(void)ps_active_watchers_db_timer_clean(0, 0);
 	(void)ps_ptable_timer_clean(0, 0);
 	(void)timer_db_update(0, 0);
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3074

#### Description

Since some customers are complaining on leftovers at active_watchers. Let's create a cleanup timer for that table too.
