### PR TITLE
pv: Add support to $hfl $hflc for Diversion header

### DIFF
--- a/src/core/parser/hf.c
+++ b/src/core/parser/hf.c
@@ -88,7 +88,7 @@ void clean_hdr_field(struct hdr_field *const hf)
 				break;
 
 			case HDR_DIVERSION_T:
-				free_diversion_body(hf->parsed);
+				free_diversion_body((diversion_body_t *)(hf->parsed));
 				break;
 
 			case HDR_EVENT_T:

--- a/src/core/parser/hf.c
+++ b/src/core/parser/hf.c
@@ -40,6 +40,7 @@
 #include "parse_expires.h"
 #include "parse_sipifmatch.h"
 #include "parse_rr.h"
+#include "parse_diversion.h"
 #include "parse_subscription_state.h"
 #include "contact/parse_contact.h"
 #include "parse_disposition.h"
@@ -87,7 +88,7 @@ void clean_hdr_field(struct hdr_field *const hf)
 				break;
 
 			case HDR_DIVERSION_T:
-				free_to(hf->parsed);
+				free_diversion_body(hf->parsed);
 				break;
 
 			case HDR_EVENT_T:

--- a/src/core/parser/parse_diversion.c
+++ b/src/core/parser/parse_diversion.c
@@ -199,6 +199,13 @@ int parse_diversion_header(struct sip_msg *msg)
 
 int free_diversion_body(diversion_body_t *div_b)
 {
+	for(int i = 0; i < div_b->num_ids; i++) {
+		/* Free to_body pointer */
+		if(div_b->id[i].param_lst) {
+			free_to_params(&(div_b->id[i]));
+		}
+	}
+
 	if(div_b != NULL) {
 		pkg_free(div_b);
 	}

--- a/src/core/parser/parse_diversion.c
+++ b/src/core/parser/parse_diversion.c
@@ -31,6 +31,7 @@
 #include "../dprint.h"
 #include "../ut.h"
 #include "../mem/mem.h"
+#include "parse_diversion.h"
 #include "parse_from.h"
 #include "parse_to.h"
 #include "msg_parser.h"
@@ -44,48 +45,165 @@
  *
  * limitations: it parses only the first occurrence
  */
-int parse_diversion_header(struct sip_msg *msg)
+#define NUM_DIVERSION_BODIES 10
+int parse_diversion_body(char *buf, int len, diversion_body_t **body)
 {
-	struct to_body *diversion_b;
+	static to_body_t uri_b[NUM_DIVERSION_BODIES]; /* Temporary storage */
+	int num_uri = 0;
+	int body_len = 0;
+	char *tmp;
+	int i;
 
-	if(!msg->diversion && (parse_headers(msg, HDR_DIVERSION_F, 0) == -1)) {
-		goto error;
-	}
-
-	if(!msg->diversion) {
-		/* header not found */
+	/* Reserves memory max NUM_DIVERSION_BODIES times */
+	memset(uri_b, 0, NUM_DIVERSION_BODIES * sizeof(to_body_t));
+	if(uri_b == NULL) {
+		LM_ERR("Error allocating memory for uri_b\n");
 		return -1;
 	}
 
+	tmp = parse_addr_spec(buf, buf + len, &uri_b[num_uri], 1);
+	if(uri_b[num_uri].error == PARSE_ERROR) {
+		LM_ERR("Error parsing Diversion body %u '%.*s'\n", num_uri, len, buf);
+		return -1;
+	}
+
+	/* id.body should contain all info including uri and params */
+	body_len = uri_b[num_uri].body.len;
+
+	/* Loop over all params */
+	to_param_t *params = uri_b[num_uri].param_lst;
+	while(params) {
+		body_len +=
+				params->name.len + params->value.len + 2; // 2 for '=' and ';'
+		params = params->next;
+	}
+
+	uri_b[num_uri].body.len = body_len;
+
+	num_uri++;
+	while(*tmp == ',' && (num_uri < NUM_DIVERSION_BODIES)) {
+		tmp++;
+		while(tmp < buf + len && (*tmp == ' ' || *tmp == '\t'))
+			tmp++;
+
+		if(tmp >= buf + len) {
+			LM_ERR("no content after comma when parsing Diversion body %u "
+				   "'%.*s'\n",
+					num_uri, len, buf);
+			return -1;
+		}
+
+		if((tmp < buf + len - 1 && *tmp == '\n')
+				|| (tmp < buf + len - 2 && *tmp == '\r'
+						&& *(tmp + 1) == '\n')) {
+			if(*tmp == '\n') {
+				tmp++;
+			} else {
+				tmp += 2;
+			}
+			if(*tmp != ' ' && *tmp != '\t') {
+				// TODO: Check if this is the correct error message
+				LM_ERR("no space after EOL when parsing Diversion body %u "
+					   "'%.*s'\n",
+						num_uri, len, buf);
+				return -1;
+			}
+			tmp++;
+		}
+		/* Parse next body */
+		tmp = parse_addr_spec(tmp, buf + len, &uri_b[num_uri], 1);
+		if(uri_b[num_uri].error == PARSE_ERROR) {
+			LM_ERR("Error parsing Diversion body %u '%.*s'\n", num_uri, len,
+					buf);
+			return -1;
+		}
+
+		/* id.body should contain all info including uri and params */
+		body_len = uri_b[num_uri].body.len;
+
+		/* Loop over all params */
+		to_param_t *params = uri_b[num_uri].param_lst;
+		while(params) {
+			body_len += params->name.len + params->value.len
+						+ 2; /*  2 for '=' and ';' */
+			params = params->next;
+		}
+
+		uri_b[num_uri].body.len = body_len;
+
+		num_uri++;
+	}
+	if(num_uri >= NUM_DIVERSION_BODIES) {
+		LM_WARN("Too many bodies in Diversion header '%.*s'\n", len, buf);
+		LM_WARN("Ignoring bodies beyond %u\n", NUM_DIVERSION_BODIES);
+	}
+	*body = pkg_malloc(sizeof(diversion_body_t) + num_uri * sizeof(to_body_t));
+	if(*body == NULL) {
+		PKG_MEM_ERROR;
+		return -1;
+	}
+	memset(*body, 0, sizeof(diversion_body_t));
+	(*body)->id = (to_body_t *)((char *)(*body) + sizeof(diversion_body_t));
+	(*body)->num_ids = num_uri;
+	for(i = 0; i < num_uri; i++) {
+		memcpy(&(*body)->id[i], &uri_b[i], sizeof(to_body_t));
+	}
+	return 0;
+}
+
+int parse_diversion_header(struct sip_msg *msg)
+{
+	diversion_body_t *diversion_b;
+	diversion_body_t **prev_diversion_body;
+	hdr_field_t *hf;
+	void **vp;
+
+	if(!msg->diversion) {
+		if(parse_headers(msg, HDR_DIVERSION_F, 0) < 0) {
+			LM_ERR("Error parsing Diversion header\n");
+			return -1;
+		}
+
+		if(!msg->diversion) {
+			/* Diversion header not found */
+			LM_DBG("Diversion header not found\n");
+			return -1;
+		}
+	}
 	/* maybe the header is already parsed! */
 	if(msg->diversion->parsed)
 		return 0;
 
-	/* bad luck! :-( - we have to parse it */
-	/* first, get some memory */
-	diversion_b = pkg_malloc(sizeof(struct to_body));
-	if(diversion_b == 0) {
-		PKG_MEM_ERROR;
-		goto error;
-	}
+	vp = &msg->diversion->parsed;
+	/* 	Set it as the first header in the list */
+	prev_diversion_body = (diversion_body_t **)vp;
 
-	/* now parse it!! */
-	memset(diversion_b, 0, sizeof(struct to_body));
-	parse_addr_spec(msg->diversion->body.s,
-			msg->diversion->body.s + msg->diversion->body.len + 1, diversion_b,
-			1);
-	if(diversion_b->error == PARSE_ERROR) {
-		LM_ERR("bad diversion header\n");
-		free_to(diversion_b);
-		goto error;
-	}
-	msg->diversion->parsed = diversion_b;
+	/* Loop through all the Diversion headers */
+	for(hf = msg->diversion; hf != NULL; hf = next_sibling_hdr(hf)) {
+		if(parse_diversion_body(hf->body.s, hf->body.len, &diversion_b) < 0) {
+			LM_ERR("Error parsing Diversion header\n");
+			return -1;
+		}
 
+		hf->parsed = (void *)diversion_b;
+		*prev_diversion_body = diversion_b;
+		prev_diversion_body = &diversion_b->next;
+
+		if(parse_headers(msg, HDR_DIVERSION_F, 1) < 0) {
+			LM_ERR("Error looking for subsequent Diversion header\n");
+			return -1;
+		}
+	}
 	return 0;
-error:
-	return -1;
 }
 
+int free_diversion_body(diversion_body_t *div_b)
+{
+	if(div_b != NULL) {
+		pkg_free(div_b);
+	}
+	return 0;
+}
 
 /*! \brief
  * Get the value of a given diversion parameter
@@ -99,7 +217,9 @@ str *get_diversion_param(struct sip_msg *msg, str *name)
 		return 0;
 	}
 
-	params = ((struct to_body *)(msg->diversion->parsed))->param_lst;
+	to_body_t *diversion =
+			get_diversion(msg)->id; /* This returns the first entry */
+	params = diversion->param_lst;
 
 	while(params) {
 		if((params->name.len == name->len)

--- a/src/core/parser/parse_diversion.h
+++ b/src/core/parser/parse_diversion.h
@@ -29,10 +29,21 @@
 #define PARSE_DIVERSION_H
 
 #include "msg_parser.h"
+#include "parse_addr_spec.h"
+
+/*! \brief
+ * Structure representing a Diversion header
+ */
+typedef struct diversion_body
+{
+	to_body_t *id;
+	int num_ids;
+	struct diversion_body *next; /*!< Next Diversion in the list */
+} diversion_body_t;
 
 
 /*! \brief casting macro for accessing Diversion body */
-#define get_diversion(p_msg) ((struct to_body *)(p_msg)->diversion->parsed)
+#define get_diversion(p_msg) ((diversion_body_t *)(p_msg)->diversion->parsed)
 
 
 /*! \brief
@@ -44,5 +55,10 @@ int parse_diversion_header(struct sip_msg *msg);
  * Get the value of a given diversion parameter
  */
 str *get_diversion_param(struct sip_msg *msg, str *name);
+
+/*! \brief
+ * Free the memory allocated for a Diversion header
+ */
+int free_diversion_body(diversion_body_t *div_b);
 
 #endif /* PARSE_DIVERSION_H */

--- a/src/modules/pv/pv_core.c
+++ b/src/modules/pv/pv_core.c
@@ -1100,7 +1100,7 @@ int pv_get_diversion(struct sip_msg *msg, pv_param_t *param, pv_value_t *res)
 	}
 
 	if(param->pvn.u.isname.name.n == 1) { /* uri */
-		return pv_get_strval(msg, param, res, &(get_diversion(msg)->uri));
+		return pv_get_strval(msg, param, res, &(get_diversion(msg)->id->uri));
 	}
 
 	if(param->pvn.u.isname.name.n == 2) { /* reason param */
@@ -2090,6 +2090,7 @@ int pv_get_hfl(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 	via_body_t *vb = NULL;
 	rr_t *rrb = NULL;
 	contact_t *cb = NULL;
+	diversion_body_t *db = NULL;
 	hdr_field_t *hf = NULL;
 	hdr_field_t thdr = {0};
 	int n = 0;
@@ -2335,6 +2336,58 @@ int pv_get_hfl(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 		return pv_get_null(msg, param, res);
 	}
 
+	if((tv.flags == 0) && (tv.ri == HDR_DIVERSION_T)) {
+		if(msg->diversion == NULL) {
+			LM_WARN("no Diversion header\n");
+			return pv_get_null(msg, param, res);
+		}
+
+		if(parse_diversion_header(msg) < 0) {
+			LM_WARN("failed to parse Diversion headers\n");
+			return pv_get_null(msg, param, res);
+		}
+
+		db = (diversion_body_t *)msg->diversion->parsed;
+		n = 0;
+
+		while(db != NULL) {
+			n += db->num_ids;
+			db = db->next;
+		}
+
+		if(idx < 0) {
+			idx = -idx;
+			if(idx > n) {
+				LM_WARN("index out of range\n");
+				return pv_get_null(msg, param, res);
+			}
+			idx = n - idx;
+		}
+
+		n = 0;
+		db = (diversion_body_t *)msg->diversion->parsed;
+		/* loop through all parsed Diversion headers lists */
+		while(db != NULL) {
+			if(n + db->num_ids > idx) {
+				/* Calculate the index within this specific list */
+				int innerIndex = idx - n;
+
+				/* Access the desired element within this list */
+				sval.s = db->id[innerIndex].body.s;
+				sval.len = db->id[innerIndex].body.len;
+				trim(&sval);
+				res->rs = sval;
+				return 0;
+			}
+
+			/* Move to the next Diversion header list */
+			n += db->num_ids;
+			db = db->next;
+		}
+		LM_DBG("unexpected diversion index out of range\n");
+		return pv_get_null(msg, param, res);
+	}
+
 	return pv_get_hdr_helper(msg, param, res, &tv, idx, idxf);
 }
 
@@ -2450,6 +2503,25 @@ int pv_get_hflc(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 			}
 		}
 		return pv_get_sintval(msg, param, res, n);
+	}
+
+	if((tv.flags == 0) && (tv.ri == HDR_DIVERSION_T)) {
+		if(msg->diversion == NULL) {
+			LM_DBG("no Diversion header\n");
+			return pv_get_sintval(msg, param, res, 0);
+		}
+		if(parse_diversion_header(msg) < 0) {
+			LM_DBG("failed to parse Diversion headers\n");
+			return pv_get_sintval(msg, param, res, 0);
+		}
+
+		diversion_body_t *db = (diversion_body_t *)msg->diversion->parsed;
+		int diversion_body_count = 0;
+		while(db != NULL) {
+			diversion_body_count += db->num_ids;
+			db = db->next;
+		}
+		return pv_get_sintval(msg, param, res, diversion_body_count);
 	}
 
 	for(hf = msg->headers; hf; hf = hf->next) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This PR adds support for $hfl(Diversion)[] and $hflc(Diversion).

This parse_diversion.c was inspired by [parse_pai_ppi.c](https://github.com/kamailio/kamailio/blob/master/src/core/parser/parse_ppi_pai.c). I am not sure if it's breaking the existing implementation and usage. 

Should probably also be documented in https://www.kamailio.org/wikidocs/cookbooks/devel/pseudovariables/#hflname-header-field-with-list-of-bodies. 

Any feedback and review is welcome.
