### PR TITLE
Update TLS docs

### DIFF
--- a/src/modules/tls/doc/rpc.xml
+++ b/src/modules/tls/doc/rpc.xml
@@ -71,6 +71,10 @@
 			will be used for new connections.
 		</para>
 		<para>
+		Reload is generally safe and usable in production environments. If possible should
+		be done in a time where the service has lower usage/connections.
+		</para>
+		<para>
 			This RPC command is exported with "RPC_EXEC_DELTA" flag, therefore its
 			execution rate can be restricted to specific time intervals by setting
 			the "rpc_exec_delta" core parameter.

--- a/src/modules/tls/doc/tls.xml
+++ b/src/modules/tls/doc/tls.xml
@@ -285,10 +285,6 @@ make -C modules/tls extra_defs="-DTLS_WR_DEBUG -DTLS_RD_DEBUG"
 			connection establishment and not after).
 		</para>
 		<para>
-			TLS specific config reloading is not safe, so for now better don't use it,
-			especially under heavy traffic.
-		</para>
-		<para>
 			This documentation is incomplete.
 			The provided selects are not documented in this file. A list with all the
 			ones implemented by the TLS module can be found in the Cookbook
@@ -364,4 +360,3 @@ event_route[tls:connection-out] {
 	</section>
 	</chapter>
 </book>
-

--- a/src/modules/tls/doc/tls.xml
+++ b/src/modules/tls/doc/tls.xml
@@ -93,7 +93,10 @@
 		</para>
 		<para>
 		When installing tls module of kamailio, a sample 'tls.cfg' file is deployed in the same
-		folder with 'kamailio.cfg', along with freshly generated self signed certificates.
+		folder with 'kamailio.cfg'. For freshly generated self signed certificates make must be called from tls folder
+		<programlisting>
+make install-tls-cert
+		</programlisting>
 		</para>
 		<para>
 		HINT: be sure you have <emphasis>enable_tls=yes</emphasis> to your kamailio.cfg.


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3717 

#### Description
<!-- Describe your changes in detail -->
This PR updates some of the TLS documentation. 

tls.reload: See #3717 for details and suggestions from core developers.

certificate generation: According to the History section, certificates are no longer generated automatically. Instead, the command `make install-tls-cert` should be used. This was verified to be working as intended and added suggestion in `Quick Start` section.