### PR TITLE
core/resolve: Check dns_cache_init and choose appropriate functions

### DIFF
--- a/src/core/resolve.c
+++ b/src/core/resolve.c
@@ -1623,7 +1623,11 @@ struct hostent *no_naptr_srv_sip_resolvehost(
 			srv_name.s = tmp_srv;
 			srv_name.len = strlen(tmp_srv);
 #ifdef USE_DNS_CACHE
-			he = dns_srv_get_he(&srv_name, port, dns_flags);
+			if(dns_cache_init) {
+				he = dns_srv_get_he(&srv_name, port, dns_flags);
+			} else {
+				he = srv_sip_resolvehost(&srv_name, 0, port, proto, 1, 0);
+			}
 #else
 			he = srv_sip_resolvehost(&srv_name, 0, port, proto, 1, 0);
 #endif
@@ -1660,6 +1664,7 @@ struct hostent *naptr_sip_resolvehost(
 	struct rdata *naptr_head;
 	char n_proto;
 	str srv_name;
+	str *name_copy = 0;
 	naptr_bmp_t tried_bmp; /* tried bitmap */
 	char origproto = PROTO_NONE;
 
@@ -1704,7 +1709,15 @@ struct hostent *naptr_sip_resolvehost(
 	he = no_naptr_srv_sip_resolvehost(name, port, proto);
 	/* fallback all the way down to A/AAAA */
 	if(he == 0) {
-		he = dns_get_he(name, dns_flags);
+		if(dns_cache_init) {
+			he = dns_get_he(name, dns_flags);
+		} else {
+			/* We need a zero terminated char* */
+			name_copy = shm_malloc(name->len + 1);
+			shm_str_dup(name_copy, name);
+			he = resolvehost(name_copy->s);
+			shm_free(name_copy);
+		}
 	}
 end:
 	if(naptr_head)
@@ -1833,6 +1846,45 @@ ip_addr_t *str2ip(str *st)
 	return ipb;
 }
 
+/*
+* Resolve a host name to a hostent.
+* @param[in] name: the host name to resolve
+* @return the hostent structure or NULL on error
+*
+* @note
+* This function is a wrapper to choose between the DNS cache and the
+* system resolver. If the DNS cache is enabled, it will use the DNS cache
+* to resolve the host name. Otherwise, it will use the system resolver.
+*/
+struct hostent *__resolvehost(char *name)
+{
+	if(dns_cache_init) {
+		return dns_resolvehost(name);
+	} else {
+		return _resolvehost(name);
+	}
+}
+
+/*
+* Resolve a host name to a hostent.
+* @param[in] name: the host name to resolve
+* @param[in] port: the port number
+* @param[in] proto: the protocol
+* @return the hostent structure or NULL on error
+*
+* @note
+* This function is a wrapper to choose between the DNS cache and the
+* system resolver. If the DNS cache is enabled, it will use the DNS cache
+* to resolve the host name. Otherwise, it will use the system resolver.
+*/
+struct hostent *__sip_resolvehost(str *name, unsigned short *port, char *proto)
+{
+	if(dns_cache_init) {
+		return dns_sip_resolvehost(name, port, proto);
+	} else {
+		return _sip_resolvehost(name, port, proto);
+	}
+}
 /* converts a str to an ipv6 address struct stored in ipb
  * - ipb must be already allocated
  * - return 0 on success; <0 on failure */

--- a/src/core/resolve.h
+++ b/src/core/resolve.h
@@ -329,14 +329,14 @@ int sip_hostport2su(
 		union sockaddr_union *su, str *host, unsigned short port, char *proto);
 
 
+/* Wrapper functions that check for dns_cache_init */
+struct hostent *__resolvehost(char *name);
+struct hostent *__sip_resolvehost(str *name, unsigned short *port, char *proto);
+
+
 /* wrappers */
-#ifdef USE_DNS_CACHE
-#define resolvehost dns_resolvehost
-#define sip_resolvehost dns_sip_resolvehost
-#else
-#define resolvehost _resolvehost
-#define sip_resolvehost _sip_resolvehost
-#endif
+#define resolvehost __resolvehost
+#define sip_resolvehost __sip_resolvehost
 
 
 #ifdef USE_NAPTR


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3350

#### Description
<!-- Describe your changes in detail -->
This PR fixes a crash when `dns_cache_init=off`.

The issue is described in #3350 and the crash is caused when trying to search in `dns_cache.c` [LOCK_DNS_HASH();](https://github.com/kamailio/kamailio/blob/d4629be286fc6d3cf61574e34ee877b2c5e9ee4a/src/core/dns_cache.c#L671). 

When `dns_cache_init=off`, the lock is never initialized and when trying to lock it crashes. 

Per my understanding, when `dns_cache_init=off`, no calls to `dns_cache.c` should be made and instead call the alternative ones from `resolve.c`, since the whole functions are compiled only when USE_DNS_CACHE definition is present.

Just a question to clarify, what is the reasoning behind USE_DNS_CACHE definition and a separate `dns_cache_init` parameter?