### PR TITLE
topos: add compatiblity for early in-dialog NOTIFY

### DIFF
--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -910,10 +910,9 @@ int tps_request_received(sip_msg_t *msg, int dialog)
 		goto error;
 	}
 	metid = get_cseq(msg)->method_id;
-	if(((metid & (METHOD_BYE | METHOD_INFO | METHOD_PRACK | METHOD_UPDATE))
-			   || ((metid & (METHOD_NOTIFY))
-					   && (msg->event
-							   && strncmp(msg->event->body.s, "talk", 4) == 0)))
+	if(((metid
+			   & (METHOD_BYE | METHOD_INFO | METHOD_PRACK | METHOD_UPDATE
+					   | METHOD_NOTIFY)))
 			&& stsd.b_contact.len <= 0) {
 		/* no B-side contact, look for INVITE transaction record */
 		if(metid & (METHOD_BYE | METHOD_UPDATE)) {

--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -910,7 +910,10 @@ int tps_request_received(sip_msg_t *msg, int dialog)
 		goto error;
 	}
 	metid = get_cseq(msg)->method_id;
-	if((metid & (METHOD_BYE | METHOD_INFO | METHOD_PRACK | METHOD_UPDATE))
+	if(((metid & (METHOD_BYE | METHOD_INFO | METHOD_PRACK | METHOD_UPDATE))
+			   || ((metid & (METHOD_NOTIFY))
+					   && (msg->event
+							   && strncmp(msg->event->body.s, "talk", 4) == 0)))
 			&& stsd.b_contact.len <= 0) {
 		/* no B-side contact, look for INVITE transaction record */
 		if(metid & (METHOD_BYE | METHOD_UPDATE)) {

--- a/src/modules/topos/tps_storage.c
+++ b/src/modules/topos/tps_storage.c
@@ -1146,7 +1146,8 @@ int tps_db_load_branch(
 
 	if((get_cseq(msg)->method_id == METHOD_SUBSCRIBE)
 			|| ((get_cseq(msg)->method_id == METHOD_NOTIFY)
-					&& (msg->event && msg->event->len > 0))) {
+					&& (msg->event && msg->event->len > 0
+							&& strncmp(msg->event->body.s, "talk", 4) != 0))) {
 		bInviteDlg = 0;
 	}
 


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
After enabling the Topos module, we ran into a bit of trouble with early in-dialog notifies. We use the `event: talk` package from Cisco Broadsoft to be able to do call control, as described in chapter 6 here: https://pubhub.devnetcloud.com/media/broadsoft-docs/docs/pdf/BW-SIPAccessSideExtensionsInterfaceSpec.pdf

This will send a NOTIFY with a header `Event: talk` before the first `200 OK`. Currently this doesn't work with the topos module, since the NOTIFY method without a B-side contact will not check the INVITE record. When added to those methods in `tps_msg.c`, it tries to check the SUBSCRIBE for all NOTIFY's in `tps_storage.c`. The NOTIFY with  `Event: talk` will follow on an INVITE, so there was a small change needed there.

I've limited it to just the NOTIFY's with the `Event: talk` header, to minimize any impact.
