### PR TITLE
goto error on cursor error

### DIFF
--- a/src/modules/db_mongodb/mongodb_dbase.c
+++ b/src/modules/db_mongodb/mongodb_dbase.c
@@ -838,6 +838,7 @@ static int db_mongodb_store_result(const db1_con_t *_h, db1_res_t **_r)
 			|| !mongoc_cursor_next(mgres->cursor, &itdoc) || !itdoc) {
 		if(mongoc_cursor_error(mgres->cursor, &error)) {
 			LM_DBG("An error occurred: %s\n", error.message);
+			goto error;
 		} else {
 			LM_DBG("no result from mongodb\n");
 		}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
If the query failed, the result set should not be parsed and used. This results in an empty result set which will most likely lead to unwanted behavior.

Background: While troubleshooting, we detected that domain.reload actually replaces domains with an empty result set if mongodb connectivity fails. This means that if, at the moment when we request domain reloading, our mongodb is unreachable for whatever reason, kamailio will store an empty list as domains and it will remain that way until we request domain reloading again.

```
DEBUG: db_mongodb [mongodb_dbase.c:849]: db_mongodb_store_result(): An error occurred: No suitable servers found (`serverSelectionTryOnce` set): [connection timeout calling ismaster on 'pdb-iop1-wrmg-2:27017'] [connection timeout calling ismaster on 'pdb-iop1-wrmg-1:27017']
DEBUG: domain [domain.c:365]: reload_tables(): number of rows in domain_attrs table: 0
DEBUG: <core> [db_res.c:79]: db_free_columns(): freeing 0 columns
DEBUG: <core> [db_res.c:138]: db_free_result(): freeing result set at 0x7fb0c9811848
DEBUG: db_mongodb [mongodb_dbase.c:973]: db_mongodb_query(): query to collection [domains]
DEBUG: db_mongodb [mongodb_dbase.c:1007]: db_mongodb_query(): query filter: { }
DEBUG: db_mongodb [mongodb_dbase.c:1043]: db_mongodb_query(): columns filter: { "projection" : { "domain" : 1, "did" : 1 } }
``` 