### PR TITLE
core: add support for custom log function

### DIFF
--- a/src/core/dprint.c
+++ b/src/core/dprint.c
@@ -46,6 +46,7 @@ static void log_callid_set(sip_msg_t *msg);
 
 char *_km_log_engine_type = NULL;
 char *_km_log_engine_data = NULL;
+km_custom_log_f _km_custom_log_func = &km_default_custom_log_func;
 
 km_log_f _km_log_func = &syslog;
 
@@ -55,6 +56,26 @@ km_log_f _km_log_func = &syslog;
 void km_log_func_set(km_log_f f)
 {
 	_km_log_func = f;
+}
+
+void km_custom_log_func_set(km_custom_log_f f)
+{
+	_km_custom_log_func = f;
+}
+
+// default custom log format handler,
+// expected to be replaced via km_custom_log_func_set
+void km_default_custom_log_func(int syslog_level, const char *mod_name,
+		const char *file_name, int line, const char *fmt, ...)
+{
+	char *custom_fmt;
+	asprintf(&custom_fmt, "%s %i:%s:%i %s", mod_name, my_pid(), file_name, line,
+			fmt);
+	va_list args;
+	va_start(args, fmt);
+	vsyslog(syslog_level, custom_fmt, args);
+	va_end(args);
+	free(custom_fmt);
 }
 
 #ifndef NO_SIG_DEBUG

--- a/src/core/dprint.h
+++ b/src/core/dprint.h
@@ -35,6 +35,12 @@
 #include "compiler_opt.h"
 #include "cfg_core.h"
 
+#ifndef CUSTOM_LOG_FMT
+#define CUSTOM_LOG_FMT 0
+#else
+#define CUSTOM_LOG_FMT 1
+#endif
+
 #define TIME_T_FMT "lld"
 #define TIME_T_CAST(x) ((long long)(x))
 
@@ -170,6 +176,14 @@ extern km_log_f _km_log_func;
 
 void km_log_func_set(km_log_f f);
 
+typedef void (*km_custom_log_f)(
+		int, const char *, const char *, int, const char *, ...);
+extern km_custom_log_f _km_custom_log_func;
+void km_custom_log_func_set(km_custom_log_f f);
+
+void km_default_custom_log_func(int syslog_level, const char *mod_name,
+		const char *file_name, int line, const char *fmt, ...);
+
 /** @brief maps log levels to their string name and corresponding syslog level */
 
 struct log_level_info
@@ -219,6 +233,7 @@ void log_prefix_init(void);
 
 #define LOGV_PREFIX_STR ((log_prefix_val) ? log_prefix_val->s : "")
 #define LOGV_PREFIX_LEN ((log_prefix_val) ? log_prefix_val->len : 0)
+#define LOGV_CUSTOM_LOG_FMT(fmt) ((log_prefix_val) ? "%s" fmt : fmt)
 
 #define LOGV_FUNCNAME_STR(vfuncname) \
 	(((void *)vfuncname != NULL) ? vfuncname : "")
@@ -267,41 +282,54 @@ void log_prefix_init(void);
 #endif
 
 #ifdef __SUNPRO_C
