### PR TITLE
[WIP] ims_registrar_pcscf,ims_qos: added a parameter for trusting the bottom Via header on requests

### DIFF
--- a/misc/examples/ims/icscf/kamailio.cfg
+++ b/misc/examples/ims/icscf/kamailio.cfg
@@ -238,10 +238,6 @@ route{
 	xlog("I-CSCF >>>>>>>>>>>>>>>>>>>> $rm $ru ($fu => $tu ($si:$sp) to $tu, $ci)\n");
 #!endif
 
-	if !($rU =~ "\+.*") {
-		prefix("+");
-	}
-
 	# per request initial checks
 	route(REQINIT);
 

--- a/src/core/ut.h
+++ b/src/core/ut.h
@@ -700,6 +700,14 @@ static inline int str2int(str *_s, unsigned int *_r)
 	str2unval(_s, _r, int, UINT_MAX);
 }
 
+/*
+ * Convert a str to unsigned short
+ */
+static inline int str2ushort(str *_s, unsigned short *_r)
+{
+	str2unval(_s, _r, short, USHRT_MAX);
+}
+
 
 #define str2snval(_s, _r, _vtype, _vmin, _vmax)                                \
 	do {                                                                       \

--- a/src/lib/ims/ims_getters.c
+++ b/src/lib/ims/ims_getters.c
@@ -1638,7 +1638,7 @@ str *cscf_get_service_route(struct sip_msg *msg, int *size, int is_shm)
 			}
 			x = pkg_reallocxf(x, (*size + k) * sizeof(str));
 			if(!x) {
-				LM_ERR("Error our of pkg memory");
+				LM_ERR("Error out of pkg memory");
 				return 0;
 			}
 			r2 = r;

--- a/src/modules/ims_icscf/location.c
+++ b/src/modules/ims_icscf/location.c
@@ -161,16 +161,14 @@ int I_perform_location_information_request(
 		free_saved_lir_transaction_data(saved_t);
 		cscf_reply_transactional(msg, 480, MSG_480_DIAMETER_ERROR);
 
+		// shm_malloc in cscf_get_public_identity_from_requri
 		if(public_identity.s && !orig)
-			shm_free(
-					public_identity
-							.s); // shm_malloc in cscf_get_public_identity_from_requri
+			shm_free(public_identity.s);
 		return CSCF_RETURN_BREAK;
 	}
+	// shm_malloc in cscf_get_public_identity_from_requri
 	if(public_identity.s && !orig)
-		shm_free(
-				public_identity
-						.s); // shm_malloc in cscf_get_public_identity_from_requri
+		shm_free(public_identity.s);
 
 	//we use async replies therefore we send break and not true when successful
 	return CSCF_RETURN_BREAK;

--- a/src/modules/ims_qos/doc/ims_qos_admin.xml
+++ b/src/modules/ims_qos/doc/ims_qos_admin.xml
@@ -579,6 +579,46 @@ modparam("ims_qos", "dialog_direction", 1)
         </programlisting>
       </example>
     </section>
+
+    <section>
+      <title><varname>trust_bottom_via</varname> (int)</title>
+      <para>
+        If set to 1 it will trust the bottom Via as the UE IP/port/transport when doing client identification.
+      </para>
+      <para>
+        Normally, the UE identification should be done on IPsec SPIs and source IP/port of the packets. 
+        In some cases the ims_* modules trust the top Via on requests and the bottom Via on responses. In some (better)
+        cases this trusts the received-from IP (or the alias in the Contact header).
+      </para>
+      <para>
+        This parameter allows for an external-to-Kamailio IPsec functionality to be used. That will be in charge of
+        guaranteeing that the bottom Via header is always correct (on requests; on responses the P-CSCF itself should
+        guarantee unmodified Via headers stack). Then the code here will always use the bottom Via as the source of
+        truth for IMS UE identification.
+      </para>
+      <para>
+        <emphasis>Note:</emphasis> this will prefer the standard received and rport values, if present, over the actual
+        Via sent-by host and port.
+      </para>
+      <para>
+        <emphasis>Note:</emphasis> !! trusting the Via header has security drawbacks, as it might be easily spoofed by
+        an attacker. Hence, without extra security, the P-CSCF shouldn't trust the Via header for client identification
+        on requests and this module would require a fix or extension for this. Currently only pcscf_save() is safe from
+        this issue, while pcscf_save_pending() and pcscf_is_registered() seem to be using by default the top/first Via
+        on requests, or the bottom/last Via on responses !!
+      </para>
+      <para><emphasis>Default value is 0 (trust received-from IP and alias in Contact, and, unfortunaly somewhat wrongly
+      top/bottom Via on requests/responses).</emphasis></para>
+      <example>
+        <title><varname>trust_bottom_via</varname> parameter usage</title>
+        <programlisting format="linespecific">
+...
+modparam("ims_qos", "trust_bottom_via", 1)
+...
+        </programlisting>
+      </example>
+    </section>
+
   </section>
 
   <section>

