### PR TITLE
cdp: fix use after free in transaction call backs

### DIFF
--- a/src/modules/cdp/transaction.c
+++ b/src/modules/cdp/transaction.c
@@ -256,10 +256,11 @@ int cdp_trans_timer(time_t now, void *ptr)
 	/* do all queued callbacks */
 	x = cb_queue->head;
 	while(x) {
+		n = x->next;
 		(x->cb)(1, *(x->ptr), 0, (now - x->expires));
 		if(x->auto_drop)
 			cdp_free_trans(x);
-		x = x->next;
+		x = n;
 	}
 	pkg_free(cb_queue);
 


### PR DESCRIPTION
If the traction is set to auto drop,
the memory will be freed and with it the next pointer.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

The use after free caused on a Load tested system crashes.
Now the next pointer is saved before executing the callback and handle the auto drop.
Then the stored next pointer is used to continue the iteration over the callbacks.