### PR TITLE
uac: add reload_delta parameter

### DIFF
--- a/src/modules/uac/doc/uac.xml
+++ b/src/modules/uac/doc/uac.xml
@@ -28,6 +28,11 @@
 			<surname>Modroiu</surname>
 				<email>ramona@rosdev.ro</email>
 		</editor>
+		<editor>
+			<firstname>Tyler</firstname>
+			<surname>Moore</surname>
+			<email>tmoore@dopensource.com</email>
+		</editor>
 	</authorgroup>
 	<copyright>
 		<year>2009-2010</year>
@@ -36,6 +41,10 @@
 	<copyright>
 		<year>2005</year>
 		<holder>Voice Sistem</holder>
+	</copyright>
+	<copyright>
+		<year>2024</year>
+		<holder>Tyler Moore, dOpenSource</holder>
 	</copyright>
 	</bookinfo>
 	<toc></toc>

--- a/src/modules/uac/doc/uac_admin.xml
+++ b/src/modules/uac/doc/uac_admin.xml
@@ -563,9 +563,7 @@ modparam("uac", "reg_active", 0)
 			Timer interval (in seconds) at which remote registrations are cleaned
 			up in case of failure or removed. When setting it take in consideration
 			the maximum value for retransmission timeout, this param should be greater
-			than it. This value also impacts how often the reload for remote
-			registrations table can be executed -- the RPC command will fail if
-			executed in less than reg_gc_interval value since the last reload.
+			than it.
 			</para>
 			<para>
 				<emphasis>
@@ -659,6 +657,35 @@ function ksr_uac_event(evname)
 end
  ...
  </programlisting>
+		</example>
+	</section>
+
+	<section id="uac.p.reload_delta">
+		<title><varname>reload_delta</varname> (int)</title>
+		<para>
+			The number of seconds that have to be waited before executing a new
+			RPC reload (uac.reg_reload). By default, RPC reloads are rate limited
+			to a maximum of one reload per the reload_delta interval.
+		</para>
+		<para>
+			If set to 0, no rate limit is configured. Note carefully: use this
+			configuration only in tests environments because executing two RPC
+			reloads of the same table at the same time can cause &kamailio;
+			to crash.
+		</para>
+		<para>
+			<emphasis>
+				The default value is 30 seconds.
+			</emphasis>
+		</para>
+
+		<example>
+			<title>Set <varname>reload_delta</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("uac", "reload_delta", 20)
+...
+			</programlisting>
 		</example>
 	</section>
 	</section>
@@ -1421,8 +1448,8 @@ event_route[uac:reply] {
 			</title>
 		<para>
 			Reload the records from database for remote registrations. There is
-			a limit of how often the reload command can be executed, by default
-			is 150 seconds between reloads -- see the reg_gc_interval parameter
+			a limit of how often the reload command can be executed. By default,
+			it is 30 seconds between reloads -- see the reload_delta parameter
 			for more details.
 		</para>
 		<example>

--- a/src/modules/uac/uac.c
+++ b/src/modules/uac/uac.c
@@ -115,6 +115,7 @@ static int child_init(int rank);
 extern int reg_timer_interval;
 extern int _uac_reg_gc_interval;
 extern int _uac_reg_use_domain;
+extern int _uac_reg_reload_delta;
 
 static pv_export_t mod_pvs[] = {
 		{{"uac_req", sizeof("uac_req") - 1}, PVT_OTHER, pv_get_uac_req,
@@ -187,7 +188,8 @@ static param_export_t params[] = {
 		{"reg_hash_size", INT_PARAM, &reg_htable_size},
 		{"reg_use_domain", PARAM_INT, &_uac_reg_use_domain},
 		{"default_socket", PARAM_STR, &uac_default_socket},
-		{"event_callback", PARAM_STR, &uac_event_callback}, {0, 0, 0}};
+		{"event_callback", PARAM_STR, &uac_event_callback},
+		{"reload_delta", INT_PARAM, &_uac_reg_reload_delta}, {0, 0, 0}};
 
 
 struct module_exports exports = {"uac", /* module name */

--- a/src/modules/uac/uac_reg.c
+++ b/src/modules/uac/uac_reg.c
@@ -63,6 +63,7 @@
 #define UAC_REG_DB_COLS_NUM 15
 
 int _uac_reg_gc_interval = 150;
+int _uac_reg_reload_delta = 30;
 
 typedef struct _reg_uac
 {
@@ -393,11 +394,11 @@ int uac_reg_ht_shift(void)
 	tn = time(NULL);
 
 	lock_get(_reg_htable_gc_lock);
-	if(_reg_htable_gc->stime > tn - _uac_reg_gc_interval) {
+	if(_reg_htable_gc->stime > tn - _uac_reg_reload_delta) {
 		lock_release(_reg_htable_gc_lock);
 		LM_ERR("shifting in-memory table is not possible in less than %d "
 			   "secs\n",
-				_uac_reg_gc_interval);
+				_uac_reg_reload_delta);
 		return -1;
 	}
 	uac_reg_reset_ht_gc();


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Add support for setting a different RPC reload interval than the reg_gc_interval parameter.  
This allows the cleanup timer to match the user's re-transmission timeout without constraining RPC reload times to a large interval.
