### PR TITLE
kafka: a few additions to the module

### DIFF
--- a/src/modules/kafka/doc/kafka_admin.xml
+++ b/src/modules/kafka/doc/kafka_admin.xml
@@ -154,6 +154,70 @@ modparam("kafka", "topic", "name=third_topic")
 		  </programlisting>
 		</example>
 	  </section>
+
+	  <section id="kafka.p.init_without_kafka">
+		<title><varname>init_without_kafka</varname> (string)</title>
+		<para>
+		  Set to anything but 0, specifies if kamailio starts even when kafka brokers are not available at startup time.
+		</para>
+		<para>
+		  Default value is <emphasis>0</emphasis> (disabled).
+		</para>
+		<example>
+		  <title>Set <varname>init_without_kafka</varname> parameter</title>
+		  <programlisting format="linespecific">
+...
+modparam("kafka", "init_without_kafka", 1)
+...
+		  </programlisting>
+		</example>
+	  </section>
+
+	  <section id="kafka.p.metadata_timeout">
+		<title><varname>metadata_timeout</varname> (string)</title>
+		<para>
+		  Specifies, in milliseconds, how much time kamailio waits to get topic metadata info at startup time.
+		</para>
+		<para>
+		  Default value is <emphasis>2000 milliseconds</emphasis> (2 seconds).
+		</para>
+		<example>
+		  <title>Set <varname>metadata_timeout</varname> parameter</title>
+		  <programlisting format="linespecific">
+...
+modparam("kafka", "metadata_timeout", 1000)
+...
+		  </programlisting>
+		</example>
+	  </section>
+
+	  <section id="kafka.p.log_without_overflow">
+		<title><varname>log_without_overflow</varname> (string)</title>
+		<para>
+		  Set to anything but 0, will skip logging most of the error messages that may happen to each kafka message sent to the broker.
+		  This is useful when e.g. kafka broker goes down, not to overflow syslog with error messages.
+		</para>
+		<para>
+		  One can alwyas check this module's stats e.g. via RPC commands and see that errors happened or not.
+		  Those errors can have 2 causes:
+		  <itemizedlist>
+			<listitem>Some errors happened with the config functions kafka_send()/kafka_send_key(). This means that the message wasn't even enqueued by librdkafka.</listitem>
+			<listitem>Some errors happened on delivery callback, managed by librdkafka. This means that the message was enqueued by librdkafka, but not managed to be delivered to the broker.</listitem>
+		  </itemizedlist>
+		</para>
+		<para>
+		  Default value is <emphasis>0</emphasis> (disabled).
+		</para>
+		<example>
+		  <title>Set <varname>log_without_overflow</varname> parameter</title>
+		  <programlisting format="linespecific">
+...
+modparam("kafka", "log_without_overflow", 1)
+...
+		  </programlisting>
+		</example>
+	  </section>
+
 	</section>
 	<section>
 	  <title>Functions</title>

--- a/src/modules/kafka/kafka_mod.c
+++ b/src/modules/kafka/kafka_mod.c
@@ -67,6 +67,7 @@ static int w_kafka_send_key(
 int child_init_ok = 0;
 int init_without_kafka = 0;
 int log_without_overflow = 0;
+int metadata_timeout = 2000;
 char *brokers_param = NULL; /**< List of brokers. */
 static int kafka_conf_param(modparam_t type, void *val);
 static int kafka_topic_param(modparam_t type, void *val);
@@ -88,7 +89,8 @@ static param_export_t params[] = {{"brokers", PARAM_STRING, &brokers_param},
 				(void *)kafka_conf_param},
 		{"topic", PARAM_STRING | USE_FUNC_PARAM, (void *)kafka_topic_param},
 		{"init_without_kafka", PARAM_INT, &init_without_kafka},
-		{"log_without_overflow", PARAM_INT, &log_without_overflow}, {0, 0, 0}};
+		{"log_without_overflow", PARAM_INT, &log_without_overflow},
+		{"metadata_timeout", PARAM_INT, &metadata_timeout}, {0, 0, 0}};
 
 /**
  * \brief Kafka :: Module interface

--- a/src/modules/kafka/kafka_mod.c
+++ b/src/modules/kafka/kafka_mod.c
@@ -66,6 +66,7 @@ static int w_kafka_send_key(
  */
 int child_init_ok = 0;
 int init_without_kafka = 0;
+int log_without_overflow = 0;
 char *brokers_param = NULL; /**< List of brokers. */
 static int kafka_conf_param(modparam_t type, void *val);
 static int kafka_topic_param(modparam_t type, void *val);
