### PR TITLE
src/Makefile.defs: recognize GCC 14 as recent ⇔  not too old compiler

### DIFF
--- a/src/Makefile.defs
+++ b/src/Makefile.defs
@@ -307,8 +307,8 @@ ifneq (,$(findstring gcc, $(CC_LONGVER)))
 					-e 's/8\.[0-9]$$/8.0+/' \
 					-e 's/9\.[0-9]\..*/9.0+/' \
 					-e 's/9\.[0-9]$$/9.0+/' \
-					-e 's/1[0-3]\.[0-9]\..*/9.0+/' \
-					-e 's/1[0-3]\.[0-9]$$/9.0+/')
+					-e 's/1[0-4]\.[0-9]\..*/9.0+/' \
+					-e 's/1[0-4]\.[0-9]$$/9.0+/')
 ifeq (,$(strip $(filter-out 3.0 3.4 4.x 4.2+ 4.5+ 5.0+ 6.0+ 7.0+ 8.0+ 9.0+,$(CC_SHORTVER))))
 	# dependencies can be generated on-the-fly while compiling *.c
 	CC_MKDEP_OPTS=-MMD -MP


### PR DESCRIPTION
similar to 87ed3d9c3ae3ecfabe6

GCC 14 will be released in April or May 2024.  Adding this now will avoid backporting the change to the 5.8 branch. (Not that 87ed3d9c3ae3ecfabe6 was backported to 5.7.)