### PR TITLE
tls_wolfssl: Initialize cipher_list for domain #3920

### DIFF
--- a/src/modules/tls_wolfssl/tls_domain.c
+++ b/src/modules/tls_wolfssl/tls_domain.c
@@ -973,7 +973,8 @@ static int ksr_tls_fix_domain(tls_domain_t *d, tls_domain_t *def)
 		return -1;
 	if(load_crl(d) < 0)
 		return -1;
-	// if (set_cipher_list(d) < 0) return -1;
+	if (set_cipher_list(d) < 0)
+		return -1;
 	if(set_verification(d) < 0)
 		return -1;
 	if(set_ssl_options(d) < 0)

--- a/src/modules/tls_wolfssl/tls_domain.c
+++ b/src/modules/tls_wolfssl/tls_domain.c
@@ -973,7 +973,7 @@ static int ksr_tls_fix_domain(tls_domain_t *d, tls_domain_t *def)
 		return -1;
 	if(load_crl(d) < 0)
 		return -1;
-	if (set_cipher_list(d) < 0)
+	if(set_cipher_list(d) < 0)
 		return -1;
 	if(set_verification(d) < 0)
 		return -1;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
In TLS WolfSSL, enable initialization of the cipher_list from the domain config.
Also from this setting kamailio exposes dangerous ciphers like RC4, NULL
| ssl-enum-ciphers:
|   TLSv1.2:
|     ciphers:
|       TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_RC4_128_SHA (secp256r1) - C
|       TLS_ECDHE_ECDSA_WITH_AES_128_CCM (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256-draft (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_NULL_SHA (secp256r1) - F
|       TLS_PSK_WITH_CHACHA20_POLY1305_SHA256 - unknown
|       TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|       TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256 (secp256r1) - A
|       TLS_ECDHE_PSK_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_ECDHE_PSK_WITH_NULL_SHA256 (secp256r1) - F
|     compressors:
|       NULL
|     cipher preference: server
|     warnings:
|       Broken cipher RC4 is deprecated by RFC 7465
|   TLSv1.3:
|     ciphers:
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_AES_128_CCM_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_AES_128_CCM_8_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_NULL_SHA256 (secp256r1) - F
|       TLS_AKE_WITH_NULL_SHA384 (secp256r1) - F
|     cipher preference: server
|_  least strength: unknown

After apply patch:
| ssl-enum-ciphers:
|   TLSv1.2:
|     ciphers:
|       TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_128_CCM (secp256r1) - A
|     compressors:
|       NULL
|     cipher preference: server
|   TLSv1.3:
|     ciphers:
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|     cipher preference: server
|_  least strength: A

version: kamailio 5.8.3 (x86_64/linux) 6f8a04-dirty
AlmaLinux release 8.10 (Cerulean Leopard)

Reported #3920 