### PR TITLE
utils: Prefer `printf` over `echo -e`.

### DIFF
--- a/pkg/kamailio/obs/kamailio.init
+++ b/pkg/kamailio/obs/kamailio.init
@@ -48,7 +48,7 @@ check_kamailio_config ()
         retcode=$?
         if [ "$retcode" != '0' ]; then
             echo "Not starting $PROG: invalid configuration file!"
-            echo -e "\n$out\n"
+            printf "\n$out\n\n"
             exit 1
         fi
 }

--- a/utils/kamctl/kamctl
+++ b/utils/kamctl/kamctl
@@ -86,7 +86,7 @@ fi
 if [ -f "$MYLIBDIR/kamctl.base" ]; then
 	. "$MYLIBDIR/kamctl.base"
 else
-	echo -e "Cannot load core functions '$MYLIBDIR/kamctl.base' - exiting ...\n"
+	printf "Cannot load core functions '%s' - exiting ...\n\n" "$MYLIBDIR/kamctl.base"
 	exit -1
 fi
 

--- a/utils/kamctl/kamctl.base
+++ b/utils/kamctl/kamctl.base
@@ -599,7 +599,7 @@ USAGE_FUNCTIONS="$USAGE_FUNCTIONS usage_acc"
 mdbg() {
 	if [ "0$VERBOSE" -ne 0 ] ; then
 		if [ -t 1 -a -z "$NOHLPRINT" ] ; then
-			echo -e "\033[1m$1\033[0m"
+			printf "\033[1m%s\033[0m\n" "$1"
 		else
 			echo "$1"
 		fi
@@ -608,7 +608,7 @@ mdbg() {
 
 mwarn() {
 	if [ -t 1 -a -z "$NOHLPRINT" ] ; then
-		echo -e '\E[37;32m'"\033[1mWARNING: $1\033[0m"
+		printf "\033[32;1mWARNING: %s\033[0m\n" "$1"
 	else
 		echo "** WARNING: $1"
 	fi
@@ -616,7 +616,7 @@ mwarn() {
 
 minfo() {
 	if [ -t 1 -a -z "$NOHLPRINT" ] ; then
-		echo -e '\E[37;33m'"\033[1mINFO: $1\033[0m"
+		printf "\033[33;1mINFO: %s\033[0m\n" "$1"
 	else
 		echo "** INFO: $1"
 	fi
@@ -624,7 +624,7 @@ minfo() {
 
 mecho() {
 	if [ -t 1 -a -z "$NOHLPRINT" ] ; then
-		echo -e "\033[1m$1\033[0m"
+		printf "\033[1m%s\033[0m\n" "$1"
 	else
 		echo "$1"
 	fi
@@ -632,7 +632,7 @@ mecho() {
 
 merr() {
 	if [ -t 1 -a -z "$NOHLPRINT" ] ; then
-		echo -e '\E[37;31m'"\033[1mERROR: $1\033[0m"
+		printf "\033[31;1mERROR: %s\033[0m\n" "$1"
 	else
 		echo "** ERROR: $1"
 	fi

--- a/utils/kamctl/kamdbctl
+++ b/utils/kamctl/kamdbctl
@@ -70,7 +70,7 @@ fi
 if [ -f "$MYLIBDIR/kamdbctl.base" ]; then
 	. "$MYLIBDIR/kamdbctl.base"
 else
-	echo -e "Cannot load core functions '$MYLIBDIR/kamdbctl.base' - exiting ...\n"
+	printf "Cannot load core functions '%s' - exiting ...\n\n" "$MYLIBDIR/kamdbctl.base"
 	exit -1
 fi
 
@@ -377,7 +377,7 @@ case $1 in
 		# create new database structures
 
 		# confirm dropping of database
-		echo -e "This will drop your current database.\nIt is recommended to first backup your database.\n"
+		printf "This will drop your current database.\nIt is recommended to first backup your database.\n\n"
 		get_answer ask "Continue with drop? (y/n): "
 		if [ "$ANSWER" != "y" ]; then
 			exit 1
@@ -396,7 +396,7 @@ case $1 in
 		# create new database structures
 
 		# confirm dropping of database
-		echo -e "This will drop your current database and create a new one.\nIt is recommended to first backup your database.\n"
+		printf "This will drop your current database and create a new one.\nIt is recommended to first backup your database.\n\n"
 		get_answer ask "Continue with reinit? (y/n): "
 		if [ "$ANSWER" != "y" ]; then
 			exit 1

--- a/utils/kamctl/kamdbctl.base
+++ b/utils/kamctl/kamdbctl.base
@@ -154,7 +154,7 @@ credentials()
 mdbg() {
 	if [ "0$VERBOSE" -ne 0 ] ; then
 		if [ -t 1 -a -z "$NOHLPRINT" ] ; then
-			echo -e "\033[1m$1\033[0m"
+			printf "\033[1m%s\033[0m\n" "$1"
 		else
 			echo "$1"
 		fi
@@ -163,7 +163,7 @@ mdbg() {
 
 mwarn() {
 	if [ -t 1 -a -z "$NOHLPRINT" ] ; then
-		echo -e '\E[37;32m'"\033[1mWARNING: $1\033[0m"
+		printf "\033[32;1mWARNING: %s\033[0m\n" "$1"
 	else
 		echo "** WARNING: $1"
 	fi
@@ -171,7 +171,7 @@ mwarn() {
 
 minfo() {
 	if [ -t 1 -a -z "$NOHLPRINT" ] ; then
-		echo -e '\E[37;33m'"\033[1mINFO: $1\033[0m"
+		printf "\033[33;1mINFO: %s\033[0m\n" "$1"
 	else
 		echo "** INFO: $1"
 	fi
@@ -179,7 +179,7 @@ minfo() {
 
 mecho() {
 	if [ -t 1 -a -z "$NOHLPRINT" ] ; then
-		echo -e "\033[1m$1\033[0m"
+		printf "\033[1m%s\033[0m\n" "$1"
 	else
 		echo "$1"
 	fi
@@ -187,7 +187,7 @@ mecho() {
 
 merr() {
 	if [ -t 1 -a -z "$NOHLPRINT" ] ; then
-		echo -e '\E[37;31m'"\033[1mERROR: $1\033[0m"
+		printf "\033[31;1mERROR: %s\033[0m\n" "$1"
 	else
 		echo "** ERROR: $1"
 	fi


### PR DESCRIPTION
On Ubuntu, `/bin/sh` defaults to `dash` whose built-in `echo` command does not support the `-e` flag. `printf`, on the other hand, supports backslash escapes by default so we use that instead.

In passing, also clean up some messy ANSI escape codes.
