### PR TITLE
http_client: Add parameter timeout_mode (timeout in seconds or ms)

### DIFF
--- a/src/modules/http_client/curlcon.c
+++ b/src/modules/http_client/curlcon.c
@@ -5,9 +5,9 @@
  * Copyright (C) 2008 Elena-Ramona Modroiu (asipto.com)
  *
  * This file is part of kamailio, a free SIP server.
- * 
+ *
  * SPDX-License-Identifier: GPL-2.0-or-later
- * 
+ *
  * Kamailio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -424,7 +424,7 @@ int curl_parse_param(char *val)
 			} else if(pit->name.len == 11
 					  && strncmp(pit->name.s, "maxdatasize", 11) == 0) {
 				if(str2int(&tok, &maxdatasize) != 0) {
-					/* Bad timeout */
+					/* Bad value */
 					LM_WARN("curl connection [%.*s]: maxdatasize bad value. "
 							"Using default\n",
 							name.len, name.s);
@@ -853,4 +853,30 @@ curl_con_t *curl_init_con(str *name)
 
 	LM_DBG("CURL: Added connection [%.*s]\n", name->len, name->s);
 	return cc;
+}
+
+/*! Fixup CURL connections - if timeout is not configured, Use as default global connection_timeout.
+ */
+void curl_conn_list_fixup(void)
+{
+	curl_con_t *cc;
+	cc = _curl_con_root;
+	while (cc) {
+		if (!(timeout_mode == 1 || timeout_mode == 2)) {
+			/* Timeout is disabled globally. Set timeout to 0 for all connections to reflect this. */
+			if (cc->timeout > 0) {
+				LM_WARN("curl connection [%.*s]: configured timeout is ignored "
+				"because timeouts are disabled (timeout_mode)\n",
+					cc->name.len, cc->name.s);
+				cc->timeout = 0;
+			}
+		}
+		else if (cc->timeout == 0) {
+			/* Timeout is not configured for that connection.
+			 * Use as default global connection_timeout (which can be seconds or milliseconds).
+			 */
+			cc->timeout = default_connection_timeout;
+		}
+		cc = cc->next;
+	}
 }

--- a/src/modules/http_client/curlcon.h
+++ b/src/modules/http_client/curlcon.h
@@ -4,9 +4,9 @@
  * Copyright (C) 2015 Olle E. Johansson, Edvina AB
  *
  * This file is part of Kamailio, a free SIP server.
- * 
+ *
  * SPDX-License-Identifier: GPL-2.0-or-later
- * 
+ *
  * Kamailio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -17,8 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
@@ -37,7 +37,7 @@
 
 extern curl_con_t *_curl_con_root;
 
-/*! Count the number of connections 
+/*! Count the number of connections
  */
 unsigned int curl_connection_count();
 
@@ -51,5 +51,9 @@ int curl_parse_param(char *val);
 
 curl_con_t *curl_get_connection(str *name);
 curl_con_pkg_t *curl_get_pkg_connection(curl_con_t *con);
+
+/*! Fixup CURL connections - if timeout is not configured, Use as default global connection_timeout.
+ */
+void curl_conn_list_fixup(void);
 
 #endif

--- a/src/modules/http_client/doc/http_client_admin.xml
+++ b/src/modules/http_client/doc/http_client_admin.xml
@@ -182,13 +182,12 @@ modparam("http_client", "maxdatasize", 2000)
 		<section id="http_client.p.connection_timeout">
 			<title><varname>connection_timeout</varname> (int)</title>
 			<para>
-			Defines in seconds how long &kamailio; waits for response
-			from servers.
+			Defines how long &kamailio; waits for response from servers.
+			Value is expressed in seconds or milliseconds, depending on parameter timeout_mode.
 			</para>
 			<para>
 			<emphasis>
-				Default value is zero, i.e.,
-				the timeout function is disabled.
+				Default value is 4 seconds.
 			</emphasis>
 			</para>
 			<example>
@@ -198,6 +197,34 @@ modparam("http_client", "maxdatasize", 2000)
 modparam("http_client", "connection_timeout", 2)
 ...
 				</programlisting>
+			</example>
+		</section>
+		<section id="http_client.p.timeout_mode">
+			<title><varname>timeout_mode</varname> (int)</title>
+			<para>
+			Defines if timeouts are enabled, and in which unit timeout values are expressed.
+			</para>
+			<para>
+			Valid values are:
+			</para>
+			<itemizedlist>
+			<listitem>
+				<para>0 - Timeouts are disabled.</para>
+			</listitem>
+			<listitem>
+				<para>1 - Timeout values are in seconds (default).</para>
+			</listitem>
+			<listitem>
+				<para>2 - Timeout values are in milliseconds.</para>
+			</listitem>
+			</itemizedlist>
+			<example>
+				<title>Set <varname>timeout_mode</varname> parameter</title>
+					<programlisting format="linespecific">
+...
+modparam("http_client", "timeout_mode", 1)
+...
+					</programlisting>
 			</example>
 		</section>
 		<section id="http_client.p.client_cert">

--- a/src/modules/http_client/functions.c
+++ b/src/modules/http_client/functions.c
@@ -6,9 +6,9 @@
  * Based on functions from siputil
  * 	Copyright (C) 2008 Juha Heinanen
  * 	Copyright (C) 2013 Carsten Bock, ng-voice GmbH
- * 
+ *
  * SPDX-License-Identifier: GPL-2.0-or-later
- * 
+ *
  * This file is part of Kamailio, a free SIP server.
  *
  * Kamailio is free software; you can redistribute it and/or modify
@@ -21,8 +21,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
@@ -262,7 +262,18 @@ static int curL_request_url(struct sip_msg *_m, const char *_met,
 			curl, CURLOPT_SSL_VERIFYHOST, (long)params->verify_host ? 2 : 0);
 
 	res |= curl_easy_setopt(curl, CURLOPT_NOSIGNAL, (long)1);
-	res |= curl_easy_setopt(curl, CURLOPT_TIMEOUT, (long)params->timeout);
+
+	/* timeout_mode parameter:
+	 * - 0 : timeout is disabled.
+	 * - 1 (default) : timeout value is in seconds.
+	 * - 2 : timeout value is in milliseconds.
+	 */
+	if (timeout_mode == 1) { /* timeout is in seconds (default) */
+		res |= curl_easy_setopt(curl, CURLOPT_TIMEOUT, (long)params->timeout);
+	} else if (timeout_mode == 2) { /* timeout is in milliseconds */
+		res |= curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, (long)params->timeout);
+	}
+
 	res |= curl_easy_setopt(
 			curl, CURLOPT_FOLLOWLOCATION, (long)params->http_follow_redirect);
 	if(params->http_follow_redirect) {

--- a/src/modules/http_client/http_client.h
+++ b/src/modules/http_client/http_client.h
@@ -2,9 +2,9 @@
  * header file of http_client.c
  *
  * Copyright (C) 2008 Juha Heinanen
- * 
+ *
  * SPDX-License-Identifier: GPL-2.0-or-later
- * 
+ *
  * This file is part of Kamailio, a free SIP server.
  *
  * Kamailio is free software; you can redistribute it and/or modify
@@ -17,8 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License 
- * along with this program; if not, write to the Free Software 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
@@ -40,6 +40,7 @@
 #include "../../lib/srdb1/db.h"
 
 extern unsigned int default_connection_timeout;
+extern unsigned int timeout_mode;
 extern char *
 		default_tls_cacert; /*!< File name: Default CA cert to use for curl TLS connection */
 extern str
@@ -139,7 +140,7 @@ typedef struct _curl_con_pkg
 	double connecttime; /*!< Seconds used for connecting last request inc TLS setup  - see
 					     https://curl.haxx.se/libcurl/c/CURLINFO_APPCONNECT_TIME.html */
 
-	/* Potential candidates:	Last TLS fingerprint used 
+	/* Potential candidates:	Last TLS fingerprint used
 
 	*/
 	struct _curl_con_pkg *next; /*!< next connection */


### PR DESCRIPTION

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

A new parameter timeout_mode is added.
This parameter defines if timeouts are enabled, and in which unit timeout values are expressed.
- 0 - Timeouts are disabled.
- 1 - Timeout values are in seconds (default).
- 2 - Timeout values are in milliseconds.

For reference, see discussion in: https://github.com/kamailio/kamailio/pull/3611

Implementation detail:

```
default global timeout = 0 (unconfigured).

Parse connections as usual. If they have a timeout configured, use it.

In mod_init:
  if global timeout == 0 (unconfigured), and timeout_mode is 1 or 2:
    if timeout_mode == 1 -> global timeout = 4 (seconds)
    if timeout_mode == 2 -> global timeout = 4000 (milliseconds)

  for each connection "conn" (fixup):
    if timeout_mode is not 1 or 2 -> conn.timeout = 0 (to reflect the fact that no timeout will be handled)
    else if conn.timeout is not configured -> conn.timeout = global timeout (in seconds or milliseconds, depending on timeout_mode).

When doing Curl requests (curL_request_url):
  if timeout_mode == 1: set CURLOPT_TIMEOUT
  if timeout_mode == 2: set CURLOPT_TIMEOUT_MS
```

