### PR TITLE
secsipid: fix build errors for older versions of secsipid lib

### DIFF
--- a/src/modules/secsipid/secsipid_mod.c
+++ b/src/modules/secsipid/secsipid_mod.c
@@ -750,6 +750,7 @@ static int w_secsipid_sign(
 static int ki_secsipid_sign_prvkey(
 		sip_msg_t *msg, str *sheaders, str *spayload, str *keydata)
 {
+#if SECSIPID_VERSION >= 0x1030000
 	str ibody = STR_NULL;
 
 	if(secsipid_libopt_list_used == 0) {
@@ -776,7 +777,6 @@ static int ki_secsipid_sign_prvkey(
 		free(_secsipid_data.value.s);
 	}
 	_secsipid_data.value = ibody;
-
 	return 1;
 
 error:
@@ -784,6 +784,10 @@ error:
 		free(ibody.s);
 	}
 	return -1;
+#else
+	LM_ERR("secsipid < 1.3.0, SecSIPIDSignJSONHPPrvKey not supported\n");
+	return -1;
+#endif
 }
 
 /**

--- a/src/modules/secsipid_proc/secsipid_proc_mod.c
+++ b/src/modules/secsipid_proc/secsipid_proc_mod.c
@@ -38,7 +38,9 @@ MODULE_VERSION
 int secsipid_proc_bind(secsipid_papi_t *papi)
 {
 	papi->SecSIPIDSignJSONHP = SecSIPIDSignJSONHP;
+#if SECSIPID_VERSION >= 0x1030000
 	papi->SecSIPIDSignJSONHPPrvKey = SecSIPIDSignJSONHPPrvKey;
+#endif
 	papi->SecSIPIDGetIdentity = SecSIPIDGetIdentity;
 	papi->SecSIPIDGetIdentityPrvKey = SecSIPIDGetIdentityPrvKey;
 	papi->SecSIPIDCheck = SecSIPIDCheck;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally

#### Description
Nightly builds broke due to https://github.com/kamailio/kamailio/commit/c8d56ed3afa19c29279e54fffd40b9810bb0d67c
https://kamailio.sipwise.com/job/kamailiodev-nightly-binaries/2517/console
