### PR TITLE
Added new auth module function auth_algorithm

### DIFF
--- a/src/modules/auth/auth_mod.c
+++ b/src/modules/auth/auth_mod.c
@@ -490,7 +490,7 @@ int w_has_credentials(sip_msg_t *msg, char *realm, char *s2)
  */
 int w_auth_algorithm(sip_msg_t *msg, char *alg, char *s2)
 {
-	if(fixup_get_svalue(msg, (gparam_t*)alg, &auth_algorithm) < 0) {
+	if(fixup_get_svalue(msg, (gparam_t *)alg, &auth_algorithm) < 0) {
 		LM_ERR("failed to get algorithm value\n");
 		return -1;
 	}
@@ -499,13 +499,13 @@ int w_auth_algorithm(sip_msg_t *msg, char *alg, char *s2)
 		hash_hex_len = HASHHEXLEN;
 		calc_HA1 = calc_HA1_md5;
 		calc_response = calc_response_md5;
-	} else if (strcmp(auth_algorithm.s, "SHA-256") == 0) {
+	} else if(strcmp(auth_algorithm.s, "SHA-256") == 0) {
 		hash_hex_len = HASHHEXLEN_SHA256;
 		calc_HA1 = calc_HA1_sha256;
 		calc_response = calc_response_sha256;
 	} else {
 		LM_ERR("Invalid algorithm provided."
-		           " Possible values are \"\", \"MD5\" or \"SHA-256\"\n");
+			   " Possible values are \"\", \"MD5\" or \"SHA-256\"\n");
 		return -1;
 	}
 

--- a/src/modules/auth/auth_mod.c
+++ b/src/modules/auth/auth_mod.c
@@ -70,10 +70,16 @@ static int mod_init(void);
  * Remove used credentials from a SIP message header
  */
 int w_consume_credentials(struct sip_msg *msg, char *s1, char *s2);
+
 /*
  * Check for credentials with given realm
  */
 int w_has_credentials(struct sip_msg *msg, char *s1, char *s2);
+
+/*
+ * Set authentication algorithm
+ */
+int w_auth_algorithm(struct sip_msg *msg, char *alg, char* s2);
 
 static int pv_proxy_authenticate(
 		struct sip_msg *msg, char *realm, char *passwd, char *flags);
@@ -170,6 +176,8 @@ static cmd_export_t cmds[] = {
 			REQUEST_ROUTE},
 	{"pv_auth_check", (cmd_function)w_pv_auth_check, 4, fixup_pv_auth_check,
 			0, REQUEST_ROUTE},
+	{"auth_algorithm", w_auth_algorithm, 1, fixup_spve_null, 0,
+			REQUEST_ROUTE},
 	{"bind_auth_s", (cmd_function)bind_auth_s, 0, 0, 0},
 
 	{0, 0, 0, 0, 0, 0}
@@ -475,6 +483,35 @@ int w_has_credentials(sip_msg_t *msg, char *realm, char *s2)
 		return -1;
 	}
 	return ki_has_credentials(msg, &srealm);
+}
+
+/**
+ *
+ */
+int w_auth_algorithm(sip_msg_t *msg, char* alg, char* s2)
+{
+	if (fixup_get_svalue(msg, (gparam_t*)alg, &auth_algorithm) < 0) {
+		LM_ERR("failed to get algorithm value\n");
+		return -1;
+	}
+
+	if (strcmp(auth_algorithm.s, "MD5") == 0) {
+		hash_hex_len = HASHHEXLEN;
+		calc_HA1 = calc_HA1_md5;
+		calc_response = calc_response_md5;
+	}
+	else if (strcmp(auth_algorithm.s, "SHA-256") == 0) {
+		hash_hex_len = HASHHEXLEN_SHA256;
+		calc_HA1 = calc_HA1_sha256;
+		calc_response = calc_response_sha256;
+	}
+	else {
+		LM_ERR("Invalid algorithm provided."
+		       " Possible values are \"\", \"MD5\" or \"SHA-256\"\n");
+		return -1;
+	}
+
+	return 1;
 }
 
 #ifdef USE_NC

