### PR TITLE
Fixed segfault when using kazoo_query in kazoo mod

### DIFF
--- a/src/modules/kazoo/kazoo.c
+++ b/src/modules/kazoo/kazoo.c
@@ -150,12 +150,14 @@ static cmd_export_t cmds[] = {
 				fixup_kz_amqp_free, ANY_ROUTE},
 		{"kazoo_publish", (cmd_function)kz_amqp_publish_ex, 4, fixup_kz_amqp,
 				fixup_kz_amqp_free, ANY_ROUTE},
-		{"kazoo_query", (cmd_function)kz_amqp_query, 4, fixup_kz_amqp,
+
+		{"kazoo_query", (cmd_function)kz_amqp_query_3, 3, fixup_kz_amqp,
 				fixup_kz_amqp_free, ANY_ROUTE},
-		{"kazoo_query", (cmd_function)kz_amqp_query, 5, fixup_kz_amqp,
+		{"kazoo_query", (cmd_function)kz_amqp_query_4, 4, fixup_kz_amqp,
 				fixup_kz_amqp_free, ANY_ROUTE},
-		{"kazoo_query", (cmd_function)kz_amqp_query_ex, 3, fixup_kz_amqp,
+		{"kazoo_query", (cmd_function)kz_amqp_query_5, 5, fixup_kz_amqp,
 				fixup_kz_amqp_free, ANY_ROUTE},
+
 		{"kazoo_pua_publish", (cmd_function)kz_pua_publish, 1, 0, 0, ANY_ROUTE},
 		{"kazoo_pua_publish_mwi", (cmd_function)kz_pua_publish_mwi, 1, 0, 0,
 				ANY_ROUTE},
@@ -168,8 +170,6 @@ static cmd_export_t cmds[] = {
 				fixup_kz_amqp4_free, ANY_ROUTE},
 		{"kazoo_subscribe", (cmd_function)kz_amqp_subscribe_simple, 4,
 				fixup_kz_amqp4, fixup_kz_amqp4_free, ANY_ROUTE},
-
-
 		{"kazoo_json", (cmd_function)kz_json_get_field, 3, fixup_kz_json,
 				fixup_kz_json_free, ANY_ROUTE},
 		{"kazoo_json_keys", (cmd_function)kz_json_get_keys, 3, fixup_kz_json,
@@ -368,7 +368,7 @@ static int mod_init(void)
 	}
 
 	kz_worker_pipes_fds =
-			(int *)shm_malloc(sizeof(int) * (dbk_consumer_workers)*2);
+			(int *)shm_malloc(sizeof(int) * (dbk_consumer_workers) * 2);
 	kz_worker_pipes = (int *)shm_malloc(sizeof(int) * dbk_consumer_workers);
 	for(i = 0; i < dbk_consumer_workers; i++) {
 		kz_worker_pipes_fds[i * 2] = kz_worker_pipes_fds[i * 2 + 1] = -1;

--- a/src/modules/kazoo/kz_amqp.h
+++ b/src/modules/kazoo/kz_amqp.h
@@ -310,10 +310,12 @@ int ki_kz_amqp_publish(
 		sip_msg_t *msg, str *exchange, str *routing_key, str *payload);
 int ki_kz_amqp_publish_hdrs(sip_msg_t *msg, str *exchange, str *routing_key,
 		str *payload, str *headers);
-int kz_amqp_query(struct sip_msg *msg, char *exchange, char *routing_key,
-		char *payload, char *dst, char *headers);
-int kz_amqp_query_ex(struct sip_msg *msg, char *exchange, char *routing_key,
-		char *payload, char *headers);
+int kz_amqp_query_3(
+		struct sip_msg *msg, char *exchange, char *routing_key, char *payload);
+int kz_amqp_query_4(struct sip_msg *msg, char *exchange, char *routing_key,
+		char *payload, str *dst);
+int kz_amqp_query_5(struct sip_msg *msg, char *exchange, char *routing_key,
+		char *payload, str *dst, char *headers);
 int kz_amqp_subscribe(struct sip_msg *msg, char *payload);
 int ki_kz_amqp_subscribe(sip_msg_t *msg, str *payload);
 int kz_amqp_subscribe_simple(struct sip_msg *msg, char *exchange,
@@ -326,6 +328,8 @@ int kz_amqp_async_query(struct sip_msg *msg, char *exchange, char *routing_key,
 int kz_amqp_async_query_ex(struct sip_msg *msg, char *_exchange,
 		char *_routing_key, char *_payload, char *_cb_route, char *_err_route,
 		char *_pub_flags);
+
+void kz_set_pseudo_var(struct sip_msg *msg, str *dst);
 
 //void kz_amqp_generic_consumer_loop(int child_no);
 void kz_amqp_manager_loop(int child_no);


### PR DESCRIPTION
A response to the amqp query caused a segfault in libc

- Refactored parts of the code to be more readable and DRY
- Split up functions for 3/4/5 arguments passed
- Tested in 5.8.2

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
The current state of the module was not usable anymore as everything up from 5.5.x caused a segfault when the kazoo_query method was executed. Refactored the module a bit to make sure it is works again 5.8.x
