### PR TITLE
ldap: option to start even when connecting to ldap server fails

### DIFF
--- a/src/modules/ldap/doc/ldap_admin.xml
+++ b/src/modules/ldap/doc/ldap_admin.xml
@@ -455,6 +455,23 @@ modparam("ldap", "config_file", "/usr/local/etc/&kamailiobinary;/ldap.ini")
 		  </programlisting>
         </example>
       </section>
+
+      <section>
+        <title><varname>connect_mode</varname> (int)</title>
+
+        <para>Control if the module must stop loading when connecting to server fails during start up. Values: 0 - stop loading; 1 - continue even if connecting to database server fails..</para>
+        <para>Default value:
+        <varname>0</varname></para>
+
+        <example>
+          <title>Set <varname>connect_mode</varname> parameter</title>
+
+          <programlisting format="linespecific">
+modparam("ldap", "connect_mode", 1)
+		      </programlisting>
+        </example>
+      </section>
+
     </section>
 
     <section>
@@ -1079,4 +1096,3 @@ if (ldap_search(
       </section>
     </section>
   </chapter>
-

--- a/src/modules/ldap/ldap_mod.c
+++ b/src/modules/ldap/ldap_mod.c
@@ -80,6 +80,7 @@ static int w_ldap_result_check_2(
 * Default module parameter values
 */
 #define DEF_LDAP_CONFIG "/usr/local/etc/kamailio/ldap.cfg"
+static int ldap_connect_mode = 0;
 
 /*
 * Module parameter variables
@@ -125,6 +126,7 @@ static cmd_export_t cmds[] = {
 static param_export_t params[] = {
 
 	{"config_file",          PARAM_STR, &ldap_config},
+	{"connect_mode",    PARAM_INT, &ldap_connect_mode},
 	{0, 0, 0}
 };
 
@@ -151,6 +153,7 @@ static int child_init(int rank)
 {
 	int i = 0, ld_count = 0;
 	char *ld_name;
+	int ret = 0;
 
 	/* don't do anything for non-worker processes */
 	if(rank == PROC_INIT || rank == PROC_MAIN || rank == PROC_TCP_MAIN)
@@ -168,9 +171,15 @@ static int child_init(int rank)
 		}
 
 		if(oldap_connect(ld_name) != 0) {
-			LM_ERR("[%s]: failed to connect to LDAP host(s)\n", ld_name);
-			ldap_disconnect(ld_name);
-			return -1;
+			if(ldap_connect_mode == 1) {
+				LM_INFO("[%s]: Failed to connect to LDAP host(s) but start "
+						"without connection enabled - proceed",
+						ld_name);
+			} else {
+				LM_ERR("[%s]: failed to connect to LDAP host(s)\n", ld_name);
+				ldap_disconnect(ld_name);
+				return -1;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This PR aims to give the option for ldap to allow kamailio to start-up even if server is not reachable/available when starting.
It follows similar logic to https://github.com/kamailio/kamailio/commit/2df43b992b1e6932974bd0c928c0465a839b75da for SQL.

A new config parameter for `ldap` module is defined, `connect_mode`, that defaults to 0, preserving the old behavior. If it's set `1`, `kamailio` will not exit and allow `ldap` to try and reconnect when necessary.