--- a/src/modules/auth/auth_mod.c
+++ b/src/modules/auth/auth_mod.c
@@ -79,7 +79,7 @@ int w_has_credentials(struct sip_msg *msg, char *s1, char *s2);
 /*
  * Set authentication algorithm
  */
-int w_auth_algorithm(struct sip_msg *msg, char *alg, char* s2);
+int w_auth_algorithm(struct sip_msg *msg, char *alg, char *s2);
 
 static int pv_proxy_authenticate(
 		struct sip_msg *msg, char *realm, char *passwd, char *flags);
@@ -488,26 +488,24 @@ int w_has_credentials(sip_msg_t *msg, char *realm, char *s2)
 /**
  *
  */
-int w_auth_algorithm(sip_msg_t *msg, char* alg, char* s2)
+int w_auth_algorithm(sip_msg_t *msg, char *alg, char *s2)
 {
-	if (fixup_get_svalue(msg, (gparam_t*)alg, &auth_algorithm) < 0) {
+	if(fixup_get_svalue(msg, (gparam_t*)alg, &auth_algorithm) < 0) {
 		LM_ERR("failed to get algorithm value\n");
 		return -1;
 	}
 
-	if (strcmp(auth_algorithm.s, "MD5") == 0) {
+	if(strcmp(auth_algorithm.s, "MD5") == 0) {
 		hash_hex_len = HASHHEXLEN;
 		calc_HA1 = calc_HA1_md5;
 		calc_response = calc_response_md5;
-	}
-	else if (strcmp(auth_algorithm.s, "SHA-256") == 0) {
+	} else if (strcmp(auth_algorithm.s, "SHA-256") == 0) {
 		hash_hex_len = HASHHEXLEN_SHA256;
 		calc_HA1 = calc_HA1_sha256;
 		calc_response = calc_response_sha256;
-	}
-	else {
+	} else {
 		LM_ERR("Invalid algorithm provided."
-		       " Possible values are \"\", \"MD5\" or \"SHA-256\"\n");
+		           " Possible values are \"\", \"MD5\" or \"SHA-256\"\n");
 		return -1;
 	}
 

--- a/src/modules/auth/doc/auth_functions.xml
+++ b/src/modules/auth/doc/auth_functions.xml
@@ -412,5 +412,21 @@ if (auth_get_www_authenticate("$fd", "0", "$var(wauth)")) {
 </programlisting>
 		</example>
 	</section>
+    <section id="auth.f.auth_algorithm">
+	<title><function>auth_algorithm(algorithm)</function></title>
+	<para>
+	  Set hash algorithm used for digest authentication thus overriding
+      algorithm parameter. Possible values are the same as those of
+      algorithm parameter.  The parameter may be a pseudo variable.
+	</para>
+	<example>
+	    <title>auth_algorithm  example</title>
+	    <programlisting>
+...
+auth_algorithm("$alg");
+...
+	    </programlisting>
+	</example>
+    </section>
 
 </section>


### PR DESCRIPTION
#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Added new Added new auth module function auth_algorithm that can be used to dynamically override algorithm parameter value.

#### Note
I was not able to test check README, because of this error:
```
/usr/src/orig/kamailio$ make modules-readme modules=modules/auth
make -C src/ modules-readme 
make[1]: Entering directory '/usr/src/orig/kamailio/src'
make --no-print-directory -C doc auth.txt
xsltproc  --novalid \
        --nonet \
        --novalid \
        --stringparam output "auth.d" \
        ../../../../doc/docbook/dep.xsl auth.xml 
xsltproc  --novalid \
	--xinclude \
        ../../../../doc/docbook/txt.xsl auth.xml | lynx -nolist -stdin -dump > auth.txt
error : Unknown IO error
warning: failed to load external entity "http://docbook.sourceforge.net/release/xsl/current/xhtml/docbook.xsl"
compilation error: file ../../../../doc/docbook/txt.xsl line 6 element import
xsl:import : unable to load http://docbook.sourceforge.net/release/xsl/current/xhtml/docbook.xsl
```

