### PR TITLE
ims_isc: bugfix: firstflag incorrect in isc_match_filter

### DIFF
--- a/src/modules/ims_isc/ims_isc_mod.c
+++ b/src/modules/ims_isc/ims_isc_mod.c
@@ -244,12 +244,10 @@ int isc_match_filter(struct sip_msg *msg, char *str1, udomain_t *d)
 
 	//sometimes s is populated by an ims_getter method cscf_get_terminating_user that alloc memory that must be free-ed at the end
 	int free_s = 0;
-
-	//the callback from the Cx interface in case of unreg terminating initial message is a FAILURE_ROUTE. Hence we need an addl. flag
-	int firstflag = 0;
+	enum isc_mark_status status = 0;
 
 	int ret = ISC_RETURN_FALSE;
-	isc_mark new_mark, old_mark;
+	isc_mark new_mark, old_mark, dummy_mark;
 
 	enum dialog_direction dir = get_dialog_direction(str1);
 
@@ -264,16 +262,27 @@ int isc_match_filter(struct sip_msg *msg, char *str1, udomain_t *d)
 	/* starting or resuming? */
 	memset(&old_mark, 0, sizeof(isc_mark));
 	memset(&new_mark, 0, sizeof(isc_mark));
+	memset(&dummy_mark, 0, sizeof(isc_mark));
+
+	if(is_route_type(FAILURE_ROUTE)) {
+		status |= ISCMARK_FAILURE;
+	}
+
 	if(isc_mark_get_from_msg(msg, &old_mark)) {
 		LM_DBG("Message returned s=%d;h=%d;d=%d;a=%.*s\n", old_mark.skip,
 				old_mark.handling, old_mark.direction, old_mark.aor.len,
 				old_mark.aor.s);
+	} else if(is_route_type(FAILURE_ROUTE)
+			  && isc_mark_get_from_lumps(msg, &dummy_mark)) {
+		LM_DBG("Message lumps returned s=%d;h=%d;d=%d;a=%.*s\n",
+				dummy_mark.skip, dummy_mark.handling, dummy_mark.direction,
+				dummy_mark.aor.len, dummy_mark.aor.s);
 	} else {
 		LM_DBG("Starting triggering\n");
-		firstflag = 1;
+		status |= ISCMARK_MISSING;
 	}
 
-	if(is_route_type(FAILURE_ROUTE) && !firstflag) {
+	if(status == ISCMARK_FOUND_LUMPS) {
 		/* need to find the handling for the failed trigger */
 		if(dir == DLG_MOBILE_ORIGINATING) {
 			k = cscf_get_originating_user(msg, &s);
@@ -307,7 +316,7 @@ int isc_match_filter(struct sip_msg *msg, char *str1, udomain_t *d)
 			}
 		}
 		struct cell *t = isc_tmb.t_gett();
-		LM_CRIT("SKIP: %d\n", old_mark.skip);
+		LM_CRIT("SKIP after AS failure: %d\n", old_mark.skip);
 		int index = old_mark.skip;
 		for(k = 0; k < t->nr_of_outgoings; k++) {
 			m = isc_checker_find(s, new_mark.direction, index, msg,
@@ -376,7 +385,7 @@ int isc_match_filter(struct sip_msg *msg, char *str1, udomain_t *d)
 				new_mark.skip = m->index + 1;
 				new_mark.handling = m->default_handling;
 				new_mark.aor = s;
-				ret = isc_forward(msg, m, &new_mark, firstflag);
+				ret = isc_forward(msg, m, &new_mark, status);
 				isc_free_match(m);
 				goto done;
 			}
@@ -417,7 +426,7 @@ int isc_match_filter(struct sip_msg *msg, char *str1, udomain_t *d)
 				new_mark.skip = m->index + 1;
 				new_mark.handling = m->default_handling;
 				new_mark.aor = s;
-				ret = isc_forward(msg, m, &new_mark, firstflag);
+				ret = isc_forward(msg, m, &new_mark, status);
 				isc_free_match(m);
 				goto done;
 			}
@@ -432,6 +441,10 @@ done:
 
 	if(old_mark.aor.s)
 		pkg_free(old_mark.aor.s);
+
+	if(dummy_mark.aor.s)
+		pkg_free(dummy_mark.aor.s);
+
 	return ret;
 }
 
@@ -543,7 +556,8 @@ int isc_from_as(struct sip_msg *msg, char *str1, char *str2)
 			cscf_get_terminating_user(msg, &s);
 			//sometimes s is populated by an ims_getter method cscf_get_terminating_user that alloc memory that must be free-ed at the end
 			free_s = 1;
