### PR TITLE
db_redis: hiredis-cluster build fix

### DIFF
--- a/src/modules/db_redis/Makefile
+++ b/src/modules/db_redis/Makefile
@@ -64,9 +64,9 @@ ifneq ($(HIREDIS_CLUSTER_BUILDER),)
 	HIREDISCLUSTERDEFS = $(shell $(HIREDIS_CLUSTER_BUILDER) --cflags)
 	HIREDISCLUSTERLIBS = $(shell $(HIREDIS_CLUSTER_BUILDER) --libs)
 	HIREDISCLUSTERLIBSPATH = $(shell $(HIREDIS_CLUSTER_BUILDER) --libs-only-L | cut -c 3-)
-	ifneq ($(shell ls $(HIREDISCLUSTERLIBSPATH) | grep libhiredis_ssl.so),)
+	ifneq ($(shell ls $(HIREDISCLUSTERLIBSPATH) | grep libhiredis_cluster_ssl.so),)
 		HIREDISCLUSTERDEFS += -DWITH_SSL
-		HIREDISCLUSTERLIBS += -lhiredis_ssl
+		HIREDISCLUSTERLIBS += -lhiredis_cluster_ssl
 	endif
 	DEFS+=-DWITH_HIREDIS_CLUSTER
 	DEFS+=$(HIREDISCLUSTERDEFS)

--- a/src/modules/db_redis/redis_connection.h
+++ b/src/modules/db_redis/redis_connection.h
@@ -25,6 +25,9 @@
 
 #ifdef WITH_HIREDIS_CLUSTER
 #include <hircluster.h>
+#ifdef WITH_SSL
+#include <hircluster_ssl.h>
+#endif
 #else
 #ifdef WITH_HIREDIS_PATH
 #include <hiredis/hiredis.h>

--- a/src/modules/db_redis/redis_dbase.c
+++ b/src/modules/db_redis/redis_dbase.c
@@ -1020,8 +1020,11 @@ static int db_redis_scan_query_keys_pattern(km_redis_con_t *con,
 #endif
 
 #ifdef WITH_HIREDIS_CLUSTER
+	return 0;
+	err : if(reply) db_redis_free_reply(&reply);
+	return -1;
 }
-#endif
+#else
 
 // for full table scans, we have to manually match all given keys
 // but only do this once for repeated invocations
@@ -1057,6 +1060,7 @@ if(*manual_keys) {
 }
 return -1;
 }
+#endif
 
 static int db_redis_scan_query_keys(km_redis_con_t *con, const str *table_name,
 		const int _n, redis_key_t **query_keys, int *query_keys_count,


### PR DESCRIPTION
fix: hiredis-cluster build with or without TLS enabled

Kamailio db_redis module can't be build while WITH_HIREDIS_CLUSTER is enabled. This reproducible for WITH_SSL defined or not.

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [x] Related to issue #3893
