### PR TITLE
topos_redis : show redis error for post mortem analysis

### DIFF
--- a/src/modules/topos_redis/topos_redis_storage.c
+++ b/src/modules/topos_redis/topos_redis_storage.c
@@ -677,6 +677,9 @@ int tps_redis_load_initial_method_branch(
 
 	if(rrpl->type != REDIS_REPLY_ARRAY) {
 		LM_WARN("invalid redis result type: %d\n", rrpl->type);
+		if(rrpl->type == REDIS_REPLY_ERROR) {
+			LM_ERR("Redis error:%s\n", rrpl->str);
+		}
 		freeReplyObject(rrpl);
 		return -1;
 	}
@@ -832,6 +835,9 @@ int tps_redis_load_branch(
 
 	if(rrpl->type != REDIS_REPLY_ARRAY) {
 		LM_WARN("invalid redis result type: %d\n", rrpl->type);
+		if(rrpl->type == REDIS_REPLY_ERROR) {
+			LM_ERR("Redis error:%s\n", rrpl->str);
+		}
 		freeReplyObject(rrpl);
 		return -1;
 	}
@@ -1037,6 +1043,9 @@ int tps_redis_load_dialog(sip_msg_t *msg, tps_data_t *md, tps_data_t *sd)
 
 	if(rrpl->type != REDIS_REPLY_ARRAY) {
 		LM_WARN("invalid redis result type: %d\n", rrpl->type);
+		if(rrpl->type == REDIS_REPLY_ERROR) {
+			LM_ERR("Redis error:%s\n", rrpl->str);
+		}
 		freeReplyObject(rrpl);
 		return -1;
 	}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Small log improvement, in order to make easier to find the origin of redis errors.

Log sample :
```
WARNING: topos_redis [topos_redis_storage.c:834]: tps_redis_load_branch(): invalid redis result type: 6
WARNING: topos [tps_storage.c:626]: tps_storage_record(): no local address - do record routing for all initial requests
ERROR: topos [tps_storage.c:637]: tps_storage_record(): failed to store
```

The root cause is probaly in redis error message and it whould be nice to log it