### PR TITLE
http_client: Add parameter connect_timeout_ms / timeout_ms

### DIFF
--- a/src/modules/http_client/doc/http_client_admin.xml
+++ b/src/modules/http_client/doc/http_client_admin.xml
@@ -200,6 +200,27 @@ modparam("http_client", "connection_timeout", 2)
 				</programlisting>
 			</example>
 		</section>
+		<section id="http_client.p.connection_timeout_ms">
+			<title><varname>connection_timeout_ms</varname> (int)</title>
+			<para>
+			Defines in milliseconds how long &kamailio; waits for response
+			from servers. If defined, supersedes parameter connection_timeout.
+			</para>
+			<para>
+			<emphasis>
+				Default value is zero, i.e.,
+				the timeout in milliseconds is disabled.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>connection_timeout_ms</varname> parameter</title>
+				<programlisting format="linespecific">
+...
+modparam("http_client", "connection_timeout_ms", 100)
+...
+				</programlisting>
+			</example>
+		</section>
 		<section id="http_client.p.client_cert">
 			<title><varname>client_cert</varname> (string)</title>
 			<para>
@@ -534,8 +555,13 @@ modparam("http_client", "query_maxdatasize", 2048)
 				Overrides the default cipher_suite modparam.
 				</para></listitem>
 				<listitem><para>
-				<emphasis>timeout</emphasis> Timeout used for this connection. Overrides the
+				<emphasis>timeout</emphasis> Timeout in seconds used for this connection. Overrides the
 				default connection_timeout for the module.
+				</para></listitem>
+				<listitem><para>
+				<emphasis>timeout_ms</emphasis> Timeout in milliseconds used for this connection.
+				Overrides the default connection_timeout_ms for the module. If defined, supersedes
+				the timeout in seconds used for this connection.
 				</para></listitem>
 				<listitem><para>
 				<emphasis>tlsversion</emphasis> TLS version used for this connection. Overrides the
@@ -611,6 +637,7 @@ modparam("http_client", "httpcon", "apifour=>http://stockholm.example.com/api/ge
 				</itemizedlist>
 				</listitem>
 				<listitem><para>timeout</para></listitem>
+				<listitem><para>timeout_ms</para></listitem>
 				<listitem><para>maxdatasize</para></listitem>
 				<listitem><para>http_follow_redirect</para></listitem>
 				<listitem><para>httpproxy</para></listitem>

--- a/src/modules/http_client/http_client.c
+++ b/src/modules/http_client/http_client.c
@@ -12,7 +12,7 @@
  * This file is part of Kamailio, a free SIP server.
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
- * 
+ *
  * Kamailio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -77,6 +77,7 @@ MODULE_VERSION
 
 /* Module parameter variables */
 unsigned int default_connection_timeout = 4;
+unsigned int default_connection_timeout_ms = 0;
 char *default_tls_cacert =
 		NULL; /*!< File name: Default CA cert to use for curl TLS connection */
 str default_tls_clientcert =
@@ -195,6 +196,7 @@ static cmd_export_t cmds[] = {
 /* Exported parameters */
 static param_export_t params[] = {
 	{"connection_timeout", PARAM_INT, &default_connection_timeout},
+	{"connection_timeout_ms", PARAM_INT, &default_connection_timeout_ms},
 	{"cacert", PARAM_STRING,  &default_tls_cacert },
 	{"client_cert", PARAM_STR, &default_tls_clientcert },
 	{"client_key", PARAM_STR, &default_tls_clientkey },
@@ -477,8 +479,8 @@ static int fixup_curl_connect(void **param, int param_no)
 }
 
 /*
- * Fix curl_connect params when posting (5 parameters): 
- *	connection (string/pvar), url (string with pvars), content-type, 
+ * Fix curl_connect params when posting (5 parameters):
+ *	connection (string/pvar), url (string with pvars), content-type,
  *      data (string/pvar, pvar)
  */
 static int fixup_curl_connect_post(void **param, int param_no)
@@ -509,8 +511,8 @@ static int fixup_curl_connect_post(void **param, int param_no)
 }
 
 /*
- * Fix curl_connect params when posting (5 parameters): 
- *	connection (string/pvar), url (string with pvars), content-type, 
+ * Fix curl_connect params when posting (5 parameters):
+ *	connection (string/pvar), url (string with pvars), content-type,
  *      data (string(with no pvar parsing), pvar)
  */
 static int fixup_curl_connect_post_raw(void **param, int param_no)

--- a/src/modules/http_client/http_client.h
+++ b/src/modules/http_client/http_client.h
@@ -2,9 +2,9 @@
  * header file of http_client.c
  *
  * Copyright (C) 2008 Juha Heinanen
- * 
+ *
  * SPDX-License-Identifier: GPL-2.0-or-later
- * 
+ *
  * This file is part of Kamailio, a free SIP server.
  *
  * Kamailio is free software; you can redistribute it and/or modify
@@ -17,8 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
@@ -40,6 +40,7 @@
 #include "../../lib/srdb1/db.h"
 
 extern unsigned int default_connection_timeout;
+extern unsigned int default_connection_timeout_ms;
 extern char *
 		default_tls_cacert; /*!< File name: Default CA cert to use for curl TLS connection */
 extern str
@@ -117,6 +118,7 @@ typedef struct _curl_con
 	unsigned int keep_connections; /*!< TRUE to keep curl connections open */
 	unsigned int port;			   /*!< The port to connect to */
 	int timeout;				   /*!< Timeout for this connection */
+	int timeout_ms;				   /*!< Timeout (ms) for this connection */
 	unsigned int maxdatasize;	   /*!< Maximum data download on GET or POST */
 	curl_res_stream_t *stream;	   /*!< Curl stream */
 	char *http_proxy;			   /*!< HTTP proxy for this connection */
@@ -139,7 +141,7 @@ typedef struct _curl_con_pkg
 	double connecttime; /*!< Seconds used for connecting last request inc TLS setup  - see
 					     https://curl.haxx.se/libcurl/c/CURLINFO_APPCONNECT_TIME.html */
 
-	/* Potential candidates:	Last TLS fingerprint used 
+	/* Potential candidates:	Last TLS fingerprint used
 
 	*/
 	struct _curl_con_pkg *next; /*!< next connection */


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

The new parameter connect_timeout_ms (global) / timeout_ms (in httpcon) allows to specify a timeout in milliseconds on curl requests.
If this parameter is defined (non zero), then the timeout in seconds is ignored.

See https://curl.se/libcurl/c/CURLOPT_TIMEOUT_MS.html

