### PR TITLE
app_python3: Fixes Kemi TypeError thrown when latency_limit_action is…

### DIFF
--- a/src/modules/app_python3/apy_kemi.c
+++ b/src/modules/app_python3/apy_kemi.c
@@ -379,8 +379,8 @@ PyObject *sr_apy_kemi_exec_func(PyObject *self, PyObject *args, int idx)
 					" took too long [%u ms] (file:%s func:%s line:%d)\n",
 					(ket->mname.len > 0) ? ket->mname.s : "",
 					(ket->mname.len > 0) ? "." : "", ket->fname.s, tdiff,
-					(pcode) ? PyBytes_AsString(pcode->co_filename) : "",
-					(pcode) ? PyBytes_AsString(pcode->co_name) : "",
+					(pcode) ? PyUnicode_AsUTF8(pcode->co_filename) : "",
+					(pcode) ? PyUnicode_AsUTF8(pcode->co_name) : "",
 					(pframe) ? PyFrame_GetLineNumber(pframe) : 0);
 #else
 			LOG(cfg_get(core, core_cfg, latency_log),


### PR DESCRIPTION

- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue # 3915

#### Description
<!-- Describe your changes in detail -->
Replace PyBytes_AsString(..) calls with calls to PyUnicode_AsUTF8(..) in the PY_VERSION_HEX >= 0x030B0000 block of apy_kemi.c. The PyBytes_AsString expects a Bytes value but receives a Unicode value instead, thus causing the TypeError exception.
