### PR TITLE
libssl thread guards: restrict execution to process_no = 0

### DIFF
--- a/src/core/rthreads.h
+++ b/src/core/rthreads.h
@@ -195,3 +195,55 @@ static void run_thread0P(_thread_proto0P fn, void *arg1)
 #endif /* USE_TLS */
 }
 #endif
+
+/*
+ * prototype:
+ * db_unixodbc_query(const db1_con_t *_h, const db_key_t *_k,
+ *    const db_op_t *_op, const db_val_t *_v, const db_key_t *_c,
+ *    const int _n, const int _nc, const db_key_t _o, db1_res_t **_r)
+ */
+#ifdef KSR_RTHREAD_NEED_4P5I2P2
+typedef int (*_thread_proto4P5I2P2)(
+		void *, void *, void *, void *, void *, int, int, void *, void *);
+struct _thread_args4P5I2P2
+{
+	_thread_proto4P5I2P2 fn;
+	void *arg1;
+	void *arg2;
+	void *arg3;
+	void *arg4;
+	void *arg5;
+	int arg6;
+	int arg7;
+	void *arg8;
+	void *arg9;
+	int *ret;
+};
+static void *run_thread_wrap4P5I2P2(struct _thread_args4P5I2P2 *args)
+{
+	*args->ret = (*args->fn)(args->arg1, args->arg2, args->arg3, args->arg4,
+			args->arg5, args->arg6, args->arg7, args->arg8, args->arg9);
+	return NULL;
+}
+
+static int run_thread4P5I2P2(_thread_proto4P5I2P2 fn, void *arg1, void *arg2,
+		void *arg3, void *arg4, void *arg5, int arg6, int arg7, void *arg8,
+		void *arg9)
+{
+#ifdef USE_TLS
+	pthread_t tid;
+	int ret;
+
+	if(likely(process_no)) {
+		return fn(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+	}
+	pthread_create(&tid, NULL, (_thread_proto)run_thread_wrap4P5I2P2,
+			&(struct _thread_args4P5I2P2){fn, arg1, arg2, arg3, arg4, arg5,
+					arg6, arg7, arg8, arg9, &ret});
+	pthread_join(tid, NULL);
+	return ret;
+#else
+	return fn(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+#endif
+}
+#endif

--- a/src/core/rthreads.h
+++ b/src/core/rthreads.h
@@ -35,13 +35,20 @@ typedef void *(*_thread_proto)(void *);
 #ifndef KSR_RTHREAD_SKIP_P
 static void *run_threadP(_thread_proto fn, void *arg)
 {
+#ifdef USE_TLS
 	pthread_t tid;
 	void *ret;
 
+	if(likely(process_no)) {
+		return fn(arg);
+	}
 	pthread_create(&tid, NULL, fn, arg);
 	pthread_join(tid, &ret);
 
 	return ret;
+#else
+	return fn(arg);
+#endif /* USE_TLS */
 }
 #endif
 
@@ -63,14 +70,21 @@ static void *run_thread_wrapPI(struct _thread_argsPI *args)
 
 static void *run_threadPI(_thread_protoPI fn, void *arg1, int arg2)
 {
+#ifdef USE_TLS
 	pthread_t tid;
 	void *ret;
+	if(likely(process_no)) {
+		return fn(arg1, arg2);
+	}
 
 	pthread_create(&tid, NULL, (_thread_proto)&run_thread_wrapPI,
 			&(struct _thread_argsPI){fn, arg1, arg2});
 	pthread_join(tid, &ret);
 
 	return ret;
+#else
+	return fn(arg1, arg2);
+#endif /* USE_TLS */
 }
 #endif
 
@@ -91,11 +105,20 @@ static void *run_thread_wrapV(struct _thread_argsV *args)
 
 static void run_threadV(_thread_protoV fn)
 {
+#ifdef USE_TLS
 	pthread_t tid;
+	if(likely(process_no)) {
+		fn();
+		return;
+	}
+
 
 	pthread_create(&tid, NULL, (_thread_proto)run_thread_wrapV,
 			&(struct _thread_argsV){fn});
 	pthread_join(tid, NULL);
+#else
+	fn();
+#endif /* USE_TLS */
 }
 #endif
 
@@ -119,14 +142,22 @@ static void *run_thread_wrap4PP(struct _thread_args4PP *args)
 
 static int run_thread4PP(_thread_proto4PP fn, void *arg1, void *arg2)
 {
+#ifdef USE_TLS
 	pthread_t tid;
 	int ret;
+
+	if(likely(process_no)) {
+		return fn(arg1, arg2);
+	}
 
 	pthread_create(&tid, NULL, (_thread_proto)run_thread_wrap4PP,
 			&(struct _thread_args4PP){fn, arg1, arg2, &ret});
 	pthread_join(tid, NULL);
 
 	return ret;
+#else
+	return fn(arg1, arg2);
+#endif
 }
 #endif
 
@@ -148,10 +179,19 @@ static void *run_thread_wrap0P(struct _thread_args0P *args)
 
 static void run_thread0P(_thread_proto0P fn, void *arg1)
 {
+#ifdef USE_TLS
 	pthread_t tid;
+
+	if(likely(process_no)) {
+		fn(arg1);
+		return;
+	}
 
 	pthread_create(&tid, NULL, (_thread_proto)run_thread_wrap0P,
 			&(struct _thread_args0P){fn, arg1});
 	pthread_join(tid, NULL);
+#else
+	fn(arg1);
+#endif /* USE_TLS */
 }
 #endif

--- a/src/modules/db_mysql/km_dbase.c
+++ b/src/modules/db_mysql/km_dbase.c
@@ -40,6 +40,7 @@
 #include "../../core/async_task.h"
 
 #define KSR_RTHREAD_NEED_4PP
+#define KSR_RTHREAD_NEED_0P
 #include "../../core/rthreads.h"
 #include "../../lib/srdb1/db_query.h"
 #include "../../lib/srdb1/db_ut.h"
@@ -228,9 +229,14 @@ db1_con_t *db_mysql_init(const str *_url)
  * \param _h handle to the closed connection
  * \return zero on success, negative value on failure
  */
-void db_mysql_close(db1_con_t *_h)
+static void db_mysql_close_impl(db1_con_t *_h)
 {
 	db_do_close(_h, db_mysql_free_connection);
+}
+
+void db_mysql_close(db1_con_t *_h)
+{
+	run_thread0P((_thread_proto0P)db_mysql_close_impl, _h);
 }
 
 

--- a/src/modules/db_postgres/km_dbase.c
+++ b/src/modules/db_postgres/km_dbase.c
@@ -45,6 +45,7 @@
 #include "../../core/clist.h"
 #define KSR_RTHREAD_NEED_PI
 #define KSR_RTHREAD_NEED_4PP
+#define KSR_RTHREAD_NEED_0P
 #include "../../core/rthreads.h"
 #include "km_dbase.h"
 #include "km_pg_con.h"
@@ -147,9 +148,14 @@ db1_con_t *db_postgres_init2(const str *_url, db_pooling_t pooling)
  * \param _h closed connection, as returned from db_postgres_init
  * \note free all memory and resources
  */
-void db_postgres_close(db1_con_t *_h)
+static void db_postgres_close_impl(db1_con_t *_h)
 {
 	db_do_close(_h, db_postgres_free_connection);
+}
+
+void db_postgres_close(db1_con_t *_h)
+{
+	run_thread0P((_thread_proto0P)db_postgres_close_impl, _h);
 }
 
 


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
@henningw @miconda this is a draft for the 5.7 stable branch which disables threading for process_no > 0. This restricts thread wrappers to the parent process.

I have done a quick smoke-test in my testlab and this seems to work (i.e. use threads only in process#0)

[Update] audit all libssl calls in default kamailio.cfg with MariaDB/PostgreSQL(and unixODBC variants).  All functions that call libssl have thread guards