### PR TITLE
tls: Add and apply tls_openssl_clear_errors function.

### DIFF
--- a/src/modules/tls/tls_ct_wrq.c
+++ b/src/modules/tls/tls_ct_wrq.c
@@ -99,6 +99,7 @@ static int ssl_flush(void *tcp_c, void *error, const void *buf, unsigned size)
 	if(unlikely(tls_c->state == S_TLS_CONNECTING)) {
 		n = tls_connect(tcp_c, &ssl_error);
 		if(unlikely(n >= 1)) {
+			tls_openssl_clear_errors();
 			n = SSL_write(ssl, buf, size);
 			if(unlikely(n <= 0))
 				ssl_error = SSL_get_error(ssl, n);
@@ -106,11 +107,13 @@ static int ssl_flush(void *tcp_c, void *error, const void *buf, unsigned size)
 	} else if(unlikely(tls_c->state == S_TLS_ACCEPTING)) {
 		n = tls_accept(tcp_c, &ssl_error);
 		if(unlikely(n >= 1)) {
+			tls_openssl_clear_errors();
 			n = SSL_write(ssl, buf, size);
 			if(unlikely(n <= 0))
 				ssl_error = SSL_get_error(ssl, n);
 		}
 	} else {
+		tls_openssl_clear_errors();
 		n = SSL_write(ssl, buf, size);
 		if(unlikely(n <= 0))
 			ssl_error = SSL_get_error(ssl, n);

--- a/src/modules/tls/tls_util.c
+++ b/src/modules/tls/tls_util.c
@@ -103,11 +103,12 @@ void collect_garbage(void)
  * This is useful to call before any SSL_* IO calls to make sure
  * we don't have any leftover errors from previous calls (OpenSSL docs).
  */
-void tls_openssl_clear_errors(void) {
-    int i;
-    char err[160];
-    while ((i = ERR_get_error())) {
-        ERR_error_string(i, err);
-        INFO("clearing leftover error before SSL_* calls: %s", err);
-    }
+void tls_openssl_clear_errors(void)
+{
+	int i;
+	char err[160];
+	while((i = ERR_get_error())) {
+		ERR_error_string(i, err);
+		INFO("clearing leftover error before SSL_* calls: %s", err);
+	}
 }

--- a/src/modules/tls/tls_util.c
+++ b/src/modules/tls/tls_util.c
@@ -96,3 +96,18 @@ void collect_garbage(void)
 
 	lock_release(tls_domains_cfg_lock);
 }
+
+/*
+ * Get any leftover errors from OpenSSL and print them.
+ * ERR_get_error() also removes the error from the OpenSSL error stack.
+ * This is useful to call before any SSL_* IO calls to make sure
+ * we don't have any leftover errors from previous calls (OpenSSL docs).
+ */
+void tls_openssl_clear_errors(void) {
+    int i;
+    char err[160];
+    while ((i = ERR_get_error())) {
+        ERR_error_string(i, err);
+        INFO("clearing leftover error before SSL_* calls: %s", err);
+    }
+}

--- a/src/modules/tls/tls_util.h
+++ b/src/modules/tls/tls_util.h
@@ -82,4 +82,6 @@ int shm_asciiz_dup(char **dest, char *val);
  */
 void collect_garbage(void);
 
+void tls_openssl_clear_errors(void);
+
 #endif /* _TLS_UTIL_H */


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This PR proposes a fix regarding an issue encountered when lower versions of TLS try to connect to a TLS server that only accepts higher levels (ie TLS1.0 clients trying to connect to a server that accepts TLS1.2+). When a good enough number of TLS clients try to connect, somehow already connected **valid TLS version** users get disconnected.

Setting the context. 

A **valid TLS 1.2+** client is connected to the server. Now multiple requests from TLSv1.0 clients and trying to connect. Server of course rejects them producing log like the following.

```
ERROR: tls [tls_server.c:1343]: tls_h_read_f(): protocol level error
ERROR: tls [tls_util.h:50]: tls_err_ret(): TLS accept:error:140940F4:SSL routines:ssl3_read_bytes:unexpected message (sni: unknown)
ERROR: tls [tls_server.c:1347]: tls_h_read_f(): src addr: xxx.xxx.xxx.xxx:54674
ERROR: tls [tls_server.c:1350]: tls_h_read_f(): dst addr: xxx.xxx.xxx.xxx:5061
```
Now, when another **valid TLS1.2+ client** tries to send an `OPTIONS` request, for example, to another **valid client**, log lines are produced in the form of where `src addr` somehow get the **valid TLS1.2 client IP**:
**_The following logs are depicting the issue_**.
```
/sbin/kamailio[275483]: ERROR: tls [tls_server.c:1343]: tls_h_read_f(): protocol level error
/sbin/kamailio[275479]: ERROR: tls [tls_server.c:1343]: tls_h_read_f(): protocol level error
/sbin/kamailio[275479]: ERROR: tls [tls_util.h:50]: tls_err_ret(): TLS accept:error:140940F4:SSL routines:ssl3_read_bytes:unexpected message (sni: unknown)
/sbin/kamailio[275479]: ERROR: tls [tls_server.c:1347]: tls_h_read_f(): src addr: **invalid TLS1.0 IP**:54420
/sbin/kamailio[275479]: ERROR: tls [tls_server.c:1350]: tls_h_read_f(): dst addr: kamaillio.domain:5061
/sbin/kamailio[275479]: ERROR: <core> [core/tcp_read.c:1476]: tcp_read_req(): ERROR: tcp_read_req: error reading - c: 0x7f7040a82128 r: 0x7f7040a82250 (-1)
/sbin/kamailio[275483]: ERROR: tls [tls_server.c:1347]: tls_h_read_f(): src addr: **valid TLS1.2+ IP address**:60692
/sbin/kamailio[275483]: ERROR: tls [tls_server.c:1350]: tls_h_read_f(): dst addr: kamaillio.domain:5061
```

In some of our local tests, this error occurs **often**, and soon enough after the **invalid clients** try to connect, and after some time the **valid TLS1.2 client** gets **DISCONNECTED**.

With this PR, we experienced much rarer occurrences and no disconnections at all. 

Relevant docs of OpenSSL for ERR_get_error and SLL_get_error can be found at: https://www.openssl.org/docs/manmaster/man3/SSL_get_error.html
https://www.openssl.org/docs/man3.0/man3/ERR_get_error.html
https://www.openssl.org/docs/man3.0/man3/ERR_clear_error.html

Fix inspired by:
https://github.com/sipwise/rtpengine/blob/e24bacaa4cda2b84aacb2183ea496c78071c2f0b/recording-daemon/packet.c#L31