### PR TITLE
db_redis: change logs on delete

### DIFF
--- a/src/modules/db_redis/redis_dbase.c
+++ b/src/modules/db_redis/redis_dbase.c
@@ -1827,13 +1827,13 @@ static int db_redis_perform_delete(const db1_con_t *_h, km_redis_con_t *con,
 					"performing delete\n",
 					CON_TABLE(_h)->len, CON_TABLE(_h)->s);
 		else
-			LM_WARN("performing table scan on table '%.*s' while performing "
-					"delete using match key "
-					"'%.*s' at offset %llx\n",
+			LM_DBG("performing table scan on table '%.*s' while performing "
+				   "delete using match key "
+				   "'%.*s' at offset %llx\n",
 					CON_TABLE(_h)->len, CON_TABLE(_h)->s, ts_scan_key->len,
 					ts_scan_key->s, (unsigned long long)ts_scan_start);
 		for(i = 0; i < _n; ++i) {
-			LM_WARN("  scan key %d is '%.*s'\n", i, _k[i]->len, _k[i]->s);
+			LM_DBG("  scan key %d is '%.*s'\n", i, _k[i]->len, _k[i]->s);
 		}
 		if(db_redis_scan_query_keys(con, CON_TABLE(_h), _n, keys, keys_count,
 				   manual_keys, manual_keys_count, ts_scan_start, ts_scan_key,


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Issue: when using usrloc with db_redis, I get constant WARNING logs for 'delete' via usrloc timer. The real WARNING, in my opinion, is when doing full table scans(which is already logged as so).

Make logs less important when performing table scans using a match key.