### PR TITLE
core: infra to run functions in threads

### DIFF
--- a/src/core/rthreads.h
+++ b/src/core/rthreads.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2024 Chan Shih-Ping
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * A set of helpers to run functions in threads.
+ *
+ * This is not a thread pool implementation -
+ * - it runs functions in a run-once thread to avoid
+ * creating thread-locals in the calling thread.
+ *
+ * Primary use case: to init libssl in a separate thread
+ */
+#include <pthread.h>
+
+/*
+ * void *fn(void *arg) { ... }
+ */
+typedef void *(*_thread_proto)(void *);
+#ifndef KSR_RTHREAD_SKIP_P
+static void *run_threadP(_thread_proto fn, void *arg)
+{
+	pthread_t tid;
+	void *ret;
+
+	pthread_create(&tid, NULL, fn, arg);
+	pthread_join(tid, &ret);
+
+	return ret;
+}
+#endif
+
+/*
+ * void *fn(void *arg1, int arg2) { ... }
+ */
+#ifdef KSR_RTHREAD_NEED_PI
+typedef void *(*_thread_protoPI)(void *, int);
+struct _thread_argsPI
+{
+	_thread_protoPI fn;
+	void *tptr;
+	int tint;
+};
+static void *run_thread_wrapPI(struct _thread_argsPI *args)
+{
+	return (*args->fn)(args->tptr, args->tint);
+}
+
+static void *run_threadPI(_thread_protoPI fn, void *arg1, int arg2)
+{
+	pthread_t tid;
+	void *ret;
+
+	pthread_create(&tid, NULL, (_thread_proto)&run_thread_wrapPI,
+			&(struct _thread_argsPI){fn, arg1, arg2});
+	pthread_join(tid, &ret);
+
+	return ret;
+}
+#endif
+
+/*
+ * void *fn(void *arg1, int arg2) { ... }
+ */
+#ifdef KSR_RTHREAD_NEED_V
+typedef void (*_thread_protoV)(void);
+struct _thread_argsV
+{
+	_thread_protoV fn;
+};
+static void *run_thread_wrapV(struct _thread_argsV *args)
+{
+	(*args->fn)();
+	return NULL;
+}
+
+static void run_threadV(_thread_protoV fn)
+{
+	pthread_t tid;
+
+	pthread_create(&tid, NULL, (_thread_proto)run_thread_wrapV,
+			&(struct _thread_argsV){fn});
+	pthread_join(tid, NULL);
+}
+#endif

--- a/src/modules/db_mysql/km_dbase.c
+++ b/src/modules/db_mysql/km_dbase.c
@@ -34,11 +34,11 @@
 #include <stdio.h>
 #include <string.h>
 #include <mysql.h>
-#include <pthread.h>
 #include <errmsg.h>
 #include "../../core/mem/mem.h"
 #include "../../core/dprint.h"
 #include "../../core/async_task.h"
+#include "../../core/rthreads.h"
 #include "../../lib/srdb1/db_query.h"
 #include "../../lib/srdb1/db_ut.h"
 #include "db_mysql.h"
@@ -213,13 +213,7 @@ static db1_con_t *db_mysql_init0(const str *_url)
 
 db1_con_t *db_mysql_init(const str *_url)
 {
-	pthread_t tid;
-	db1_con_t *ret;
-
-	pthread_create(&tid, NULL, (void *(*)(void *))db_mysql_init0, (void *)_url);
-	pthread_join(tid, (void **)&ret);
-
-	return ret;
+	return run_threadP((_thread_proto)db_mysql_init0, (void *)_url);
 }
 /**
  * Shut down the database module.

--- a/src/modules/db_unixodbc/dbase.c
+++ b/src/modules/db_unixodbc/dbase.c
@@ -22,10 +22,10 @@
  *
  */
 
-#include <pthread.h>
 #include "../../core/mem/mem.h"
 #include "../../core/dprint.h"
 #include "../../core/async_task.h"
