### PR TITLE
ims_registrar_scscf: fix for location AOR with empty host

### DIFF
--- a/src/modules/ims_registrar_scscf/lookup.c
+++ b/src/modules/ims_registrar_scscf/lookup.c
@@ -115,8 +115,9 @@ int lookup(struct sip_msg *_m, udomain_t *_d, char *ue_type_c)
 	// add user part
 	memcpy(aor.s + aor.len, _m->parsed_uri.user.s, _m->parsed_uri.user.len);
 	aor.len += _m->parsed_uri.user.len;
-	// add '@'
-	aor.s[aor.len++] = '@';
+	// add '@' - but only if there is a host part, else we make bad URIs like tel:+123@
+	if(_m->parsed_uri.host.len > 0)
+		aor.s[aor.len++] = '@';
 	// add host part
 	memcpy(aor.s + aor.len, _m->parsed_uri.host.s, _m->parsed_uri.host.len);
 	aor.len += _m->parsed_uri.host.len;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

The `ims_registrar_scscf` was not able to function with global-number tel-URIs. This fix prevents a bad AOR to search by from being formed, when the host part of Request-URI is empty.

e.g. INVITE with Request-URI `tel:+123` --> AOR to search by was `tel:+123@` --> not found in `ims_usrloc_scscf`
