### PR TITLE
libssl thread guards: audit of kamailio.cfg with MariaDB/PostgreSQL/unixODBC

### DIFF
--- a/src/core/rthreads.h
+++ b/src/core/rthreads.h
@@ -201,3 +201,56 @@ static void run_thread0P(_thread_proto0P fn, void *arg1)
 #endif
 }
 #endif
+
+/*
+ * prototype:
+ * db_unixodbc_query(const db1_con_t *_h, const db_key_t *_k,
+ *    const db_op_t *_op, const db_val_t *_v, const db_key_t *_c,
+ *    const int _n, const int _nc, const db_key_t _o, db1_res_t **_r)
+ */
+#ifdef KSR_RTHREAD_NEED_4P5I2P2
+typedef int (*_thread_proto4P5I2P2)(
+		void *, void *, void *, void *, void *, int, int, void *, void *);
+struct _thread_args4P5I2P2
+{
+	_thread_proto4P5I2P2 fn;
+	void *arg1;
+	void *arg2;
+	void *arg3;
+	void *arg4;
+	void *arg5;
+	int arg6;
+	int arg7;
+	void *arg8;
+	void *arg9;
+	int *ret;
+};
+static void *run_thread_wrap4P5I2P2(struct _thread_args4P5I2P2 *args)
+{
+	*args->ret = (*args->fn)(args->arg1, args->arg2, args->arg3, args->arg4,
+			args->arg5, args->arg6, args->arg7, args->arg8, args->arg9);
+	return NULL;
+}
+
+static int run_thread4P5I2P2(_thread_proto4P5I2P2 fn, void *arg1, void *arg2,
+		void *arg3, void *arg4, void *arg5, int arg6, int arg7, void *arg8,
+		void *arg9)
+{
+#ifdef USE_TLS
+	pthread_t tid;
+	int ret;
+
+	if(likely(ksr_tls_threads_mode == 0
+			   || (ksr_tls_threads_mode == 1 && process_no > 0))) {
+		return fn(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+	}
+	pthread_create(&tid, NULL, (_thread_proto)run_thread_wrap4P5I2P2,
+			&(struct _thread_args4P5I2P2){fn, arg1, arg2, arg3, arg4, arg5,
+					arg6, arg7, arg8, arg9, &ret});
+	pthread_join(tid, NULL);
+	return ret;
+#else
+	return fn(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+#endif
+}
+#endif

--- a/src/modules/db_mysql/km_dbase.c
+++ b/src/modules/db_mysql/km_dbase.c
@@ -40,6 +40,7 @@
 #include "../../core/async_task.h"
 
 #define KSR_RTHREAD_NEED_4PP
+#define KSR_RTHREAD_NEED_0P
 #include "../../core/rthreads.h"
 #include "../../lib/srdb1/db_query.h"
 #include "../../lib/srdb1/db_ut.h"
@@ -228,9 +229,14 @@ db1_con_t *db_mysql_init(const str *_url)
  * \param _h handle to the closed connection
  * \return zero on success, negative value on failure
  */
-void db_mysql_close(db1_con_t *_h)
+static void db_mysql_close_impl(db1_con_t *_h)
 {
 	db_do_close(_h, db_mysql_free_connection);
+}
+
+void db_mysql_close(db1_con_t *_h)
+{
+	run_thread0P((_thread_proto0P)db_mysql_close_impl, _h);
 }
 
 

--- a/src/modules/db_postgres/km_dbase.c
+++ b/src/modules/db_postgres/km_dbase.c
@@ -45,6 +45,7 @@
 #include "../../core/clist.h"
 #define KSR_RTHREAD_NEED_PI
 #define KSR_RTHREAD_NEED_4PP
+#define KSR_RTHREAD_NEED_0P
 #include "../../core/rthreads.h"
 #include "km_dbase.h"
 #include "km_pg_con.h"
@@ -147,9 +148,14 @@ db1_con_t *db_postgres_init2(const str *_url, db_pooling_t pooling)
  * \param _h closed connection, as returned from db_postgres_init
  * \note free all memory and resources
  */
-void db_postgres_close(db1_con_t *_h)
+static void db_postgres_close_impl(db1_con_t *_h)
 {
 	db_do_close(_h, db_postgres_free_connection);
+}
+
+void db_postgres_close(db1_con_t *_h)
+{
+	run_thread0P((_thread_proto0P)db_postgres_close_impl, _h);
 }
 
 

--- a/src/modules/db_unixodbc/dbase.c
+++ b/src/modules/db_unixodbc/dbase.c
@@ -26,6 +26,8 @@
 #include "../../core/dprint.h"
 #include "../../core/async_task.h"
 #define KSR_RTHREAD_NEED_4PP
+#define KSR_RTHREAD_NEED_4P5I2P2
+#define KSR_RTHREAD_NEED_0P
 #include "../../core/rthreads.h"
 #include "../../lib/srdb1/db_query.h"
 #include "val.h"
@@ -254,9 +256,14 @@ db1_con_t *db_unixodbc_init(const str *_url)
  * Shut down database module
  * No function should be called after this
  */
-void db_unixodbc_close(db1_con_t *_h)
+static void db_unixodbc_close_impl(db1_con_t *_h)
 {
 	return db_do_close(_h, db_unixodbc_free_connection);
+}
+
+void db_unixodbc_close(db1_con_t *_h)
+{
+	run_thread0P((_thread_proto0P)db_unixodbc_close_impl, _h);
 }
 
 /*
@@ -299,7 +306,7 @@ static int db_unixodbc_store_result(const db1_con_t *_h, db1_res_t **_r)
 /*
  * Release a result set from memory
  */
-int db_unixodbc_free_result(db1_con_t *_h, db1_res_t *_r)
+static int db_unixodbc_free_result_impl(db1_con_t *_h, db1_res_t *_r)
 {
 	if((!_h) || (!_r)) {
 		LM_ERR("invalid parameter value\n");
@@ -315,6 +322,12 @@ int db_unixodbc_free_result(db1_con_t *_h, db1_res_t *_r)
 	return 0;
 }
 
+int db_unixodbc_free_result(db1_con_t *_h, db1_res_t *_r)
+{
+	return run_thread4PP(
+			(_thread_proto4PP)db_unixodbc_free_result_impl, _h, _r);
+}
+
 /*
  * Query table for specified rows
  * _h: structure representing database connection
@@ -326,13 +339,22 @@ int db_unixodbc_free_result(db1_con_t *_h, db1_res_t *_r)
  * _nc: number of columns to return
  * _o: order by the specified column
  */
-int db_unixodbc_query(const db1_con_t *_h, const db_key_t *_k,
+static int db_unixodbc_query_impl(const db1_con_t *_h, const db_key_t *_k,
 		const db_op_t *_op, const db_val_t *_v, const db_key_t *_c,
 		const int _n, const int _nc, const db_key_t _o, db1_res_t **_r)
 {
 	return db_do_query(_h, _k, _op, _v, _c, _n, _nc, _o, _r,
 			db_unixodbc_val2str, db_unixodbc_submit_query,
 			db_unixodbc_store_result);
+}
+
+int db_unixodbc_query(const db1_con_t *_h, const db_key_t *_k,
+		const db_op_t *_op, const db_val_t *_v, const db_key_t *_c,
+		const int _n, const int _nc, const db_key_t _o, db1_res_t **_r)
+{
+	return run_thread4P5I2P2((_thread_proto4P5I2P2)db_unixodbc_query_impl,
+			(void *)_h, (void *)_k, (void *)_op, (void *)_v, (void *)_c, _n,
+			_nc, (void *)_o, (void *)_r);
 }
 
 /*!


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This PR audits functions calling libssl  in the  default kamailio.cfg + database using MariaDB and PostgreSQL (including unixODBC variants) and then adds  thread guards to all such functions.

The audit platform is Debian 12.
1. mariadb-client, libmariadb-dev, odbc-mariadb
2. postgresql-15, postgresql-client-15, odbc-postgresql

Thread guards added to:
* `db_XXXX_close()`
*  `db_unixodbc_free_result()`, `db_unixodbc_query`



