### PR TITLE
Add AoR argument to ims_ipsec_pcscf ipsec_destroy()

### DIFF
--- a/src/modules/ims_ipsec_pcscf/cmd.c
+++ b/src/modules/ims_ipsec_pcscf/cmd.c
@@ -1041,7 +1041,7 @@ cleanup:
 }
 
 
-int ipsec_destroy(struct sip_msg *m, udomain_t *d)
+int ipsec_destroy(struct sip_msg *m, udomain_t *d, str *uri)
 {
 	struct pcontact_info ci;
 	pcontact_t *pcontact = NULL;
@@ -1051,6 +1051,12 @@ int ipsec_destroy(struct sip_msg *m, udomain_t *d)
 	if(m->first_line.type == SIP_REPLY) {
 		t = tmb.t_gett();
 	}
+
+        // Insert URI in SIP message
+        if(uri != NULL) {
+                m->first_line.u.request.uri.s = uri->s;
+                m->first_line.u.request.uri.len = uri->len;
+        }
 
 	// Find the contact
 	if(fill_contact(&ci, m, t, 0) != 0) {

--- a/src/modules/ims_ipsec_pcscf/cmd.h
+++ b/src/modules/ims_ipsec_pcscf/cmd.h
@@ -65,7 +65,7 @@ struct udomain_t;
 
 int ipsec_create(struct sip_msg *m, udomain_t *d, int _cflags);
 int ipsec_forward(struct sip_msg *m, udomain_t *d, int _cflags);
-int ipsec_destroy(struct sip_msg *m, udomain_t *d);
+int ipsec_destroy(struct sip_msg *m, udomain_t *d, str *uri);
 int ipsec_cleanall();
 int ipsec_reconfig();
 void ipsec_on_expire(pcontact_t *c, int type, void *param);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [X] Related to issue #3570

#### Description
<!-- Describe your changes in detail -->
Added optional AoR argument to ipsec_destroy(); to permit insertion of a real AoR from a cfg script. Otherwise, ipsec_destroy() uses the dummy AoR you@kamailio.org. The dummy AoR does not identify the IPSec SA of any UE present in the registrar, so no IPSec SA can be torn down.
The real AoR, if present as an argument to ipsec_destroy() replaces the dummy AoR in m->first_line.u.request.uri.s, before calling fill_contact() (see changes to cmd.c / cmd.h).
All other changes address ims_ipsec_pcscf_mod.c only, as required to implement the ipsec_destroy() optional argument.