### PR TITLE
pv_core: Fix negative index bug for hfl()

### DIFF
--- a/src/modules/pv/pv_core.c
+++ b/src/modules/pv/pv_core.c
@@ -2149,7 +2149,7 @@ int pv_get_hfl(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 			return pv_get_null(msg, param, res);
 		}
 		if(idx < 0) {
-			n = 1;
+			n = 0;
 			/* count Via header bodies */
 			for(hf = msg->h_via1; hf != NULL; hf = hf->next) {
 				if(hf->type == HDR_VIA_T) {
@@ -2207,7 +2207,7 @@ int pv_get_hfl(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 		}
 
 		if(idx < 0) {
-			n = 1;
+			n = 0;
 			/* count Record-Route/Route header bodies */
 			for(; hf != NULL; hf = hf->next) {
 				if(hf->type == tv.ri) {
@@ -2290,7 +2290,7 @@ int pv_get_hfl(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 			return pv_get_null(msg, param, res);
 		}
 		if(idx < 0) {
-			n = 1;
+			n = 0;
 			/* count Contact header bodies */
 			for(hf = msg->contact; hf != NULL; hf = hf->next) {
 				if(hf->type == HDR_CONTACT_T) {


### PR DESCRIPTION
Before: -1 yielded null and -2 the last element of a header

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3653

#### Description
<!-- Describe your changes in detail -->

This PR fixes a bug referenced in #3653.

Before fix `$(hfl(HEADER)[-1]` where `HEADER='Via' | Contact | Route | Record-Route ` produced `null` instead of the last element of header.