### PR TITLE
[5.7] Restore libssl default behaviour on stable; opt-in to libssl thread-guards required

### DIFF
--- a/etc/kamailio.cfg
+++ b/etc/kamailio.cfg
@@ -220,6 +220,13 @@ enable_tls=yes
 
 /* upper limit for TLS connections */
 tls_max_connections=2048
+
+/* For OpenSSL 3 integration
+ * functions calling libssl3 can be invoked in a transient thread
+ * 0: disable threaded calls
+ * 1: use threads for process#0 only
+ * 2: use threads for all processes */
+tls_threads_mode=1
 #!endif
 
 /* set it to yes to enable sctp and load sctp.so module */
@@ -256,6 +263,12 @@ voicemail.srv_port = "5060" desc "VoiceMail Port"
 
 /* set paths to location of modules */
 # mpath="/usr/local/lib/kamailio/modules/"
+
+# when using TLS with OpenSSL it is recommended to load this module
+# first so that OpenSSL is initialized correctly
+#!ifdef WITH_TLS
+loadmodule "tls.so"
+#!endif
 
 #!ifdef WITH_MYSQL
 loadmodule "db_mysql.so"
@@ -317,10 +330,6 @@ loadmodule "rtpengine.so"
 #!else
 loadmodule "rtpproxy.so"
 #!endif
-#!endif
-
-#!ifdef WITH_TLS
-loadmodule "tls.so"
 #!endif
 
 #!ifdef WITH_HTABLE

--- a/src/core/cfg.lex
+++ b/src/core/cfg.lex
@@ -439,6 +439,7 @@ TCP_WAIT_DATA	"tcp_wait_data"
 TCP_SCRIPT_MODE	"tcp_script_mode"
 DISABLE_TLS		"disable_tls"|"tls_disable"
 ENABLE_TLS		"enable_tls"|"tls_enable"
+TLS_THREADS_MODE	"tls_threads_mode"
 TLSLOG			"tlslog"|"tls_log"
 TLS_PORT_NO		"tls_port_no"
 TLS_METHOD		"tls_method"
@@ -953,6 +954,7 @@ IMPORTFILE      "import_file"
 <INITIAL>{TCP_SCRIPT_MODE}	{ count(); yylval.strval=yytext; return TCP_SCRIPT_MODE; }
 <INITIAL>{DISABLE_TLS}	{ count(); yylval.strval=yytext; return DISABLE_TLS; }
 <INITIAL>{ENABLE_TLS}	{ count(); yylval.strval=yytext; return ENABLE_TLS; }
+<INITIAL>{TLS_THREADS_MODE}	{ count(); yylval.strval=yytext; return TLS_THREADS_MODE; }
 <INITIAL>{TLSLOG}		{ count(); yylval.strval=yytext; return TLS_PORT_NO; }
 <INITIAL>{TLS_PORT_NO}	{ count(); yylval.strval=yytext; return TLS_PORT_NO; }
 <INITIAL>{TLS_METHOD}	{ count(); yylval.strval=yytext; return TLS_METHOD; }

--- a/src/core/cfg.y
+++ b/src/core/cfg.y
@@ -469,6 +469,7 @@ extern char *default_routename;
 %token TCP_SCRIPT_MODE
 %token DISABLE_TLS
 %token ENABLE_TLS
+%token TLS_THREADS_MODE
 %token TLSLOG
 %token TLS_PORT_NO
 %token TLS_METHOD
@@ -1440,6 +1441,14 @@ assign_stm:
 		#endif
 	}
 	| ENABLE_TLS EQUAL error { yyerror("boolean value expected"); }
