### PR TITLE
tm: Update doc for t_check_trans()

### DIFF
--- a/src/modules/tm/doc/functions.xml
+++ b/src/modules/tm/doc/functions.xml
@@ -1480,11 +1480,19 @@ if (t_check_status("(487)|(408)")) {
 				</note>
 			</listitem>
 			<listitem>
-				<para>For other requests (non ACKs and non CANCELs), in case of
-				a retransmission matching a transaction, it resends the last
-				reply for that transaction and terminates the config execution.
-				Otherwise, it returns false (in case of new requests for which
-				no transaction exists yet).</para>
+				<para>
+				For other requests (non ACKs and non CANCELs):
+					<para>
+						In case of a retransmission matching a transaction,
+					it resends the last reply for that transaction and returns 0.
+					One must manually check against this return code and configure
+					to exit script exection if desired to do so.
+					</para>
+					<para>
+						In case of new requests for which no transaction
+					exists yet, it returns -1.
+					</para>
+				</para>
 			</listitem>
 		</itemizedlist>
 	</para>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
I was looking in code at how t_check_trans() works and updated doc. Please let me know if I understood correctly how it behaves for non-acks and non-cancel, when transaction is found.