### PR TITLE
tls: remove confusing error message when trying to print socket for <default> server

### DIFF
--- a/src/modules/tls/tls_domain.c
+++ b/src/modules/tls/tls_domain.c
@@ -1155,14 +1155,14 @@ static int ksr_tls_fix_domain(tls_domain_t *d, tls_domain_t *def)
 					   d->ctx[i], tls_server_name_cb)) {
 				LM_ERR("register server_name callback handler for socket "
 					   "[%s:%d], server_name='%s' failed for proc %d\n",
-						ip_addr2a(&d->ip), d->port,
+						(d->ip.af > 0) ? ip_addr2a(&d->ip) : "0.0.0.0", d->port,
 						(d->server_name.s) ? d->server_name.s : "<default>", i);
 				return -1;
 			}
 			if(!SSL_CTX_set_tlsext_servername_arg(d->ctx[i], d)) {
 				LM_ERR("register server_name callback handler data for socket "
 					   "[%s:%d], server_name='%s' failed for proc %d\n",
-						ip_addr2a(&d->ip), d->port,
+						(d->ip.af > 0) ? ip_addr2a(&d->ip) : "0.0.0.0", d->port,
 						(d->server_name.s) ? d->server_name.s : "<default>", i);
 				return -1;
 			}
@@ -1175,7 +1175,7 @@ static int ksr_tls_fix_domain(tls_domain_t *d, tls_domain_t *def)
 			&& (d->server_name.len > 0 || (d->type & TLS_DOMAIN_DEF))) {
 		LM_NOTICE("registered server_name callback handler for socket "
 				  "[%s:%d], server_name='%s' ...\n",
-				ip_addr2a(&d->ip), d->port,
+				(d->ip.af > 0) ? ip_addr2a(&d->ip) : "0.0.0.0", d->port,
 				(d->server_name.s) ? d->server_name.s : "<default>");
 	}
 #endif


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally

#### Description

On start:
```
CRITICAL: <core> [core/ip_addr.c:232]: ip_addr2sbuf(): unknown address family 0
NOTICE: tls [tls_domain.c:1176]: ksr_tls_fix_domain(): registered server_name callback handler for socket [:0], server_name='<default>' ...
```
Now it will print:

```
NOTICE: tls [tls_domain.c:1176]: ksr_tls_fix_domain(): registered server_name callback handler for socket [0.0.0.0:0], server_name='<default>' ...
```
