### PR TITLE
ims_charging: Various improvements to make module compatible to other charging server vendors

### DIFF
--- a/src/modules/cdp/acctstatemachine.c
+++ b/src/modules/cdp/acctstatemachine.c
@@ -176,6 +176,8 @@ int cc_acc_client_stateful_sm_process(
 					//nothing we can do here, we have sent callback, client needs to send CCR Update
 					LM_DBG("Reservation close to expiring\n");
 					break;
+				case ACC_CC_EV_SESSION_MODIFIED:
+					break;
 				default:
 					LM_ERR("Received unknown event [%d] in state [%d]\n", event,
 							x->state);

--- a/src/modules/cdp/diameter_code_avp.h
+++ b/src/modules/cdp/diameter_code_avp.h
@@ -266,6 +266,8 @@ typedef enum
 	AVP_Service_Selection = 493, //RFC5778
 	AVP_Call_Id = 494,
 
+	AVP_Time_Quota_Threshold = 868, // 3GPP TS 32.299
+
 } AAA_AVPCodeNr;
 
 enum

--- a/src/modules/cdp/peerstatemachine.c
+++ b/src/modules/cdp/peerstatemachine.c
@@ -1350,11 +1350,9 @@ void Rcv_Process(peer *p, AAAMessage *msg)
 		switch(session->type) {
 			case ACCT_CC_CLIENT:
 				if(is_req(msg)) {
-					LM_WARN("unhandled receive request on Credit Control Acct "
-							"session\n");
-					AAASessionsUnlock(
-							session->hash); //must be called because we don't call state machine here
-					session = 0; //we don't call SM here so we must not set to 0
+					cc_acc_client_stateful_sm_process(
+							session, ACC_CC_EV_SESSION_MODIFIED, msg);
+					session = 0;
 				} else {
 					cc_acc_client_stateful_sm_process(
 							session, ACC_CC_EV_RECV_ANS, msg);

--- a/src/modules/cdp/session.c
+++ b/src/modules/cdp/session.c
@@ -491,7 +491,7 @@ int cdp_sessions_timer(time_t now, void *ptr)
 								15; //15 seconds - TODO: add as config parameter
 						//we should check for reservation expiring if the state is open
 						if(x->u.cc_acc.state == ACC_CC_ST_OPEN) {
-							if(last_res_timestamp) {
+							if(last_res_timestamp && res_valid_for) {
 								//we have obv already started reservations
 								if((last_res_timestamp + res_valid_for)
 										< (time(0) + last_reservation

--- a/src/modules/ims_charging/Ro_data.h
+++ b/src/modules/ims_charging/Ro_data.h
@@ -416,6 +416,7 @@ typedef struct
 	uint32_t validity_time;
 	final_unit_indication_t *final_unit_action;
 	uint32_t resultcode;
+	uint32_t time_quota_threshold;
 } multiple_services_credit_control_t;
 
 typedef struct
@@ -424,6 +425,7 @@ typedef struct
 	uint32_t cc_request_type;
 	uint32_t cc_request_number;
 	multiple_services_credit_control_t *mscc;
+	str origin_host;
 } Ro_CCA_t;
 
 event_type_t *new_event_type(str *sip_method, str *event, uint32_t *expires);
@@ -446,7 +448,8 @@ void ims_information_free(ims_information_t *x);
 void service_information_free(service_information_t *x);
 
 Ro_CCR_t *new_Ro_CCR(int32_t acc_record_type, str *user_name,
-		ims_information_t *ims_info, subscription_id_t *subscription);
+		ims_information_t *ims_info, subscription_id_t *subscription,
+		str *destination_host);
 void Ro_free_CCR(Ro_CCR_t *x);
 void Ro_free_CCA(Ro_CCA_t *x);
 

--- a/src/modules/ims_charging/ccr.c
+++ b/src/modules/ims_charging/ccr.c
@@ -1,4 +1,5 @@
 #include "../cdp_avp/cdp_avp_mod.h"
+#include "../../lib/ims/ims_getters.h"
 
 #include "ccr.h"
 #include "Ro_data.h"
@@ -402,6 +403,10 @@ Ro_CCA_t *Ro_parse_CCA_avps(AAAMessage *cca)
 						case AVP_Validity_Time:
 							mscc->validity_time = get_4bytes(mscc_avp->data.s);
 							break;
+						case AVP_Time_Quota_Threshold:
+							mscc->time_quota_threshold =
+									get_4bytes(mscc_avp->data.s);
+							break;
 						case AVP_Result_Code:
 							mscc->resultcode = get_4bytes(mscc_avp->data.s);
 							break;
@@ -477,6 +482,9 @@ Ro_CCA_t *Ro_parse_CCA_avps(AAAMessage *cca)
 			case AVP_Result_Code:
 				x = get_4bytes(avp->data.s);
 				ro_cca_data->resultcode = x;
+				break;
+			case AVP_Origin_Host:
+				str_dup(ro_cca_data->origin_host, avp->data, pkg);
 				break;
 		}
 		avp = avp->next;

--- a/src/modules/ims_charging/config.h
+++ b/src/modules/ims_charging/config.h
@@ -8,6 +8,7 @@ typedef struct
 	str destination_host;
 	str destination_realm;
 	str *service_context_id;
+	int strip_plus_from_e164;
 } client_ro_cfg;
 
 #endif

--- a/src/modules/ims_charging/doc/ims_charging_admin.xml
+++ b/src/modules/ims_charging/doc/ims_charging_admin.xml
@@ -839,6 +839,26 @@ modparam("ims_charging", "vendor_specific_id", 10)
       </example>
     </section>
 
+    <section>
+      <title><varname>strip_plus_from_e164</varname> (int)</title>
+
+      <para>Strip + from subscription id when E.164 format is used. This is according
+        to spec, but this parameter is to keep existing behavior as the default.</para>
+
+      <para><emphasis>Default value is 0.</emphasis></para>
+
+      <example>
+        <title><varname>strip_plus_from_e164</varname>parameter
+        usage</title>
+
+        <programlisting format="linespecific">
+...
+modparam("ims_charging", "strip_plus_from_e164", 1)
+...
+        </programlisting>
+      </example>
+    </section>
+
   </section>
 
   <section>

--- a/src/modules/ims_charging/ims_ro.h
+++ b/src/modules/ims_charging/ims_ro.h
@@ -36,4 +36,7 @@ int get_direction_as_int(str *direction);
 void init_custom_user(pv_spec_t *custom_user_avp);
 void init_app_provided_party(pv_spec_t *app_provided_party_avp_p);
 
+AAAMessage *ro_process_rar(AAAMessage *rtr);
+AAAMessage *ro_process_asr(AAAMessage *rtr);
+
 #endif /* CLIENT_RF_IMS_RO_H */

--- a/src/modules/ims_charging/ro_db_handler.h
+++ b/src/modules/ims_charging/ro_db_handler.h
@@ -12,9 +12,9 @@
 #include "../../lib/srdb1/db.h"
 #include "ro_session_hash.h"
 
-#define RO_TABLE_VERSION 2
+#define RO_TABLE_VERSION 3
 #define RO_SESSION_TABLE_NAME "ro_session"
-#define RO_SESSION_TABLE_COL_NUM 24
+#define RO_SESSION_TABLE_COL_NUM 25
 
 #define ID_COL "id"
 #define HASH_ENTRY_COL "hash_entry"
@@ -40,6 +40,7 @@
 #define MAC_COL "mac"
 #define APP_PROVIDED_PARTY_COL "app_provided_party"
 #define IS_FINAL_ALLOCATION_COL "is_final_allocation"
+#define ORIGIN_HOST_COL "origin_host"
 
 int init_ro_db(const str *db_url, int dlg_hash_size, int db_update_period,
 		int fetch_num_rows);

--- a/src/modules/ims_charging/ro_session_hash.h
+++ b/src/modules/ims_charging/ro_session_hash.h
@@ -85,6 +85,8 @@ struct ro_session
 	unsigned int is_final_allocation;
 	long billed;
 	unsigned int ccr_sent;
+	str origin_host;
+	int ro_timer_buffer;
 };
 
 /*! entries in the main ro_session table */
@@ -229,7 +231,7 @@ struct ro_session *build_new_ro_session(int direction, int auth_appid,
 		unsigned int requested_secs, unsigned int validity_timeout,
 		int active_rating_group, int active_service_identifier,
 		str *incoming_trunk_id, str *outgoing_trunk_id, str *pani,
-		str *app_provided_party);
+		str *app_provided_party, int ro_timer_buffer);
 
 /*!
  * \brief Refefence a ro_session with locking
@@ -255,6 +257,8 @@ void unref_ro_session_helper(struct ro_session *ro_session, unsigned int cnt,
 
 struct ro_session *lookup_ro_session(
 		unsigned int h_entry, str *callid, int direction, unsigned int *del);
+
+struct ro_session *lookup_ro_session_by_session_id(str *session_id);
 
 void free_impu_data(struct impu_data *impu_data);
 

--- a/src/modules/ims_charging/ro_timer.c
+++ b/src/modules/ims_charging/ro_timer.c
@@ -333,13 +333,15 @@ void resume_ro_session_ontimeout(
 		} else {
 			int timer_timeout = i_req->new_credit;
 
-			if(i_req->new_credit > ro_timer_buffer /*TIMEOUTBUFFER*/) {
+			if(i_req->new_credit
+					> i_req->ro_session->ro_timer_buffer /*TIMEOUTBUFFER*/) {
 
 				// We haven't finished using our 1st block of units, and we need to set the timer to
-				// (new_credit - ro_timer_buffer[5 secs]) to ensure we get new credit before our previous
+				// (new_credit - i_req->ro_session->ro_timer_buffer[5 secs]) to ensure we get new credit before our previous
 				// reservation is exhausted. This will only be done the first time, because the timer
 				// will always be fired 5 seconds before we run out of time thanks to this operation
-				timer_timeout = i_req->new_credit - ro_timer_buffer;
+				timer_timeout =
+						i_req->new_credit - i_req->ro_session->ro_timer_buffer;
 			}
 
 			ret = insert_ro_timer(&i_req->ro_session->ro_tl, timer_timeout);

--- a/utils/kamctl/mysql/ims_charging-create.sql
+++ b/utils/kamctl/mysql/ims_charging-create.sql
@@ -1,4 +1,4 @@
-INSERT INTO version (table_name, table_version) values ('ro_session','2');
+INSERT INTO version (table_name, table_version) values ('ro_session','3');
 CREATE TABLE `ro_session` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `hash_entry` int(10) unsigned NOT NULL,
@@ -24,6 +24,7 @@ CREATE TABLE `ro_session` (
   `mac` varchar(17) DEFAULT NULL,
   `app_provided_party` varchar(100) DEFAULT NULL,
   `is_final_allocation` int(1) unsigned NOT NULL,
+  `origin_host` varchar(150) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `hash_idx` (`hash_entry`,`hash_id`)
 );


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
**Use origin-host of CCR response as destination-host of subsequent CCR requests**
When connecting to a diameter node which using relay, it may load balance requests to multiple servers for handling. This change ensures that subsequent requests are sent to the same server.

**Honour AVP_Time_Quota_Threshold in CCR response**
Charging server indicates it want an interim update X number of seconds before all quota has been used.

**Add new modparam «strip_plus_from_e164»**
The existing formatitng routine check if it's a tel: or sip: uri, and sets E.164 or SIP according to that. If it's E.164, it strips "tel:" too. A subscription id with leading "+" is actually of type SIP.

I didn't want to make a breaking change here, so I introduced a new setting which fixes the behaviour.

**Moved subscription id formatting into a common function**
For more clean code, and one place to make further adjustments.

**Handle CCR response without AVP_Validity_Time**
If missing, various places in the module reported immediate expire.

**Handle IMS_RAR (Re-auth) request from charging server**
Typical scenario is that there's a missing interim update, and the server want to check if the session is still alive. At reception we try a lookup and if found, schedule a new request.

**Handle IMS_ASR (Abort) request from charging server**
Similar handling as for re-auth, but for server-initiated termination of the call.

**Fixed issue with signed/unsigned int related to check for Expires header**
cscf_get_expires_hdr() returns signed (-1 for not found), while that value was added
to the outgoing diameter request unsigned. That again resulted in an Expires AVP with
a really large value, and was rejected by the charging server.

Most probably cscf_get_expires_hdr() should be changed to return unsigned since the value theoretical can be that big, but since that is a common function for the ims modules it would require more testing than I'm capable of right now.

**Use str_dup() and str_free() from ims_getters instead of locally defined**
Those were needed more places.

-- 

I'm a little bit unsure about updating a string allocated in shm, where the length is changed (look in ims_ro.c, credit_control_session_callback()). Is the correct way to do a shm_free() and then reallocate, or is there a more simple way of doing it?