### PR TITLE
app_python3s: support for Free-Threading Python and clean-up

### DIFF
--- a/src/modules/app_python3s/apy3s_kemi.c
+++ b/src/modules/app_python3s/apy3s_kemi.c
@@ -64,6 +64,8 @@ sr_apy_env_t *sr_apy_env_get()
 /**
  *
  */
+extern __thread PyThreadState *_save;
+
 int apy3s_exec_func(sip_msg_t *_msg, char *fname, char *fparam, int emode)
 {
 	PyObject *pFunc, *pArgs, *pValue;
@@ -77,7 +79,10 @@ int apy3s_exec_func(sip_msg_t *_msg, char *fname, char *fparam, int emode)
 	}
 
 	/* clear error state */
+	/* clang-format off */
+	Py_BLOCK_THREADS
 	PyErr_Clear();
+	/* clang-format on */
 
 	if(lock_try(_sr_python_reload_lock) == 0) {
 		if(_sr_python_reload_version
@@ -164,7 +169,10 @@ error:
 	}
 	/* clear error state */
 	PyErr_Clear();
+	/* clang-format off */
+	Py_UNBLOCK_THREADS
 	return rval;
+	/* clang-format on */
 }
 
 

--- a/src/modules/app_python3s/apy3s_kemi.c
+++ b/src/modules/app_python3s/apy3s_kemi.c
@@ -746,6 +746,11 @@ static PyObject *init_KSR(void)
 	/* special sub-modules - x.modf() can have variable number of params */
 	_sr_apy_ksr_modules_list[m] = PyModule_Create(&KSR_x_moduledef);
 	PyModule_AddObject(_sr_apy_ksr_module, "x", _sr_apy_ksr_modules_list[m]);
+#if defined(Py_GIL_DISABLED) && !defined(KSR_PYTHON_DISABLE_FREETHREADING)
+#warning Python Free Threading build
+	PyUnstable_Module_SetGIL(_sr_apy_ksr_module, Py_MOD_GIL_NOT_USED);
+	PyUnstable_Module_SetGIL(_sr_apy_ksr_modules_list[m], Py_MOD_GIL_NOT_USED);
+#endif
 	Py_INCREF(_sr_apy_ksr_modules_list[m]);
 	m++;
 
@@ -781,6 +786,11 @@ static PyObject *init_KSR(void)
 			mmodule->m_size = -1;
 
 			_sr_apy_ksr_modules_list[m] = PyModule_Create(mmodule);
+#if defined(Py_GIL_DISABLED) && !defined(KSR_PYTHON_DISABLE_FREETHREADING)
+#warning Python Free Threading build
+			PyUnstable_Module_SetGIL(
+					_sr_apy_ksr_modules_list[m], Py_MOD_GIL_NOT_USED);
+#endif
 			PyModule_AddObject(_sr_apy_ksr_module, emods[k].kexp[0].mname.s,
 					_sr_apy_ksr_modules_list[m]);
 			Py_INCREF(_sr_apy_ksr_modules_list[m]);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
https://py-free-threading.github.io/

- support for free-threading Python
    - Enable `app_python3s` module to build with Free Threading CPython builds
    - Can be gated with `-DKSR_PYTHON_DISABLE_FREETHREADING`
    - ff Python is a non-free-threading build this change has no effect; does not affect stable distros and Kamailio packaging
- refactor GIL and thread state handling
    - was using PyGILState_XXX for thread-correctness;  this is redundant for this module as those functions are for C-threads created by Python unaware libraries
    - if the Python script created background tasks using the threading module these tasks would block as KEMI calls did not release the GIL
    - fixed by using the macros Py_BLOCK|UNBLOCK_THREADS: these allow Python threads to run when the KEMI call is complete and has returned to the Kamailio event loop
