### PR TITLE
tm: Emit request event when tm.cancel is called

### DIFF
--- a/src/modules/tm/t_cancel.c
+++ b/src/modules/tm/t_cancel.c
@@ -29,12 +29,15 @@
 #include "t_funcs.h"
 #include "../../core/dprint.h"
 #include "../../core/ut.h"
+#include "../../core/kemi.h"
 #include "t_reply.h"
 #include "t_cancel.h"
 #include "t_msgbuilder.h"
 #include "t_lookup.h" /* for t_lookup_callid in fifo_uac_cancel */
 #include "t_hooks.h"
 
+
+extern str tm_event_callback;
 
 typedef struct cancel_reason_map
 {
@@ -86,6 +89,11 @@ void prepare_to_cancel(
 	int i;
 	int branches_no;
 	branch_bm_t mask;
+	int rt, backup_rt;
+	struct run_act_ctx ctx;
+	sip_msg_t msg;
+	sr_kemi_eng_t *keng = NULL;
+	str evname = str_init("tm:local-request");
 
 	*cancel_bm = 0;
 	branches_no = t->nr_of_outgoings;
@@ -95,6 +103,49 @@ void prepare_to_cancel(
 		*cancel_bm |= ((mask & (1 << i)) && prepare_cancel_branch(t, i, 1))
 					  << i;
 	}
+
+	rt = -1;
+	if(tm_event_callback.s == NULL || tm_event_callback.len <= 0) {
+		rt = route_lookup(&event_rt, "tm:local-request");
+		if(rt < 0 || event_rt.rlist[rt] == NULL) {
+			LM_DBG("tm:local-request not found\n");
+			return;
+		}
+	} else {
+		keng = sr_kemi_eng_get();
+		if(keng == NULL) {
+			LM_DBG("event callback (%s) set, but no cfg engine\n",
+					tm_event_callback.s);
+			return;
+		}
+	}
+
+	/* Check if msg is null */
+	if(build_sip_msg_from_buf(
+			   &msg, t->uac->request.buffer, t->uac->request.buffer_len, 0)
+			< 0) {
+		LM_ERR("fail to parse msg\n");
+		return;
+	}
+
+	/* Call event */
+	backup_rt = get_route_type();
+	set_route_type(REQUEST_ROUTE);
+	init_run_actions_ctx(&ctx);
+	if(rt >= 0) {
+		run_top_route(event_rt.rlist[rt], &msg, 0);
+	} else {
+		if(keng != NULL) {
+
+			if(sr_kemi_route(
+					   keng, &msg, EVENT_ROUTE, &tm_event_callback, &evname)
+					< 0) {
+				LM_ERR("error running event route kemi callback\n");
+			}
+		}
+	}
+	set_route_type(backup_rt);
+	free_sip_msg(&msg);
 }
 
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3831

#### Description
<!-- Describe your changes in detail -->

The `tm` currently does not trigger the `tm:local-request` event for CANCEL requests that are created by the tm.cancel RPC function. This pull request adds support for triggering the tm:local-request event for CANCEL requests.

According to [docs](https://www.kamailio.org/docs/modules/devel/modules/tm#tm.e.local-request) an event `tm:local-request` should be created for every request that is originates from kamailio and creates a transaction. 