--- a/src/modules/ims_qos/ims_qos_mod.h
+++ b/src/modules/ims_qos/ims_qos_mod.h
@@ -72,3 +72,4 @@ int create_return_code(int result);
 
 
 #endif /* MOD_H */
+

--- a/src/modules/ims_qos/rx_aar.h
+++ b/src/modules/ims_qos/rx_aar.h
@@ -63,8 +63,8 @@ typedef struct saved_transaction
 	gen_lock_t *lock;
 	unsigned int ignore_replies;
 	unsigned int answers_not_received;
-	unsigned int
-			failed; //will start at 0 - if 1 fails we can set the flag up (1)
+	// will start at 0 - if 1 fails we can set the flag up (1)
+	unsigned int failed;
 	unsigned int tindex;
 	unsigned int tlabel;
 	unsigned int ticks;

--- a/src/modules/ims_qos/rx_authdata.h
+++ b/src/modules/ims_qos/rx_authdata.h
@@ -50,6 +50,8 @@
 #ifndef RX_AUTH_DATA_H
 #define RX_AUTH_DATA_H
 
+#include "../../modules/ims_dialog/dlg_load.h"
+
 extern struct tm_binds tmb;
 extern struct cdp_binds cdpb;
 extern ims_dlg_api_t dlgb;

--- a/src/modules/ims_qos/rx_avp.c
+++ b/src/modules/ims_qos/rx_avp.c
@@ -1358,7 +1358,7 @@ inline int rx_get_result_code(AAAMessage *msg, unsigned int *data)
 }
 
 /**
- * Creates and adds an Acct-Application-Id AVP.
+ * Creates and adds an Specific-Action AVP
  * @param msg - the Diameter message to add to.
  * @param data - the value for the AVP payload
  * @return CSCF_RETURN_TRUE on success or 0 on error

--- a/src/modules/ims_qos/rx_avp.h
+++ b/src/modules/ims_qos/rx_avp.h
@@ -102,3 +102,4 @@ unsigned int rx_get_abort_cause(AAAMessage *msg);
 int rx_add_specific_action_avp(AAAMessage *msg, unsigned int data);
 
 #endif /*__PCC_AVP_H*/
+

--- a/src/modules/ims_registrar_pcscf/doc/ims_registrar_pcscf.xml
+++ b/src/modules/ims_registrar_pcscf/doc/ims_registrar_pcscf.xml
@@ -55,6 +55,12 @@
 
         <email>carsten@ng-voice.com</email>
       </author>
+
+      <author>
+        <firstname>Dragos</firstname>
+        <surname>Vingarzan</surname>
+        <email>vingarzan -at- gmail dot com</email>
+      </author>
     </authorgroup>
 
     <copyright>

--- a/src/modules/ims_registrar_pcscf/doc/ims_registrar_pcscf_admin.xml
+++ b/src/modules/ims_registrar_pcscf/doc/ims_registrar_pcscf_admin.xml
@@ -289,6 +289,45 @@ modparam("ims_registrar_pcscf", "delete_delay", 10)
       </example>
     </section>
 
+    <section>
+      <title><varname>trust_bottom_via</varname> (int)</title>
+      <para>
+        If set to 1 it will trust the bottom Via as the UE IP/port/transport when doing client identification.
+      </para>
+      <para>
+        Normally, the UE identification should be done on IPsec SPIs and source IP/port of the packets. 
+        In some cases the ims_* modules trust the top Via on requests and the bottom Via on responses. In some (better)
+        cases this trusts the received-from IP (or the alias in the Contact header).
+      </para>
+      <para>
+        This parameter allows for an external-to-Kamailio IPsec functionality to be used. That will be in charge of
+        guaranteeing that the bottom Via header is always correct (on requests; on responses the P-CSCF itself should
+        guarantee unmodified Via headers stack). Then the code here will always use the bottom Via as the source of
+        truth for IMS UE identification.
+      </para>
+      <para>
+        <emphasis>Note:</emphasis> this will prefer the standard received and rport values, if present, over the actual
+        Via sent-by host and port.
+      </para>
+      <para>
+        <emphasis>Note:</emphasis> !! trusting the Via header has security drawbacks, as it might be easily spoofed by
+        an attacker. Hence, without extra security, the P-CSCF shouldn't trust the Via header for client identification
+        on requests and this module would require a fix or extension for this. Currently only pcscf_save() is safe from
+        this issue, while pcscf_save_pending() and pcscf_is_registered() seem to be using by default the top/first Via
+        on requests, or the bottom/last Via on responses !!
+      </para>
+      <para><emphasis>Default value is 0 (trust received-from IP and alias in Contact, and, unfortunaly somewhat wrongly
+      top/bottom Via on requests/responses).</emphasis></para>
+      <example>
+        <title><varname>trust_bottom_via</varname> parameter usage</title>
+        <programlisting format="linespecific">
+...
+modparam("ims_registrar_pcscf", "trust_bottom_via", 1)
+...
+        </programlisting>
+      </example>
+    </section>
+
   </section>
 
   <section>

