### PR TITLE
utils/kamctl: make root host/port configurable

### DIFF
--- a/utils/kamctl/kamctlrc
+++ b/utils/kamctl/kamctlrc
@@ -44,6 +44,14 @@
 ## database access host (from where is kamctl used)
 # DBACCESSHOST=192.168.0.1
 
+## database host for super user (useful for specifying a local socket or virtual hostname)
+# defaults to value of DBHOST when not set
+# DBROOTHOST="localhost"
+
+## database port for super user (on some DB specifying the port will force TCP connections)
+# default value will depend on client DB tool
+# DBROOTPORT=""
+
 ## database super user (for ORACLE this is 'scheme-creator' user)
 # DBROOTUSER="root"
 

--- a/utils/kamctl/kamdbctl.base
+++ b/utils/kamctl/kamdbctl.base
@@ -20,6 +20,9 @@ DBROUSER=${DBROUSER:-kamailioro}
 # password for read-only user
 DBROPW=${DBROPW:-kamailioro}
 
+# address of database server for root connections
+DBROOTHOST=${DBROOTHOST:-$DBHOST}
+
 # user name column
 USERCOL=${USERCOL:-username}
 

--- a/utils/kamctl/kamdbctl.mysql
+++ b/utils/kamctl/kamdbctl.mysql
@@ -27,23 +27,22 @@ fi
 # config vars
 #################################################################
 
-# full privileges MySQL user
-if [ -z "$DBROOTUSER" ]; then
-	DBROOTUSER="root"
-fi
-
 # Set DBROOTPW in kamctlrc or via next line to set the database
 # root password if you want to run this script without any user prompt.
 # This is unsafe, but useful e.g. for automatic testing.
 #DBROOTPW=""
 
-
-if [ -z "$DBPORT" ] ; then
-	CMD="mysql -h $DBHOST -u$DBROOTUSER "
-	DUMP_CMD="mysqldump -h $DBHOST -u$DBROOTUSER -c -t "
-else
-	CMD="mysql -h $DBHOST -P $DBPORT -u$DBROOTUSER "
-	DUMP_CMD="mysqldump -h $DBHOST -P $DBPORT -u$DBROOTUSER -c -t "
+# build the client base commands one param at a time
+# let the client choose defaults where not specified
+CMD="mysql -h $DBROOTHOST"
+DUMP_CMD="mysqldump -c -t -h $DBROOTHOST"
+if [ -n "$DBROOTPORT" ] ; then
+	CMD="$CMD -P $DBROOTPORT"
+	DUMP_CMD="$DUMP_CMD -P $DBROOTPORT"
+fi
+if [ -n "$DBROOTUSER" ]; then
+  	CMD="$CMD -u $DBROOTUSER"
+  	DUMP_CMD="mysqldump -u $DBROOTUSER"
 fi
 
 #################################################################

--- a/utils/kamctl/kamdbctl.pgsql
+++ b/utils/kamctl/kamdbctl.pgsql
@@ -51,12 +51,12 @@ if [ -z "$DBROOTUSER" ]; then
 	fi
 fi
 
-if [ -z "$DBPORT" ] ; then
-	CMD="psql -q -h $DBHOST -U $DBROOTUSER "
-	DUMP_CMD="pg_dump -h $DBHOST -U $DBROOTUSER -c"
+if [ -z "$DBROOTPORT" ] ; then
+	CMD="psql -q -h $DBROOTHOST -U $DBROOTUSER "
+	DUMP_CMD="pg_dump -h $DBROOTHOST -U $DBROOTUSER -c"
 else
-	CMD="psql -q -h $DBHOST -p $DBPORT -U $DBROOTUSER "
-	DUMP_CMD="pg_dump -h $DBHOST -p $DBPORT -U $DBROOTUSER -c"
+	CMD="psql -q -h $DBROOTHOST -p $DBROOTPORT -U $DBROOTUSER "
+	DUMP_CMD="pg_dump -h $DBROOTHOST -p $DBROOTPORT -U $DBROOTUSER -c"
 fi
 
 #################################################################


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
- add support for configuring the DB root host/port connection parameters separate from the ro/rw settings. This allows the user to authenticate over the specific socket configured (tcp/udp/unix) for each connection type (root/ro/rw).
- note that support is added for mysql and postgresql connections. no changes to the other DB engine connection parameters.
