### PR TITLE
cdp: Support for diameter routing agent (DRA) / relaying

### DIFF
--- a/src/modules/cdp/diameter.h
+++ b/src/modules/cdp/diameter.h
@@ -87,6 +87,8 @@
 #define to_32x_len(_len_) ((_len_) + (((_len_)&3) ? 4 - ((_len_)&3) : 0))
 
 
+#define RELAY_APP_ID 0xffffffff
+
 /* AAA TYPES */
 
 #define AAA_NO_VENDOR_ID 0

--- a/src/modules/cdp/routing.c
+++ b/src/modules/cdp/routing.c
@@ -98,7 +98,8 @@ peer *get_first_connected_route(
 					cdp_session
 							->hash); /*V1.1 - As we were...no call seems to pass cdp_session unlocked */
 			if(p && !p->disabled && (p->state == I_Open || p->state == R_Open)
-					&& peer_handles_application(p, app_id, vendor_id)) {
+					&& (peer_handles_application(p, app_id, vendor_id)
+							|| peer_handles_application(p, RELAY_APP_ID, 0))) {
 				p->last_selected = time(NULL);
 				LM_DBG("Found a sticky peer [%.*s] for this session - "
 					   "re-using\n",
@@ -121,7 +122,8 @@ peer *get_first_connected_route(
 					(p->state == I_Open || p->state == R_Open) ? "opened"
 															   : "closed");
 		if(p && !p->disabled && (p->state == I_Open || p->state == R_Open)
-				&& peer_handles_application(p, app_id, vendor_id)) {
+				&& (peer_handles_application(p, app_id, vendor_id)
+						|| peer_handles_application(p, RELAY_APP_ID, 0))) {
 			LM_DBG("The peer %.*s matches - will forward there\n", i->fqdn.len,
 					i->fqdn.s);
 			if(peer_count != 0) { //check the metric


### PR DESCRIPTION

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
If an endpoint responds with a CEA (Capabilities-Exchange Answer) indicating support for relaying (application-id 0xffffffff), let this endpoint be used for any application. The DRA will then be responsible for routing the request to the correct destination.

To fully support this, there might be a need for additional changes in some of the modules. That is to make sure subsequent requests for a given session is always routed to the same destination, indicated by Origin-Host in answers from a diameter server. Destination-Host of the new request should then be filled with this value.

A change for the ims_charging module is on the way.