--- a/src/modules/ims_registrar_pcscf/doc/ims_registrar_pcscf_admin.xml
+++ b/src/modules/ims_registrar_pcscf/doc/ims_registrar_pcscf_admin.xml
@@ -212,6 +212,35 @@ modparam("ims_registrar_pcscf", "ignore_contact_rxport_check", 1)
     </section>
 
     <section>
+      <title><varname>ignore_contact_rxproto_check</varname> (int)</title>
+
+      <para>
+        Validate, if the protocol, from which the request was received, is the
+        same as used during registration.
+
+        Note: with IMS, the UE opens IPsec Security Associations between IPs
+        and ports with the P-CSCF. These are for both UDP and TCP, with a
+        single negotiation, which does not need to specify the protocol. Hence
+        why is this checked at all? Before it could be ignored if the parameter
+        ignore_contact_rxport_check was set (bug/typo maybe?).
+      </para>
+
+      <para>This Parameter is primarily used by the "is_registered" function.</para>
+
+      <para><emphasis>Default value is 1 (ignore protocol, for best compliance).</emphasis></para>
+
+      <example>
+        <title><varname>ignore_contact_rxproto_check</varname> parameter usage</title>
+
+        <programlisting format="linespecific">
+...
+modparam("ims_registrar_pcscf", "ignore_contact_rxproto_check", 1)
+...
+        </programlisting>
+      </example>
+    </section>
+
+    <section>
       <title><varname>ignore_reg_state</varname> (int)</title>
 
       <para>Validate, if the found contact is really and completely registered.</para>

--- a/src/modules/ims_registrar_pcscf/ims_registrar_pcscf_mod.c
+++ b/src/modules/ims_registrar_pcscf/ims_registrar_pcscf_mod.c
@@ -83,9 +83,13 @@ int publish_reginfo = 0;
 int subscribe_to_reginfo = 0;
 int subscription_expires = 3600;
 int ignore_reg_state = 0;
-/**!< ignore port checks between received port on message and registration received port.
+/** ignore port checks between received port on message and registration received port.
  * this is useful for example if you register with UDP but possibly send invite over TCP (message too big) */
 int ignore_contact_rxport_check = 0;
+/** ignore proto checks between the one that the message was received over and registration one.
+ * Since in IMS is registering the IP:port of the UE with IPsec for any transport, why was this even needed? Hence
+ * setting to 1 as default.*/
+int ignore_contact_rxproto_check = 1;
 /** If set, this uses the bottom Via for identification of UE, always, on both requests and responses, over Contact. */
 int trust_bottom_via = 0;
 
