### PR TITLE
modules/statsd: ensure statsd failures do not stop execution

### DIFF
--- a/src/modules/statsd/statsd.c
+++ b/src/modules/statsd/statsd.c
@@ -50,6 +50,7 @@ static int func_incr(struct sip_msg *msg, char *key);
 static int func_incr_with_labels(struct sip_msg *msg, char *key, char *labels);
 static int func_decr(struct sip_msg *msg, char *key);
 static int func_decr_with_labels(struct sip_msg *msg, char *key, char *labels);
+static int convert_result(bool result);
 static char *get_milliseconds(char *dst);
 
 typedef struct StatsdParams
@@ -133,69 +134,69 @@ void mod_destroy(void)
 
 static int func_gauge(struct sip_msg *msg, char *key, char *val)
 {
-	return statsd_gauge(key, val, NULL);
+	return convert_result(statsd_gauge(key, val, NULL));
 }
 
 static int func_gauge_with_labels(
 		struct sip_msg *msg, char *key, char *val, char *labels)
 {
-	return statsd_gauge(key, val, labels);
+	return convert_result(statsd_gauge(key, val, labels));
 }
 
 static int ki_statsd_gauge(sip_msg_t *msg, str *key, str *val)
 {
-	return statsd_gauge(key->s, val->s, NULL);
+	return convert_result(statsd_gauge(key->s, val->s, NULL));
 }
 
 static int ki_statsd_gauge_with_labels(
 		sip_msg_t *msg, str *key, str *val, str *labels)
 {
-	return statsd_gauge(key->s, val->s, labels->s);
+	return convert_result(statsd_gauge(key->s, val->s, labels->s));
 }
 
 static int func_histogram(struct sip_msg *msg, char *key, char *val)
 {
-	return statsd_histogram(key, val, NULL);
+	return convert_result(statsd_histogram(key, val, NULL));
 }
 
 static int func_histogram_with_labels(
 		struct sip_msg *msg, char *key, char *val, char *labels)
 {
-	return statsd_histogram(key, val, labels);
+	return convert_result(statsd_histogram(key, val, labels));
 }
 
 
 static int ki_statsd_histogram(sip_msg_t *msg, str *key, str *val)
 {
-	return statsd_histogram(key->s, val->s, NULL);
+	return convert_result(statsd_histogram(key->s, val->s, NULL));
 }
 
 static int ki_statsd_histogram_with_labels(
 		sip_msg_t *msg, str *key, str *val, str *labels)
 {
-	return statsd_histogram(key->s, val->s, labels->s);
+	return convert_result(statsd_histogram(key->s, val->s, labels->s));
 }
 
 static int func_set(struct sip_msg *msg, char *key, char *val)
 {
-	return statsd_set(key, val, NULL);
+	return convert_result(statsd_set(key, val, NULL));
 }
 
 static int func_set_with_labels(
 		struct sip_msg *msg, char *key, char *val, char *labels)
 {
-	return statsd_set(key, val, labels);
+	return convert_result(statsd_set(key, val, labels));
 }
 
 static int ki_statsd_set(sip_msg_t *msg, str *key, str *val)
 {
-	return statsd_set(key->s, val->s, NULL);
+	return convert_result(statsd_set(key->s, val->s, NULL));
 }
 
 static int ki_statsd_set_with_labels(
 		sip_msg_t *msg, str *key, str *val, str *labels)
 {
-	return statsd_set(key->s, val->s, labels->s);
+	return convert_result(statsd_set(key->s, val->s, labels->s));
 }
 
 static int func_time_start(struct sip_msg *msg, char *key)
@@ -278,42 +279,51 @@ static int ki_statsd_stop_with_labels(sip_msg_t *msg, str *key, str *labels)
 
 static int func_incr(struct sip_msg *msg, char *key)
 {
-	return statsd_count(key, "+1", NULL);
+	return convert_result(statsd_count(key, "+1", NULL));
 }
 
 static int func_incr_with_labels(struct sip_msg *msg, char *key, char *labels)
 {
-	return statsd_count(key, "+1", labels);
+	return convert_result(statsd_count(key, "+1", labels));
 }
 
 static int ki_statsd_incr(sip_msg_t *msg, str *key)
 {
-	return statsd_count(key->s, "+1", NULL);
+	return convert_result(statsd_count(key->s, "+1", NULL));
 }
 
 static int ki_statsd_incr_with_labels(sip_msg_t *msg, str *key, str *labels)
 {
-	return statsd_count(key->s, "+1", labels->s);
+	return convert_result(statsd_count(key->s, "+1", labels->s));
 }
 
 static int func_decr(struct sip_msg *msg, char *key)
 {
-	return statsd_count(key, "-1", NULL);
+	return convert_result(statsd_count(key, "-1", NULL));
 }
 
 static int func_decr_with_labels(struct sip_msg *msg, char *key, char *labels)
 {
-	return statsd_count(key, "-1", labels);
+	return convert_result(statsd_count(key, "-1", labels));
 }
 
 static int ki_statsd_decr(sip_msg_t *msg, str *key)
 {
-	return statsd_count(key->s, "-1", NULL);
+	return convert_result(statsd_count(key->s, "-1", NULL));
 }
 
 static int ki_statsd_decr_with_labels(sip_msg_t *msg, str *key, str *labels)
 {
-	return statsd_count(key->s, "-1", labels->s);
+	return convert_result(statsd_count(key->s, "-1", labels->s));
+}
+
+static int convert_result(bool result)
+{
+	if(result == false) {
+		return -1;
+	}
+
+	return 0;
 }
 
 char *get_milliseconds(char *dst)

--- a/src/modules/statsd/statsd.c
+++ b/src/modules/statsd/statsd.c
@@ -116,7 +116,6 @@ static int mod_init(void)
 	rc = statsd_init(statsd_params.ip, statsd_params.port);
 	if(rc == false) {
 		LM_ERR("Statsd connection failed (ERROR_CODE: %i)\n", rc);
-		return -1;
 	} else {
 		LM_INFO("Statsd: success connection to statsd server\n");
 	}
@@ -323,7 +322,7 @@ static int convert_result(bool result)
 		return -1;
 	}
 
-	return 0;
+	return 1;
 }
 
 char *get_milliseconds(char *dst)


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

2 issues:

**Issue 1:**
Currently statsd functions return bool: `true` or `false` depending when
the function succeeds or fails respectively.

This value gets implicitly converted to `int`: `true` -> `1`, `false` ->
`0`.

For Kamailio `1` means succesfull execution, but `0` means to stop
processing messages, which is not what we want as statsd should not impact
flow execution. Instead we want to return `-1` which signifies error,
but the flow continues.


**Issue 2:**
statsd_init executes `statsd_connect` which tries to connect to statd
server.

If connection fails then kamailio fails to start.
This is not the desired behaviour as:
1. Kamailio should continue working even if statsd server is down,
   metrics should not impact runtime.
2. `statsd_connect` is also re-executed each time we try to send the metric https://github.com/salemove/kamailio/blame/master/src/modules/statsd/lib_statsd.c#L76,
so it's initial result is not essential.

Note, that before 5.8 the result of init was already ignored due to
implicit conversion of `false` to `0`
until after
https://github.com/kamailio/kamailio/commit/0186246fce8f0e4bb46b30c05174983cd957a3ba
was introduced (which could be considered a breaking change even if it
seemingly fixes a bug in conversion).