+	| TLS_THREADS_MODE EQUAL NUMBER {
+		#ifdef USE_TLS
+			ksr_tls_threads_mode = $3;
+		#else
+			warn("tls support not compiled in");
+		#endif
+	}
+	| TLS_THREADS_MODE EQUAL error { yyerror("int value expected"); }
 	| TLSLOG EQUAL NUMBER {
 		#ifdef CORE_TLS
 			tls_log=$3;

--- a/src/core/globals.h
+++ b/src/core/globals.h
@@ -108,6 +108,7 @@ extern int ksr_tcp_script_mode;
 #ifdef USE_TLS
 extern int tls_disable;
 extern unsigned short tls_port_no;
+extern int ksr_tls_threads_mode;
 #endif
 #ifdef USE_SCTP
 extern int sctp_disable;

--- a/src/core/rthreads.h
+++ b/src/core/rthreads.h
@@ -27,6 +27,7 @@
  */
 #include <pthread.h>
 
+#include "./globals.h"
 /*
  * prototype: void *fn(void *arg) { ... }
  */
@@ -39,9 +40,11 @@ static void *run_threadP(_thread_proto fn, void *arg)
 	pthread_t tid;
 	void *ret;
 
-	if(likely(process_no)) {
+	if(likely(ksr_tls_threads_mode == 0
+			   || (ksr_tls_threads_mode == 1 && process_no > 0))) {
 		return fn(arg);
 	}
+
 	pthread_create(&tid, NULL, fn, arg);
 	pthread_join(tid, &ret);
 
@@ -73,7 +76,9 @@ static void *run_threadPI(_thread_protoPI fn, void *arg1, int arg2)
 #ifdef USE_TLS
 	pthread_t tid;
 	void *ret;
-	if(likely(process_no)) {
+
+	if(likely(ksr_tls_threads_mode == 0
+			   || (ksr_tls_threads_mode == 1 && process_no > 0))) {
 		return fn(arg1, arg2);
 	}
 
@@ -84,7 +89,7 @@ static void *run_threadPI(_thread_protoPI fn, void *arg1, int arg2)
 	return ret;
 #else
 	return fn(arg1, arg2);
-#endif /* USE_TLS */
+#endif
 }
 #endif
 
@@ -107,18 +112,19 @@ static void run_threadV(_thread_protoV fn)
 {
 #ifdef USE_TLS
 	pthread_t tid;
-	if(likely(process_no)) {
+
+	if(likely(ksr_tls_threads_mode == 0
+			   || (ksr_tls_threads_mode == 1 && process_no > 0))) {
 		fn();
 		return;
 	}
-
 
 	pthread_create(&tid, NULL, (_thread_proto)run_thread_wrapV,
 			&(struct _thread_argsV){fn});
 	pthread_join(tid, NULL);
 #else
 	fn();
-#endif /* USE_TLS */
+#endif
 }
 #endif
 
@@ -146,10 +152,10 @@ static int run_thread4PP(_thread_proto4PP fn, void *arg1, void *arg2)
 	pthread_t tid;
 	int ret;
 
-	if(likely(process_no)) {
+	if(likely(ksr_tls_threads_mode == 0
+			   || (ksr_tls_threads_mode == 1 && process_no > 0))) {
 		return fn(arg1, arg2);
 	}
-
 	pthread_create(&tid, NULL, (_thread_proto)run_thread_wrap4PP,
 			&(struct _thread_args4PP){fn, arg1, arg2, &ret});
 	pthread_join(tid, NULL);
@@ -182,17 +188,17 @@ static void run_thread0P(_thread_proto0P fn, void *arg1)
 #ifdef USE_TLS
 	pthread_t tid;
 
-	if(likely(process_no)) {
+	if(likely(ksr_tls_threads_mode == 0
+			   || (ksr_tls_threads_mode == 1 && process_no > 0))) {
 		fn(arg1);
 		return;
 	}
-
 	pthread_create(&tid, NULL, (_thread_proto)run_thread_wrap0P,
 			&(struct _thread_args0P){fn, arg1});
 	pthread_join(tid, NULL);
 #else
-	fn(arg1);
-#endif /* USE_TLS */
+	fn(arg1)
+#endif
 }
 #endif
 
@@ -234,7 +240,8 @@ static int run_thread4P5I2P2(_thread_proto4P5I2P2 fn, void *arg1, void *arg2,
 	pthread_t tid;
 	int ret;
 
-	if(likely(process_no)) {
+	if(likely(ksr_tls_threads_mode == 0
+			   || (ksr_tls_threads_mode == 1 && process_no > 0))) {
 		return fn(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
 	}
 	pthread_create(&tid, NULL, (_thread_proto)run_thread_wrap4P5I2P2,

--- a/src/main.c
+++ b/src/main.c
@@ -326,8 +326,9 @@ int tcp_disable = 0;	 /* 1 if tcp is disabled */
 int tls_disable = 0; /* tls enabled by default */
 #else
 int tls_disable = 1; /* tls disabled by default */
-#endif /* CORE_TLS */
-#endif /* USE_TLS */
+#endif						  /* CORE_TLS */
+int ksr_tls_threads_mode = 0; /* threads execution mode for tls with libssl */
+#endif						  /* USE_TLS */
 #ifdef USE_SCTP
 int sctp_children_no = 0;
 int sctp_disable = 2; /* 1 if sctp is disabled, 2 if auto mode, 0 enabled */

--- a/src/modules/tls/tls_mod.c
+++ b/src/modules/tls/tls_mod.c
@@ -451,9 +451,9 @@ static int mod_child(int rank)
 #if OPENSSL_VERSION_NUMBER >= 0x010101000L
         /*
          * OpenSSL 3.x/1.1.1: create shared SSL_CTX* in worker to avoid init of
-         * libssl in rank 0(thread#1)
+         * libssl in rank 0(thread#1). Requires tls_threads_mode = 1 config.
          */
-        if(rank == PROC_SIPINIT) {
+        if((rank == PROC_SIPINIT && ksr_tls_threads_mode) || (rank == PROC_INIT && !ksr_tls_threads_mode)) {
 #else
         if(rank == PROC_INIT) {
 #endif


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This PR restores the default behaviour of stable branch and makes libssl thread-guard work opt-in.
- user's config from 5.7.3 will run unchanged
- backport tls_threads_mode = 0|1|2 from dev; user must explicitly opt-in to libssl changes

Scenario 1: user does not change 5.7.3 configuration; then libssl thread-guards will be disabled and Kamailio will run as before. `tls.so` runs in `PROC_INIT` — no change

Scenario 2: user sets `tls_threads_mode = 1` in the configuration. libssl thread guards are active and module functions calling libssl will be run in threads in process_no=0; `tls.so` runs in `PROC_SIPINIT`.

Default: `tls_threads_mode = 0` so that stable libssl behaviour is unchanged



