### PR TITLE
misc/examples/ims/icscf: fix bad prefix added on all incoming requests

### DIFF
--- a/misc/examples/ims/icscf/kamailio.cfg
+++ b/misc/examples/ims/icscf/kamailio.cfg
@@ -238,10 +238,6 @@ route{
 	xlog("I-CSCF >>>>>>>>>>>>>>>>>>>> $rm $ru ($fu => $tu ($si:$sp) to $tu, $ci)\n");
 #!endif
 
-	if !($rU =~ "\+.*") {
-		prefix("+");
-	}
-
 	# per request initial checks
 	route(REQINIT);
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to PR https://github.com/kamailio/kamailio/pull/3891 - splitting by components

#### Description
<!-- Describe your changes in detail -->

The I-CSCF routing script was forcing a `+` to be added as prefix to all incoming Request-URIs, if they didn't have one. This was breaking valid IMPUs, e.g. `sip:alice@ims.com` --> `sip:+alice@ims.com`, which wouldn't exist in  HSS.

I don't know why this was valid or useful before. Even if the Request-URI is a tel-URI, one should not blindly transform that, since the meaning of global and local numbers are quite different (so maybe fix the upstreams?).