### PR TITLE
cdp: Add and apply cdp_openssl_clear_errors function

### DIFF
--- a/src/modules/cdp/cdp_tls.c
+++ b/src/modules/cdp/cdp_tls.c
@@ -1,5 +1,6 @@
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 #include "cdp_tls.h"
+#include "utils.h"
 
 cfg_option_t methods[] = {{"TLSv1", .val = TLS_USE_TLSv1},
 		{"TLSv1.0", .val = TLS_USE_TLSv1},
@@ -184,6 +185,7 @@ SSL *init_ssl_conn(int client_fd, SSL_CTX *ctx)
 		goto cleanup;
 	}
 	/* Perform the TLS handshake */
+	cdp_openssl_clear_errors();
 	ssl_ret = SSL_connect(ssl);
 	if(ssl_ret != 1) {
 		error = SSL_get_error(ssl, ssl_ret);

--- a/src/modules/cdp/receiver.c
+++ b/src/modules/cdp/receiver.c
@@ -71,6 +71,7 @@
 #include "diameter_peer.h"
 
 #include "../../core/cfg/cfg_struct.h"
+#include "utils.h"
 
 extern dp_config *config; /**< Configuration for this diameter peer 	*/
 extern int method;
@@ -537,6 +538,7 @@ static inline int do_read(serviced_peer_t *sp, char *dst, int n)
 	char *err_str;
 
 	if(sp->tls_conn) {
+		cdp_openssl_clear_errors();
 		cnt = SSL_read(sp->tls_conn, dst, n);
 		if(unlikely(cnt < 0)) {
 			ssl_err = SSL_get_error(sp->tls_conn, cnt);
@@ -687,6 +689,7 @@ static int do_write(serviced_peer_t *sp, const void *buf, int num)
 	char *err_str;
 
 	if(sp->tls_conn) {
+		cdp_openssl_clear_errors();
 		cnt = SSL_write(sp->tls_conn, buf, num);
 		if(unlikely(cnt <= 0)) {
 			ssl_err = SSL_get_error(sp->tls_conn, cnt);

--- a/src/modules/cdp/utils.c
+++ b/src/modules/cdp/utils.c
@@ -1,0 +1,21 @@
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+#include "../../core/dprint.h"
+#include "utils.h"
+
+/*
+ * Get any leftover errors from OpenSSL and print them.
+ * ERR_get_error() also removes the error from the OpenSSL error stack.
+ * This is useful to call before any SSL_* IO calls to make sure
+ * we don't have any leftover errors from previous calls (OpenSSL docs).
+ */
+void cdp_openssl_clear_errors(void)
+{
+	int i;
+	char err[160];
+	while((i = ERR_get_error())) {
+		ERR_error_string(i, err);
+		INFO("clearing leftover error before SSL_* calls: %s", err);
+	}
+}

--- a/src/modules/cdp/utils.h
+++ b/src/modules/cdp/utils.h
@@ -72,4 +72,6 @@
 		}                                        \
 	}
 
+void cdp_openssl_clear_errors(void);
+
 #endif /*UTILS_H_*/


### PR DESCRIPTION
- Add new function to clear OpenSSL errors prior to any SSL_* call
- Apply function where appropriate

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [x] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This PR proposes similar fixes like https://github.com/kamailio/kamailio/pull/3607. 

OpenSSL docs suggest that the error stack must be empty for [SSL_get_error() to work reliably](https://www.openssl.org/docs/man3.0/man3/SSL_get_error.html).  

_Note: This has not been tested like previous PR and any feedback of course is appreciated._