### PR TITLE
pv: Ensure URI enclosed in <> when changing Display Name

### DIFF
--- a/src/modules/pv/pv_core.c
+++ b/src/modules/pv/pv_core.c
@@ -76,6 +76,8 @@ int _pv_pid = 0;
 #define PV_HDR_DELIM ","
 #define PV_HDR_DELIM_LEN (sizeof(PV_HDR_DELIM) - 1)
 
+static int is_uri_enclosed(struct sip_msg *msg, struct to_body *tb);
+
 int pv_get_msgid(struct sip_msg *msg, pv_param_t *param, pv_value_t *res)
 {
 	if(msg == NULL)
@@ -3607,9 +3609,13 @@ int pv_set_xto_attr(struct sip_msg *msg, pv_param_t *param, int op,
 		pv_value_t *val, struct to_body *tb, int type)
 {
 	str buf = {0, 0};
+	str buf_uri = {0, 0};
 	struct lump *l = NULL;
 	int loffset = 0;
+	int loffset_uri = 0;
 	int llen = 0;
+	int llen_uri = 0;
+	int is_enclosed = 0;
 
 	if(msg == NULL || param == NULL) {
 		LM_ERR("bad parameters\n");
@@ -3683,7 +3689,7 @@ int pv_set_xto_attr(struct sip_msg *msg, pv_param_t *param, int op,
 			}
 			buf.s = pkg_malloc(val->rs.len);
 			if(buf.s == 0) {
-				LM_ERR("no more pkg mem\n");
+				PKG_MEM_ERROR;
 				goto error;
 			}
 			buf.len = val->rs.len;
@@ -3715,6 +3721,29 @@ int pv_set_xto_attr(struct sip_msg *msg, pv_param_t *param, int op,
 			}
 			buf.len = val->rs.len;
 			memcpy(buf.s, val->rs.s, val->rs.len);
+
+			/* Check if the URI is enclosed in angle brackets */
+			is_enclosed = is_uri_enclosed(msg, tb);
+			/* If uri is not enclosed, we need to enclose it in < >
+				before adding display name */
+			if(!is_enclosed) {
+				LM_DBG("URI is not enclosed in angle brackets\n");
+				/* Enclose URI in angle brackets */
+				loffset_uri = tb->uri.s - msg->buf;
+				llen_uri = tb->uri.len;
+				/* Add angle brackets */
+				buf_uri.s = pkg_malloc(tb->uri.len + 2);
+				if(buf_uri.s == 0) {
+					LM_ERR("no more pkg mem\n");
+					goto error;
+				}
+				buf_uri.len = tb->uri.len + 2;
+				buf_uri.s[0] = '<';
+				memcpy(buf_uri.s + 1, tb->uri.s, tb->uri.len);
+				buf_uri.s[buf_uri.len - 1] = '>';
+				LM_DBG("URI after enclosing: %.*s\n", buf_uri.len, buf_uri.s);
+			}
+
 			if(tb->display.len == 0) {
 				l = anchor_lump(msg, tb->body.s - msg->buf, 0, 0);
 				buf.s[buf.len] = ' ';
@@ -3744,12 +3773,50 @@ int pv_set_xto_attr(struct sip_msg *msg, pv_param_t *param, int op,
 		if(buf.s != 0)
 			pkg_free(buf.s);
 	}
+
+	if(llen_uri > 0) {
+		if((l = del_lump(msg, loffset_uri, llen_uri, 0)) == 0) {
+			LM_ERR("failed to delete xto attribute %d\n", type);
+			goto error;
+		}
+	}
+	/* set new value when given */
+	if(l != NULL && buf_uri.len > 0) {
+		if(insert_new_lump_after(l, buf_uri.s, buf_uri.len, 0) == 0) {
+			LM_ERR("failed to set xto attribute %d\n", type);
+			goto error;
+		}
+	} else {
+		if(buf_uri.s != 0)
+			pkg_free(buf_uri.s);
+	}
+
 	return 0;
 
 error:
 	if(buf.s != 0)
 		pkg_free(buf.s);
 	return -1;
+}
+
+int is_uri_enclosed(struct sip_msg *msg, struct to_body *tb)
+{
+	/* Check for the presence of display name */
+	if(tb->display.len == 0) {
+		/* 	Display name not found */
+		char *uri_body = tb->body.s;
+
+		/* Assuming a valid sip message (true otherwise parser fails way before)
+		 if it starts with '<' there is a respective '>'.
+		 Also, parser trims any leading white space if no DisplayName is found
+		*/
+		if(uri_body[0] == '<') {
+			return 1;
+		}
+		return 0;
+	}
+	/* Display name found, URI should/must be enclosed */
+	return 1;
 }
 
 int pv_set_to_attr(struct sip_msg *msg, pv_param_t *param, int op,


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This PR fixes a bug in pseudo-variables related to "From" and "To" headers and changing the `Display Name` through `$tu/$fu/$fn/$tn`.

According to standard the URI must be enclosed in <> if a `Display Name` is given, but it may or may NOT if no display name is present.

So, if one tries to modify the `from`/`to` header with an initial empty display name and URI that is NOT enclosed in <>, it yields an invalid message.

This PR makes sure that if URI was not enclosed in <> and display name is modified, that will wrap URI in <>.