### PR TITLE
core: Fix check to also work for KEMI framework

### DIFF
--- a/src/core/onsend.c
+++ b/src/core/onsend.c
@@ -87,7 +87,18 @@ int run_onsend(sip_msg_t *orig_msg, dest_info_t *dst, char *buf, int len)
 			orig_msg->fwd_send_flags = fwd_snd_flags_bak;
 			orig_msg->rpl_send_flags = rpl_snd_flags_bak;
 			exec_post_script_cb(orig_msg, ONSEND_CB_TYPE);
-			if((ret == 0) && !(ra_ctx.run_flags & DROP_R_F)) {
+			/*
+			 * KEMI case (python,lua,jsdt)
+			 * ret = 1 always
+			 * Native case:
+			 * ret = 1 success
+			 * ret = 0 drop the message
+			 */
+			if(ra_ctx.run_flags & DROP_R_F) {
+				ret = 0;
+			} else if(ret == 0) {
+				/* Native case where run_actions return 0
+				   but DROP_R_F is not set */
 				ret = 1;
 			}
 		} else {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This PR fixes an issue regarding KEMI framework for onsend_route.

KSR.set_drop() in [ksr_onsend_route](https://www.kamailio.org/wikidocs/cookbooks/5.7.x/core/#onsend_route) does not make kamailio dropping the message when using kemi (python3) (probably holds true for other engines too):

This is exactly the example from [documentation](https://kamailio.org/docs/tutorials/devel/kamailio-kemi-framework/kemimods/#ksrxdrop):
```
def ksr_onsend_route(self, msg):
  KSR.set_drop()
  exit()
```

The issue arises because we are not setting `ret = 0` when the drop flag is set, but instead check if it's not set to return `ret=1` (The case for native that returns `0` but no `DROP_R_F` was set).

**Note**:
KEMI Case: `ret = 1` always See [app_python3/apy_kemi.c](https://github.com/kamailio/kamailio/blob/79697b4d565665b696ee39021e27d82e716bc176/src/modules/app_python3/apy_kemi.c#L88-L92)
Native case: `ret` can be `0` for drop, or `1` for success