### PR TITLE
uac: fix socket length settings

### DIFF
--- a/src/modules/uac/uac_send.c
+++ b/src/modules/uac/uac_send.c
@@ -210,6 +210,7 @@ int pv_set_uac_req(
 				_uac_req.s_body.len = 0;
 				_uac_req.s_method.len = 0;
 				_uac_req.s_callid.len = 0;
+				_uac_req.s_sock.len = 0;
 				_uac_req.evroute = 0;
 				_uac_req.evtype = 0;
 				_uac_req.evcode = 0;
@@ -399,7 +400,7 @@ int pv_set_uac_req(
 			break;
 		case 12:
 			if(tval == NULL) {
-				_uac_req.s_apasswd.len = 0;
+				_uac_req.s_sock.len = 0;
 				return 0;
 			}
 			if(!(tval->flags & PV_VAL_STR)) {


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

This PR fixes the setting of uac_req object's socket length.
