### PR TITLE
http_client: Add parameter connect_timeout_ms / timeout_ms (2)

### DIFF
--- a/src/modules/http_client/curlcon.c
+++ b/src/modules/http_client/curlcon.c
@@ -5,9 +5,9 @@
  * Copyright (C) 2008 Elena-Ramona Modroiu (asipto.com)
  *
  * This file is part of kamailio, a free SIP server.
- * 
+ *
  * SPDX-License-Identifier: GPL-2.0-or-later
- * 
+ *
  * Kamailio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -69,6 +69,7 @@ typedef struct raw_http_client_conn
 	int verify_host;
 	int tlsversion;
 	int timeout;
+	int timeout_ms;
 	int maxdatasize;
 	int http_follow_redirect;
 	int authmethod;
@@ -107,12 +108,13 @@ static cfg_option_t http_client_options[] = {
 				.flags = CFG_STR_PKGMEM},								/* 9 */
 		{"tlsversion", .f = cfg_parse_enum_opt, .param = tls_versions}, /* 10 */
 		{"timeout", .f = cfg_parse_int_opt},							/* 11 */
-		{"maxdatasize", .f = cfg_parse_int_opt},						/* 12 */
-		{"httpredirect", .f = cfg_parse_bool_opt},						/* 13 */
-		{"httpproxy", .f = cfg_parse_str_opt, .flags = CFG_STR_PKGMEM}, /* 14 */
-		{"httpproxyport", .f = cfg_parse_int_opt},						/* 15 */
-		{"authmethod", .f = cfg_parse_int_opt},							/* 16 */
-		{"keepconnections", .f = cfg_parse_int_opt},					/* 17 */
+		{"timeout_ms", .f = cfg_parse_int_opt},							/* 12 */
+		{"maxdatasize", .f = cfg_parse_int_opt},						/* 13 */
+		{"httpredirect", .f = cfg_parse_bool_opt},						/* 14 */
+		{"httpproxy", .f = cfg_parse_str_opt, .flags = CFG_STR_PKGMEM}, /* 15 */
+		{"httpproxyport", .f = cfg_parse_int_opt},						/* 16 */
+		{"authmethod", .f = cfg_parse_int_opt},							/* 17 */
+		{"keepconnections", .f = cfg_parse_int_opt},					/* 18 */
 		{0}};
 
 /*! Count the number of connections
@@ -197,6 +199,7 @@ curl_con_pkg_t *curl_get_pkg_connection(curl_con_t *con)
  *	Parameters
  *		httpredirect
  *		timeout
+ *		timeout_ms
  *		useragent
  *		failover
  *		maxdatasize
@@ -222,7 +225,12 @@ int curl_parse_param(char *val)
 
 	unsigned int http_proxy_port = default_http_proxy_port;
 	unsigned int maxdatasize = default_maxdatasize;
-	unsigned int timeout = default_connection_timeout;
+	unsigned int timeout = 0;
+	unsigned int timeout_ms = 0;
+	/* timeout and timeout_ms are initialized to 0.
+	 * The default timeout configuration is applied only if neither "timeout" nor "timeout_ms" is set for that specific connection.
+	 * This is checked later on.
+	 */
 	unsigned int http_follow_redirect = default_http_follow_redirect;
 	unsigned int verify_peer = default_tls_verify_peer;
 	unsigned int verify_host = default_tls_verify_host;
@@ -407,10 +415,19 @@ int curl_parse_param(char *val)
 					LM_WARN("curl connection [%.*s]: timeout bad value. Using "
 							"default\n",
 							name.len, name.s);
-					timeout = default_connection_timeout;
+					timeout = 0;
 				}
 				LM_DBG("curl [%.*s] - timeout [%d]\n", pit->name.len,
 						pit->name.s, timeout);
