### PR TITLE
sipcapture: docs - fix default value for parameter

### DIFF
--- a/src/modules/sipcapture/doc/sipcapture_admin.xml
+++ b/src/modules/sipcapture/doc/sipcapture_admin.xml
@@ -89,7 +89,7 @@
 		</para>
 		<para>
 		<emphasis>
-			Default value is "".
+			Default value is <quote>DEFAULT_DB_URL</quote>.
 		</emphasis>
 		</para>
 		<example>


### PR DESCRIPTION

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue) _== Fix of documentation of a long standing error_
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description


The sipcapture module actually uses the DEFAULT_DB_URL instead of "no database at all". When you do not set the parameter, the module will try to connect to the default db. [See source code of parameter](https://github.com/volkland/kamailio/blob/74361cdeacee8864216d309a4842b71fb484a412/src/modules/sipcapture/sipcapture.c#L178).
