### PR TITLE
dialog: don't send the BYE if dialog is in deleted state

### DIFF
--- a/src/modules/dialog/dlg_req_within.c
+++ b/src/modules/dialog/dlg_req_within.c
@@ -383,6 +383,14 @@ static inline int send_bye(struct dlg_cell *cell, int dir, str *hdrs)
 	dlg_iuid_t *iuid = NULL;
 	str lhdrs;
 
+	/* dialog is already in deleted state, nothing to do */
+	if(cell->state == DLG_STATE_DELETED) {
+		LM_WARN("dlg [%u:%u] with callid %.*s already in deleted state, BYE "
+				"not sent.\n",
+				cell->h_entry, cell->h_id, cell->callid.len, cell->callid.s);
+		return 0;
+	}
+
 	/* Send Cancel or final response for non-confirmed dialogs */
 	if(cell->state != DLG_STATE_CONFIRMED_NA
 			&& cell->state != DLG_STATE_CONFIRMED) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
We've recently been exeperiencing a core dump in dialog module. The core dump was caused by trying to terminate via rpc command a dialog that had just been terminated by one of the parties sending a BYE. That's because send_bye treats a deleted dialog as a non confimed one (https://github.com/kamailio/kamailio/blob/404b47791678c4eaccd4cfc7a83e0bb97a29b5d3/src/modules/dialog/dlg_req_within.c#L387) and tries then to access a transaction that does not exist anymore (https://github.com/kamailio/kamailio/blob/404b47791678c4eaccd4cfc7a83e0bb97a29b5d3/src/modules/dialog/dlg_req_within.c#L391) and crashes. 