-			if(memcmp(old_mark.aor.s, s.s, s.len) != 0) {
+			if(!old_mark.aor.s || !s.len
+					|| memcmp(old_mark.aor.s, s.s, s.len) != 0) {
 				LM_DBG("This is a new call....... RURI has been retargeted\n");
 				return ISC_RETURN_RETARGET;
 			}

--- a/src/modules/ims_isc/ims_isc_mod.h
+++ b/src/modules/ims_isc/ims_isc_mod.h
@@ -79,6 +79,29 @@ enum dialog_direction
 	/** Unknown 	*/
 };
 
+/* Method of obtaining isc_mark
+First bit -> 0=REQUEST_ROUTE/1=FAILURE_ROUTE 
+Second bit -> 0=Found/1=Missing
+*/
+enum isc_mark_status
+{
+	ISCMARK_FOUND_ROUTE_HEADER =
+			0, /*Request has been received from AS, old ISCMARK found in Route header field*/
+	ISCMARK_FOUND_LUMPS =
+			1, /*Request to AS has been rejected or timed out, old ISCMARK found in lumps*/
+	ISCMARK_MISSING_START_TRIGGERING =
+			2, /*Request has been received without old ISCMARK in Route header field*/
+	ISCMARK_MISSING_START_TRIGGERING_SAR =
+			3 /*SAR/SAA has happened with HSS, due to terminating request (no old ISCMARK)*/
+};
+
+/* ISCMARK Status bits*/
+
+/* ISCMARK is obtained in failure route*/
+#define ISCMARK_FAILURE (1 << 0)
+/* ISCMARK could not be found */
+#define ISCMARK_MISSING (1 << 1)
+
 /* Various constants */
 /** User Not Registered */
 #define IMS_USER_NOT_REGISTERED 0

--- a/src/modules/ims_isc/isc.c
+++ b/src/modules/ims_isc/isc.c
@@ -56,10 +56,11 @@
  * @param msg - the SIP message
  * @param m  - the isc_match that matched with info about where to forward it
  * @param mark  - the isc_mark that should be used to mark the message
+ * @param status - the state of the isc_mark
  * @returns #ISC_RETURN_TRUE if OK, #ISC_RETURN_ERROR if not
  */
-int isc_forward(
-		struct sip_msg *msg, isc_match *m, isc_mark *mark, int firstflag)
+int isc_forward(struct sip_msg *msg, isc_match *m, isc_mark *mark,
+		enum isc_mark_status status)
 {
 	struct cell *t;
 	unsigned int hash, label;
@@ -80,7 +81,7 @@ int isc_forward(
 	msg->dst_uri.s[msg->dst_uri.len] = '\0';
 
 	/* append branch if last trigger failed */
-	if(is_route_type(FAILURE_ROUTE) && !firstflag)
+	if(status == ISCMARK_FOUND_LUMPS)
 		append_branch(msg, &(msg->first_line.u.request.uri), &(msg->dst_uri), 0,
 				Q_UNSPECIFIED, 0, 0, 0, 0, 0, 0);
 

--- a/src/modules/ims_isc/isc.h
+++ b/src/modules/ims_isc/isc.h
@@ -70,8 +70,8 @@ extern int isc_fr_inv_timeout; /**< default ISC INVITE response timeout in ms */
 /**	SIP Status Code to send to client on Session Termination because AS did not respond */
 
 
-int isc_forward(
-		struct sip_msg *msg, isc_match *m, isc_mark *mark, int firstflag);
+int isc_forward(struct sip_msg *msg, isc_match *m, isc_mark *mark,
+		enum isc_mark_status status);
 
 
 #endif

--- a/src/modules/ims_isc/mark.h
+++ b/src/modules/ims_isc/mark.h
@@ -74,6 +74,7 @@ typedef struct _isc_mark
 
 
 int isc_mark_get_from_msg(struct sip_msg *msg, isc_mark *mark);
+int isc_mark_get_from_lumps(struct sip_msg *msg, isc_mark *mark);
 void isc_mark_get(str x, isc_mark *mark);
 int base16_to_bin(char *from, int len, char *to);
 int isc_mark_drop_route(struct sip_msg *msg);


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
The function isc_match_filter uses a local variable "firstflag",
to handle the case of an HSS based terminating unregistered service.

In that case, the S-CSCF exchanges SAR/SAA with the HSS in order
to learn the subscription data and the iFC for an unregistered
user or for a PSI.

The firstflag is necessary to make a distiction between the
FAILURE ROUTE that is used for this case and the FAILURE ROUTE
that is used for transaction failure towards the AS.

The error is, the firstflag is set for the latter case, too,
which leads to a wrong handling of communication errors towards
the AS.

This PR introduces a new function that looks for the old
ISCMARK in the lumps of the stored message and hence can make a
distinction between the SAR/SAA case and the AS failure case.

The `firstflag` variable now uses an enum `isc_mark_status` which describes the 4 possible states.