### PR TITLE
Build for el9 without legacy geoip

### DIFF
--- a/pkg/kamailio/obs/kamailio.spec
+++ b/pkg/kamailio/obs/kamailio.spec
@@ -9,6 +9,7 @@
 %bcond_with dnssec
 %bcond_without evapi
 %bcond_without geoip
+%bcond_without geoip1
 %bcond_without http_async_client
 %bcond_without ims
 %bcond_without jansson
@@ -46,6 +47,7 @@
 %bcond_with dnssec
 %bcond_without evapi
 %bcond_without geoip
+%bcond_without geoip1
 %bcond_without http_async_client
 %bcond_without ims
 %bcond_without jansson
@@ -93,6 +95,7 @@
 %bcond_with dnssec
 %bcond_without evapi
 %bcond_without geoip
+%bcond_without geoip1
 %bcond_without http_async_client
 %bcond_without ims
 %bcond_without jansson
@@ -139,7 +142,8 @@
 %bcond_without cnxcc
 %bcond_with dnssec
 %bcond_without evapi
-%bcond_without geoip
+%bcond_with geoip
+%bcond_with geoip1
 %bcond_without http_async_client
 %bcond_without ims
 %bcond_without jansson
@@ -170,6 +174,7 @@
 %bcond_with dnssec
 %bcond_with evapi
 %bcond_without geoip
+%bcond_without geoip1
 %bcond_without http_async_client
 %bcond_without ims
 %bcond_without jansson
@@ -470,8 +475,12 @@ suspended when sending the event, to be resumed at a later point, maybe triggere
 %package    geoip
 Summary:    MaxMind GeoIP support for Kamailio
 Group:      %{PKGGROUP}
-Requires:   GeoIP, libmaxminddb, kamailio = %ver
-BuildRequires:  GeoIP-devel, libmaxminddb-devel
+%if %{with geoip1}
+Requires:   GeoIP
+BuildRequires:  GeoIP-devel
+%endif
+Requires:   libmaxminddb, kamailio = %ver
+BuildRequires:  libmaxminddb-devel
 
 %description    geoip
 MaxMind GeoIP support for Kamailio.
@@ -1227,7 +1236,9 @@ make every-module skip_modules="app_mono db_cassandra db_oracle iptrtpproxy \
     kev \
 %endif
 %if %{with geoip}
+%if %{with geoip1}
     kgeoip \
+%endif
     kgeoip2 \
 %endif
     kgzcompress \
@@ -1340,7 +1351,9 @@ make install-modules-all skip_modules="app_mono db_cassandra db_oracle \
     kev \
 %endif
 %if %{with geoip}
+%if %{with geoip1}
     kgeoip \
+%endif
     kgeoip2 \
 %endif
     kgzcompress \
@@ -1938,9 +1951,11 @@ fi
 %if %{with geoip}
 %files      geoip
 %defattr(-,root,root)
+%if %{with geoip1}
 %doc %{_docdir}/kamailio/modules/README.geoip
-%doc %{_docdir}/kamailio/modules/README.geoip2
 %{_libdir}/kamailio/modules/geoip.so
+%endif
+%doc %{_docdir}/kamailio/modules/README.geoip2
 %{_libdir}/kamailio/modules/geoip2.so
 %endif
 
@@ -2421,6 +2436,9 @@ fi
 
 
 %changelog
+* Thu Sep 10 2024 Oded Arbel <oded@geek.co.il>
+  - Added option to disable building the geoip module that require the obsolete and unsupported GeoIP library
+    and default to not building it for distributions that no longer ship it.
 * Tue Sep 13 2022 Gustavo Almeida <galmeida@broadvoice.com>
   - added readline-devel build dependency
 * Sat Aug 31 2019 Sergey Safarov <s.safarov@gmail.com> 5.3.0-dev7


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue

#### Description

The `kamailio-geoip` RPM sub package currently builds both the `geoip` module - based on [the old and out of support MaxMind GeoIP library](https://github.com/maxmind/geoip-api-c) - and the newer `geoip2` module - based on [the currently supported `libmaxminddb`](https://github.com/maxmind/libmaxminddb).

The old GeoIP C library had its end of support date at May 2022 but for a while was still shipped for many distributions. At this point though, the EPEL repository that shipped the GeoIP library for RHEL-based operating systems, has removed it from their repositories for "Enterprise Linux 9":
![Screenshot_20240620_144233](https://github.com/kamailio/kamailio/assets/381782/bb1f2481-57f7-48af-b0f1-0ba1c14a3042)

Therefor builds using the bundled spec file fail on EL9 installations.

The suggested change is to add an RPM build option `--with geoip2` that when specified will build just the `geoip2` module for the `kamailio-geoip` RPM subpackage. This build option is not enabled by default, unless the build is running on a RHEL 9 based OS - in which case it is set as the default, because otherwise trivial builds break. To revert to the older behavior in RHEL 9 based OSs (and assuming you have the required unsupported library installed correctly) one will need to set both `--without geoip2 --with geoip`.