### PR TITLE
5.7 db modules: init libssl in a thread

### DIFF
--- a/src/core/rthreads.h
+++ b/src/core/rthreads.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 Chan Shih-Ping
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * A set of helpers to run functions in threads.
+ *
+ * This is not a thread pool implementation -
+ * - it runs functions in a run-once thread to avoid
+ * creating thread-locals in the calling thread.
+ *
+ * Primary use case: to init libssl in a separate thread
+ */
+#include <pthread.h>
+
+/*
+ * prototype: void *fn(void *arg) { ... }
+ */
+typedef void *(*_thread_proto)(void *);
+
+#ifndef KSR_RTHREAD_SKIP_P
+static void *run_threadP(_thread_proto fn, void *arg)
+{
+	pthread_t tid;
+	void *ret;
+
+	pthread_create(&tid, NULL, fn, arg);
+	pthread_join(tid, &ret);
+
+	return ret;
+}
+#endif
+
+/*
+ * prototype: void *fn(void *arg1, int arg2) { ... }
+ */
+#ifdef KSR_RTHREAD_NEED_PI
+typedef void *(*_thread_protoPI)(void *, int);
+struct _thread_argsPI
+{
+	_thread_protoPI fn;
+	void *tptr;
+	int tint;
+};
+static void *run_thread_wrapPI(struct _thread_argsPI *args)
+{
+	return (*args->fn)(args->tptr, args->tint);
+}
+
+static void *run_threadPI(_thread_protoPI fn, void *arg1, int arg2)
+{
+	pthread_t tid;
+	void *ret;
+
+	pthread_create(&tid, NULL, (_thread_proto)&run_thread_wrapPI,
+			&(struct _thread_argsPI){fn, arg1, arg2});
+	pthread_join(tid, &ret);
+
+	return ret;
+}
+#endif
+
+/*
+ * prototype: void fn(void) { ... }
+ */
+#ifdef KSR_RTHREAD_NEED_V
+typedef void (*_thread_protoV)(void);
+struct _thread_argsV
+{
+	_thread_protoV fn;
+};
+static void *run_thread_wrapV(struct _thread_argsV *args)
+{
+	(*args->fn)();
+	return NULL;
+}
+
+static void run_threadV(_thread_protoV fn)
+{
+	pthread_t tid;
+
+	pthread_create(&tid, NULL, (_thread_proto)run_thread_wrapV,
+			&(struct _thread_argsV){fn});
+	pthread_join(tid, NULL);
+}
+#endif

--- a/src/modules/db_mysql/km_dbase.c
+++ b/src/modules/db_mysql/km_dbase.c
@@ -38,6 +38,7 @@
 #include "../../core/mem/mem.h"
 #include "../../core/dprint.h"
 #include "../../core/async_task.h"
+#include "../../core/rthreads.h"
 #include "../../lib/srdb1/db_query.h"
 #include "../../lib/srdb1/db_ut.h"
 #include "db_mysql.h"
@@ -197,8 +198,10 @@ static char *db_mysql_tquote = "`";
  * No function should be called before this
  * \param _url URL used for initialization
  * \return zero on success, negative value on failure
+ *
+ * Init libssl in a thread
  */
-db1_con_t *db_mysql_init(const str *_url)
+static db1_con_t *db_mysql_init0(const str *_url)
 {
 	db1_con_t *c;
 	c = db_do_init(_url, (void *)db_mysql_new_connection);
@@ -208,6 +211,10 @@ db1_con_t *db_mysql_init(const str *_url)
 }
 
 
+db1_con_t *db_mysql_init(const str *_url)
+{
+	return run_threadP((_thread_proto)db_mysql_init0, (void *)_url);
+}
 /**
  * Shut down the database module.
  * No function should be called after this


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [X] Related to issue #3738 (replace XXXX with an open issue number)

#### Description
5.7.4 has OpenSSL fixes for tls and outbound but missed out the db modules—the most common users of libssl

This PR updates db_mysql, db_unixodbc, db_postgres to init libssl in a thread to handle more configurations (tls + db module)

This PR syncs all the OpenSSL thread-local fixes from master to 5.7


