### PR TITLE
textopsx/doc: fixed hard-to-read documentation for textopsx

### DIFF
--- a/src/modules/textopsx/doc/selects.xml
+++ b/src/modules/textopsx/doc/selects.xml
@@ -9,30 +9,35 @@
 	<title>@hf_value</title>
 	<para>
 		Get value of required header-value or param. Note that functions called 'value2'
-		works with Authorization-like headers where comma is not treated as value delimiter. Formats:
-		@hf_value.HFNAME[IDX]    # idx value, negative value counts from bottom
-		@hf_value.HFNAME.PARAM_NAME
-		@hf_value.HFNAME[IDX].PARAM_NAME
-		@hf_value.HFNAME.p.PARAM_NAME  # or .param., useful if required called "uri", "p", "param"
-		@hf_value.HFNAME[IDX].p.PARAM_NAME # dtto
-		@hf_value.HFNAME[IDX].uri # (&lt; &amp; &gt; excluded)
-		@hf_value.HFNAME[*]     # return comma delimited list of all values (combines headers)
-		@hf_value.HFNAME        # the same as above [*] but may be parsed by cfg.y
-		@hf_value.HFNAME[*].uri # return comma delimited list of uris (&lt; &amp; &gt; excluded)
-		@hf_value.HFNAME.uri    # the same as above [*] but may be parsed by cfg.y
-		@hf_value.HFNAME[IDX].name  # returns name part, quotes excluded
-		@hf_value.HFNAME.name   # returns name part of the first value
+		works with Authorization-like headers where comma is not treated as value delimiter. 
+	</para>
+	<para>
+	Formats:
+	<itemizedlist>
+		<listitem>@hf_value.HFNAME[IDX]    # idx value, negative value counts from bottom</listitem>
+		<listitem>@hf_value.HFNAME.PARAM_NAME</listitem>
+		<listitem>@hf_value.HFNAME[IDX].PARAM_NAME</listitem>
+		<listitem>@hf_value.HFNAME.p.PARAM_NAME  # or .param., useful if required called "uri", "p", "param"</listitem>
+		<listitem>@hf_value.HFNAME[IDX].p.PARAM_NAME # dtto</listitem>
+		<listitem>@hf_value.HFNAME[IDX].uri # (&lt; &amp; &gt; excluded)</listitem>
+		<listitem>@hf_value.HFNAME[*]     # return comma delimited list of all values (combines headers)</listitem>
+		<listitem>@hf_value.HFNAME        # the same as above [*] but may be parsed by cfg.y</listitem>
+		<listitem>@hf_value.HFNAME[*].uri # return comma delimited list of uris (&lt; &amp; &gt; excluded)</listitem>
+		<listitem>@hf_value.HFNAME.uri    # the same as above [*] but may be parsed by cfg.y</listitem>
+		<listitem>@hf_value.HFNAME[IDX].name  # returns name part, quotes excluded</listitem>
+		<listitem>@hf_value.HFNAME.name   # returns name part of the first value</listitem>
 
-		@hf_value2.HFNAME        # returns value of first header
-		@hf_value2.HFNAME[IDX]   # returns value of idx's header
-		@hf_value2.HFNAME.PARAM_NAME
-		@hf_value2.HFNAME[IDX].PARAM_NAME
+		<listitem>@hf_value2.HFNAME        # returns value of first header</listitem>
+		<listitem>@hf_value2.HFNAME[IDX]   # returns value of idx's header</listitem>
+		<listitem>@hf_value2.HFNAME.PARAM_NAME</listitem>
+		<listitem>@hf_value2.HFNAME[IDX].PARAM_NAME</listitem>
 
-		@hf_value.HFNAME[IDX].uri  # return URI, quotes excluded
-		@hf_value.HFNAME.p.uri  # returns param named uri, not URI itself
-		@hf_value.HFNAME.p.name # returns param named name, not name itself
-		@hf_value.HFNAME[IDX].uri.name #  any sel_any_uri nested features may be used
-		@hf_value.HFNAME[IDX].nameaddr.name # select_any_nameaddr
+		<listitem>@hf_value.HFNAME[IDX].uri  # return URI, quotes excluded</listitem>
+		<listitem>@hf_value.HFNAME.p.uri  # returns param named uri, not URI itself</listitem>
+		<listitem>@hf_value.HFNAME.p.name # returns param named name, not name itself</listitem>
+		<listitem>@hf_value.HFNAME[IDX].uri.name #  any sel_any_uri nested features may be used</listitem>
+		<listitem>@hf_value.HFNAME[IDX].nameaddr.name # select_any_nameaddr</listitem>
+	</itemizedlist>
 	</para>
 	<para>Meaning of the parameters is as follows:</para>
 	<itemizedlist>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [N/A] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Part of the documentation of the textopsx module (the selectors) was hard to read, since it was missing line-wraps in the example.

- itemizing the list of examples for readability