### PR TITLE
rtpengine: fix pkg mem leak in send_rtpp_command()

### DIFF
--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -3672,6 +3672,7 @@ static char *send_rtpp_command(
 
 		len = _rtpe_lwscb.request(&node->rn_url, (str *)&rtpe_proto, &request,
 				&response, rtpengine_tout_ms * 1000);
+		pkg_free(request.s);
 
 		if(len < 0) {
 			LM_ERR("failed to do websocket request\n");


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3777
#### Description
<!-- Describe your changes in detail -->
- freed request.s after sending request to websocket in send_rtpp_command method.
