### PR TITLE
ndb_redis: docs - refine docs regarding client certificates

### DIFF
--- a/src/modules/db_redis/doc/db_redis_admin.xml
+++ b/src/modules/db_redis/doc/db_redis_admin.xml
@@ -225,6 +225,12 @@ modparam("db_redis", "verbosity", 0)
 				If set to 1, TLS is used to connect to the DB.
 			</para>
 			<para>
+				If TLS is enabled, the module will validate the Redis server certificate against the
+				ca_path. There is currently no way to connect with a specified client certificate, the
+				<ulink url="https://redis.io/docs/management/security/encryption/#client-certificate-authentication">corresponding configuration</ulink>
+				to check client certificates in the Redis server must therefore be turned off.
+			</para>
+			<para>
 				Default value: 0.
 			</para>
 			<example>
@@ -256,9 +262,9 @@ modparam("db_redis", "db_pass", "r3d1sPass")
 		</section>
 
 		<section id="db_redis.p.ca_path">
-			<title><varname>ac_path</varname> (string)</title>
+			<title><varname>ca_path</varname> (string)</title>
 			<para>
-				Sets the path where Certificates Authorities certs are stored.
+				Sets the path where Certificates Authorities certs for the Redis server certificate are stored.
 			</para>
 			<para>
 				Default value: "" (empty).

--- a/src/modules/ndb_redis/doc/ndb_redis_admin.xml
+++ b/src/modules/ndb_redis/doc/ndb_redis_admin.xml
@@ -76,6 +76,12 @@
 			server name when querying the REDIS instance.
 		</para>
 		<para>
+			If tls is enabled, the module will validate the REDIS server certificate against the
+			ca_path. There is currently no way to connect with a specified client certificate, the
+			<ulink url="https://redis.io/docs/management/security/encryption/#client-certificate-authentication">corresponding configuration</ulink>
+			to check client certificates in the REDIS server must therefore be turned off.
+		</para>
+		<para>
 		<emphasis>
 			Default value is NULL.
 		</emphasis>
@@ -330,9 +336,9 @@ modparam("ndb_redis", "debug", 1)
 		</example>
 	</section>
 	<section id="ndb_redis.p.ca_path">
-		<title><varname>ac_path</varname> (string)</title>
+		<title><varname>ca_path</varname> (string)</title>
 		<para>
-			Sets the path where Certificates Authorities certs are stored.
+			Sets the path where Certificates Authorities certs for the REDIS server certificate are stored.
 		</para>
 		<para>
 			Default value: "" (empty).


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

The created ssl context in the `db_redis` and `ndb_redis` modules does not use client certificates [1], [2] which is against the default in current Redis configurations [3]. The used Redis server therefore needs to be configured to not use tls-auth-clients [3]. Without setting this configuration in Redis, no TLS connection to the Redis server can be established, since Redis will not accept unsigned/not-validated client certificates.

There is also a small typo in "ac_path" in both docs which was fixed to "ca_path", added with some more specification to _which_ certificate is validated.

[1]: https://github.com/kamailio/kamailio/blob/8047c958b42ea5af2e8f9ede0152f892ac0eea3a/src/modules/db_redis/redis_connection.c#L168
[2]: https://github.com/kamailio/kamailio/blob/8047c958b42ea5af2e8f9ede0152f892ac0eea3a/src/modules/db_redis/redis_connection.c#L212
[3]: https://redis.io/docs/management/security/encryption/#client-certificate-authentication