### PR TITLE
tcp/docs: Added tcp_accept_iplimit config sample

### DIFF
--- a/etc/kamailio.cfg
+++ b/etc/kamailio.cfg
@@ -211,6 +211,9 @@ tcp_connection_lifetime=3605
 /* upper limit for TCP connections (it includes the TLS connections) */
 tcp_max_connections=2048
 
+/* upper limit for TCP connections for one ip address - default 1024 */
+#tcp_accept_iplimit=1024
+
 #!ifdef WITH_JSONRPC
 tcp_accept_no_cl=yes
 #!endif


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
We noticed that configuration option tcp_accept_iplimit was included in newer kamailio versions (most notably 5.7.4), and it was a breaking change for us. Added sample configuration value in /etc/kamailio.cfg file - already tested in our production deployment.
