### PR TITLE
xhttp_prom: export pkg mem statistics

### DIFF
--- a/src/modules/kex/api.c
+++ b/src/modules/kex/api.c
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2024 Ovidiu Sas (VoIP Embedded, Inc)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/*!
+ * \file
+ * \brief API integration
+ * \ingroup kex
+ * Module: \ref kex
+ */
+
+#include <stddef.h>
+
+#include "api.h"
+#include "pkg_stats.h"
+#include "../../core/mod_fix.h"
+
+int get_pkmem_stats_api(pkg_proc_stats_t **_pkg_procstatslist)
+{
+	*_pkg_procstatslist = get_pkg_proc_stats_list();
+	return get_pkg_proc_stats_no();
+}
+
+/*
+ * Function to load the kex api.
+ */
+int bind_kex(kex_api_t *kob)
+{
+	if(kob == NULL) {
+		LM_WARN("Cannot load kex API into a NULL pointer\n");
+		return -1;
+	}
+	kob->get_pkmem_stats = get_pkmem_stats_api;
+	return 0;
+}

--- a/src/modules/kex/api.h
+++ b/src/modules/kex/api.h
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2024 Ovidiu Sas (VoIP Embedded, Inc)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/*!
+ * \file
+ * \brief API
+ * \ingroup kex
+ * Module: \ref kex
+ */
+
+#include "pkg_stats.h"
+#include "../../core/sr_module.h"
+
+#ifndef _KEX_API_H_
+#define _KEX_API_H_
+
+typedef int (*kex_get_pkmem_stats_f)(pkg_proc_stats_t **_pkg_procstatslist);
+
+/*
+ * Struct with the kex api.
+ */
+typedef struct kex_binds
+{
+	kex_get_pkmem_stats_f get_pkmem_stats;
+} kex_api_t;
+
+typedef int (*bind_kex_f)(kex_api_t *);
+
+/*
+ * function exported by module - it will load the other functions
+ */
+int bind_kex(kex_api_t *);
+
+/*
+ * Function to be called directly from other modules to load
+ * the kex API.
+ */
+inline static int load_kex_api(kex_api_t *kob)
+{
+	bind_kex_f bind_kex_exports;
+
+	if(!(bind_kex_exports = (bind_kex_f)find_export("bind_kex", 0, 0))) {
+		LM_ERR("Failed to import bind_kex\n");
+		return -1;
+	}
+	return bind_kex_exports(kob);
+}
+
+#endif /*_KEX_API_H_*/

--- a/src/modules/kex/kex_mod.c
+++ b/src/modules/kex/kex_mod.c
@@ -41,6 +41,7 @@
 #include "core_stats.h"
 #include "pkg_stats.h"
 #include "mod_stats.h"
+#include "api.h"
 
 
 MODULE_VERSION
@@ -105,6 +106,7 @@ static cmd_export_t cmds[] = {
 	{"setdebug", (cmd_function)w_setdebug, 1, fixup_igp_null,
 			fixup_free_igp_null, ANY_ROUTE},
 	{"resetdebug", (cmd_function)w_resetdebug, 0, 0, 0, ANY_ROUTE},
+	{"bind_kex", (cmd_function)bind_kex, 0, 0, 0, 0},
 
 	{0, 0, 0, 0, 0, 0}
 };

--- a/src/modules/kex/pkg_stats.c
+++ b/src/modules/kex/pkg_stats.c
@@ -39,21 +39,7 @@
 #include "../../core/mem/shm_mem.h"
 #include "../../core/rpc.h"
 #include "../../core/rpc_lookup.h"
-
-
-/**
- *
- */
-typedef struct pkg_proc_stats
-{
-	int rank;
-	unsigned int pid;
-	unsigned long used;
-	unsigned long available;
-	unsigned long real_used;
-	unsigned long total_frags;
-	unsigned long total_size;
-} pkg_proc_stats_t;
+#include "pkg_stats.h"
 
 /**
  *
@@ -63,7 +49,23 @@ static pkg_proc_stats_t *_pkg_proc_stats_list = NULL;
 /**
  *
  */
+pkg_proc_stats_t *get_pkg_proc_stats_list(void)
+{
+	return _pkg_proc_stats_list;
+}
+
+/**
+ *
+ */
 static int _pkg_proc_stats_no = 0;
+
+/**
+ *
+ */
+int get_pkg_proc_stats_no(void)
+{
+	return _pkg_proc_stats_no;
+}
 
 /**
  *

--- a/src/modules/kex/pkg_stats.h
+++ b/src/modules/kex/pkg_stats.h
@@ -25,14 +25,31 @@
  * \ingroup kex
  */
 
+#include "../../core/dprint.h"
 
 #ifndef _PKG_STATS_H_
 #define _PKG_STATS_H_
+
+/*
+ *
+ */
+typedef struct pkg_proc_stats
+{
+	int rank;
+	unsigned int pid;
+	unsigned long used;
+	unsigned long available;
+	unsigned long real_used;
+	unsigned long total_frags;
+	unsigned long total_size;
+} pkg_proc_stats_t;
 
 int pkg_proc_stats_init(void);
 int pkg_proc_stats_myinit(int rank);
 int pkg_proc_stats_destroy(void);
 int register_pkg_proc_stats(void);
 int pkg_proc_stats_init_rpc(void);
+pkg_proc_stats_t *get_pkg_proc_stats_list(void);
+int get_pkg_proc_stats_no(void);
 
 #endif /*_PKG_STATS_H_*/

--- a/src/modules/xhttp_prom/xhttp_prom.h
+++ b/src/modules/xhttp_prom/xhttp_prom.h
@@ -33,6 +33,7 @@
 
 #include "../../core/str.h"
 #include "../../core/parser/msg_parser.h"
+#include "../../modules/kex/api.h"
 
 
 #define ERROR_REASON_BUF_LEN 1024
@@ -82,5 +83,20 @@ extern str xhttp_prom_beginning;
  * @brief timeout in minutes to delete old metrics.
  */
 extern int timeout_minutes;
+
+/**
+ * @brief enable or disable pkgmem statistics.
+ */
+extern int pkgmem_stats_enabled;
+
+/**
+ * @brief pointer to pkgmem statistics.
+ */
+extern pkg_proc_stats_t *pkg_proc_stats;
+
+/**
+ * @brief number of pkgmem statistics.
+ */
+extern int pkg_proc_stats_no;
 
 #endif /* _XHTTP_PROM_H */


### PR DESCRIPTION
#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Enhance xhttp_prom module to export pkgmem stats.
The new stats can be enabled via a new module parameter: `xhttp_prom_pkg_stats`.
Default value for the new module parameter: 0 (no pkg mem stats are generated).
Any value different then 0 will export the pkg mem statistics.