+#include "../../core/rthreads.h"
 #include "../../lib/srdb1/db_query.h"
 #include "val.h"
 #include "connection.h"
@@ -241,14 +241,7 @@ static db1_con_t *db_unixodbc_init0(const str *_url)
 
 db1_con_t *db_unixodbc_init(const str *_url)
 {
-	pthread_t tid;
-	db1_con_t *ret;
-
-	pthread_create(
-			&tid, NULL, (void *(*)(void *))db_unixodbc_init0, (void *)_url);
-	pthread_join(tid, (void **)&ret);
-
-	return ret;
+	return run_threadP((_thread_proto)&db_unixodbc_init0, (void *)_url);
 }
 
 /*

--- a/src/modules/outbound/outbound_mod.c
+++ b/src/modules/outbound/outbound_mod.c
@@ -40,6 +40,10 @@
 #include "../../core/parser/parse_uri.h"
 #include "../../core/parser/parse_supported.h"
 
+#define KSR_RTHREAD_SKIP_P
+#define KSR_RTHREAD_NEED_V
+#include "../../core/rthreads.h"
+
 #include "api.h"
 #include "config.h"
 
@@ -75,26 +79,25 @@ struct module_exports exports = {
 		destroy						 /* destroy function */
 };
 
-static void *mod_init_openssl(void *arg) {
-    if(flow_token_secret.s) {
-        assert(ob_key.len == SHA_DIGEST_LENGTH);
-        LM_DBG("flow_token_secret mod param set. use persistent ob_key");
+static void mod_init_openssl(void)
+{
+	if(flow_token_secret.s) {
+		assert(ob_key.len == SHA_DIGEST_LENGTH);
+		LM_DBG("flow_token_secret mod param set. use persistent ob_key");
 #if OPENSSL_VERSION_NUMBER < 0x030000000L
-        SHA1((const unsigned char *)flow_token_secret.s, flow_token_secret.len,
-             (unsigned char *)ob_key.s);
+		SHA1((const unsigned char *)flow_token_secret.s, flow_token_secret.len,
+				(unsigned char *)ob_key.s);
 #else
-        EVP_Q_digest(NULL, "SHA1", NULL, flow_token_secret.s,
-                     flow_token_secret.len, (unsigned char *)ob_key.s, NULL);
+		EVP_Q_digest(NULL, "SHA1", NULL, flow_token_secret.s,
+				flow_token_secret.len, (unsigned char *)ob_key.s, NULL);
 #endif
-    } else {
-        if(RAND_bytes((unsigned char *)ob_key.s, ob_key.len) == 0) {
-            LM_ERR("unable to get %d cryptographically strong pseudo-"
-                   "random bytes\n",
-                   ob_key.len);
-        }
-    }
-
-    return NULL;
+	} else {
+		if(RAND_bytes((unsigned char *)ob_key.s, ob_key.len) == 0) {
+			LM_ERR("unable to get %d cryptographically strong pseudo-"
+				   "random bytes\n",
+					ob_key.len);
+		}
+	}
 }
 
 static int mod_init(void)
@@ -116,12 +119,9 @@ static int mod_init(void)
 	ob_key.len = OB_KEY_LEN;
 
 #if OPENSSL_VERSION_NUMBER < 0x010101000L
-        mod_init_openssl(NULL);
+	mod_init_openssl(NULL);
 #else
-        pthread_t tid;
-        void *retval;
-        pthread_create(&tid, NULL, mod_init_openssl, NULL);
-        pthread_join(tid, &retval);
+	run_threadV(mod_init_openssl);
 #endif
 
 	if(cfg_declare("outbound", outbound_cfg_def, &default_outbound_cfg,


### PR DESCRIPTION
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Introduce utility functions that run module functions in a run-once thread —- primary use case is to init libssl in a thread. Also to avoid a lot of duplicate pthread_XXXX code.

Does not affect core as it is just a header file, however it could be put into core or a utility object.

This infra is applied to a few modules to see the code savings.
