### PR TITLE
usrloc: check on db delete the return value of memchr

### DIFF
--- a/src/modules/usrloc/urecord.c
+++ b/src/modules/usrloc/urecord.c
@@ -491,13 +491,17 @@ int db_delete_urecord(urecord_t *_r)
 	vals[0].val.str_val.len = _r->aor.len;
 
 	if(ul_use_domain) {
-		dom = memchr(_r->aor.s, '@', _r->aor.len);
-		vals[0].val.str_val.len = dom - _r->aor.s;
-
 		vals[1].type = DB1_STR;
 		vals[1].nul = 0;
-		vals[1].val.str_val.s = dom + 1;
-		vals[1].val.str_val.len = _r->aor.s + _r->aor.len - dom - 1;
+		dom = memchr(_r->aor.s, '@', _r->aor.len);
+		if(dom == 0) {
+			vals[0].val.str_val.len = 0;
+			vals[1].val.str_val = _r->aor;
+		} else {
+			vals[0].val.str_val.len = dom - _r->aor.s;
+			vals[1].val.str_val.s = dom + 1;
+			vals[1].val.str_val.len = _r->aor.s + _r->aor.len - dom - 1;
+		}
 	}
 
 	if(ul_dbf.use_table(ul_dbh, _r->domain) < 0) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
When inserting into the database the AOR is split at the @ sign and if there is no @ sign in the AOR only the domain part is filled and the user part is left empty.

But for deleting this is not done and the query failed to be executed and the AOR is not deleted. This PR add this behaviour of only comparing against the domain part if the AOR doesn't contain a @ sign.