### PR TITLE
pua and pua_dialoginfo improvements

### DIFF
--- a/src/modules/pua/pua_db.c
+++ b/src/modules/pua/pua_db.c
@@ -2,6 +2,7 @@
  * pua db - presence user agent database support
  *
  * Copyright (C) 2011 Crocodile RCS Ltd
+ * Copyright (C) 2024 Victor Seva (Sipwise)
  *
  * This file is part of Kamailio, a free SIP server.
  *
@@ -790,16 +791,25 @@ int insert_record_puadb(ua_pres_t *pres)
 
 /******************************************************************************/
 
-ua_pres_t *get_record_puadb(
-		str pres_id, str *etag, ua_pres_t *result, db1_res_t **dbres)
+ua_pres_t *get_record_puadb(str *pres_uri, str pres_id, str *etag,
+		ua_pres_t *result, db1_res_t **dbres)
 {
-	db_key_t q_cols[2];
-	db_val_t q_vals[2], *values;
+	db_key_t q_cols[3];
+	db_val_t q_vals[3], *values;
 	db_row_t *rows;
 	db1_res_t *res;
 	int n_query_cols = 0, nr_rows;
 	db_query_f query_fn =
 			pua_dbf.query_lock ? pua_dbf.query_lock : pua_dbf.query;
+
+	if(pres_uri != NULL) {
+		q_cols[n_query_cols] = &str_pres_uri_col;
+		q_vals[n_query_cols].type = DB1_STR;
+		q_vals[n_query_cols].nul = 0;
+		q_vals[n_query_cols].val.str_val.s = pres_uri->s;
+		q_vals[n_query_cols].val.str_val.len = pres_uri->len;
+		n_query_cols++;
+	}
 
 	q_cols[n_query_cols] = &str_pres_id_col;
 	q_vals[n_query_cols].type = DB1_STR;

--- a/src/modules/pua/pua_db.h
+++ b/src/modules/pua/pua_db.h
@@ -2,6 +2,7 @@
  * pua_db headers - presence user agent db headers
  *
  * Copyright (C) 2011 Crocodile RCS Ltd
+ * Copyright (C) 2024 Victor Seva (Sipwise)
  *
  * This file is part of Kamailio, a free SIP server.
  *
@@ -58,8 +59,8 @@ int update_dialog_puadb(ua_pres_t *pres, int expires, str *contact);
 list_entry_t *get_subs_list_puadb(str *did);
 
 int insert_record_puadb(ua_pres_t *pres);
-ua_pres_t *get_record_puadb(
-		str pres_id, str *etag, ua_pres_t *result, db1_res_t **res);
+ua_pres_t *get_record_puadb(str *pres_uri, str pres_id, str *etag,
+		ua_pres_t *result, db1_res_t **res);
 int delete_record_puadb(ua_pres_t *pres);
 int update_record_puadb(ua_pres_t *pres, int expires, str *contact);
 int update_version_puadb(ua_pres_t *pres);

--- a/src/modules/pua/send_publish.c
+++ b/src/modules/pua/send_publish.c
@@ -309,7 +309,7 @@ void publ_cback_func(struct cell *t, int type, struct tmcb_params *ps)
 		if(pua_dbf.affected_rows != NULL || dbmode != PUA_DB_ONLY) {
 			if(find_and_update_record(hentity, hash_code, lexpire, &etag) > 0)
 				goto done;
-		} else if((db_presentity = get_record_puadb(
+		} else if((db_presentity = get_record_puadb(hentity->pres_uri,
 						   hentity->id, &hentity->etag, &dbpres, &res))
 				  != NULL) {
 			update_record_puadb(hentity, lexpire, &etag);
@@ -468,7 +468,8 @@ int send_publish(publ_info_t *publ)
 		dbpres.pres_uri = &pres_uri;
 		dbpres.watcher_uri = &watcher_uri;
 		dbpres.extra_headers = &extra_headers;
-		presentity = get_record_puadb(publ->id, publ->etag, &dbpres, &res);
+		presentity = get_record_puadb(
+				publ->pres_uri, publ->id, publ->etag, &dbpres, &res);
 	} else {
 		ua_pres_t pres;
 

--- a/src/modules/pua_dialoginfo/doc/pua_dialoginfo.xml
+++ b/src/modules/pua_dialoginfo/doc/pua_dialoginfo.xml
@@ -50,6 +50,11 @@
 			<surname>Gaisnon</surname>
 			<email>frederic.gaisnon@gmail.com</email>
 		</editor>
+		<editor>
+			<firstname>Victor</firstname>
+			<surname>Seva</surname>
+			<email>vseva@sipwise.com</email>
+		</editor>
 	</authorgroup>
 	<copyright>
 	    <year>2006</year>
@@ -63,6 +68,10 @@
 		<year>2021</year>
 		<holder>MomentTech</holder>
 	</copyright>
+	<copyright>
+		<year>2024</year>
+		<holder>Sipwise</holder>
+	</copyright>
   </bookinfo>
     <toc></toc>
 
@@ -70,5 +79,3 @@
 
 
 </book>
-
-

--- a/src/modules/pua_dialoginfo/doc/pua_dialoginfo_admin.xml
+++ b/src/modules/pua_dialoginfo/doc/pua_dialoginfo_admin.xml
@@ -211,6 +211,11 @@
 				<emphasis>pua</emphasis>.
 			</para>
 			</listitem>
+			<listitem>
+			<para>
+				<emphasis>uuid</emphasis> if <varname>use_uuid</varname> is enabled.
+			</para>
+			</listitem>
 			</itemizedlist>
 		</para>
 	</section>
@@ -232,6 +237,25 @@
 
 	<section>
 		<title>Parameters</title>
+
+	<section id="pua_dialoginfo.p.use_uuid">
+		<title><varname>use_uuid</varname> (int)</title>
+		<para>
+			If this parameter is set, the pres_id will be generated using libuuid via uuid module.
+			uuid module has to be loaded before pua_dialoginfo in this case.
+		</para>
+		<para>
+			<emphasis>Default value is <quote>0</quote>.</emphasis>
+		</para>
+		<example>
+			<title>Set <varname>use_uuid</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("pua_dialoginfo", "use_uuid", 1)
+...
+</programlisting>
+		</example>
+		</section>
 
 		<section id="pua_dialoginfo.p.include_callid">
 		<title><varname>include_callid</varname> (int)</title>

--- a/src/modules/pua_dialoginfo/pua_dialoginfo.c
+++ b/src/modules/pua_dialoginfo/pua_dialoginfo.c
@@ -51,6 +51,7 @@
 MODULE_VERSION
 
 /* Default module parameter values */
+#define DEF_USE_UUID 0
 #define DEF_INCLUDE_CALLID 1
 #define DEF_INCLUDE_LOCALREMOTE 1
 #define DEF_INCLUDE_TAGS 1
@@ -91,6 +92,7 @@ static str callee_entity_when_publish_disabled = {0, 0}; /* pubruri_callee */
 static str local_identity_dlg_var = STR_NULL;
 
 /* Module parameter variables */
+int use_uuid = DEF_USE_UUID;
 int include_callid = DEF_INCLUDE_CALLID;
 int include_localremote = DEF_INCLUDE_LOCALREMOTE;
 int include_tags = DEF_INCLUDE_TAGS;
@@ -123,6 +125,7 @@ static cmd_export_t cmds[] = {
 };
 
 static param_export_t params[] = {
+	{"use_uuid", INT_PARAM, &use_uuid},
 	{"include_callid", INT_PARAM, &include_callid},
 	{"include_localremote", INT_PARAM, &include_localremote},
 	{"include_tags", INT_PARAM, &include_tags},
@@ -733,8 +736,16 @@ struct dlginfo_cell *get_dialog_data(struct dlg_cell *dlg, int type,
 	int len;
 
 	// generate new random uuid
-	if(sruid_next_safe(&_puadi_sruid) < 0) {
-		return NULL;
+	if(use_uuid) {
+		_puadi_sruid.uid.len = SRUID_SIZE;
+		if(sruid_uuid_generate(_puadi_sruid.uid.s, &_puadi_sruid.uid.len) < 0) {
+			LM_ERR("uuid not generated\n");
+			return NULL;
+		}
+	} else {
+		if(sruid_next_safe(&_puadi_sruid) < 0) {
+			return NULL;
+		}
 	}
 	LM_DBG("uuid generated: '%.*s'\n", _puadi_sruid.uid.len,
 			_puadi_sruid.uid.s);


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally

#### Description

We are seeing a lot of error messages like:
> ERROR: <null> pua [pua_db.c:895]: get_record_puadb(): Too many rows found (2)

After some investigation I come up with a couple of fixes:

* pua: improve the query to support caller|callee with same pres_id (same dialog)
* pua_dialoginfo: support uuid to generate pres_id to improve randomness


