### PR TITLE
cdp: Fix for undefined symbols when using older/unsupported OpenSSL

### DIFF
--- a/src/modules/cdp/receiver.c
+++ b/src/modules/cdp/receiver.c
@@ -533,6 +533,7 @@ done:
 
 static inline int do_read(serviced_peer_t *sp, char *dst, int n)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	int cnt, ssl_err;
 	char *err_str;
 
@@ -547,6 +548,11 @@ static inline int do_read(serviced_peer_t *sp, char *dst, int n)
 	} else {
 		cnt = recv(sp->tcp_socket, dst, n, 0);
 	}
+#else
+	int cnt;
+
+	cnt = recv(sp->tcp_socket, dst, n, 0);
+#endif
 	return cnt;
 }
 
@@ -684,6 +690,7 @@ error_and_reset:
 
 static int do_write(serviced_peer_t *sp, const void *buf, int num)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	int cnt, ssl_err;
 	char *err_str;
 
@@ -698,6 +705,11 @@ static int do_write(serviced_peer_t *sp, const void *buf, int num)
 	} else {
 		cnt = write(sp->tcp_socket, buf, num);
 	}
+#else
+	int cnt;
+
+	cnt = write(sp->tcp_socket, buf, num);
+#endif
 	return cnt;
 }
 


### PR DESCRIPTION
This was originaly fixed in #3601, but that did not handle the change in #3612 very well.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Fix for undefined symbols when using older/unsupported OpenSSL.
This was originaly fixed in #3601, but that did not handle the change in #3612 very well.
