### PR TITLE
ims_registrar_pcscf,ims_qos: support for trusting bottom via

### DIFF
--- a/src/core/ut.h
+++ b/src/core/ut.h
@@ -700,6 +700,14 @@ static inline int str2int(str *_s, unsigned int *_r)
 	str2unval(_s, _r, int, UINT_MAX);
 }
 
+/*
+ * Convert a str to unsigned short
+ */
+static inline int str2ushort(str *_s, unsigned short *_r)
+{
+	str2unval(_s, _r, short, USHRT_MAX);
+}
+
 
 #define str2snval(_s, _r, _vtype, _vmin, _vmax)                                \
 	do {                                                                       \

--- a/src/lib/ims/ims_getters.c
+++ b/src/lib/ims/ims_getters.c
@@ -1638,7 +1638,7 @@ str *cscf_get_service_route(struct sip_msg *msg, int *size, int is_shm)
 			}
 			x = pkg_reallocxf(x, (*size + k) * sizeof(str));
 			if(!x) {
-				LM_ERR("Error our of pkg memory");
+				LM_ERR("Error out of pkg memory");
 				return 0;
 			}
 			r2 = r;

--- a/src/modules/ims_qos/doc/ims_qos.xml
+++ b/src/modules/ims_qos/doc/ims_qos.xml
@@ -55,6 +55,12 @@
 
         <email>carsten@ng-voice.com</email>
       </author>
+
+      <author>
+        <firstname>Dragos</firstname>
+        <surname>Vingarzan</surname>
+        <email>vingarzan -at- gmail dot com</email>
+      </author>    
     </authorgroup>
 
     <copyright>

--- a/src/modules/ims_qos/doc/ims_qos_admin.xml
+++ b/src/modules/ims_qos/doc/ims_qos_admin.xml
@@ -579,6 +579,47 @@ modparam("ims_qos", "dialog_direction", 1)
         </programlisting>
       </example>
     </section>
+
+    <section>
+      <title><varname>trust_bottom_via</varname> (int)</title>
+      <para>
+        If set to 1 it will trust the bottom Via as the UE IP/port/transport when doing client identification.
+      </para>
+      <para>
+        Normally, the UE identification should be done on IPsec SPIs and source IP/port of the packets. 
+        In some cases the ims_* modules trust the top Via on requests and the bottom Via on responses. In some (better)
+        cases this trusts the received-from IP (or the alias in the Contact header).
+      </para>
+      <para>
+        This parameter allows for an external-to-Kamailio IPsec functionality to be used. That will be in charge of
+        guaranteeing that the bottom Via header is always correct (on requests; on responses the P-CSCF itself should
+        guarantee unmodified Via headers stack). Then the code here will always use the bottom Via as the source of
+        truth for IMS UE identification.
+      </para>
+      <para>
+        <emphasis>Note:</emphasis> this will prefer the standard received and rport values, if present, over the actual
+        Via sent-by host and port.
+      </para>
+      <para>
+        <emphasis>Note:</emphasis> !! trusting the Via header has security drawbacks, as it might be easily spoofed by
+        an attacker. Hence, without extra security, the P-CSCF shouldn't trust the Via header for client identification
+        on requests and the ims_registrar_pcscf module would require a fix or extension for that. !!
+      </para>
+      <para>
+        See also the same parameter in the ims_registrar_pcscf module.
+      </para>
+      <para><emphasis>Default value is 0 (trust received-from IP and alias in Contact, and, unfortunaly somewhat wrongly
+      top/bottom Via on requests/responses).</emphasis></para>
+      <example>
+        <title><varname>trust_bottom_via</varname> parameter usage</title>
+        <programlisting format="linespecific">
+...
+modparam("ims_qos", "trust_bottom_via", 1)
+...
+        </programlisting>
+      </example>
+    </section>
+
   </section>
 
   <section>

--- a/src/modules/ims_qos/rx_aar.h
+++ b/src/modules/ims_qos/rx_aar.h
@@ -63,8 +63,8 @@ typedef struct saved_transaction
 	gen_lock_t *lock;
 	unsigned int ignore_replies;
 	unsigned int answers_not_received;
