### PR TITLE
Allow builders to disable wolfssl module

### DIFF
--- a/pkg/kamailio/obs/kamailio.spec
+++ b/pkg/kamailio/obs/kamailio.spec
@@ -29,6 +29,7 @@
 %bcond_without sctp
 %bcond_without websocket
 %bcond_without xmlrpc
+%bcond_without wolfssl
 %endif
 
 %if 0%{?rhel} == 7
@@ -65,6 +66,7 @@
 %bcond_without sctp
 %bcond_without websocket
 %bcond_without xmlrpc
+%bcond_without wolfssl
 %endif
 
 %if 0%{?rhel} == 8
@@ -111,6 +113,7 @@
 %bcond_without sctp
 %bcond_without websocket
 %bcond_without xmlrpc
+%bcond_without wolfssl
 %endif
 
 %if 0%{?rhel} == 9
@@ -157,6 +160,7 @@
 %bcond_without sctp
 %bcond_without websocket
 %bcond_without xmlrpc
+%bcond_without wolfssl
 %endif
 
 %if 0%{?suse_version}
@@ -186,6 +190,7 @@
 %bcond_without sctp
 %bcond_without websocket
 %bcond_without xmlrpc
+%bcond_without wolfssl
 %endif
 
 # build with openssl 1.1.1 on RHEL 7 based dists
@@ -1037,6 +1042,7 @@ BuildRequires:  openssl-devel
 TLS transport for Kamailio.
 
 
+%if %{with wolfssl}
 %package    tls_wolfssl
 Summary:    TLS transport for Kamailio based on wolfSSL
 Group:      %{PKGGROUP}
@@ -1044,6 +1050,7 @@ BuildRequires: pkgconfig(wolfssl)
 
 %description    tls_wolfssl
 TLS transport for Kamailio based on wolfSSL
+%endif
 
 
 %package    tcpops
@@ -1291,7 +1298,11 @@ make every-module skip_modules="app_mono db_cassandra db_oracle iptrtpproxy \
 %if "%{?_unitdir}" != ""
     ksystemd \
 %endif
-    ktls ktls_wolfssl kunixodbc kutils \
+    ktls \
+%if %{with wolfssl}
+    ktls_wolfssl \
+%endif
+    kunixodbc kutils \
 %if %{with websocket}
     kwebsocket \
 %endif
@@ -1400,7 +1411,11 @@ make install-modules-all skip_modules="app_mono db_cassandra db_oracle \
 %if "%{?_unitdir}" != ""
     ksystemd \
 %endif
-    ktls ktls_wolfssl kunixodbc kutils \
+    ktls \
+%if %{with wolfssl}
+    ktls_wolfssl \
+%endif
+    kunixodbc kutils \
 %if %{with websocket}
     kwebsocket \
 %endif
@@ -2337,10 +2352,12 @@ fi
 %{_libdir}/kamailio/modules/tls.so
 
 
+%if %{with wolfssl}
 %files      tls_wolfssl
 %defattr(-,root,root)
 %doc %{_docdir}/kamailio/modules/README.tls_wolfssl
 %{_libdir}/kamailio/modules/tls_wolfssl.so
+%endif
 
 
 %files      tcpops


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3592

#### Description

Building the WolfSSL module should be optional, even if it is on by default, builders should be able to choose to not need to install 4th party repositories.

See pr #3592 and specifically [this comment](https://github.com/kamailio/kamailio/pull/3592#issuecomment-1987308765)