### PR TITLE
core: timer_proc don't execute timers on shutdown phase

### DIFF
--- a/src/core/timer_proc.c
+++ b/src/core/timer_proc.c
@@ -29,6 +29,7 @@
 #include "pt.h"
 #include "ut.h"
 #include "mem/shm_mem.h"
+#include "sr_module.h"
 
 #include <unistd.h>
 
@@ -76,6 +77,9 @@ int fork_basic_timer(int child_id, char *desc, int make_sock, timer_function *f,
 		if(cfg_child_init())
 			return -1;
 		for(;;) {
+			if(unlikely(ksr_shutdown_phase() != 0)) {
+				return 0;
+			}
 			sleep(interval);
 			cfg_update();
 			f(get_ticks(), param); /* ticks in s for compatibility with old
@@ -99,6 +103,9 @@ int fork_basic_timer_w(int child_id, char *desc, int make_sock,
 		if(cfg_child_init())
 			return -1;
 		for(;;) {
+			if(unlikely(ksr_shutdown_phase() != 0)) {
+				return 0;
+			}
 			sleep(interval);
 			cfg_update();
 			f(get_ticks(), worker,
@@ -141,6 +148,9 @@ int fork_basic_utimer(int child_id, char *desc, int make_sock,
 		if(cfg_child_init())
 			return -1;
 		for(;;) {
+			if(unlikely(ksr_shutdown_phase() != 0)) {
+				return 0;
+			}
 			sleep_us(uinterval);
 			cfg_update();
 			ts = get_ticks_raw();
@@ -165,6 +175,9 @@ int fork_basic_utimer_w(int child_id, char *desc, int make_sock,
 		if(cfg_child_init())
 			return -1;
 		for(;;) {
+			if(unlikely(ksr_shutdown_phase() != 0)) {
+				return 0;
+			}
 			sleep_us(uinterval);
 			cfg_update();
 			ts = get_ticks_raw();
@@ -273,6 +286,9 @@ int fork_sync_timer(int child_id, char *desc, int make_sock, timer_function *f,
 		if(cfg_child_init())
 			return -1;
 		for(;;) {
+			if(unlikely(ksr_shutdown_phase() != 0)) {
+				return 0;
+			}
 			if(ts2 > interval)
 				sleep_us(1000); /* 1 millisecond sleep to catch up */
 			else
@@ -324,6 +340,9 @@ int fork_sync_utimer(int child_id, char *desc, int make_sock,
 		if(cfg_child_init())
 			return -1;
 		for(;;) {
+			if(unlikely(ksr_shutdown_phase() != 0)) {
+				return 0;
+			}
 			if(ts2 > uinterval)
 				sleep_us(1);
 			else


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [X] Tested changes locally

#### Description

If kamailio is in the shutdown phase proc timers should not be executed since memory objects are getting destroyed and cores could happen 