-	unsigned int
-			failed; //will start at 0 - if 1 fails we can set the flag up (1)
+	// will start at 0 - if 1 fails we can set the flag up (1)
+	unsigned int failed;
 	unsigned int tindex;
 	unsigned int tlabel;
 	unsigned int ticks;

--- a/src/modules/ims_qos/rx_authdata.h
+++ b/src/modules/ims_qos/rx_authdata.h
@@ -50,6 +50,8 @@
 #ifndef RX_AUTH_DATA_H
 #define RX_AUTH_DATA_H
 
+#include "../../modules/ims_dialog/dlg_load.h"
+
 extern struct tm_binds tmb;
 extern struct cdp_binds cdpb;
 extern ims_dlg_api_t dlgb;

--- a/src/modules/ims_qos/rx_avp.c
+++ b/src/modules/ims_qos/rx_avp.c
@@ -1358,7 +1358,7 @@ inline int rx_get_result_code(AAAMessage *msg, unsigned int *data)
 }
 
 /**
- * Creates and adds an Acct-Application-Id AVP.
+ * Creates and adds an Specific-Action AVP
  * @param msg - the Diameter message to add to.
  * @param data - the value for the AVP payload
  * @return CSCF_RETURN_TRUE on success or 0 on error

--- a/src/modules/ims_registrar_pcscf/doc/ims_registrar_pcscf.xml
+++ b/src/modules/ims_registrar_pcscf/doc/ims_registrar_pcscf.xml
@@ -55,6 +55,12 @@
 
         <email>carsten@ng-voice.com</email>
       </author>
+
+      <author>
+        <firstname>Dragos</firstname>
+        <surname>Vingarzan</surname>
+        <email>vingarzan -at- gmail dot com</email>
+      </author>
     </authorgroup>
 
     <copyright>

--- a/src/modules/ims_registrar_pcscf/doc/ims_registrar_pcscf_admin.xml
+++ b/src/modules/ims_registrar_pcscf/doc/ims_registrar_pcscf_admin.xml
@@ -212,6 +212,37 @@ modparam("ims_registrar_pcscf", "ignore_contact_rxport_check", 1)
     </section>
 
     <section>
+      <title><varname>ignore_contact_rxproto_check</varname> (int)</title>
+
+      <para>
+        Validate, if the protocol, from which the request was received, is the
+        same as used during registration.
+
+        Note: with IMS, the UE opens IPsec Security Associations between IPs
+        and ports with the P-CSCF. These are for both UDP and TCP, with a
+        single negotiation, which does not need to specify the protocol. 
+      </para>
+      <para> 
+        (Before the introduction of this parameter, the similar one for port was
+        used to also ignore the protocol. But that might've been a type/mistake.)
+      </para>
+
+      <para>This Parameter is primarily used by the "is_registered" function.</para>
+
+      <para><emphasis>Default value is 1 (ignore protocol, for best compliance).</emphasis></para>
+
+      <example>
+        <title><varname>ignore_contact_rxproto_check</varname> parameter usage</title>
+
+        <programlisting format="linespecific">
+...
+modparam("ims_registrar_pcscf", "ignore_contact_rxproto_check", 1)
+...
+        </programlisting>
+      </example>
+    </section>
+
+    <section>
       <title><varname>ignore_reg_state</varname> (int)</title>
 
       <para>Validate, if the found contact is really and completely registered.</para>
@@ -284,6 +315,48 @@ modparam("ims_registrar_pcscf", "reginfo_queue_size_threshold", 42)
         <programlisting format="linespecific">
 ...
 modparam("ims_registrar_pcscf", "delete_delay", 10)
+...
+        </programlisting>
+      </example>
+    </section>
+
+    <section>
+      <title><varname>trust_bottom_via</varname> (int)</title>
+      <para>
+        If set to 1 it will trust the bottom Via as the UE IP/port/transport when doing client identification.
+      </para>
+      <para>
+        Normally, the UE identification should be done on IPsec SPIs and source IP/port of the packets. 
+        In some cases the ims_* modules trust the top Via on requests and the bottom Via on responses. In some (better)
+        cases this module trusts the received-from IP (or the alias in the Contact header).
+      </para>
+      <para>
+        This parameter allows for an external-to-Kamailio IPsec functionality to be used. That will be in charge of
+        guaranteeing that the bottom Via header is always correct (on requests; on responses the P-CSCF itself should
+        guarantee unmodified Via headers stack). Then the code here will always use the bottom Via as the source of
+        truth for IMS UE identification.
+      </para>
+      <para>
+        <emphasis>Note:</emphasis> this will prefer the standard received and rport values, if present, over the actual
+        Via sent-by host and port.
+      </para>
+      <para>
+        <emphasis>Note:</emphasis> !! trusting the Via header has security drawbacks, as it might be easily spoofed by
+        an attacker. Hence, without extra security, the P-CSCF shouldn't trust the Via header for client identification
+        on and this module would require a fix or extension for this. Currently only pcscf_save() is safe from
+        this issue, while pcscf_save_pending() and pcscf_is_registered() seem to be using by default the top/first Via
+        on requests, or the bottom/last Via on responses !!
+      </para>
+      <para>
+        See also the same parameter in the ims_qos module.
+      </para>
+      <para><emphasis>Default value is 0 (trust received-from IP and alias in Contact, and, unfortunaly somewhat wrongly
+      top/bottom Via on requests/responses).</emphasis></para>
+      <example>
+        <title><varname>trust_bottom_via</varname> parameter usage</title>
+        <programlisting format="linespecific">
+...
+modparam("ims_registrar_pcscf", "trust_bottom_via", 1)
 ...
         </programlisting>
       </example>

--- a/src/modules/ims_registrar_pcscf/ims_registrar_pcscf_mod.c
+++ b/src/modules/ims_registrar_pcscf/ims_registrar_pcscf_mod.c
@@ -83,9 +83,15 @@ int publish_reginfo = 0;
 int subscribe_to_reginfo = 0;
 int subscription_expires = 3600;
 int ignore_reg_state = 0;
-/**!< ignore port checks between received port on message and registration received port.
+/** ignore port checks between received port on message and registration received port.
  * this is useful for example if you register with UDP but possibly send invite over TCP (message too big) */
 int ignore_contact_rxport_check = 0;
