### PR TITLE
ims_registrar_scscf: fix uninitialized access of memory, minor refactors

### DIFF
--- a/src/modules/ims_registrar_scscf/ims_registrar_scscf_mod.c
+++ b/src/modules/ims_registrar_scscf/ims_registrar_scscf_mod.c
@@ -786,7 +786,7 @@ static int assign_save_fixup3_async(void **param, int param_no)
 	return 0;
 }
 
-static int unit_fixup(void **param, int param_no)
+static int uint_fixup(void **param, int param_no)
 {
 	str s;
 	unsigned int *num;
@@ -826,7 +826,7 @@ static int save_fixup4(void **param, int param_no)
 	if(param_no < 4) {
 		return assign_save_fixup3_async(param, param_no);
 	} else if(param_no == 4) {
-		return unit_fixup(param, param_no);
+		return uint_fixup(param, param_no);
 	}
 
 	return 0;

--- a/src/modules/ims_registrar_scscf/ims_registrar_scscf_mod.c
+++ b/src/modules/ims_registrar_scscf/ims_registrar_scscf_mod.c
@@ -814,7 +814,7 @@ static int uint_fixup(void **param, int param_no)
 
 static int free_uint_fixup(void **param, int param_no)
 {
-	if(*param && param_no == 2) {
+	if(*param && param_no == 4) {
 		pkg_free(*param);
 		*param = 0;
 	}

--- a/src/modules/ims_registrar_scscf/ims_registrar_scscf_mod.c
+++ b/src/modules/ims_registrar_scscf/ims_registrar_scscf_mod.c
@@ -131,7 +131,9 @@ struct _pv_req_data _pv_treq;
 static int mod_init(void);
 static int child_init(int);
 static void mod_destroy(void);
-static int w_save(
+static int w_save2(struct sip_msg *_m, char *_route, char *_d);
+static int w_save3(struct sip_msg *_m, char *_route, char *_d, char *mode);
+static int w_save4(
 		struct sip_msg *_m, char *_route, char *_d, char *mode, char *_cflags);
 static int w_assign_server_unreg(
 		struct sip_msg *_m, char *_route, char *_d, char *_direction);
@@ -231,11 +233,11 @@ static pv_export_t mod_pvs[] = {
  * Exported functions
  */
 static cmd_export_t cmds[] = {
-		{"save", (cmd_function)w_save, 2, assign_save_fixup3_async, 0,
+		{"save", (cmd_function)w_save2, 2, assign_save_fixup3_async, 0,
 				REQUEST_ROUTE | ONREPLY_ROUTE},
-		{"save", (cmd_function)w_save, 3, assign_save_fixup3_async, 0,
+		{"save", (cmd_function)w_save3, 3, assign_save_fixup3_async, 0,
 				REQUEST_ROUTE | ONREPLY_ROUTE},
-		{"save", (cmd_function)w_save, 4, save_fixup3, free_uint_fixup,
+		{"save", (cmd_function)w_save4, 4, save_fixup3, free_uint_fixup,
 				REQUEST_ROUTE | ONREPLY_ROUTE},
 		{"lookup", (cmd_function)w_lookup, 1, domain_fixup, 0,
 				REQUEST_ROUTE | FAILURE_ROUTE},
@@ -677,9 +679,21 @@ AAAMessage *callback_cdp_request(AAAMessage *request, void *param)
 /*! \brief
  * Wrapper to save(location)
  */
-static int w_save(
+static int w_save2(struct sip_msg *_m, char *_route, char *_d)
+{
+	return save(_m, _d, _route, 0);
+}
+
+static int w_save3(struct sip_msg *_m, char *_route, char *_d, char *_mode)
+{
+	/* mode is unsed. Docs says legacy parameter? Maybe to be compatible with registrar/save? */
+	return save(_m, _d, _route, 0);
+}
+
+static int w_save4(
 		struct sip_msg *_m, char *_route, char *_d, char *mode, char *_cflags)
 {
+	/* mode is unsed. Docs says legacy parameter? Maybe to be compatible with registrar/save? */
 	if(_cflags) {
 		return save(_m, _d, _route, ((int)(*_cflags)));
 	}

--- a/src/modules/ims_registrar_scscf/ims_registrar_scscf_mod.c
+++ b/src/modules/ims_registrar_scscf/ims_registrar_scscf_mod.c
@@ -145,7 +145,7 @@ static int w_lookup_path_to_contact(struct sip_msg *_m, char *contact_uri);
 static int domain_fixup(void **param, int param_no);
 static int assign_save_fixup3_async(void **param, int param_no);
 static int free_uint_fixup(void **param, int param_no);
-static int save_fixup3(void **param, int param_no);
+static int save_fixup4(void **param, int param_no);
 static int unreg_fixup(void **param, int param_no);
 static int fetchc_fixup(void **param, int param_no);
 /*! \brief Functions */
@@ -237,7 +237,7 @@ static cmd_export_t cmds[] = {
 				REQUEST_ROUTE | ONREPLY_ROUTE},
 		{"save", (cmd_function)w_save3, 3, assign_save_fixup3_async, 0,
 				REQUEST_ROUTE | ONREPLY_ROUTE},
-		{"save", (cmd_function)w_save4, 4, save_fixup3, free_uint_fixup,
+		{"save", (cmd_function)w_save4, 4, save_fixup4, free_uint_fixup,
 				REQUEST_ROUTE | ONREPLY_ROUTE},
 		{"lookup", (cmd_function)w_lookup, 1, domain_fixup, 0,
 				REQUEST_ROUTE | FAILURE_ROUTE},
@@ -821,27 +821,10 @@ static int free_uint_fixup(void **param, int param_no)
 	return 0;
 }
 
-static int save_fixup3(void **param, int param_no)
+static int save_fixup4(void **param, int param_no)
 {
-	if(strlen((char *)*param) <= 0) {
-		LM_ERR("empty parameter %d not allowed\n", param_no);
-		return -1;
-	}
-
-	if(param_no == 1) { //route name - static or dynamic string (config vars)
-		if(fixup_spve_null(param, param_no) < 0)
-			return -1;
-		return 0;
-	} else if(param_no == 2) {
-		udomain_t *d;
-
-		if(ul.register_udomain((char *)*param, &d) < 0) {
-			LM_ERR("Error doing fixup on save");
-			return -1;
-		}
-		*param = (void *)d;
-	} else if(param_no == 3) {
-		return 0;
+	if(param_no < 4) {
+		return assign_save_fixup3_async(param, param_no);
 	} else if(param_no == 4) {
 		return unit_fixup(param, param_no);
 	}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
A couple small changes to the ims_registrar_scscf which prevents kamailio from crashing on my system.
I would love to have more testing because I only did tests in my single user IMS setup.