### PR TITLE
db_mysql: enable TLS when building with mariadb-connector-c

### DIFF
--- a/src/modules/db_mysql/doc/db_mysql_admin.xml
+++ b/src/modules/db_mysql/doc/db_mysql_admin.xml
@@ -46,6 +46,7 @@
 			<listitem>
 			<para>
 				<emphasis>mysql</emphasis> - the development libraries for the MySQL database. In some Linux distributions named "libmysqlclient-dev".
+				<emphasis>MariaDB</emphasis> - the development libraries for the MariaDB database. In some Linux distributions named "libmariadbclient-dev".
 			</para>
 			</listitem>
 			</itemizedlist>
@@ -198,7 +199,10 @@ modparam("db_mysql", "update_affected_found", 1)
 		defined.
 		</para>
 		<para>
-		Note: this option is supported only by libmysqlclient, not by libmariadbclient.
+                MariaDB client configuration uses the following values: 0, 1 use plain, 2/3/4 for MYSQL_OPT_SSL_ENFORCE,
+                5 for MYSQL_OPT_SSL_VERIFY_SERVER_CERT (see MariaDB Connector/C documentation)
+
+                Other values are ignored.
 		</para>
 		<para>
 		<emphasis>
@@ -298,4 +302,3 @@ default-character-set = utf8
 		</para>
 	</section>
 </chapter>
-

--- a/src/modules/db_mysql/km_my_con.c
+++ b/src/modules/db_mysql/km_my_con.c
@@ -116,7 +116,32 @@ struct my_con *db_mysql_new_connection(const struct db_id *id)
 			(const void *)&db_mysql_timeout_interval);
 	mysql_options(ptr->con, MYSQL_OPT_WRITE_TIMEOUT,
 			(const void *)&db_mysql_timeout_interval);
-#if MYSQL_VERSION_ID > 50710 && !defined(MARIADB_BASE_VERSION)
+
+#ifdef MARIADB_BASE_VERSION
+	/*
+	 * emulate SSL_MODE_XXXX from MySQL
+	 */
+
+	switch(db_mysql_opt_ssl_mode) {
+		case 0: /* opt_ssl_mode = 0(off) */
+		case 1: /* SSL_MODE_DISABLED */
+			break;
+		case 2: /* SSL_MODE_PREFERRED */
+		case 3: /* SSL_MODE_REQUIRED */
+		case 4: /* SSL_MODE_VERIFY_CA */
+			mysql_optionsv(ptr->con, MYSQL_OPT_SSL_ENFORCE, (void *)&(int){1});
+			break;
+		case 5: /* SSL_MODE_VERIFY_IDENTITY */
+			mysql_optionsv(ptr->con, MYSQL_OPT_SSL_VERIFY_SERVER_CERT,
+					(void *)&(int){1});
+			break;
+		default:
+			LM_WARN("opt_ssl_mode = %d not supported by MariaDB Connector/C\n",
+					db_mysql_opt_ssl_mode);
+			break;
+	}
+#else
+#ifdef MYSQL_VERSION_ID> 50710
 	if(db_mysql_opt_ssl_mode != 0) {
 		unsigned int optuint = 0;
 		if(db_mysql_opt_ssl_mode == 1) {
@@ -136,7 +161,8 @@ struct my_con *db_mysql_new_connection(const struct db_id *id)
 				"ignoring\n",
 				(unsigned int)db_mysql_opt_ssl_mode);
 	}
-#endif
+#endif /* MYSQL_VERSION_ID */
+#endif /* MARIADB_BASE_VERSION */
 
 #if MYSQL_VERSION_ID > 50012
 	/* set reconnect flag if enabled */


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X]  Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #3735

#### Description
When db_mysql is built with mariadb-connector-c it does not use TLS and fails if the server requires TLS. It seems to be related to the fact that the MYSQL object needs to have a minimal non-NULL configuration (unlike MySQL Connector/C).

This is a minimal setting to allow TLS. A more full-featured solution would be to enable db_mysql to read from an external configuration file.

@linuxmaniac, kindly take a look

UPDATE: the flag is MYSQL_OPT_SSL_ENFORCE which uses TLS if server advertises it. It does not make TLS mandatory (i..e doesn't fail if server has no TLS)

UPDATE: reuse module param `opt_ssl_mode` to configure MariaDB Connector/C.

Use existing `opt_ssl_mode` and map as follows.:

1. 0(off), 1(SSL_MODE_DISABLED): mariadb-connector-c defaults
2. 2(SSL_MODE_PREFERRED)  3(SSL_MODE_REQUIRED) 4(SSL_MODE_VERIFY_CA): `MYSQL_OPT_SSL_ENFORCE`
3. 5(SSL_MODE_VERIFY_IDENTITY): `MYSQL_OPT_SSL_VERIFY_SERVER_CERT`
