### PR TITLE
parser/contact: Change addition order to the end of list

### DIFF
--- a/src/core/parser/contact/contact.c
+++ b/src/core/parser/contact/contact.c
@@ -208,6 +208,18 @@ static inline int skip_name(str *_s)
 	return -1;
 }
 
+static inline void contact_append(contact_t **head, contact_t *node)
+{
+	contact_t *ptr = *head;
+	if(*head == NULL) {
+		*head = node;
+		return;
+	}
+	while(ptr->next != NULL) {
+		ptr = ptr->next;
+	}
+	ptr->next = node;
+}
 
 /*
  * Parse contacts in a Contact HF
@@ -298,8 +310,7 @@ int parse_contacts(str *_s, contact_t **_c)
 		_s->len--;
 		trim_leading(_s);
 
-		c->next = *_c;
-		*_c = c;
+		contact_append(_c, c);
 		c = NULL;
 
 		if(_s->len == 0) {
@@ -318,8 +329,8 @@ error:
 
 ok:
 	c->len = _s->s - c->name.s;
-	c->next = *_c;
-	*_c = c;
+	contact_append(_c, c);
+	c = NULL;
 	return 0;
 }
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3653

#### Description
<!-- Describe your changes in detail -->
- Contacts are now added at the end of the list.
- hfl(Contact)[index] is now returning in the correct order.

Currently, if a sip message contains multiple Contacts or just 2, let's say 
```
Contact: <sip:bob0@example.com>;expires=3600,<sip:bob1@example.com>;expires=3600,<sip:bob2@example.com>;expires=3600
Contact: <sip:bob3@example.com>;expires=3600,<sip:bob4@example.com>;expires=3600,<sip:bob5@example.com>;expires=3600
```

contacts are stored in the reversed order, ie bob2, bob1,bob0 and bob5,bob4,bob3.

This can be seen with a simple config file such as:
```
#kamailio.cfg
...
request_route {
    ...
	xlog("L_INFO", "Contact headers: $hfl(Contact)\n");
	xlog("L_INFO", "Contact headers 0: $(hfl(Contact)[0])\n");
	xlog("L_INFO", "Contact headers 1: $(hfl(Contact)[1])\n");
	xlog("L_INFO", "Contact headers 2: $(hfl(Contact)[2])\n");
	xlog("L_INFO", "Contact headers 3: $(hfl(Contact)[3])\n");
	xlog("L_INFO", "Contact headers 4: $(hfl(Contact)[4])\n");
	xlog("L_INFO", "Contact headers 5: $(hfl(Contact)[5])\n");
	xlog("L_INFO", "Contact headers 6: $(hfl(Contact)[6])\n");
	xlog("L_INFO", "Contact headers 7: $(hfl(Contact)[7])\n");
	xlog("L_INFO", "Contact headers -1: $(hfl(Contact)[-1])\n");
	xlog("L_INFO", "Contact headers -2: $(hfl(Contact)[-2])\n");
	xlog("L_INFO", "Contact headers -3: $(hfl(Contact)[-3])\n");
	xlog("L_INFO", "Contact headers -4: $(hfl(Contact)[-4])\n");
	xlog("L_INFO", "Contact headers -5: $(hfl(Contact)[-5])\n");
	xlog("L_INFO", "Contact headers -6: $(hfl(Contact)[-6])\n");
```

that prints in the log all the contacts reversed:

```
Contact headers: <sip:bob2@example.com>;expires=3600
Contact headers 0: <sip:bob2@example.com>;expires=3600
Contact headers 1: <sip:bob1@example.com>;expires=3600
Contact headers 2: <sip:bob0@example.com>;expires=3600
Contact headers 3: <sip:bob5@example.com>;expires=3600
Contact headers 4: <sip:bob4@example.com>;expires=3600
Contact headers 5: <sip:bob3@example.com>;expires=3600
Contact headers 6: <null>
Contact headers 7: <null>
Contact headers -1: <sip:bob3@example.com>;expires=3600
Contact headers -2: <sip:bob4@example.com>;expires=3600
Contact headers -3: <sip:bob5@example.com>;expires=3600
Contact headers -4: <sip:bob0@example.com>;expires=3600
Contact headers -5: <sip:bob1@example.com>;expires=3600
Contact headers -6: <sip:bob2@example.com>;expires=3600
```

This PR fixes and produces:
```
Contact headers: <sip:bob0@example.com>;expires=3600
Contact headers 0: <sip:bob0@example.com>;expires=3600
Contact headers 1: <sip:bob1@example.com>;expires=3600
Contact headers 2: <sip:bob2@example.com>;expires=3600
Contact headers 3: <sip:bob3@example.com>;expires=3600
Contact headers 4: <sip:bob4@example.com>;expires=3600
Contact headers 5: <sip:bob5@example.com>;expires=3600
Contact headers 6: <null>
Contact headers 7: <null>
Contact headers -1: <null>
Contact headers -2: <sip:bob5@example.com>;expires=3600
Contact headers -3: <sip:bob4@example.com>;expires=3600
Contact headers -4: <sip:bob3@example.com>;expires=3600
Contact headers -5: <sip:bob2@example.com>;expires=3600
Contact headers -6: <sip:bob1@example.com>;expires=3600
```

The `contact headers -1: <null>` if fixed via #3697.
