### PR TITLE
fixed handle_ruri_alias_mode(1) cannot proper handle multi alias

### DIFF
--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -1160,8 +1160,6 @@ static int ki_handle_ruri_alias_mode(struct sip_msg *msg, int mode)
 				/* use first alias parameter */
 				break;
 			}
-			rest = rest + _ksr_contact_alias.len;
-			rest_len = rest_len - _ksr_contact_alias.len;
 		}
 		sep = memchr(rest, 59 /* ; */, rest_len);
 		if(sep == NULL) {

--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -1153,7 +1153,7 @@ static int ki_handle_ruri_alias_mode(struct sip_msg *msg, int mode)
 	}
 	start = NULL;
 	/* locate last alias parameter */
-	while(rest_len > _ksr_contact_alias.len + 4) {
+	while(rest_len > _ksr_contact_alias.len) {
 		if(strncmp(rest, _ksr_contact_alias.s, _ksr_contact_alias.len) == 0) {
 			start = rest;
 			if(mode == 0) {


### PR DESCRIPTION
when receive BYE sip:xxx@xxxx;alias=ip1;alias=ip2 SIP/2.0, handle_ruri_alias_mode(1) doesn't work as documented