### PR TITLE
corex: Fix unknown af in list_sockets rpc call

### DIFF
--- a/src/modules/corex/corex_rpc.c
+++ b/src/modules/corex/corex_rpc.c
@@ -61,8 +61,8 @@ static void corex_rpc_list_sockets(rpc_t *rpc, void *ctx)
 				return;
 			}
 
-			if(rpc->struct_add(th, "sss{", "af", get_af_name(proto), "proto",
-					   get_valid_proto_name(proto), "name", si->name.s,
+			if(rpc->struct_add(th, "sss{", "af", get_af_name(si->address.af),
+					   "proto", get_valid_proto_name(proto), "name", si->name.s,
 					   "addrlist", &ih)
 					< 0) {
 				rpc->fault(ctx, 500, "Internal error address list structure");


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3799 

#### Description
<!-- Describe your changes in detail -->
This PR fixes the unknown address family when calling `corex.list_sockets` rpc call by providing the correct argument (address.af) to `get_af_name()` instead of proto.