### PR TITLE
cdp: fix disabled parts for openssl version newer than 1.1.0

### DIFF
--- a/src/modules/cdp/cdp_tls.c
+++ b/src/modules/cdp/cdp_tls.c
@@ -1,4 +1,3 @@
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 #include "cdp_tls.h"
 
 cfg_option_t methods[] = {{"TLSv1", .val = TLS_USE_TLSv1},
@@ -14,6 +13,7 @@ cfg_option_t methods[] = {{"TLSv1", .val = TLS_USE_TLSv1},
 
 tls_methods_t tls_methods[TLS_METHOD_MAX];
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 void init_ssl_methods(void)
 {
 	/* openssl 1.1.0+ */
@@ -76,10 +76,12 @@ void init_ssl_methods(void)
 	tls_methods[TLS_USE_TLSv1_3_PLUS - 1].TLSMethodMin = TLS1_3_VERSION;
 #endif
 }
+#endif
 
 /*
  * Convert TLS method string to integer
  */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 int tls_parse_method(str *m)
 {
 	cfg_option_t *opt;
@@ -95,7 +97,9 @@ int tls_parse_method(str *m)
 
 	return opt->val;
 }
+#endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 SSL_CTX *init_ssl_ctx(int method)
 {
 	SSL_CTX *ctx;
@@ -131,7 +135,9 @@ SSL_CTX *init_ssl_ctx(int method)
 	}
 	return ctx;
 }
+#endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 int load_certificates(SSL_CTX *ctx, str *cert, str *key)
 {
 	str cert_fixed = STR_NULL;
@@ -163,6 +169,7 @@ int load_certificates(SSL_CTX *ctx, str *cert, str *key)
 	}
 	return 0;
 }
+#endif
 
 /*
  * Get any leftover errors from OpenSSL and print them.
@@ -170,6 +177,7 @@ int load_certificates(SSL_CTX *ctx, str *cert, str *key)
  * This is useful to call before any SSL_* IO calls to make sure
  * we don't have any leftover errors from previous calls (OpenSSL docs).
  */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 void cdp_openssl_clear_errors(void)
 {
 	int i;
@@ -179,7 +187,9 @@ void cdp_openssl_clear_errors(void)
 		LM_INFO("clearing leftover error before SSL_* calls: %s\n", err);
 	}
 }
+#endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 SSL *init_ssl_conn(int client_fd, SSL_CTX *ctx)
 {
 	X509 *cert = NULL;
@@ -237,14 +247,18 @@ cleanup:
 
 	return NULL;
 }
+#endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 void cleanup_ssl(SSL_CTX *tls_ctx, SSL *tls_conn)
 {
 	SSL_shutdown(tls_conn);
 	SSL_free(tls_conn);
 	SSL_CTX_free(tls_ctx);
 }
+#endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 int to_ssl(SSL_CTX **tls_ctx_p, SSL **tls_conn_p, int tcp_sock, int method)
 {
 	*tls_ctx_p = init_ssl_ctx(method);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This PR fixes the disabled parts of the TLS code in cdp module which resulted in getting an error (**undefined symbol init_ssl_methods**) whenever cdp module was loaded and following openssl version was used.

```
openssl version
OpenSSL 1.1.1f  31 Mar 2020
```