+/** ignore proto checks between the one that the message was received over and registration one.
+ * Since in IMS is registering the IP:port of the UE with IPsec for any transport, why was this even needed? Hence
+ * setting to 1 as default.*/
+int ignore_contact_rxproto_check = 1;
+/** If set, this uses the bottom Via for identification of UE, always, on both requests and responses, over Contact. */
+int trust_bottom_via = 0;
 
 time_t time_now;
 
@@ -106,7 +112,7 @@ unsigned short rcv_avp_type = 0;
 int_str rcv_avp_name;
 
 ims_registrar_pcscf_params_t _imsregp_params = {
-	.delete_delay = 0
+		.delete_delay = 0,
 };
 
 // static str orig_prefix = {"sip:orig@",9};
@@ -186,11 +192,14 @@ static param_export_t params[] = {{"pcscf_uri", PARAM_STR, &pcscf_uri},
 		{"subscription_expires", INT_PARAM, &subscription_expires},
 		{"ignore_contact_rxport_check", INT_PARAM,
 				&ignore_contact_rxport_check},
+		{"ignore_contact_rxproto_check", INT_PARAM,
+				&ignore_contact_rxproto_check},
 		{"ignore_reg_state", INT_PARAM, &ignore_reg_state},
 		{"force_icscf_uri", PARAM_STR, &force_icscf_uri},
 		{"reginfo_queue_size_threshold", INT_PARAM,
 				&reginfo_queue_size_threshold},
 		{"delete_delay", PARAM_INT, &_imsregp_params.delete_delay},
+		{"trust_bottom_via", PARAM_INT, &trust_bottom_via},
 		//	{"store_profile_dereg",	INT_PARAM, &store_data_on_dereg},
 		{0, 0, 0}};
 
