### PR TITLE
permissions: introduce func `allow_register_include_port()`

### DIFF
--- a/src/modules/permissions/doc/permissions.xml
+++ b/src/modules/permissions/doc/permissions.xml
@@ -48,6 +48,13 @@
 			<email>eschmidbauer@voipxswitch.com</email>
 		</address>
 		</editor>
+		<editor>
+		<firstname>Donat</firstname>
+		<surname>Zenichev</surname>
+		<address>
+			<email>dzenichev@sipwise.com</email>
+		</address>
+		</editor>
 	</authorgroup>
 	<copyright>
 		<year>2003</year>

--- a/src/modules/permissions/doc/permissions_admin.xml
+++ b/src/modules/permissions/doc/permissions_admin.xml
@@ -121,6 +121,8 @@
 		similar to the algorithm described in
 		<xref linkend="sec-call-routing"/>. The only difference is in the way
 		how pairs are created.
+		Additionally one can use <function moreinfo="none">allow_register_include_port</function>
+		function in order to include the port value of the Contact into the check.
 		</para>
 		<para>
 		Instead of the From header field the function uses the To header field because
@@ -384,6 +386,7 @@ modparam("permissions", "check_all_branches", 0)
 		Suffix to be appended to basename to create filename of the allow
 		file when version with one parameter of either
 		<function moreinfo="none">allow_routing</function> or
+		<function moreinfo="none">allow_register_include_port</function> or
 		<function moreinfo="none">allow_register</function> is used.
 		</para>
 		<note>
@@ -411,6 +414,7 @@ modparam("permissions", "allow_suffix", ".allow")
 		Suffix to be appended to basename to create filename of the deny file
 		when version with one parameter of either
 		<function moreinfo="none">allow_routing</function> or
+		<function moreinfo="none">allow_register_include_port</function> or
 		<function moreinfo="none">allow_register</function> is used.
 		</para>
 		<note>
@@ -1097,6 +1101,98 @@ if (method=="REGISTER") {
 </programlisting>
 		</example>
 	</section>
+	<section id ="permissions.f.allow_register_include_port">
+		<title>
+		<function moreinfo="none">allow_register_include_port(basename)</function>
+		</title>
+		<para>
+		The function does exacty the same thing as <function>allow_register(basename)</function>
+		apart that it tells the module to include the port value of Contact into the check.
+		No additional function parameters required.
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>basename</emphasis> - Basename from which allow
+			and deny filenames will be created by appending contents of
+			<varname>allow_suffix</varname> and <varname>deny_suffix</varname>
+			parameters.
+			</para>
+			<para>
+			If the parameter doesn't contain full pathname then the function
+			expects the file to be located in the same directory as the main
+			configuration file of the server.
+			</para>
+		</listitem>
+		</itemizedlist>
+		<para>
+		This function can be used from REQUEST_ROUTE, FAILURE_ROUTE.
+		</para>
+		<example>
+		<title><function>allow_register_include_port(basename)</function> usage</title>
+		<programlisting format="linespecific">
+...
+if (method=="REGISTER") {
+	if (allow_register_include_port("register")) {
+		save("location");
+		exit;
+	} else {
+		sl_send_reply("403", "Forbidden");
+	};
+};
+...
+</programlisting>
+		</example>
+	</section>
+	<section id ="permissions.f.allow_register_include_port_fileargs">
+		<title>
+		<function moreinfo="none">allow_register_include_port(allow_file, deny_file)</function>
+		</title>
+		<para>
+		The function does exacty the same thing as <function>allow_register(allow_file, deny_file)</function>
+		apart that it tells the module to include the port value of Contact into the check.
+		No additional function parameters required.
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>allow_file</emphasis> - File containing allow rules.
+			</para>
+			<para>
+			If the parameter doesn't contain full pathname then the function
+			expects the file to be located in the same directory as the main
+			configuration file of the server.
+			</para>
+		</listitem>
+		<listitem>
+			<para><emphasis>deny_file</emphasis> - File containing deny rules.
+			</para>
+			<para>
+			If the parameter doesn't contain full pathname then the function
+			expects the file to be located in the same directory as the main
+			configuration file of the server.
+			</para>
+		</listitem>
+		</itemizedlist>
+		<para>
+		This function can be used from REQUEST_ROUTE, FAILURE_ROUTE.
+		</para>
+		<example>
+		<title><function>allow_register_include_port(allow_file, deny_file)</function> usage</title>
+		<programlisting format="linespecific">
+...
+if (method=="REGISTER") {
+	if (allow_register_include_port("register.allow", "register.deny")) {
+		save("location");
+		exit;
+	} else {
+		sl_send_reply("403", "Forbidden");
+	};
+};
+...
+</programlisting>
+		</example>
+	</section>
 	<section id ="permissions.f.allow_uri">
 		<title>
 		<function moreinfo="none">allow_uri(basename, pvar)</function>
@@ -1491,5 +1587,51 @@ if (allow_trusted("$si", "any", "$ai")) {
 		</example>
 
 	</section> <!-- Address File Format -->
+
+	<section>
+		<title>Register File Format</title>
+		<para>
+		It is a text file with one record per line. Lines starting with '#' are
+		considered comments and ignored. Comments can be also at the end of
+		records, by using '#' to start the comment part of the line.
+		</para>
+		<para>
+		Each record line has the format:
+		</para>
+		<programlisting format="linespecific">
+...
+(from_list,str) (req_uri_list,str)
+...
+</programlisting>
+		<para>
+		The 'str' indicates that the value has to be a string compatible with
+		POSIX Extended Regular Expressions.
+		</para>
+		<example>
+		<title>Register File Sample</title>
+		<programlisting format="linespecific">
+...
+# Syntax:
+#	from_list [EXCEPT from_list] : req_uri_list [EXCEPT req_uri_list]
+#
+# 	from_list and req_uri_list are comma separated expressions
+# 	Expressions are treated as case insensitive POSIX Extended Regular Expressions.
+# 	Keyword ALL matches any expression.
+#
+# Examples (requires a usage of allow_register() function):
+#	ALL : "^sip:361[0-9]*@abc\.com$" EXCEPT "^sip:361[0-9]*3@abc\.com$", "^sip:361[0-9]*4@abc\.com$"
+#
+#	"^sip:3677[0-9]*@abc\.com$" :  "^sip:361[0-9]*@abc\.com$"
+#
+#	All : ALL
+#
+# Examples including port check (requires a usage of allow_register_include_port() function):
+#
+# ALL : "^sip:.*@192.168.0.1:5062"
+...
+</programlisting>
+		</example>
+
+	</section> <!-- Register File Format -->
 
 </chapter>


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Introduce new function: `allow_register_include_port()` to be able to check the whole Contact header including port.

Example, register.deny content is:
```
	ALL : "^sip:.*192.168.0.101:5062"
```

If the Contact is: "Contact: <sip:testuser1004@192.168.0.101:5062>" then this will check the Contact hf including port of it.

Otherwise if usual `allow_register()` function is used, then only the "testuser1004@192.168.0.101" will be taken into account, which will lead the regex to be failing and letting the check to pass through.

The func `allow_register_include_port()` works similarly as `allow_register()` except it checks Contact's port.

A separate function was created in order to not complicate things by introducing one more parameter to the
existing function `allow_register()`, which already takes a variable amount of parameters, so 1 or 2 parameters
(depending on if it is a "basename" or "allow-file, deny-file").

Documentation updated accordingly.
Additionally, "Register File Format" section has been added to the doc (to provide allow/deny file examples).

Full backwards compatibility is kept in place,
no need for users of the module to change anything in their configuration or kamailio script itself.
