### PR TITLE
siputils: generated icid-value too short

### DIFF
--- a/src/modules/siputils/chargingvector.c
+++ b/src/modules/siputils/chargingvector.c
@@ -147,7 +147,7 @@ static void sip_generate_charging_vector(char *pcv, const unsigned int maxsize)
 	const char *endptr = ptr + maxsize - 1;
 
 	for(int i = 0; i < len && ptr < endptr; i++) {
-		ptr += (snprintf(ptr, 3, "%02X", newConferenceIdentifier[i]) - 1);
+		ptr += snprintf(ptr, 3, "%02X", newConferenceIdentifier[i]);
 	}
 }
 
@@ -258,6 +258,7 @@ static int sip_get_charging_vector(
 	}
 
 	sip_initialize_pcv_buffers();
+	_siputils_pcv_status = PCV_NONE;
 
 	for(hf = msg->headers; hf; hf = hf->next) {
 		if(hf->name.s[0] != 'P') {
@@ -298,7 +299,6 @@ static int sip_get_charging_vector(
 		}
 	}
 	LM_DBG("No valid P-Charging-Vector header found.\n");
-	_siputils_pcv_status = PCV_NONE;
 	*hf_pcv = NULL;
 	return 1;
 }
@@ -482,7 +482,7 @@ int sip_handle_pcv(struct sip_msg *msg, char *flags, char *str2)
 
 		/* if generated and added, copy buffer and reparse it */
 		sip_initialize_pcv_buffers();
-		_siputils_pcv.len = body_len - CRLF_LEN;
+		_siputils_pcv.len = body_len;
 		memcpy(_siputils_pcv.s, pcv_body, _siputils_pcv.len);
 		if(sip_parse_charging_vector(
 				   _siputils_pcv_buf, sizeof(_siputils_pcv_buf))) {


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [-] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
- icid-value is only 17 characters and not unique 
- Re-parsing of generated PCV with icid-generated is 2 characters too short, cutting generated-by value or creating false warning

Following warning was produced, which shows the problem.
> WARNING: siputils [chargingvector.c:240]: sip_parse_charging_vector(): icid-generated-at is missing icid-> value=4557000A000E52000;icid-generated-a
