### PR TITLE
Add fix_actions function parameter in fix_actions to allow call of free_fixup functions and free resources

### DIFF
--- a/src/core/route.h
+++ b/src/core/route.h
@@ -103,12 +103,13 @@ void push(struct action *a, struct action **head);
 int add_actions(struct action *a, struct action **head);
 void print_rls(void);
 int fix_rls(void);
+int free_rls(void);
 
 int eval_expr(struct run_act_ctx *h, struct expr *e, struct sip_msg *msg);
 
 
 /* fixup functions*/
-int fix_actions(struct action *a);
+int fix_actions(struct action *a, int free_fixup);
 int fix_expr(struct expr *exp);
 
 

--- a/src/core/rvalue.c
+++ b/src/core/rvalue.c
@@ -2828,7 +2828,7 @@ static int fix_rval(struct rvalue *rv, struct rval_expr *rve)
 		case RV_BEXPR:
 			return fix_expr(rv->v.bexpr);
 		case RV_ACTION_ST:
-			return fix_actions(rv->v.action);
+			return fix_actions(rv->v.action, 0);
 		case RV_SEL:
 			if(resolve_select(&rv->v.sel) < 0) {
 				if(rve == NULL) {

--- a/src/core/switch.c
+++ b/src/core/switch.c
@@ -219,7 +219,7 @@ int fix_switch(struct action *t)
 			c->is_default = 1;
 			def_a = c->actions;
 		}
-		if(c->actions && ((ret = fix_actions(c->actions)) < 0))
+		if(c->actions && ((ret = fix_actions(c->actions, 0)) < 0))
 			goto error;
 	}
 	LM_DBG("%d cases, %d default\n", n, default_found);
@@ -540,7 +540,7 @@ static int fix_match(struct action *t)
 			c->is_default = 1;
 			def_a = c->actions;
 		}
-		if(c->actions && ((ret = fix_actions(c->actions)) < 0))
+		if(c->actions && ((ret = fix_actions(c->actions, 0)) < 0))
 			goto error;
 	}
 	LM_DBG("%d cases, %d default\n", n, default_found);

--- a/src/main.c
+++ b/src/main.c
@@ -588,6 +588,8 @@ void cleanup(int show_status)
 		shm_global_unlock();
 	}
 #endif
+	/*Free fixed-up routing lists and params from main process */
+	free_rls();
 	destroy_rpcs();
 	destroy_modules();
 #ifdef USE_DNS_CACHE
@@ -897,6 +899,8 @@ void sig_usr(int signo)
 					  the safe part (values not requiring callbacks), to
 					  account for processes that might not have registered
 					  config support */
+				/*Free fixed routing lists and params from children process */
+				free_rls();
 				cfg_update_no_cbs();
 				memlog = cfg_get(core, core_cfg, memlog);
 				if(memlog <= cfg_get(core, core_cfg, debug)) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3814

#### Description
<!-- Describe your changes in detail -->
When the fixup is done in main using fix_rls function (fixing the route lists in cfg file), all the children inherit the memory allocated as a copy that needs separate management. 

The function responsible for the fixup (fix_actions) is also used to call the free_fixup function with an added argument. 

Then on main, we call the free_rls ( as fix_rls) on two separate occasions. Once in cleanup() function for the main process and once in the sig_usr() function for each of the children.

This seems to work fine and after debugging with `file_out` fixups, I can no longer see memory leaks due to the malloced memory in one of the fixups.

- main.c: Call free_rls() in cleanup() function to clean route lists and fixed up parameters in main process.

- main.c: Call free_rls() in sig_usr() function to clean route lists and fixed up parameters in child processes.

My question is, after a parameter is fixed, is it saved somewhere else, therefore we can immediately free the fix-up resources and not on shutdown?
