### PR TITLE
sqlops: Don't truncated sql command when logging.

### DIFF
--- a/src/modules/sqlops/doc/sqlops_admin.xml
+++ b/src/modules/sqlops/doc/sqlops_admin.xml
@@ -194,6 +194,28 @@ modparam("sqlops", "tr_buf_size", 4096)
 </programlisting>
 		</example>
 	</section>
+	<section id="sqlops.p.log_buf_size">
+		<title><varname>log_buf_size</varname> (int)</title>
+		<para>
+		The size of the buffer (characters) when logging raw SQL operations.
+		</para>
+		<para>
+		Note: When the buffer is smaller than the SQL operation, the operation is logged truncated up to log_buf_size.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 128.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>log_buf_size</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("sqlops", "log_buf_size", 4096)
+...
+</programlisting>
+		</example>
+	</section>
 	<section id="sqlops.p.connect_mode">
 		<title><varname>connect_mode</varname> (int)</title>
 		<para>
@@ -607,4 +629,3 @@ xlog("Affected rows: $sqlrows(ca)\n");
 		</section>
 	</section>
 </chapter>
-

--- a/src/modules/sqlops/sql_api.c
+++ b/src/modules/sqlops/sql_api.c
@@ -36,6 +36,7 @@
 #include "sql_api.h"
 
 extern int sqlops_results_maxsize;
+extern int sqlops_log_buf_size;
 
 sql_con_t *_sql_con_root = NULL;
 sql_result_t *_sql_result_root = NULL;
@@ -276,7 +277,9 @@ int sql_do_query(sql_con_t *con, str *query, sql_result_t *res)
 	}
 	if(con->dbf.raw_query(con->dbh, query, &db_res) != 0) {
 		LM_ERR("cannot do the query [%.*s]\n",
-				(query->len > 64) ? 64 : query->len, query->s);
+				(query->len > sqlops_log_buf_size) ? sqlops_log_buf_size
+												   : query->len,
+				query->s);
 		return -1;
 	}
 

--- a/src/modules/sqlops/sqlops.c
+++ b/src/modules/sqlops/sqlops.c
@@ -77,6 +77,7 @@ static int sql_res_param(modparam_t type, void *val);
 extern int sqlops_tr_buf_size;
 
 int sqlops_results_maxsize = 32;
+int sqlops_log_buf_size = 128;
 
 static int sqlops_connect_mode = 0;
 
@@ -106,6 +107,7 @@ static param_export_t params[] = {
 		{"sqlcon", PARAM_STRING | USE_FUNC_PARAM, (void *)sql_con_param},
 		{"sqlres", PARAM_STRING | USE_FUNC_PARAM, (void *)sql_res_param},
 		{"tr_buf_size", PARAM_INT, &sqlops_tr_buf_size},
+		{"log_buf_size", PARAM_INT, &sqlops_log_buf_size},
 		{"connect_mode", PARAM_INT, &sqlops_connect_mode},
 		{"results_maxsize", PARAM_INT, &sqlops_results_maxsize}, {0, 0, 0}};
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This PR Fixes a bug where logging shows a truncated command instead of the original one.

Original query in .cfg:  `sql_query("ca", "UPDATE dialog SET timeout = timeout + 1 WHERE callid = '$ci' AND timeout > 0;`

logged error before fix:

sql_do_query(): cannot do the query [UPDATE dialog SET timeout = timeout + 1 WHERE callid = 'al@there]

logged error after fix:

sql_do_query(): cannot do the query [UPDATE dialog SET timeout = timeout + 1 WHERE callid = 'al@there.com AND timeout > 0;]