@@ -298,14 +307,13 @@ static int mod_init(void)
 	bind_ipsec_pcscf =
 			(bind_ipsec_pcscf_t)find_export("bind_ims_ipsec_pcscf", 1, 0);
 	if(!bind_ipsec_pcscf) {
-		LM_ERR("can't bind ims_ipsec_pcscf\n");
-		return -1;
+		LM_WARN("can't bind ims_ipsec_pcscf - will start without\n");
+	} else {
+		if(bind_ipsec_pcscf(&ipsec_pcscf) < 0) {
+			return -1;
+		}
+		LM_INFO("Successfully bound to PCSCF IPSEC module\n");
 	}
-
-	if(bind_ipsec_pcscf(&ipsec_pcscf) < 0) {
-		return -1;
-	}
-	LM_INFO("Successfully bound to PCSCF IPSEC module\n");
 
 	if(subscribe_to_reginfo == 1) {
 		/* Bind to PUA: */

--- a/src/modules/ims_registrar_pcscf/notify.c
+++ b/src/modules/ims_registrar_pcscf/notify.c
@@ -403,7 +403,7 @@ int process_body(struct sip_msg *msg, str notify_body, udomain_t *domain)
 				LM_ERR("wrong format[%.*s] - failed unsubscribing to reginfo\n",
 						aor.len, aor.s);
 			}
-			reginfo_subscribe_real(msg, presentity_uri_pv, 0, 0);
+			reginfo_subscribe_real(msg, presentity_uri_pv, 0, 0, 0);
 			pv_elem_free_all(presentity_uri_pv);
 		}
 

--- a/src/modules/ims_registrar_pcscf/save.c
+++ b/src/modules/ims_registrar_pcscf/save.c
@@ -60,6 +60,7 @@ extern time_t time_now;
 extern unsigned int pending_reg_expires;
 extern int subscribe_to_reginfo;
 extern int subscription_expires;
+extern int trust_bottom_via;
 extern pua_api_t pua;
 extern ipsec_pcscf_api_t ipsec_pcscf;
 