+			} else if(pit->name.len == 10
+					  && strncmp(pit->name.s, "timeout_ms", 10) == 0) {
+				if(str2int(&tok, &timeout_ms) != 0) {
+					LM_WARN("curl connection [%.*s]: timeout_ms bad value. Using default\n",
+							name.len, name.s);
+					timeout_ms = 0;
+				}
+				LM_DBG("curl [%.*s] - timeout_ms [%d]\n", pit->name.len,
+						pit->name.s, timeout_ms);
 			} else if(pit->name.len == 9
 					  && strncmp(pit->name.s, "useragent", 9) == 0) {
 				useragent = tok;
@@ -424,7 +441,7 @@ int curl_parse_param(char *val)
 			} else if(pit->name.len == 11
 					  && strncmp(pit->name.s, "maxdatasize", 11) == 0) {
 				if(str2int(&tok, &maxdatasize) != 0) {
-					/* Bad timeout */
+					/* Bad value */
 					LM_WARN("curl connection [%.*s]: maxdatasize bad value. "
 							"Using default\n",
 							name.len, name.s);
@@ -524,7 +541,26 @@ int curl_parse_param(char *val)
 	cc->tlsversion = tlsversion;
 	cc->verify_peer = verify_peer;
 	cc->verify_host = verify_host;
-	cc->timeout = timeout;
+
+	/* Store timeout in milliseconds for internal use.
+	 * If parameter timeout_ms is defined, use it.
+	 * Otherwise, use timeout (seconds) * 1000.
+	 * The default timeout configuration is applied only if neither "timeout" nor "timeout_ms" is set for that specific connection.
+	 */
+	if (timeout > 0 || timeout_ms > 0) {
+		if (timeout_ms == 0) {
+			cc->timeout = 1000 * timeout;
+		} else {
+			cc->timeout = timeout_ms;
+		}
+	} else {
+		if (default_connection_timeout_ms == 0) {
+			cc->timeout = 1000 * default_connection_timeout;
+		} else {
+			cc->timeout = default_connection_timeout_ms;
+		}
+	}
+
 	cc->maxdatasize = maxdatasize;
 	if(http_proxy_port > 0) {
 		cc->http_proxy_port = http_proxy_port;
@@ -621,7 +657,14 @@ int curl_parse_conn(void *param, cfg_parser_t *parser, unsigned int flags)
 	raw_cc->verify_peer = default_tls_verify_peer;
 	raw_cc->verify_host = default_tls_verify_host;
 	raw_cc->maxdatasize = default_maxdatasize;
-	raw_cc->timeout = default_connection_timeout;
+
+	raw_cc->timeout = 0;
+	raw_cc->timeout_ms = 0;
+	/* timeout and timeout_ms are initialized to 0.
+	 * The default timeout configuration is applied only if neither "timeout" nor "timeout_ms" is set for that specific connection.
+	 * This is checked later on (in fixup function).
+	 */
+
 	raw_cc->http_follow_redirect = default_http_follow_redirect;
 	raw_cc->tlsversion = default_tls_version;
 	raw_cc->authmethod = default_authmethod;
@@ -643,12 +686,13 @@ int curl_parse_conn(void *param, cfg_parser_t *parser, unsigned int flags)
 	http_client_options[9].param = &raw_cc->ciphersuites;
 	/* tlsversion is set using enum types */
 	http_client_options[11].param = &raw_cc->timeout;
-	http_client_options[12].param = &raw_cc->maxdatasize;
-	http_client_options[13].param = &raw_cc->http_follow_redirect;
-	http_client_options[14].param = &raw_cc->http_proxy;
-	http_client_options[15].param = &raw_cc->http_proxy_port;
-	http_client_options[16].param = &raw_cc->authmethod;
-	http_client_options[17].param = &raw_cc->keep_connections;
+	http_client_options[12].param = &raw_cc->timeout_ms;
+	http_client_options[13].param = &raw_cc->maxdatasize;
+	http_client_options[14].param = &raw_cc->http_follow_redirect;
+	http_client_options[15].param = &raw_cc->http_proxy;
+	http_client_options[16].param = &raw_cc->http_proxy_port;
+	http_client_options[17].param = &raw_cc->authmethod;
+	http_client_options[18].param = &raw_cc->keep_connections;
 
 	cfg_set_options(parser, http_client_options);
 
@@ -721,7 +765,26 @@ int fixup_raw_http_client_conn_list(void)
 
 		cc->verify_peer = raw_cc->verify_peer;
 		cc->verify_host = raw_cc->verify_host;
-		cc->timeout = raw_cc->timeout;
+
+		/* Store timeout in milliseconds for internal use.
+		 * If parameter timeout_ms is defined, use it.
+		 * Otherwise, use timeout (seconds) * 1000.
+		 * The default timeout configuration is applied only if neither "timeout" nor "timeout_ms" is set for that specific connection.
+		 */
+		if (raw_cc->timeout > 0 || raw_cc->timeout_ms > 0) {
+			if (raw_cc->timeout_ms == 0) {
+				cc->timeout = 1000 * raw_cc->timeout;
+			} else {
+				cc->timeout = raw_cc->timeout_ms;
+			}
+		} else {
+			if (default_connection_timeout_ms == 0) {
+				cc->timeout = 1000 * default_connection_timeout;
+			} else {
+				cc->timeout = default_connection_timeout_ms;
+			}
+		}
+
 		cc->maxdatasize = raw_cc->maxdatasize;
 		cc->http_follow_redirect = raw_cc->http_follow_redirect;
 		cc->keep_connections = raw_cc->keep_connections;

--- a/src/modules/http_client/doc/http_client_admin.xml
+++ b/src/modules/http_client/doc/http_client_admin.xml
@@ -187,8 +187,7 @@ modparam("http_client", "maxdatasize", 2000)
 			</para>
 			<para>
 			<emphasis>
-				Default value is zero, i.e.,
-				the timeout function is disabled.
+				Default value is 4.
 			</emphasis>
 			</para>
 			<example>
@@ -196,6 +195,27 @@ modparam("http_client", "maxdatasize", 2000)
 				<programlisting format="linespecific">
 ...
 modparam("http_client", "connection_timeout", 2)
+...
+				</programlisting>
+			</example>
+		</section>
+		<section id="http_client.p.connection_timeout_ms">
+			<title><varname>connection_timeout_ms</varname> (int)</title>
+			<para>
+			Defines in milliseconds how long &kamailio; waits for response
+			from servers. If defined (non zero), supersedes parameter connection_timeout.
+			</para>
+			<para>
+			<emphasis>
+				Default value is zero, i.e.,
+				the timeout in seconds (parameter connection_timeout) is used.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>connection_timeout_ms</varname> parameter</title>
+				<programlisting format="linespecific">
+...
+modparam("http_client", "connection_timeout_ms", 100)
 ...
 				</programlisting>
 			</example>
@@ -534,8 +554,13 @@ modparam("http_client", "query_maxdatasize", 2048)
 				Overrides the default cipher_suite modparam.
 				</para></listitem>
 				<listitem><para>
-				<emphasis>timeout</emphasis> Timeout used for this connection. Overrides the
+				<emphasis>timeout</emphasis> Timeout in seconds used for this connection. Overrides the
 				default connection_timeout for the module.
+				</para></listitem>
+				<listitem><para>
+				<emphasis>timeout_ms</emphasis> Timeout in milliseconds used for this connection.
+				Overrides the default connection_timeout_ms for the module. If defined, supersedes
+				the timeout in seconds used for this connection.
 				</para></listitem>
 				<listitem><para>
 				<emphasis>tlsversion</emphasis> TLS version used for this connection. Overrides the
@@ -611,6 +636,7 @@ modparam("http_client", "httpcon", "apifour=>http://stockholm.example.com/api/ge
 				</itemizedlist>
 				</listitem>
 				<listitem><para>timeout</para></listitem>
+				<listitem><para>timeout_ms</para></listitem>
 				<listitem><para>maxdatasize</para></listitem>
 				<listitem><para>http_follow_redirect</para></listitem>
 				<listitem><para>httpproxy</para></listitem>

--- a/src/modules/http_client/functions.c
+++ b/src/modules/http_client/functions.c
@@ -6,9 +6,9 @@
  * Based on functions from siputil
  * 	Copyright (C) 2008 Juha Heinanen
  * 	Copyright (C) 2013 Carsten Bock, ng-voice GmbH
- * 
+ *
  * SPDX-License-Identifier: GPL-2.0-or-later
- * 
+ *
  * This file is part of Kamailio, a free SIP server.
  *
  * Kamailio is free software; you can redistribute it and/or modify
@@ -21,8 +21,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
@@ -262,7 +262,10 @@ static int curL_request_url(struct sip_msg *_m, const char *_met,
 			curl, CURLOPT_SSL_VERIFYHOST, (long)params->verify_host ? 2 : 0);
 
 	res |= curl_easy_setopt(curl, CURLOPT_NOSIGNAL, (long)1);
-	res |= curl_easy_setopt(curl, CURLOPT_TIMEOUT, (long)params->timeout);
+
+	/* timeout is stored as ms internally */
+	res |= curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, (long)params->timeout);
+
 	res |= curl_easy_setopt(
 			curl, CURLOPT_FOLLOWLOCATION, (long)params->http_follow_redirect);
 	if(params->http_follow_redirect) {
@@ -679,7 +682,16 @@ int http_client_request_c(sip_msg_t *_m, char *_url, str *_dst, char *_body,
 	query_params.tlsversion = default_tls_version;
 	query_params.verify_peer = default_tls_verify_peer;
 	query_params.verify_host = default_tls_verify_host;
-	query_params.timeout = default_connection_timeout;
+
+	/* If parameter timeout_ms is defined, use it.
+	 * Otherwise, use timeout (seconds) * 1000.
+	 */
+	if (default_connection_timeout_ms == 0) {
+		query_params.timeout = 1000 * default_connection_timeout;
+	} else {
+		query_params.timeout = default_connection_timeout_ms;
+	}
+
 	query_params.http_follow_redirect = default_http_follow_redirect;
 	query_params.oneline = default_query_result;
 	query_params.maxdatasize = default_query_maxdatasize;

--- a/src/modules/http_client/http_client.c
+++ b/src/modules/http_client/http_client.c
@@ -12,7 +12,7 @@
  * This file is part of Kamailio, a free SIP server.
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
- * 
+ *
  * Kamailio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -77,6 +77,7 @@ MODULE_VERSION
 
 /* Module parameter variables */
 unsigned int default_connection_timeout = 4;
+unsigned int default_connection_timeout_ms = 0;
 char *default_tls_cacert =
 		NULL; /*!< File name: Default CA cert to use for curl TLS connection */
 str default_tls_clientcert =
@@ -195,6 +196,7 @@ static cmd_export_t cmds[] = {
 /* Exported parameters */
 static param_export_t params[] = {
 	{"connection_timeout", PARAM_INT, &default_connection_timeout},
+	{"connection_timeout_ms", PARAM_INT, &default_connection_timeout_ms},
 	{"cacert", PARAM_STRING,  &default_tls_cacert },
 	{"client_cert", PARAM_STR, &default_tls_clientcert },
 	{"client_key", PARAM_STR, &default_tls_clientkey },
@@ -477,8 +479,8 @@ static int fixup_curl_connect(void **param, int param_no)
 }
 
 /*
- * Fix curl_connect params when posting (5 parameters): 
- *	connection (string/pvar), url (string with pvars), content-type, 
+ * Fix curl_connect params when posting (5 parameters):
+ *	connection (string/pvar), url (string with pvars), content-type,
  *      data (string/pvar, pvar)
  */
 static int fixup_curl_connect_post(void **param, int param_no)
@@ -509,8 +511,8 @@ static int fixup_curl_connect_post(void **param, int param_no)
 }
 
 /*
- * Fix curl_connect params when posting (5 parameters): 
- *	connection (string/pvar), url (string with pvars), content-type, 
+ * Fix curl_connect params when posting (5 parameters):
+ *	connection (string/pvar), url (string with pvars), content-type,
  *      data (string(with no pvar parsing), pvar)
  */
 static int fixup_curl_connect_post_raw(void **param, int param_no)

--- a/src/modules/http_client/http_client.h
+++ b/src/modules/http_client/http_client.h
@@ -2,9 +2,9 @@
  * header file of http_client.c
  *
  * Copyright (C) 2008 Juha Heinanen
- * 
+ *
  * SPDX-License-Identifier: GPL-2.0-or-later
- * 
+ *
  * This file is part of Kamailio, a free SIP server.
  *
  * Kamailio is free software; you can redistribute it and/or modify
@@ -17,8 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
@@ -40,6 +40,7 @@
 #include "../../lib/srdb1/db.h"
 
 extern unsigned int default_connection_timeout;
+extern unsigned int default_connection_timeout_ms;
 extern char *
 		default_tls_cacert; /*!< File name: Default CA cert to use for curl TLS connection */
 extern str
@@ -116,7 +117,7 @@ typedef struct _curl_con
 	int http_follow_redirect; /*!< TRUE if we should follow HTTP 302 redirects */
 	unsigned int keep_connections; /*!< TRUE to keep curl connections open */
 	unsigned int port;			   /*!< The port to connect to */
-	int timeout;				   /*!< Timeout for this connection */
+	int timeout;				   /*!< Timeout (ms) for this connection */
 	unsigned int maxdatasize;	   /*!< Maximum data download on GET or POST */
 	curl_res_stream_t *stream;	   /*!< Curl stream */
 	char *http_proxy;			   /*!< HTTP proxy for this connection */
@@ -139,7 +140,7 @@ typedef struct _curl_con_pkg
 	double connecttime; /*!< Seconds used for connecting last request inc TLS setup  - see
 					     https://curl.haxx.se/libcurl/c/CURLINFO_APPCONNECT_TIME.html */
 
-	/* Potential candidates:	Last TLS fingerprint used 
+	/* Potential candidates:	Last TLS fingerprint used
 
 	*/
 	struct _curl_con_pkg *next; /*!< next connection */


### PR DESCRIPTION

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description


The new parameter connect_timeout_ms (global) / timeout_ms (in httpcon) allows to specify a timeout in milliseconds on curl requests.
If this parameter is defined (non zero), then the timeout in seconds is ignored.

If either timeout or timeout_ms is defined at connection level, then they take precedence over the global parameters.
These principles also apply to the file configuration.

The timeout in ms is used internally to set CURLOPT_TIMEOUT_MS.
The value is shown in ms when using RPC "httpclient.listcon".


