### PR TITLE
p_usrloc: Add update/delete based on uniq

### DIFF
--- a/src/modules/p_usrloc/doc/p_usrloc_admin.xml
+++ b/src/modules/p_usrloc/doc/p_usrloc_admin.xml
@@ -643,6 +643,11 @@ modparam("p_usrloc", "default_db_type", "cluster")
 					<emphasis>2</emphasis> uses the new style using aor, contact and call-id
 				</para>
 			</listitem>
+			<listitem>
+				<para>
+					<emphasis>3</emphasis> uses contact uniq value + ruid value
+				</para>
+			</listitem>
 		</itemizedlist>
 	</para>
 	<para>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Add a new update/delete function based on contact's uniq uniq. Some devices may use same uniq for multiple contacts, so I needed to restrain it further based on ruid value.