@@ -176,10 +177,33 @@ static inline int update_contacts(struct sip_msg *req, struct sip_msg *rpl,
 				ci.searchflag =
 						SEARCH_NORMAL; /* this must be reset for each contact iteration */
 
-				if(puri.params.len > 6
-						&& (alias_start = _strnistr(
-									puri.params.s, "alias=", puri.params.len))
-								   != NULL) {
+				if(trust_bottom_via) {
+					struct via_body *vb = cscf_get_last_via(req);
+					if(vb == 0) {
+						LM_ERR("No via header in request\n");
+						return -1;
+					}
+					if(vb->received != NULL && vb->received->value.len > 0) {
+						ci.received_host = vb->received->value;
+					} else {
+						ci.received_host = vb->host;
+					}
+					if(vb->rport != NULL && vb->rport->value.len > 0) {
+						str2ushort(&vb->rport->value, &ci.received_port);
+					} else {
+						ci.received_port = vb->port;
+					}
+					// this probably doesn't matter, since IMS UEs register IPs for both
+					ci.received_proto = vb->proto;
+					ci.searchflag = SEARCH_RECEIVED;
+					LM_DBG("bottom Via from request: Via sent-by host [%.*s], "
+						   "port [%d], proto [%d]\n",
+							ci.received_host.len, ci.received_host.s,
+							ci.received_port, ci.received_proto);
+				} else if(puri.params.len > 6
+						  && (alias_start = _strnistr(
+									  puri.params.s, "alias=", puri.params.len))
+									 != NULL) {
 					LM_DBG("contact has an alias [%.*s] - we can use that as "
 						   "the received\n",
 							puri.params.len, puri.params.s);
@@ -281,11 +305,13 @@ static inline int update_contacts(struct sip_msg *req, struct sip_msg *rpl,
 							LM_DBG("ul.register_ulcb(pcontact, "
 								   "PCSCF_CONTACT_EXPIRE|PCSCF_CONTACT_DELETE.."
 								   ".)\n");
-							if(ul.register_ulcb(pcontact,
-									   PCSCF_CONTACT_EXPIRE
-											   | PCSCF_CONTACT_DELETE,
-									   ipsec_pcscf.ipsec_on_expire, NULL)
-									!= 1) {
+							if(ipsec_pcscf.ipsec_on_expire != NULL
+									&& ul.register_ulcb(pcontact,
+											   PCSCF_CONTACT_EXPIRE
+													   | PCSCF_CONTACT_DELETE,
+											   ipsec_pcscf.ipsec_on_expire,
+											   NULL)
+											   != 1) {
 								LM_DBG("Error subscribing for contact\n");
 							}
 
@@ -322,7 +348,7 @@ int save_pending(struct sip_msg *_m, udomain_t *_d)
 	char srcip[50];
 	memset(&ci, 0, sizeof(struct pcontact_info));
 
-	vb = cscf_get_ue_via(_m);
+	vb = trust_bottom_via ? cscf_get_last_via(_m) : cscf_get_ue_via(_m);
 	port = vb->port ? vb->port : 5060;
 	proto = vb->proto;
 
@@ -369,14 +395,27 @@ int save_pending(struct sip_msg *_m, udomain_t *_d)
 	ci.num_service_routes = 0;
 	ci.expires = local_time_now + pending_reg_expires;
 	ci.reg_state = PCONTACT_ANY;
-	ci.searchflag =
-			SEARCH_RECEIVED; //we want to make sure we are very specific with this search to make sure we get the correct contact to put into reg_pending.
+	// we want to make sure we are very specific with this search to make
+	// sure we get the correct contact to put into reg_pending.
+	ci.searchflag = SEARCH_RECEIVED;
 
-	// Received Info: First try AVP, otherwise simply take the source of the request:
+	// Received Info: First see trust_bottom_via exception, then try AVP,
+	// otherwise simply take the source of the request:
 	memset(&val, 0, sizeof(int_str));
-	if(rcv_avp_name.n != 0
-			&& search_first_avp(rcv_avp_type, rcv_avp_name, &val, 0)
-			&& val.s.len > 0) {
+	if(trust_bottom_via) {
+		if(vb->received && vb->received->value.len > 0) {
+			ci.received_host = vb->received->value;
+		}
+		if(vb->rport && vb->rport->value.len > 0) {
+			str2ushort(&vb->rport->value, &ci.received_port);
+		}
+		if(ci.received_port == 0) {
+			ci.received_port = 5060;
+		}
+		ci.received_proto = vb->proto;
+	} else if(rcv_avp_name.n != 0
+			  && search_first_avp(rcv_avp_type, rcv_avp_name, &val, 0)
+			  && val.s.len > 0) {
 		if(val.s.len > RECEIVED_MAX_SIZE) {
 			LM_ERR("received too long\n");
 			goto error;
@@ -436,8 +475,9 @@ int save_pending(struct sip_msg *_m, udomain_t *_d)
 	ul.lock_udomain(_d, &ci.via_host, ci.via_port, ci.via_prot);
 	if(ul.get_pcontact(_d, &ci, &pcontact, 0)
 			!= 0) { //need to insert new contact
-		ipsec_pcscf
-				.ipsec_reconfig(); // try to clean all ipsec SAs/Policies if there is no registered contacts
+		// try to clean all ipsec SAs/Policies if there is no registered contacts
+		if(ipsec_pcscf.ipsec_reconfig != NULL)
+			ipsec_pcscf.ipsec_reconfig();
 
 		LM_DBG("Adding pending pcontact: <%.*s>\n", c->uri.len, c->uri.s);
 		ci.reg_state = PCONTACT_REG_PENDING;
@@ -620,8 +660,8 @@ int save(struct sip_msg *_m, udomain_t *_d, int _cflags)
 				   "received");
 			goto done;
 		}
-		reginfo_subscribe_real(
-				_m, presentity_uri_pv, service_routes, subscription_expires);
+		reginfo_subscribe_real(_m, presentity_uri_pv, service_routes,
+				num_service_routes, subscription_expires);
 		pv_elem_free_all(presentity_uri_pv);
 	}
 

--- a/src/modules/ims_registrar_pcscf/subscribe.h
+++ b/src/modules/ims_registrar_pcscf/subscribe.h
@@ -34,7 +34,7 @@
 #include "../../core/parser/msg_parser.h"
 
 
-int reginfo_subscribe_real(
-		struct sip_msg *msg, pv_elem_t *uri, str *service_routes, int expires);
+int reginfo_subscribe_real(struct sip_msg *msg, pv_elem_t *uri,
+		str *service_routes, int num_service_routes, int expires);
 
 #endif

--- a/src/modules/ims_usrloc_pcscf/udomain.c
+++ b/src/modules/ims_usrloc_pcscf/udomain.c
@@ -496,7 +496,7 @@ int get_pcontact_from_cache(udomain_t *_d, pcontact_info_t *contact_info,
 					contact_info->aor.len, contact_info->aor.s);
 			return 1;
 		}
-		LM_DBG("checking for rinstance");
+		LM_DBG("checking for rinstance\n");
 		/*check for alias - NAT */
 		params = needle_uri.sip_params.s;
 		params_len = needle_uri.sip_params.len;
@@ -548,7 +548,7 @@ int get_pcontact_from_cache(udomain_t *_d, pcontact_info_t *contact_info,
 			int check2_passed = 0;
 			ip_addr_t c_ip_addr;
 			ip_addr_t ci_ip_addr;
-			LM_DBG("mached a record by aorhash: %u\n", aorhash);
+			LM_DBG("matched a record by aorhash: %u\n", aorhash);
 
 			// convert 'contact->contact host' ip string to ip_addr_t
 			if(str2ipxbuf(&c->contact_host, &c_ip_addr) < 0) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to draft-PR https://github.com/kamailio/kamailio/pull/3891

#### Description
<!-- Describe your changes in detail -->
Normally, the IMS P-CSCF should identify the clients (UEs) by the received IP address and ports on Rx. The current code is using a mix of that, plus using Contact and Via headers, with arguable potential security issues.

This patch adds a new parameter to `ims_registrar_pcscf` and `ims_qos` modules, allowing for an optional outsource of the IPsec functionality to another element, which is also in charge of checking/enforcing correct UE Via header. The existing code is allowed to work as before, with the default value of the flag being towards that.

List of functional changes:
- `ims_qos`
  - added `trust_bottom_via` parameter
  - used it on `w_rx_aar_register()`
- `ims_registrar_pcscf`
  - added `trust_bottom_via` parameter
  - used it on `update_contacts()`, `save_pending()`, `check_contact()`, `getContactP()`, `check_service_routes()`, `enforce_service_routes()`
  - made `ims_ipsec_pcscf` dependency optional, with checks when used
  - skipped checks of `port-uc` in `checkcontact()` if the `ims_ipsec_pcscf` module was not loaded
  - added `ignore_contact_rxproto_check` parameter - IMS devices open IPsec Security Associations just between IPs and ports, with both UDP and TCP protocols allowed. The default then was set here to always ignore protocol checks. Before, the `ignore_contact_rxport_check` was used to skip this and still make it work, but that seemed like a typo/mistake with hidden effects.

List of indirect changes:
- `core/ut.h`: added a `str2ushort()` macro, since code was using some dangerous casting and macros with a larger type
- `ims_registrar_pcscf`: added `Route` headers in `SUBSCRIBE` to `reginfo`, with values from `Service-Route`s, as per 3GPP specs.
- `ims_usrloc_pcscf`: small log fixes

For even more context, please see the discussion in https://github.com/kamailio/kamailio/pull/3891