### PR TITLE
ims_registrar_scscf: fixing em_max_expires

### DIFF
--- a/src/modules/ims_registrar_scscf/config.c
+++ b/src/modules/ims_registrar_scscf/config.c
@@ -31,19 +31,19 @@
 #include "config.h"
 
 struct cfg_group_registrar default_registrar_cfg = {
-		3600,		   /* default_expires */
-		0,			   /* default_expires_range */
-		60,			   /* min_expires */
-		0,			   /* max_expires */
-		3600,		   /* emergency contact default expires */
-		60,			   /* emergency contact max expires */
-		0,			   /* emergency contact min expires */
-		0,			   /* max_contacts */
-		0,			   /* retry_after */
-		0,			   /* case_sensitive */
-		Q_UNSPECIFIED, /* default_q */
-		1,			   /* append_branches */
-		""			   /* realm_pref */
+		.default_expires = 3600,	/* default_expires */
+		.default_expires_range = 0, /* default_expires_range */
+		.min_expires = 60,			/* min_expires */
+		.max_expires = 600000,		/* max_expires */
+		.em_default_expires = 1800, /* emergency contact default expires */
+		.em_max_expires = 3600,		/* emergency contact max expires */
+		.em_min_expires = 0,		/* emergency contact min expires */
+		.max_contacts = 0,			/* max_contacts */
+		.retry_after = 0,			/* retry_after */
+		.case_sensitive = 0,		/* case_sensitive */
+		.default_q = Q_UNSPECIFIED, /* default_q */
+		.append_branches = 1,		/* append_branches */
+		.realm_pref = ""			/* realm_pref */
 };
 
 void *registrar_cfg = &default_registrar_cfg;

--- a/src/modules/ims_registrar_scscf/ims_registrar_scscf_mod.c
+++ b/src/modules/ims_registrar_scscf/ims_registrar_scscf_mod.c
@@ -284,7 +284,7 @@ static param_export_t params[] = {
 		{"max_expires", INT_PARAM, &default_registrar_cfg.max_expires},
 		{"em_default_expires", INT_PARAM,
 				&default_registrar_cfg.em_default_expires},
-		{"em_min_expires", INT_PARAM, &default_registrar_cfg.em_max_expires},
+		{"em_max_expires", INT_PARAM, &default_registrar_cfg.em_max_expires},
 		{"em_min_expires", INT_PARAM, &default_registrar_cfg.em_min_expires},
 
 		{"default_q", INT_PARAM, &default_registrar_cfg.default_q},

--- a/src/modules/ims_registrar_scscf/save.c
+++ b/src/modules/ims_registrar_scscf/save.c
@@ -125,20 +125,24 @@ static inline int calc_contact_expires(
 						  : default_registrar_cfg.default_expires;
 		goto end;
 	}
-	if(!sos_reg && r < default_registrar_cfg.min_expires) {
+	if(!sos_reg && r < default_registrar_cfg.min_expires
+			&& default_registrar_cfg.min_expires != 0) {
 		r = default_registrar_cfg.min_expires;
 		goto end;
 	}
-	if(sos_reg && r < default_registrar_cfg.em_min_expires) {
+	if(sos_reg && r < default_registrar_cfg.em_min_expires
+			&& default_registrar_cfg.em_min_expires != 0) {
 		r = default_registrar_cfg.em_min_expires;
 		goto end;
 	}
-	if(!sos_reg && r > default_registrar_cfg.max_expires) {
+	if(!sos_reg && r > default_registrar_cfg.max_expires
+			&& default_registrar_cfg.max_expires != 0) {
 		r = default_registrar_cfg.max_expires;
 		goto end;
 	}
-	if(sos_reg && r > default_registrar_cfg.em_max_expires) {
-		r = default_registrar_cfg.em_min_expires;
+	if(sos_reg && r > default_registrar_cfg.em_max_expires
+			&& default_registrar_cfg.em_max_expires != 0) {
+		r = default_registrar_cfg.em_max_expires;
 		goto end;
 	}
 end:


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

In case of Emergency-Registrations the S-CSCF was wrongly setting the expires of the `;sos` contacts to `em_min_expires` if they were above `em_max_expires`.

Other smaller related fixes:
- Fixed also another typo in the config params definition.
- Added some code to more easily make sense of which attributes of a struct are set with what.
- Added conditions to respect the parameter documentation which indicate that if set to 0, the expires conditions won't be used.
