### PR TITLE
add "active" field to rtpengine.show as alternate of "disabled"

### DIFF
--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -1784,13 +1784,14 @@ static int add_rtpp_node_info(
 
 	if((1 == crt_rtpp->rn_disabled)
 			&& (crt_rtpp->rn_recheck_ticks == RTPENGINE_MAX_RECHECK_TICKS)) {
-		rpc->struct_add(vh, "s", "disabled", "1(permanent)");
+		rpc->struct_add(vh, "b", "disabled", 1);
 	} else {
-		rpc->struct_add(vh, "d", "disabled", crt_rtpp->rn_disabled);
+		rpc->struct_add(vh, "b", "disabled", 0);
 	}
+	rpc->struct_add(vh, "b", "active", crt_rtpp->rn_disabled == 0);
 
 	if(crt_rtpp->rn_recheck_ticks == RTPENGINE_MAX_RECHECK_TICKS) {
-		rpc->struct_add(vh, "s", "recheck_ticks", "N/A");
+		rpc->struct_add(vh, "d", "recheck_ticks", -1);
 	} else {
 		rtpp_ticks = crt_rtpp->rn_recheck_ticks - get_ticks();
 		rtpp_ticks = rtpp_ticks < 0 ? 0 : rtpp_ticks;


### PR DESCRIPTION

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3896 
 
#### Description

As per issue #3896, "active" is a boolean field that just describes whether the socket will be used, while "disabled" now just describes whether the socket was disabled by an RPC command. Also make "disabled" and "recheck_ticks" fields have a fixed value type of boolean and number respectively.

use `"recheck_ticks": -1` instead of "N/A" as per discussion.
