### PR TITLE
db_cluster: Update log levels and failed connection id

### DIFF
--- a/src/modules/db_cluster/dbcl_api.c
+++ b/src/modules/db_cluster/dbcl_api.c
@@ -72,9 +72,12 @@ extern int dbcl_max_query_length;
 								cls->usedcon = cls->rlist[i].clist[j];         \
 								return 0;                                      \
 							} else {                                           \
-								LM_DBG("serial operation - failure on cluster" \
-									   " [%.*s] (%d/%d)\n",                    \
-										cls->name.len, cls->name.s, i, j);     \
+								LM_WARN("serial operation - failure on "       \
+										"cluster"                              \
+										" [%.*s] (%d/%d) [%.*s]\n",            \
+										cls->name.len, cls->name.s, i, j,      \
+										cls->rlist[i].clist[j]->name.len,      \
+										cls->rlist[i].clist[j]->name.s);       \
 								sec = get_ticks() - sec;                       \
 								if(sec >= dbcl_max_query_length) {             \
 									dbcl_inactive_con(cls->rlist[i].clist[j]); \
@@ -106,10 +109,12 @@ extern int dbcl_max_query_length;
 										(j + 1) % cls->rlist[i].clen;          \
 								return 0;                                      \
 							} else {                                           \
-								LM_DBG("round robin operation - failure on "   \
-									   "cluster"                               \
-									   " [%.*s] (%d/%d)\n",                    \
-										cls->name.len, cls->name.s, i, j);     \
+								LM_WARN("round robin operation - failure on "  \
+										"cluster"                              \
+										" [%.*s] (%d/%d) [%.*s]\n",            \
+										cls->name.len, cls->name.s, i, j,      \
+										cls->rlist[i].clist[j]->name.len,      \
+										cls->rlist[i].clist[j]->name.s);       \
 								sec = get_ticks() - sec;                       \
 								if(sec >= dbcl_max_query_length) {             \
 									dbcl_inactive_con(cls->rlist[i].clist[j]); \
@@ -124,7 +129,7 @@ extern int dbcl_max_query_length;
 					return -1;                                                 \
 			}                                                                  \
 		}                                                                      \
-		LM_DBG("no successful read on cluster [%.*s]\n", cls->name.len,        \
+		LM_ERR("no successful read on cluster [%.*s]\n", cls->name.len,        \
 				cls->name.s);                                                  \
 		return ret;                                                            \
 	} while(0)
@@ -167,9 +172,12 @@ extern int dbcl_max_query_length;
 								cls->usedcon = cls->wlist[i].clist[j];         \
 								return 0;                                      \
 							} else {                                           \
-								LM_DBG("serial operation - failure on cluster" \
-									   " [%.*s] (%d/%d)\n",                    \
-										cls->name.len, cls->name.s, i, j);     \
+								LM_WARN("serial operation - failure on "       \
+										"cluster"                              \
+										" [%.*s] (%d/%d) [%.*s]\n",            \
+										cls->name.len, cls->name.s, i, j,      \
+										cls->rlist[i].clist[j]->name.len,      \
+										cls->rlist[i].clist[j]->name.s);       \
 								sec = get_ticks() - sec;                       \
 								if(sec >= dbcl_max_query_length) {             \
 									dbcl_inactive_con(cls->wlist[i].clist[j]); \
@@ -201,10 +209,12 @@ extern int dbcl_max_query_length;
 										(j + 1) % cls->wlist[i].clen;          \
 								return 0;                                      \
 							} else {                                           \
-								LM_DBG("round robin operation - failure on "   \
-									   "cluster"                               \
-									   " [%.*s] (%d/%d)\n",                    \
-										cls->name.len, cls->name.s, i, j);     \
+								LM_WARN("round robin operation - failure on "  \
+										"cluster"                              \
+										" [%.*s] (%d/%d) [%.*s]\n",            \
+										cls->name.len, cls->name.s, i, j,      \
+										cls->rlist[i].clist[j]->name.len,      \
+										cls->rlist[i].clist[j]->name.s);       \
 								sec = get_ticks() - sec;                       \
 								if(sec >= dbcl_max_query_length) {             \
 									dbcl_inactive_con(cls->wlist[i].clist[j]); \
@@ -232,10 +242,12 @@ extern int dbcl_max_query_length;
 								cls->usedcon = cls->wlist[i].clist[j];         \
 								rok = 1;                                       \
 							} else {                                           \
-								LM_DBG("parallel operation - failure on "      \
-									   "cluster"                               \
-									   " [%.*s] (%d/%d)\n",                    \
-										cls->name.len, cls->name.s, i, j);     \
+								LM_WARN("parallel operation - failure on "     \
+										"cluster"                              \
+										" [%.*s] (%d/%d) [%.*s]\n",            \
+										cls->name.len, cls->name.s, i, j,      \
+										cls->rlist[i].clist[j]->name.len,      \
+										cls->rlist[i].clist[j]->name.s);       \
 								sec = get_ticks() - sec;                       \
 								if(sec >= dbcl_max_query_length) {             \
 									dbcl_inactive_con(cls->wlist[i].clist[j]); \
@@ -253,7 +265,7 @@ extern int dbcl_max_query_length;
 					return -1;                                                 \
 			}                                                                  \
 		}                                                                      \
-		LM_DBG("no successful write on cluster [%.*s]\n", cls->name.len,       \
+		LM_ERR("no successful write on cluster [%.*s]\n", cls->name.len,       \
 				cls->name.s);                                                  \
 		return ret;                                                            \
 	} while(0)
@@ -303,9 +315,12 @@ extern int dbcl_max_query_length;
 								cls->usedcon = cls->wlist[i].clist[j];         \
 								return 0;                                      \
 							} else {                                           \
-								LM_DBG("serial operation - failure on cluster" \
-									   " [%.*s] (%d/%d)\n",                    \
-										cls->name.len, cls->name.s, i, j);     \
+								LM_WARN("serial operation - failure on "       \
+										"cluster"                              \
+										" [%.*s] (%d/%d) [%.*s]\n",            \
+										cls->name.len, cls->name.s, i, j,      \
+										cls->rlist[i].clist[j]->name.len,      \
+										cls->rlist[i].clist[j]->name.s);       \
 								sec = get_ticks() - sec;                       \
 								if(sec >= dbcl_max_query_length) {             \
 									dbcl_inactive_con(cls->wlist[i].clist[j]); \
@@ -343,10 +358,12 @@ extern int dbcl_max_query_length;
 										(j + 1) % cls->wlist[i].clen;          \
 								return 0;                                      \
 							} else {                                           \
-								LM_DBG("round robin operation - failure on "   \
-									   "cluster"                               \
-									   " [%.*s] (%d/%d)\n",                    \
-										cls->name.len, cls->name.s, i, j);     \
+								LM_WARN("round robin operation - failure on "  \
+										"cluster"                              \
+										" [%.*s] (%d/%d) [%.*s]\n",            \
+										cls->name.len, cls->name.s, i, j,      \
+										cls->rlist[i].clist[j]->name.len,      \
+										cls->rlist[i].clist[j]->name.s);       \
 								sec = get_ticks() - sec;                       \
 								if(sec >= dbcl_max_query_length) {             \
 									dbcl_inactive_con(cls->wlist[i].clist[j]); \
@@ -380,10 +397,12 @@ extern int dbcl_max_query_length;
 								cls->usedcon = cls->wlist[i].clist[j];         \
 								rok = 1;                                       \
 							} else {                                           \
-								LM_DBG("parallel operation - failure on "      \
-									   "cluster"                               \
-									   " [%.*s] (%d/%d)\n",                    \
-										cls->name.len, cls->name.s, i, j);     \
+								LM_WARN("parallel operation - failure on "     \
+										"cluster"                              \
+										" [%.*s] (%d/%d) [%.*s]\n",            \
+										cls->name.len, cls->name.s, i, j,      \
+										cls->rlist[i].clist[j]->name.len,      \
+										cls->rlist[i].clist[j]->name.s);       \
 								sec = get_ticks() - sec;                       \
 								if(sec >= dbcl_max_query_length) {             \
 									dbcl_inactive_con(cls->wlist[i].clist[j]); \
@@ -401,7 +420,7 @@ extern int dbcl_max_query_length;
 					return -1;                                                 \
 			}                                                                  \
 		}                                                                      \
-		LM_DBG("no successful write on cluster [%.*s]\n", cls->name.len,       \
+		LM_ERR("no successful write on cluster [%.*s]\n", cls->name.len,       \
 				cls->name.s);                                                  \
 		return ret;                                                            \
 	} while(0)


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This PR aims to update some warning levels used in `db_cluster` module to prevent silent failures.

When `db_cluster` tries to do some action in a `db_connector`, it should log some kind of warning (with `conid` that failed) or error instead of debug.
When iterating on db_connectors and one fails, it will log a warning with `conid` and if all of the available db are not available it will log an error indicating failure.