### PR TITLE
multiple subsytems: unsigned integer conversion fixes

### DIFF
--- a/src/lib/srdb1/db_ut.c
+++ b/src/lib/srdb1/db_ut.c
@@ -596,6 +596,10 @@ int db_val2pv_spec(struct sip_msg *msg, db_val_t *dbval, pv_spec_t *pvs)
 				pv.flags = PV_VAL_INT | PV_TYPE_INT;
 				pv.ri = (long)dbval->val.int_val;
 				break;
+			case DB1_UINT:
+				pv.flags = PV_VAL_INT | PV_TYPE_INT;
+				pv.ri = (long)dbval->val.uint_val;
+				break;
 			case DB1_DATETIME:
 				pv.flags = PV_VAL_INT | PV_TYPE_INT;
 				pv.ri = (long)dbval->val.time_val;

--- a/src/modules/htable/ht_db.c
+++ b/src/modules/htable/ht_db.c
@@ -132,6 +132,8 @@ static int ht_pack_values(
 			len += RES_ROWS(db_res)[row].values[c].val.blob_val.len;
 		} else if(RES_ROWS(db_res)[row].values[c].type == DB1_INT) {
 			len += 12;
+		} else if(RES_ROWS(db_res)[row].values[c].type == DB1_UINT) {
+			len += 12;
 		} else {
 			LM_ERR("unsupported data type for column %d\n", c);
 			return -1;
@@ -163,6 +165,11 @@ static int ht_pack_values(
 		} else if(RES_ROWS(db_res)[row].values[c].type == DB1_INT) {
 			iv.s = sint2str(
 					RES_ROWS(db_res)[row].values[c].val.int_val, &iv.len);
+			strncpy(p, iv.s, iv.len);
+			p += iv.len;
+		} else if(RES_ROWS(db_res)[row].values[c].type == DB1_UINT) {
+			iv.s = int2str(
+					RES_ROWS(db_res)[row].values[c].val.uint_val, &iv.len);
 			strncpy(p, iv.s, iv.len);
 			p += iv.len;
 		}

--- a/src/modules/permissions/address.c
+++ b/src/modules/permissions/address.c
@@ -192,41 +192,49 @@ int reload_address_db_table(address_tables_group_t *atg)
 					ROW_N(row + i));
 			goto dberror;
 		}
-		if((VAL_TYPE(val) != DB1_INT) || VAL_NULL(val) || (VAL_INT(val) <= 0)) {
+		if((VAL_TYPE(val) != DB1_INT && VAL_TYPE(val) != DB1_UINT)
+				|| VAL_NULL(val) || (VAL_INT(val) <= 0)) {
 			LM_DBG("failure during checks of database value 1 (group) in "
 				   "address table\n");
 			goto dberror;
 		}
-		if((VAL_TYPE(val + 1) != DB1_STRING)
-				&& (VAL_TYPE(val + 1) != DB1_STR)) {
+		if((VAL_TYPE(val + 1) != DB1_STRING && VAL_TYPE(val + 1) != DB1_STR)
+				|| VAL_NULL(val + 1)) {
 			LM_DBG("failure during checks of database value 2 (IP address) in "
-				   "address table - not a string value\n");
+				   "address table\n");
 			goto dberror;
 		}
-		if(VAL_NULL(val + 1)) {
-			LM_DBG("failure during checks of database value 2 (IP address) in "
-				   "address table - NULL value not permitted\n");
-			goto dberror;
-		}
-		if((VAL_TYPE(val + 2) != DB1_INT) || VAL_NULL(val + 2)) {
+		if((VAL_TYPE(val + 2) != DB1_INT && VAL_TYPE(val + 2) != DB1_UINT)
+				|| VAL_NULL(val + 2)) {
 			LM_DBG("failure during checks of database value 3 (subnet "
 				   "size/CIDR) in address table\n");
 			goto dberror;
 		}
-		if((VAL_TYPE(val + 3) != DB1_INT) || VAL_NULL(val + 3)) {
+		if((VAL_TYPE(val + 3) != DB1_INT && VAL_TYPE(val + 3) != DB1_UINT)
+				|| VAL_NULL(val + 3)) {
 			LM_DBG("failure during checks of database value 4 (port) in "
 				   "address table\n");
 			goto dberror;
 		}
+		if(VAL_TYPE(val + 4) != DB1_STRING && VAL_TYPE(val + 4) != DB1_STR) {
+			LM_DBG("failure during checks of database value 5 (tag) in address "
+				   "table\n");
+			goto dberror;
+		}
+
 		gid = VAL_UINT(val);
 		ips.s = (char *)VAL_STRING(val + 1);
 		ips.len = strlen(ips.s);
 		mask = VAL_UINT(val + 2);
 		port = VAL_UINT(val + 3);
-		tagv.s = VAL_NULL(val + 4) ? NULL : (char *)VAL_STRING(val + 4);
-		if(tagv.s != NULL) {
+		if(VAL_NULL(val + 4)) {
+			tagv.s = NULL;
+			tagv.len = 0;
+		} else {
+			tagv.s = (char *)VAL_STRING(val + 4);
 			tagv.len = strlen(tagv.s);
 		}
+
 		if(reload_address_insert(atg, gid, &ips, mask, port, &tagv) < 0) {
 			goto dberror;
 		}


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Adding support for converting unsigned integers from database tables into kamailio pseudo variables usable in the routing config.  
This is quite useful when pulling `int unsigned` fields from a database, in modules that support "extra fields" in their module parameters.  