### PR TITLE
sca: contact-fallback

### DIFF
--- a/src/modules/sca/doc/sca_admin.xml
+++ b/src/modules/sca/doc/sca_admin.xml
@@ -306,6 +306,26 @@ modparam("sca", "server_address", "sip:10.10.10.10:5060")
 		</example>
 	</section>
 
+	<section id="sca.p.contact_fallback">
+		<title><varname>contact_fallback</varname> (string)</title>
+		<para>
+		contact used if defined when no contact is found in processed message.
+		</para>
+		<para>
+		<emphasis>
+			Default value is "" (disabled).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>contact_fallback</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("sca", "contact_fallback", "sip:127.0.0.1:5085;transport=udp")
+...
+</programlisting>
+		</example>
+	</section>
+
 	<section id="sca.p.from_uri_avp">
 		<title><varname>from_uri_avp</varname> (string)</title>
 		<para>

--- a/src/modules/sca/sca.c
+++ b/src/modules/sca/sca.c
@@ -151,6 +151,7 @@ int line_seize_max_expires = 15;
 int purge_expired_interval = 120;
 int onhold_bflag = -1;
 str server_address = STR_NULL;
+str contact_fallback = STR_NULL;
 str from_uri_avp_param = STR_NULL;
 str to_uri_avp_param = STR_NULL;
 
@@ -165,6 +166,7 @@ static param_export_t params[] = {
 		{"line_seize_max_expires", INT_PARAM, &line_seize_max_expires},
 		{"purge_expired_interval", INT_PARAM, &purge_expired_interval},
 		{"onhold_bflag", INT_PARAM, &onhold_bflag},
+		{"contact_fallback", PARAM_STR, &contact_fallback},
 		{"server_address", PARAM_STR, &server_address},
 		{"from_uri_avp", PARAM_STR, &from_uri_avp_param},
 		{"to_uri_avp", PARAM_STR, &to_uri_avp_param},
@@ -335,6 +337,10 @@ static int sca_set_config(sca_mod *scam)
 
 	if(server_address.s) {
 		scam->cfg->server_address = &server_address;
+	}
+
+	if(contact_fallback.s) {
+		scam->cfg->contact_fallback = &contact_fallback;
 	}
 
 	if(from_uri_avp_param.s) {

--- a/src/modules/sca/sca.h
+++ b/src/modules/sca/sca.h
@@ -41,6 +41,7 @@ struct _sca_config
 	int purge_expired_interval;
 	int onhold_bflag;
 	str *server_address;
+	str *contact_fallback;
 	avp_flags_t from_uri_avp_type;
 	avp_name_t from_uri_avp;
 	avp_flags_t to_uri_avp_type;

--- a/src/modules/sca/sca_call_info.c
+++ b/src/modules/sca/sca_call_info.c
@@ -1988,7 +1988,7 @@ int sca_call_info_update(
 			rc = -1;
 			goto done;
 		}
-	} else if(rc < 0) {
+	} else if(rc < 0 && !sca->cfg->contact_fallback) {
 		LM_ERR("Bad Contact\n");
 		goto done;
 	}
@@ -2036,6 +2036,13 @@ int sca_call_info_update(
 
 	LM_DBG("to_aor[%.*s] from_aor[%.*s]\n", STR_FMT(&to_aor),
 			STR_FMT(&from_aor));
+
+	if(contact_uri.s == NULL && sca->cfg->contact_fallback) {
+		contact_uri.s = sca->cfg->contact_fallback->s;
+		contact_uri.len = sca->cfg->contact_fallback->len;
+		LM_DBG("No Contact header, using default owner[%.*s]\n",
+				STR_FMT(&contact_uri));
+	}
 
 	// early check to see if we're dealing with any SCA endpoints
 	if(sca_uri_is_shared_appearance(sca, &from_aor)) {


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally

#### Description
Another step to merge the functionality that is already used in Sipwise kamailio flavor:

be able to define a fallback contact to be used when message processed has no contact
