### PR TITLE
core/tcp_main: Match protocol when lookup tcp/tls connections

### DIFF
--- a/src/core/forward.h
+++ b/src/core/forward.h
@@ -188,7 +188,8 @@ static inline int msg_send_buffer(
 			su2ip_addr(&ip, &dst->to);
 			if(tcp_connection_match == TCPCONN_MATCH_STRICT) {
 				con = tcpconn_lookup(dst->id, &ip, port, from,
-						(dst->send_sock) ? dst->send_sock->port_no : 0, 0);
+						(dst->send_sock) ? dst->send_sock->port_no : 0, 0,
+						PROTO_NONE);
 			} else {
 				con = tcpconn_get(dst->id, &ip, port, from, 0);
 			}

--- a/src/core/forward.h
+++ b/src/core/forward.h
@@ -189,7 +189,7 @@ static inline int msg_send_buffer(
 			if(tcp_connection_match == TCPCONN_MATCH_STRICT) {
 				con = tcpconn_lookup(dst->id, &ip, port, from,
 						(dst->send_sock) ? dst->send_sock->port_no : 0, 0,
-						PROTO_NONE);
+						dst->proto);
 			} else {
 				con = tcpconn_get(dst->id, &ip, port, from, 0);
 			}

--- a/src/core/tcp_conn.h
+++ b/src/core/tcp_conn.h
@@ -407,7 +407,8 @@ struct tcp_connection *tcpconn_get(int id, struct ip_addr *ip, int port,
 		union sockaddr_union *local_addr, ticks_t timeout);
 
 struct tcp_connection *tcpconn_lookup(int id, struct ip_addr *ip, int port,
-		union sockaddr_union *local_addr, int try_local_port, ticks_t timeout);
+		union sockaddr_union *local_addr, int try_local_port, ticks_t timeout,
+		sip_protos_t proto);
 
 typedef struct tcp_event_info
 {

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -5435,7 +5435,7 @@ int wss_send(dest_info_t *dst, const char *buf, unsigned len)
 			if(tcp_connection_match == TCPCONN_MATCH_STRICT) {
 				con = tcpconn_lookup(dst->id, &ip, port, from,
 						(dst->send_sock) ? dst->send_sock->port_no : 0, 0,
-						PROTO_NONE);
+						dst->proto);
 			} else {
 				con = tcpconn_get(dst->id, &ip, port, from, 0);
 			}

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1697,8 +1697,8 @@ void tcpconn_rm(struct tcp_connection *c)
 
 /* finds a connection, if id=0 uses the ip addr, port, local_ip and local port
  *  (host byte order) and tries to find the connection that matches all of
- *   them. Wild cards can be used for local_ip and local_port (a 0 filled
- *   ip address and/or a 0 local port).
+ *   them. Wild cards can be used for local_ip, local_port and proto (a 0 filled
+ *   ip address and/or a 0 local port and/or PROTO_NONE).
  * WARNING: unprotected (locks) use tcpconn_get unless you really
  * know what you are doing */
 struct tcp_connection *_tcpconn_find(int id, struct ip_addr *ip, int port,
@@ -1754,7 +1754,7 @@ struct tcp_connection *_tcpconn_find(int id, struct ip_addr *ip, int port,
 
 
 /**
- * find if a tcp connection exits by id or remote+local address/port
+ * find if a tcp connection exits by id or remote+local address/port and protocol
  * - return: 1 if found; 0 if not found
  */
 int tcpconn_exists(int conn_id, ip_addr_t *peer_ip, int peer_port,
@@ -1774,6 +1774,7 @@ int tcpconn_exists(int conn_id, ip_addr_t *peer_ip, int peer_port,
 /* TCP connection find with locks and timeout
  * - local_addr contains the desired local ip:port. If null any local address
  * will be used. IN*ADDR_ANY or 0 port are wild cards.
+ * - proto is the protocol to match (PROTO_NONE for any)
  * - try_local_port makes the search use it first, instead of port from local_addr
  * If found, the connection's reference counter will be incremented, you might
  * want to decrement it after use.

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1758,13 +1758,12 @@ struct tcp_connection *_tcpconn_find(int id, struct ip_addr *ip, int port,
  * - return: 1 if found; 0 if not found
  */
 int tcpconn_exists(int conn_id, ip_addr_t *peer_ip, int peer_port,
-		ip_addr_t *local_ip, int local_port)
+		ip_addr_t *local_ip, int local_port, sip_protos_t proto)
 {
 	tcp_connection_t *c;
 
 	TCPCONN_LOCK;
-	c = _tcpconn_find(
-			conn_id, peer_ip, peer_port, local_ip, local_port, PROTO_NONE);
+	c = _tcpconn_find(conn_id, peer_ip, peer_port, local_ip, local_port, proto);
 	TCPCONN_UNLOCK;
 	if(c) {
 		return 1;
@@ -4497,7 +4496,8 @@ static inline int handle_new_connect(struct socket_info *si)
 	if(likely(tcpconn)) {
 		if(tcp_accept_unique) {
 			if(tcpconn_exists(0, &tcpconn->rcv.dst_ip, tcpconn->rcv.dst_port,
-					   &tcpconn->rcv.src_ip, tcpconn->rcv.src_port)) {
+					   &tcpconn->rcv.src_ip, tcpconn->rcv.src_port,
+					   si->proto)) {
 				LM_ERR("duplicated connection by local and remote addresses\n");
 				_tcpconn_free(tcpconn);
 				tcp_safe_close(new_sock);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue [reported in lists](https://lists.kamailio.org/mailman3/hyperkitty/list/sr-users@lists.kamailio.org/thread/NJ3HM4UGBII2RN35PDD2SQSCUCZC2T3I/)

#### Description
<!-- Describe your changes in detail -->
This PR aims to fix a bug/security issue where data that was supposed to be encrypted and transferred through TLS, were transferred instead with TCP protocol.

More information and how to replicate can be found in the above [issue](https://lists.kamailio.org/mailman3/hyperkitty/list/sr-users@lists.kamailio.org/thread/NJ3HM4UGBII2RN35PDD2SQSCUCZC2T3I/) in list.

This PR suggests using also the protocol to match if a TCP connection exists, and when doing connection lookups, otherwise, it might return a wrong connection, ie a TCP one when we are asking for a TLS one (a case when source ip/port and dest IP are same but dest port is set 0 (wildcard) ).

`tcpconn_get` was left unchanged due to being used by some modules and not wanting to break them. Please advise whether it should be beneficial to also change it.

In some cases like, `tcpconn_add_alias` and `tcpconn_get`  we used the `PROTO_NONE` which preserves the original behavior. `tcpconn_add_alias` we do have the protocol available, should it be also used?
`tcpconn_get` does not have the protocol available unless we pass it as an argument.