@@ -188,6 +192,8 @@ static param_export_t params[] = {{"pcscf_uri", PARAM_STR, &pcscf_uri},
 		{"subscription_expires", INT_PARAM, &subscription_expires},
 		{"ignore_contact_rxport_check", INT_PARAM,
 				&ignore_contact_rxport_check},
+		{"ignore_contact_rxproto_check", INT_PARAM,
+				&ignore_contact_rxproto_check},
 		{"ignore_reg_state", INT_PARAM, &ignore_reg_state},
 		{"force_icscf_uri", PARAM_STR, &force_icscf_uri},
 		{"reginfo_queue_size_threshold", INT_PARAM,

--- a/src/modules/ims_registrar_pcscf/ims_registrar_pcscf_mod.c
+++ b/src/modules/ims_registrar_pcscf/ims_registrar_pcscf_mod.c
@@ -86,6 +86,8 @@ int ignore_reg_state = 0;
 /**!< ignore port checks between received port on message and registration received port.
  * this is useful for example if you register with UDP but possibly send invite over TCP (message too big) */
 int ignore_contact_rxport_check = 0;
+/** If set, this uses the bottom Via for identification of UE, always, on both requests and responses, over Contact. */
+int trust_bottom_via = 0;
 
 time_t time_now;
 
@@ -106,7 +108,7 @@ unsigned short rcv_avp_type = 0;
 int_str rcv_avp_name;
 
 ims_registrar_pcscf_params_t _imsregp_params = {
-	.delete_delay = 0
+		.delete_delay = 0,
 };
 
 // static str orig_prefix = {"sip:orig@",9};
@@ -191,6 +193,7 @@ static param_export_t params[] = {{"pcscf_uri", PARAM_STR, &pcscf_uri},
 		{"reginfo_queue_size_threshold", INT_PARAM,
 				&reginfo_queue_size_threshold},
 		{"delete_delay", PARAM_INT, &_imsregp_params.delete_delay},
+		{"trust_bottom_via", PARAM_INT, &trust_bottom_via},
 		//	{"store_profile_dereg",	INT_PARAM, &store_data_on_dereg},
 		{0, 0, 0}};
 
@@ -298,14 +301,13 @@ static int mod_init(void)
 	bind_ipsec_pcscf =
 			(bind_ipsec_pcscf_t)find_export("bind_ims_ipsec_pcscf", 1, 0);
 	if(!bind_ipsec_pcscf) {
-		LM_ERR("can't bind ims_ipsec_pcscf\n");
-		return -1;
+		LM_WARN("can't bind ims_ipsec_pcscf - will start without\n");
+	} else {
+		if(bind_ipsec_pcscf(&ipsec_pcscf) < 0) {
+			return -1;
+		}
+		LM_INFO("Successfully bound to PCSCF IPSEC module\n");
 	}
-
-	if(bind_ipsec_pcscf(&ipsec_pcscf) < 0) {
-		return -1;
-	}
-	LM_INFO("Successfully bound to PCSCF IPSEC module\n");
 
 	if(subscribe_to_reginfo == 1) {
 		/* Bind to PUA: */

--- a/src/modules/ims_registrar_pcscf/notify.c
+++ b/src/modules/ims_registrar_pcscf/notify.c
@@ -403,7 +403,7 @@ int process_body(struct sip_msg *msg, str notify_body, udomain_t *domain)
 				LM_ERR("wrong format[%.*s] - failed unsubscribing to reginfo\n",
 						aor.len, aor.s);
 			}
-			reginfo_subscribe_real(msg, presentity_uri_pv, 0, 0);
+			reginfo_subscribe_real(msg, presentity_uri_pv, 0, 0, 0);
 			pv_elem_free_all(presentity_uri_pv);
 		}
 

--- a/src/modules/ims_registrar_pcscf/service_routes.c
+++ b/src/modules/ims_registrar_pcscf/service_routes.c
@@ -27,6 +27,7 @@
 #include "../../core/parser/msg_parser.h"
 #include "../../core/data_lump.h"
 #include "../../lib/ims/ims_getters.h"
+#include "../ims_ipsec_pcscf/cmd.h"
 
 #define STR_APPEND(dst, src)                             \
 	{                                                    \
@@ -40,7 +41,9 @@ static unsigned int current_msg_id = 0;
 static pcontact_t *c = NULL;
 
 extern usrloc_api_t ul;
+extern ipsec_pcscf_api_t ipsec_pcscf;
 extern int ignore_contact_rxport_check;
+extern int trust_bottom_via;
 static str *asserted_identity;
 static str *registration_contact;
 
@@ -117,43 +120,81 @@ int checkcontact(struct sip_msg *_m, pcontact_t *c)
 {
 	int security_server_port = -1;
 	str received_host = {0, 0};
+	unsigned short received_port = 0;
+	char received_proto = 0;
 	char srcip[50];
+
+	if(trust_bottom_via) {
+		struct via_body *vb = cscf_get_last_via(_m);
+		if(vb == 0) {
+			LM_ERR("No via header in request\n");
+			return -1;
+		}
+		if(vb->received != NULL && vb->received->value.len > 0) {
+			received_host = vb->received->value;
+		} else {
+			received_host = vb->host;
+		}
+		if(vb->rport != NULL && vb->rport->value.len > 0) {
+			str2ushort(&vb->rport->value, &received_port);
+		} else {
+			received_port = vb->port;
+		}
+		// this probably doesn't matter, since IMS UEs register IPs for both
+		received_proto = vb->proto;
+	} else {
+		received_host.len = ip_addr2sbuf(&_m->rcv.src_ip, srcip, sizeof(srcip));
+		received_host.s = srcip;
+		received_port = _m->rcv.src_port;
+		received_proto = _m->rcv.proto;
+	}
 
 	LM_DBG("Port %d (search %d), Proto %d (search %d), reg_state %s (search "
 		   "%s)\n",
-			c->received_port, _m->rcv.src_port, c->received_proto,
-			_m->rcv.proto, reg_state_to_string(c->reg_state),
+			c->received_port, received_port, c->received_proto, received_proto,
+			reg_state_to_string(c->reg_state),
 			reg_state_to_string(PCONTACT_REGISTERED));
 
-	if(c->security) {
-		switch(c->security->type) {
-			case SECURITY_IPSEC:
-				security_server_port = c->security->data.ipsec->port_uc;
-				break;
-			case SECURITY_TLS:
-			case SECURITY_NONE:
-				break;
+
+	if(ipsec_pcscf.ipsec_on_expire == NULL) {
+		LM_DBG("ims_ipsec_pcscf module not loaded - skipping port-uc checks\n");
+	} else {
+		if(c->security) {
+			switch(c->security->type) {
+				case SECURITY_IPSEC:
+					security_server_port = c->security->data.ipsec->port_uc;
+					break;
+				case SECURITY_TLS:
+				case SECURITY_NONE:
+					break;
+			}
+		} else if(c->security_temp) {
+			switch(c->security_temp->type) {
+				case SECURITY_IPSEC:
+					security_server_port =
+							c->security_temp->data.ipsec->port_uc;
+					break;
+				case SECURITY_TLS:
+				case SECURITY_NONE:
+					break;
+			}
 		}
-	} else if(c->security_temp) {
-		switch(c->security_temp->type) {
-			case SECURITY_IPSEC:
-				security_server_port = c->security_temp->data.ipsec->port_uc;
-				break;
-			case SECURITY_TLS:
-			case SECURITY_NONE:
-				break;
+
+		if(!ignore_contact_rxport_check && (c->received_port == received_port)
+				&& (security_server_port == received_port)) {
+			LM_DBG("check contact failed - port-uc %d is neither contact "
+				   "received_port %d, nor message received port %d\n",
+					security_server_port, c->received_port, _m->rcv.src_port);
+			return 1;
 		}
 	}
 
 	if((ignore_reg_state || (c->reg_state == PCONTACT_REGISTERED))
+			// Weird... this condition is for rxport, not rxproto. If it was intentional, a comment would be nice,
+			// otherwise I'm thinking it's an unintended effect.
 			&& (ignore_contact_rxport_check
-					|| (c->received_port == _m->rcv.src_port)
-					|| (security_server_port == _m->rcv.src_port))
-			&& (ignore_contact_rxport_check
-					|| (c->received_proto == _m->rcv.proto))) {
+					|| (c->received_proto == received_proto))) {
 
-		received_host.len = ip_addr2sbuf(&_m->rcv.src_ip, srcip, sizeof(srcip));
-		received_host.s = srcip;
 		LM_DBG("Received host len %d (search %d)\n", c->received_host.len,
 				received_host.len);
 		// Then check the length:
@@ -199,7 +240,7 @@ pcontact_t *getContactP(struct sip_msg *_m, udomain_t *_d,
 	b = cscf_parse_contacts(_m);
 
 	if(_m->first_line.type == SIP_REPLY && _m->contact && _m->contact->parsed
-			&& b->contacts) {
+			&& b->contacts && !trust_bottom_via) {
 		mustRetryViaSearch = 1;
 		mustRetryReceivedSearch = 1;
 		LM_DBG("This is a reply - to look for contact we favour the contact "
@@ -224,7 +265,7 @@ pcontact_t *getContactP(struct sip_msg *_m, udomain_t *_d,
 		else
 			LM_DBG("This is a request - using first via to find contact\n");
 
-		vb = cscf_get_ue_via(_m);
+		vb = trust_bottom_via ? cscf_get_last_via(_m) : cscf_get_ue_via(_m);
 		host = vb->host;
 		port = vb->port ? vb->port : 5060;
 		proto = vb->proto;
@@ -234,8 +275,27 @@ pcontact_t *getContactP(struct sip_msg *_m, udomain_t *_d,
 		   "[%d://%.*s:%d]\n",
 			proto, host.len, host.s, port);
 
-	received_host.len = ip_addr2sbuf(&_m->rcv.src_ip, srcip, sizeof(srcip));
-	received_host.s = srcip;
+	if(trust_bottom_via && vb->received && vb->received->value.len > 0) {
+		received_host = vb->received->value;
+	} else {
+		received_host.len = ip_addr2sbuf(&_m->rcv.src_ip, srcip, sizeof(srcip));
+		received_host.s = srcip;
+	}
+	unsigned short received_port = 0;
+	if(trust_bottom_via && vb->rport && vb->rport->value.len > 0) {
+		received_port = atoi(vb->rport->value.s);
+	} else {
+		received_port = _m->rcv.src_port;
+	}
+	if(received_port == 0) {
+		received_port = 5060;
+	}
+	char received_proto = 0;
+	if(trust_bottom_via && vb->proto) {
+		received_proto = vb->proto;
+	} else {
+		received_proto = _m->rcv.proto;
+	}
 
 	//    if (_m->id != current_msg_id) {
 	current_msg_id = _m->id;
@@ -245,8 +305,8 @@ pcontact_t *getContactP(struct sip_msg *_m, udomain_t *_d,
 	search_ci.reg_state = reg_state;
 	search_ci.received_host.s = received_host.s;
 	search_ci.received_host.len = received_host.len;
-	search_ci.received_port = _m->rcv.src_port;
-	search_ci.received_proto = _m->rcv.proto;
+	search_ci.received_port = received_port;
+	search_ci.received_proto = received_proto;
 	search_ci.searchflag = SEARCH_RECEIVED;
 	search_ci.num_service_routes = 0;
 	if(is_registered_fallback2ip == 1) {
@@ -351,6 +411,7 @@ tryagain:
 	if(!c && mustRetryViaSearch) {
 		LM_DBG("This is a reply so we will search using the last via once "
 			   "more...\n");
+		// if trust_bottom_via was set, we wouldn't get here, hence this remains as is.
 		vb = cscf_get_ue_via(_m);
 		search_ci.via_host = vb->host;
 		search_ci.via_port = vb->port ? vb->port : 5060;
@@ -396,7 +457,7 @@ int check_service_routes(struct sip_msg *_m, udomain_t *_d)
 
 	//	LM_DBG("Got %i Route-Headers.\n", c->num_service_routes);
 
-	vb = cscf_get_ue_via(_m);
+	vb = trust_bottom_via ? cscf_get_last_via(_m) : cscf_get_ue_via(_m);
 	port = vb->port ? vb->port : 5060;
 	proto = vb->proto;
 
@@ -597,7 +658,7 @@ int force_service_routes(struct sip_msg *_m, udomain_t *_d)
 	/* we need to be sure we have seen all HFs */
 	parse_headers(_m, HDR_EOH_F, 0);
 
-	vb = cscf_get_ue_via(_m);
+	vb = trust_bottom_via ? cscf_get_last_via(_m) : cscf_get_ue_via(_m);
 	port = vb->port ? vb->port : 5060;
 	proto = vb->proto;
 

--- a/src/modules/ims_registrar_pcscf/service_routes.c
+++ b/src/modules/ims_registrar_pcscf/service_routes.c
@@ -158,7 +158,7 @@ int checkcontact(struct sip_msg *_m, pcontact_t *c)
 
 	if(ipsec_pcscf.ipsec_on_expire == NULL) {
 		LM_DBG("ims_ipsec_pcscf module not loaded - skipping port-uc checks\n");
-	} else {
+	} else if(!ignore_contact_rxport_check) {
 		if(c->security) {
 			switch(c->security->type) {
 				case SECURITY_IPSEC:
@@ -180,8 +180,8 @@ int checkcontact(struct sip_msg *_m, pcontact_t *c)
 			}
 		}
 
-		if(!ignore_contact_rxport_check && (c->received_port == received_port)
-				&& (security_server_port == received_port)) {
+		if(c->received_port != received_port
+				&& security_server_port != received_port) {
 			LM_DBG("check contact failed - port-uc %d is neither contact "
 				   "received_port %d, nor message received port %d\n",
 					security_server_port, c->received_port, _m->rcv.src_port);
@@ -190,8 +190,9 @@ int checkcontact(struct sip_msg *_m, pcontact_t *c)
 	}
 
 	if((ignore_reg_state || (c->reg_state == PCONTACT_REGISTERED))
-			// Weird... this condition is for rxport, not rxproto. If it was intentional, a comment would be nice,
-			// otherwise I'm thinking it's an unintended effect.
+			// Weird... this condition is for rxport, not rxproto. If it was
+			// intentional, a comment would be nice, otherwise I'm thinking
+			// it's an unintended effect.
 			&& (ignore_contact_rxport_check
 					|| (c->received_proto == received_proto))) {
 

--- a/src/modules/ims_registrar_pcscf/subscribe.c
+++ b/src/modules/ims_registrar_pcscf/subscribe.c
@@ -40,37 +40,65 @@ extern str pcscf_uri;
 extern str force_icscf_uri;
 
 #define P_ASSERTED_IDENTITY_HDR_PREFIX "P-Asserted-Identity: <"
+#define ROUTE_HDR_PREFIX "Route: <"
+#define ROUTE_HDR_SEPARATOR ">, <"
+#define ROUTE_HDR_END ">" CRLF
 
-int reginfo_subscribe_real(
-		struct sip_msg *msg, pv_elem_t *uri, str *service_routes, int expires)
+int reginfo_subscribe_real(struct sip_msg *msg, pv_elem_t *uri,
+		str *service_routes, int num_service_routes, int expires)
 {
 	str uri_str = {0, 0};
 	char uri_buf[512];
 	int uri_buf_len = 512;
 	//subs_info_t subs;
-	str p_asserted_identity_header;
+	str extra_headers = {0};
 	reginfo_event_t *new_event;
 	str *subs_outbound_proxy = 0;
 
 	int len = strlen(P_ASSERTED_IDENTITY_HDR_PREFIX) + pcscf_uri.len + 1
 			  + CRLF_LEN;
-	p_asserted_identity_header.s = (char *)pkg_malloc(len);
-	if(p_asserted_identity_header.s == NULL) {
+	if(service_routes != NULL) {
+		len += strlen(ROUTE_HDR_PREFIX) + strlen(ROUTE_HDR_END);
+		for(int i = 0; i < num_service_routes; i++) {
+			len += service_routes[i].len + strlen(ROUTE_HDR_SEPARATOR);
+		}
+	}
+	extra_headers.s = (char *)pkg_malloc(len);
+	if(extra_headers.s == NULL) {
 		SHM_MEM_ERROR_FMT("%d bytes failed", len);
 		goto error;
 	}
 
-	memcpy(p_asserted_identity_header.s, P_ASSERTED_IDENTITY_HDR_PREFIX,
+	// Add P-Asserted-Identity header with pscscf_uri, as configured
+	memcpy(extra_headers.s, P_ASSERTED_IDENTITY_HDR_PREFIX,
 			strlen(P_ASSERTED_IDENTITY_HDR_PREFIX));
-	p_asserted_identity_header.len = strlen(P_ASSERTED_IDENTITY_HDR_PREFIX);
-	memcpy(p_asserted_identity_header.s + p_asserted_identity_header.len,
-			pcscf_uri.s, pcscf_uri.len);
-	p_asserted_identity_header.len += pcscf_uri.len;
-	*(p_asserted_identity_header.s + p_asserted_identity_header.len) = '>';
-	p_asserted_identity_header.len++;
-	memcpy(p_asserted_identity_header.s + p_asserted_identity_header.len, CRLF,
-			CRLF_LEN);
-	p_asserted_identity_header.len += CRLF_LEN;
+	extra_headers.len += strlen(P_ASSERTED_IDENTITY_HDR_PREFIX);
+	memcpy(extra_headers.s + extra_headers.len, pcscf_uri.s, pcscf_uri.len);
+	extra_headers.len += pcscf_uri.len;
+	*(extra_headers.s + extra_headers.len) = '>';
+	extra_headers.len++;
+	memcpy(extra_headers.s + extra_headers.len, CRLF, CRLF_LEN);
+	extra_headers.len += CRLF_LEN;
+
+	// Add Service-Routes as Routes - TS 24.229 5.2.3
+	if(service_routes != NULL && num_service_routes > 0) {
+		memcpy(extra_headers.s + extra_headers.len, ROUTE_HDR_PREFIX,
+				strlen(ROUTE_HDR_PREFIX));
+		extra_headers.len += strlen(ROUTE_HDR_PREFIX);
+		for(int i = 0; i < num_service_routes; i++) {
+			memcpy(extra_headers.s + extra_headers.len, service_routes[i].s,
+					service_routes[i].len);
+			extra_headers.len += service_routes[i].len;
+			if(i < num_service_routes - 1) {
+				memcpy(extra_headers.s + extra_headers.len, ROUTE_HDR_SEPARATOR,
+						strlen(ROUTE_HDR_SEPARATOR));
+				extra_headers.len += strlen(ROUTE_HDR_SEPARATOR);
+			}
+		}
+		memcpy(extra_headers.s + extra_headers.len, ROUTE_HDR_END,
+				strlen(ROUTE_HDR_END));
+		extra_headers.len += strlen(ROUTE_HDR_END);
+	}
 
 	if(pv_printf(msg, uri, uri_buf, &uri_buf_len) < 0) {
 		LM_ERR("cannot print uri into the format\n");
@@ -79,19 +107,20 @@ int reginfo_subscribe_real(
 	uri_str.s = uri_buf;
 	uri_str.len = uri_buf_len;
 
-	LM_DBG("p_asserted_identity_header: [%.*s]", p_asserted_identity_header.len,
-			p_asserted_identity_header.s);
+	LM_DBG("p_asserted_identity_header: [%.*s]", extra_headers.len,
+			extra_headers.s);
 
 	LM_DBG("Subscribing to %.*s\n", uri_str.len, uri_str.s);
 
 	if(force_icscf_uri.s && force_icscf_uri.len) {
 		subs_outbound_proxy = &force_icscf_uri;
+	} else if(service_routes != NULL && num_service_routes > 0) {
+		subs_outbound_proxy = &service_routes[0];
 	}
 
 	new_event = new_reginfo_event(REG_EVENT_SUBSCRIBE, 0, 0, 0, &uri_str,
 			&pcscf_uri, &pcscf_uri, subs_outbound_proxy, expires, UPDATE_TYPE,
-			REGINFO_SUBSCRIBE, REGINFO_EVENT, &p_asserted_identity_header,
-			&uri_str);
+			REGINFO_SUBSCRIBE, REGINFO_EVENT, &extra_headers, &uri_str);
 
 	if(!new_event) {
 		LM_ERR("Unable to create event for cdp callback\n");
@@ -100,16 +129,16 @@ int reginfo_subscribe_real(
 	//push the new event onto the stack (FIFO)
 	push_reginfo_event(new_event);
 
-	if(p_asserted_identity_header.s) {
-		pkg_free(p_asserted_identity_header.s);
+	if(extra_headers.s) {
+		pkg_free(extra_headers.s);
 	}
 
 	return 1;
 
 error:
 
-	if(p_asserted_identity_header.s) {
-		pkg_free(p_asserted_identity_header.s);
+	if(extra_headers.s) {
+		pkg_free(extra_headers.s);
 	}
 	return -1;
 }

--- a/src/modules/ims_registrar_pcscf/subscribe.h
+++ b/src/modules/ims_registrar_pcscf/subscribe.h
@@ -34,7 +34,7 @@
 #include "../../core/parser/msg_parser.h"
 
 
-int reginfo_subscribe_real(
-		struct sip_msg *msg, pv_elem_t *uri, str *service_routes, int expires);
+int reginfo_subscribe_real(struct sip_msg *msg, pv_elem_t *uri,
+		str *service_routes, int num_service_routes, int expires);
 
 #endif

--- a/src/modules/ims_usrloc_pcscf/udomain.c
+++ b/src/modules/ims_usrloc_pcscf/udomain.c
@@ -496,7 +496,7 @@ int get_pcontact_from_cache(udomain_t *_d, pcontact_info_t *contact_info,
 					contact_info->aor.len, contact_info->aor.s);
 			return 1;
 		}
-		LM_DBG("checking for rinstance");
+		LM_DBG("checking for rinstance\n");
 		/*check for alias - NAT */
 		params = needle_uri.sip_params.s;
 		params_len = needle_uri.sip_params.len;
@@ -548,7 +548,7 @@ int get_pcontact_from_cache(udomain_t *_d, pcontact_info_t *contact_info,
 			int check2_passed = 0;
 			ip_addr_t c_ip_addr;
 			ip_addr_t ci_ip_addr;
-			LM_DBG("mached a record by aorhash: %u\n", aorhash);
+			LM_DBG("matched a record by aorhash: %u\n", aorhash);
 
 			// convert 'contact->contact host' ip string to ip_addr_t
 			if(str2ipxbuf(&c->contact_host, &c_ip_addr) < 0) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
  - Not yet - first let's see if the work is valid, then I'll recompose the whole work to satisfy this. Otherwise... if I need to fix something, it's too hard to work like this...
- [ ] Each component has a single commit (if not, squash them into one commit)
  - ditto
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Normally, the IMS P-CSCF should identify the clients (UEs) by the received IP address and ports on Rx. The current code is using a mix of that, plus using Contact and Via headers, with arguable potential security issues.

This patch adds a new parameter to `ims_registrar_pcscf` and `ims_qos` modules, allowing for an optional outsource of the IPsec functionality to another element, which is also in charge of checking/enforcing correct UE Via header. The existing code is allowed to work as before, with the default value of the flag being towards that.

List of functional changes:
- `ims_qos`
  - added `trust_bottom_via` parameter
  - used it on `w_rx_aar_register()`
- `ims_registrar_pcscf`
  - added `trust_bottom_via` parameter
  - used it on `update_contacts()`, `save_pending()`, `check_contact()`, `getContactP()`, `check_service_routes()`, `enforce_service_routes()`
  - made `ims_ipsec_pcscf` dependency optional, with checks when used
  - skipped checks of `port-uc` in `checkcontact()` if the `ims_ipsec_pcscf` module was not loaded

List of indirect changes:
- default I-CSCF config example contained a questionable line which adds a `+` as a prefix in Request-URI. After way too much time wasted to figure out why the Diameter LIR has bogus SIP or TEL URI values in UserName AVP, I have discovered this. Seems like someone had just tel-URIs in their network, but otherwise the blind addition of this prefix makes no sense to me.
- `lib/ims`: added a `str2ushort()` macro, since code was using some dangerous casting and macros with a larger type
- `ims_registrar_pcscf`: added `Route` headers in `SUBSCRIBE` to `reginfo`, with values from `Service-Route`s, as per 3GPP specs.

List of non-functional fixes:
- (automatic) code formatting on files that I have touched
  -  in array initialization, if the last element (typically a `{0}`) has a seemingly useless `,` after, clang-format does a better job at aligning things for readability
- spelling in comments
- comments at the end of line moved above the line they refer to; with just 80 columns code-formatting, commenting on the same line provides for some super weird and hard to read code, so IMHO should not be allowed (or ... much harder now... increase to 120 columns)

Note: this was cleaned-up in https://github.com/kamailio/kamailio/pull/3901