-#define LOG_FX(facility, level, lname, prefix, funcname, fmt, ...)            \
-	do {                                                                      \
-		if(DPRINT_NON_CRIT                                                    \
-				&& get_debug_level(LOG_MNAME, LOG_MNAME_LEN) >= (level)) {    \
-			int __llevel;                                                     \
-			__llevel = ((level) < L_ALERT)                                    \
-							   ? L_ALERT                                      \
-							   : (((level) > L_DBG) ? L_DBG : level);         \
-			DPRINT_CRIT_ENTER;                                                \
-			if(unlikely(log_stderr)) {                                        \
-				if(unlikely(log_color))                                       \
-					dprint_color(__llevel);                                   \
-				fprintf(stderr, "%2d(%d) %s: %.*s%s%s%s" fmt, process_no,     \
-						my_pid(),                                             \
-						(lname) ? (lname) : LOG_LEVEL2NAME(__llevel),         \
-						LOGV_PREFIX_LEN, LOGV_PREFIX_STR, (prefix),           \
-						LOGV_FUNCNAME_STR(funcname),                          \
-						LOGV_FUNCSUFFIX_STR(funcname), __VA_ARGS__);          \
-				if(unlikely(log_color))                                       \
-					dprint_color_reset();                                     \
-			} else {                                                          \
-				_km_log_func(LOG2SYSLOG_LEVEL(__llevel)                       \
-									 | (((facility) != DEFAULT_FACILITY)      \
-													 ? (facility)             \
-													 : get_debug_facility(    \
-															 LOG_MNAME,       \
-															 LOG_MNAME_LEN)), \
-						"%s: %.*s%s%s%s" fmt,                                 \
-						(lname) ? (lname) : LOG_LEVEL2NAME(__llevel),         \
-						LOGV_PREFIX_LEN, LOGV_PREFIX_STR, (prefix),           \
-						LOGV_FUNCNAME_STR(funcname),                          \
-						LOGV_FUNCSUFFIX_STR(funcname), __VA_ARGS__);          \
-			}                                                                 \
-			DPRINT_CRIT_EXIT;                                                 \
-		}                                                                     \
+#define LOG_FX(facility, level, lname, prefix, funcname, fmt, ...)           \
+	do {                                                                     \
+		if(DPRINT_NON_CRIT                                                   \
+				&& get_debug_level(LOG_MNAME, LOG_MNAME_LEN) >= (level)) {   \
+			int __llevel;                                                    \
+			__llevel = ((level) < L_ALERT)                                   \
+							   ? L_ALERT                                     \
+							   : (((level) > L_DBG) ? L_DBG : level);        \
+			DPRINT_CRIT_ENTER;                                               \
+			if(unlikely(log_stderr)) {                                       \
+				if(unlikely(log_color))                                      \
+					dprint_color(__llevel);                                  \
+				fprintf(stderr, "%2d(%d) %s: %.*s%s%s%s" fmt, process_no,    \
+						my_pid(),                                            \
+						(lname) ? (lname) : LOG_LEVEL2NAME(__llevel),        \
+						LOGV_PREFIX_LEN, LOGV_PREFIX_STR, (prefix),          \
+						LOGV_FUNCNAME_STR(funcname),                         \
+						LOGV_FUNCSUFFIX_STR(funcname), __VA_ARGS__);         \
+				if(unlikely(log_color))                                      \
+					dprint_color_reset();                                    \
+			} else {                                                         \
+				if(CUSTOM_LOG_FMT) {                                         \
+					_km_custom_log_func(                                     \
+							LOG2SYSLOG_LEVEL(__llevel) |                     \
+									| (((facility) != DEFAULT_FACILITY)      \
+													? (facility)             \
+													: get_debug_facility(    \
+															LOG_MNAME,       \
+															LOG_MNAME_LEN)), \
+							LOG_MNAME, __FILE__, __LINE__,                   \
+							LOGV_CUSTOM_LOG_FMT(fmt), __VA_ARGS__);          \
+				} else {                                                     \
+					_km_log_func(                                            \
+							LOG2SYSLOG_LEVEL(__llevel)                       \
+									| (((facility) != DEFAULT_FACILITY)      \
+													? (facility)             \
+													: get_debug_facility(    \
+															LOG_MNAME,       \
+															LOG_MNAME_LEN)), \
+							"%s: %.*s%s%s%s" fmt,                            \
+							(lname) ? (lname) : LOG_LEVEL2NAME(__llevel),    \
+							LOGV_PREFIX_LEN, LOGV_PREFIX_STR, (prefix),      \
+							LOGV_FUNCNAME_STR(funcname),                     \
+							LOGV_FUNCSUFFIX_STR(funcname), __VA_ARGS__);     \
+				}                                                            \
+			}                                                                \
+			DPRINT_CRIT_EXIT;                                                \
+		}                                                                    \
 	} while(0)
 
 #define LOG_FL(facility, level, lname, prefix, ...) \
@@ -322,60 +350,72 @@ void log_prefix_init(void);
 
 
 #else /* ! __SUNPRO_C */
-#define LOG_FX(facility, level, lname, prefix, funcname, fmt, args...)        \
-	do {                                                                      \
-		if(DPRINT_NON_CRIT                                                    \
-				&& get_debug_level(LOG_MNAME, LOG_MNAME_LEN) >= (level)) {    \
-			int __llevel;                                                     \
-			__llevel = ((level) < L_ALERT)                                    \
-							   ? L_ALERT                                      \
-							   : (((level) > L_DBG) ? L_DBG : level);         \
-			DPRINT_CRIT_ENTER;                                                \
-			if(_ksr_slog_func) { /* structured logging */                     \
-				ksr_logdata_t __kld = {0};                                    \
-				__kld.v_facility =                                            \
-						LOG2SYSLOG_LEVEL(__llevel)                            \
-						| (((facility) != DEFAULT_FACILITY)                   \
-										? (facility)                          \
-										: get_debug_facility(                 \
-												LOG_MNAME, LOG_MNAME_LEN));   \
-				__kld.v_level = __llevel;                                     \
-				__kld.v_lname = (lname) ? (lname) : LOG_LEVEL2NAME(__llevel); \
-				__kld.v_fname = __FILE__;                                     \
-				__kld.v_fline = __LINE__;                                     \
-				__kld.v_mname = LOG_MNAME;                                    \
-				__kld.v_func = LOGV_FUNCNAME_STR(funcname);                   \
-				__kld.v_locinfo = prefix;                                     \
-				_ksr_slog_func(&__kld, fmt, ##args);                          \
-			} else { /* classic logging */                                    \
-				if(unlikely(log_stderr)) {                                    \
-					if(unlikely(log_color))                                   \
-						dprint_color(__llevel);                               \
-					fprintf(stderr, "%2d(%d) %s: %.*s%s%s%s" fmt, process_no, \
-							my_pid(),                                         \
-							(lname) ? (lname) : LOG_LEVEL2NAME(__llevel),     \
-							LOGV_PREFIX_LEN, LOGV_PREFIX_STR, (prefix),       \
-							LOGV_FUNCNAME_STR(funcname),                      \
-							LOGV_FUNCSUFFIX_STR(funcname), ##args);           \
-					if(unlikely(log_color))                                   \
-						dprint_color_reset();                                 \
-				} else {                                                      \
-					_km_log_func(                                             \
-							LOG2SYSLOG_LEVEL(__llevel)                        \
-									| (((facility) != DEFAULT_FACILITY)       \
-													? (facility)              \
-													: get_debug_facility(     \
-															LOG_MNAME,        \
-															LOG_MNAME_LEN)),  \
-							"%s: %.*s%s%s%s" fmt,                             \
-							(lname) ? (lname) : LOG_LEVEL2NAME(__llevel),     \
-							LOGV_PREFIX_LEN, LOGV_PREFIX_STR, (prefix),       \
-							LOGV_FUNCNAME_STR(funcname),                      \
-							LOGV_FUNCSUFFIX_STR(funcname), ##args);           \
-				}                                                             \
-			}                                                                 \
-			DPRINT_CRIT_EXIT;                                                 \
-		}                                                                     \
+#define LOG_FX(facility, level, lname, prefix, funcname, fmt, args...)           \
+	do {                                                                         \
+		if(DPRINT_NON_CRIT                                                       \
+				&& get_debug_level(LOG_MNAME, LOG_MNAME_LEN) >= (level)) {       \
+			int __llevel;                                                        \
+			__llevel = ((level) < L_ALERT)                                       \
+							   ? L_ALERT                                         \
+							   : (((level) > L_DBG) ? L_DBG : level);            \
+			DPRINT_CRIT_ENTER;                                                   \
+			if(_ksr_slog_func) { /* structured logging */                        \
+				ksr_logdata_t __kld = {0};                                       \
+				__kld.v_facility =                                               \
+						LOG2SYSLOG_LEVEL(__llevel)                               \
+						| (((facility) != DEFAULT_FACILITY)                      \
+										? (facility)                             \
+										: get_debug_facility(                    \
+												LOG_MNAME, LOG_MNAME_LEN));      \
+				__kld.v_level = __llevel;                                        \
+				__kld.v_lname = (lname) ? (lname) : LOG_LEVEL2NAME(__llevel);    \
+				__kld.v_fname = __FILE__;                                        \
+				__kld.v_fline = __LINE__;                                        \
+				__kld.v_mname = LOG_MNAME;                                       \
+				__kld.v_func = LOGV_FUNCNAME_STR(funcname);                      \
+				__kld.v_locinfo = prefix;                                        \
+				_ksr_slog_func(&__kld, fmt, ##args);                             \
+			} else { /* classic logging */                                       \
+				if(unlikely(log_stderr)) {                                       \
+					if(unlikely(log_color))                                      \
+						dprint_color(__llevel);                                  \
+					fprintf(stderr, "%2d(%d) %s: %.*s%s%s%s" fmt, process_no,    \
+							my_pid(),                                            \
+							(lname) ? (lname) : LOG_LEVEL2NAME(__llevel),        \
+							LOGV_PREFIX_LEN, LOGV_PREFIX_STR, (prefix),          \
+							LOGV_FUNCNAME_STR(funcname),                         \
+							LOGV_FUNCSUFFIX_STR(funcname), ##args);              \
+					if(unlikely(log_color))                                      \
+						dprint_color_reset();                                    \
+				} else {                                                         \
+					if(CUSTOM_LOG_FMT) {                                         \
+						_km_custom_log_func(                                     \
+								LOG2SYSLOG_LEVEL(__llevel)                       \
+										| (((facility) != DEFAULT_FACILITY)      \
+														? (facility)             \
+														: get_debug_facility(    \
+																LOG_MNAME,       \
+																LOG_MNAME_LEN)), \
+								LOG_MNAME, __FILE__, __LINE__,                   \
+								LOGV_CUSTOM_LOG_FMT(fmt), ##args);               \
+					} else {                                                     \
+						_km_log_func(                                            \
+								LOG2SYSLOG_LEVEL(__llevel)                       \
+										| (((facility) != DEFAULT_FACILITY)      \
+														? (facility)             \
+														: get_debug_facility(    \
+																LOG_MNAME,       \
+																LOG_MNAME_LEN)), \
+								"%s: %.*s%s%s%s" fmt,                            \
+								(lname) ? (lname) : LOG_LEVEL2NAME(__llevel),    \
+								LOGV_PREFIX_LEN, LOGV_PREFIX_STR, (prefix),      \
+								LOGV_FUNCNAME_STR(funcname),                     \
+								LOGV_FUNCSUFFIX_STR(funcname), ##args);          \
+					}                                                            \
+				}                                                                \
+			}                                                                    \
+			DPRINT_CRIT_EXIT;                                                    \
+		}                                                                        \
 	} while(0)
 
 #define LOG_FL(facility, level, lname, prefix, fmt, args...) \


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Allow Kamailio modules to register their log function so that all Kamailio log messages (coming from core and other modules) are logged uniformly in the format defined by the custom log function. 

To enable the custom log format feature, Kamailio must be compiled with the `CUSTOM_LOG_FMT` flag. Then the module that wishes to modify the log format has to call `km_custom_log_func_set` during the initialization to supply a custom log formatting function (see `km_default_custom_log_func` as an example).