@@ -86,7 +87,8 @@ static param_export_t params[] = {{"brokers", PARAM_STRING, &brokers_param},
 		{"configuration", PARAM_STRING | USE_FUNC_PARAM,
 				(void *)kafka_conf_param},
 		{"topic", PARAM_STRING | USE_FUNC_PARAM, (void *)kafka_topic_param},
-		{"init_without_kafka", PARAM_INT, &init_without_kafka}, {0, 0, 0}};
+		{"init_without_kafka", PARAM_INT, &init_without_kafka},
+		{"log_without_overflow", PARAM_INT, &log_without_overflow}, {0, 0, 0}};
 
 /**
  * \brief Kafka :: Module interface

--- a/src/modules/kafka/kfk.c
+++ b/src/modules/kafka/kfk.c
@@ -35,7 +35,10 @@
 #include "../../core/mem/pkg.h"
 #include "../../core/mem/shm_mem.h"
 #include "../../core/locking.h"
+#include "../../core/counters.h"
 
+extern stat_var *total_messages;
+extern stat_var *total_messages_err;
 extern int child_init_ok;
 extern int init_without_kafka;
 extern int log_without_overflow;
@@ -1045,9 +1048,11 @@ static int kfk_stats_add(const char *topic, rd_kafka_resp_err_t err)
 	lock_get(stats_lock);
 
 	stats_general->total++;
+	update_stat(total_messages, 1);
 
 	if(err) {
 		stats_general->error++;
+		update_stat(total_messages_err, 1);
 	}
 
 	LM_DBG("General stats: total = %" PRIu64 "  error = %" PRIu64 "\n",

--- a/src/modules/kafka/kfk.c
+++ b/src/modules/kafka/kfk.c
@@ -240,6 +240,16 @@ int kfk_init(char *brokers)
 	 */
 	rk_conf = rd_kafka_conf_new();
 
+	/* Add brokers */
+	LM_DBG("Adding brokers: %s\n", brokers);
+	if(rd_kafka_conf_set(
+			   rk_conf, "bootstrap.servers", brokers, errstr, sizeof(errstr))
+			!= RD_KAFKA_CONF_OK) {
+		LM_ERR("No valid brokers specified: %s\n", brokers);
+		return -1;
+	}
+	LM_DBG("Added brokers: %s\n", brokers);
+
 	/* Set logger */
 	rd_kafka_conf_set_log_cb(rk_conf, kfk_logger);
 
@@ -266,14 +276,6 @@ int kfk_init(char *brokers)
 	}
 	rk_conf = NULL; /* Now owned by producer. */
 	LM_DBG("Producer handle created\n");
-
-	LM_DBG("Adding broker: %s\n", brokers);
-	/* Add brokers */
-	if(rd_kafka_brokers_add(rk, brokers) == 0) {
-		LM_ERR("No valid brokers specified: %s\n", brokers);
-		return -1;
-	}
-	LM_DBG("Added broker: %s\n", brokers);
 
 	/* Topic creation and configuration. */
 	if(kfk_topic_list_configure()) {

--- a/src/modules/kafka/kfk.c
+++ b/src/modules/kafka/kfk.c
@@ -1045,6 +1045,8 @@ static kfk_stats_t *kfk_stats_topic_new(str *topic, rd_kafka_resp_err_t err)
 		goto error;
 	}
 	memcpy(st->topic_name->s, topic->s, topic->len);
+	st->topic_name->s[topic->len] = '\0';
+	st->topic_name->len = topic->len;
 
 	st->total++;
 	if(err) {

--- a/src/modules/kafka/kfk.c
+++ b/src/modules/kafka/kfk.c
@@ -39,6 +39,7 @@
 extern int child_init_ok;
 extern int init_without_kafka;
 extern int log_without_overflow;
+extern int metadata_timeout;
 
 /**
  * \brief data type for a configuration property.
@@ -730,11 +731,6 @@ static int kfk_topic_list_configure()
 	return 0;
 }
 
-/* -1 means RD_POLL_INFINITE */
-/* 100000 means 100 seconds */
-#define METADATA_TIMEOUT \
-	100000 /**< Timeout when asking for metadata in milliseconds. */
-
 /**
  * \brief check that a topic exists in cluster.
  *
@@ -756,7 +752,7 @@ static int kfk_topic_exist(str *topic_name)
 
 	/* Get metadata for all topics. */
 	rd_kafka_resp_err_t res;
-	res = rd_kafka_metadata(rk, 1, NULL, &metadatap, METADATA_TIMEOUT);
+	res = rd_kafka_metadata(rk, 1, NULL, &metadatap, metadata_timeout);
 	if(res != RD_KAFKA_RESP_ERR_NO_ERROR) {
 		LM_ERR("Failed to get metadata: %s\n", rd_kafka_err2str(res));
 		goto error;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Hello, I recently did some tests with kamailio's kafka module, with focus on what happens when kafka broker goes down.

First thing I noticed is that kamailio won't start initially if kafka broker is down. Second thing I noticed syslog overflowing with err logs, when kafka broker is down. Third, I noticed that when it starts, kamailio queries topic metadata and waited up to 100 seconds for any answer. I've added modparams for all these three to change behavior.  Updated doc for all the new modparams.

I've also updated stats errors counting when exposed cfg functions failed for any reason. And some rework to stats function to accept str* instead of char* topic. Also moved librdkafka's poll() function at the begining of the cfg function logic, so polling happens even when some errors happen with the cfg function.