### PR TITLE
http_async_client: fixed crash on curl callback

### DIFF
--- a/src/modules/http_async_client/http_multi.c
+++ b/src/modules/http_async_client/http_multi.c
@@ -157,9 +157,11 @@ void event_cb(int fd, short kind, void *userp)
 /* CURLMOPT_SOCKETFUNCTION */
 int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 {
+	struct http_m_cell *cell;
 	struct http_m_global *g = (struct http_m_global *)cbp;
-	struct http_m_cell *cell = (struct http_m_cell *)sockp;
 	const char *whatstr[] = {"none", "IN", "OUT", "INOUT", "REMOVE"};
+
+	cell = http_m_cell_lookup(e);
 
 	LM_DBG("socket callback: s=%d e=%p what=%s\n", s, e, whatstr[what]);
 	if(what == CURL_POLL_REMOVE) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4019

#### Description
I assume that the crash #4019 happens, because of an issue in libcurl, namely in the `event_cb` function ([in this line](https://github.com/kamailio/kamailio/blob/master/src/modules/http_async_client/http_multi.c#L110)) kamailio removes the pointer to the `cell`  object (which was attached to this `g->multi` curl descriptor earlier), and the `cell` object memory is released [at this line](https://github.com/kamailio/kamailio/blob/master/src/modules/http_async_client/http_multi.c#L110). However, the crash happens when `event_cb` is called when `curl_multi_remove_handle` is called [at this line](https://github.com/kamailio/kamailio/blob/master/src/modules/http_async_client/http_multi.c#L124).
In this fix `cell` object is retrieved from the corresponding CURL descriptor and then it's compared with the `cell` object passed to this callback.
With this change when this issue happens the `cell` object, which is retrieved from the corresponding CURL descriptor, is NULL pointer, because it was removed earlier [in this line](https://github.com/kamailio/kamailio/blob/master/src/modules/http_async_client/http_multi.c#L110), so the crash should not appear.
However it might be fixed in other way, namely we may not to pass `cell` to the `event_cb` callback and always retrieve it from CURL descriptor. I would appreciate if developers comment that.
