### PR TITLE
db_sqlite: Add busy timeout param to improve concurrency

### DIFF
--- a/src/modules/db_sqlite/db_sqlite.c
+++ b/src/modules/db_sqlite/db_sqlite.c
@@ -92,6 +92,7 @@ static db_param_list_t *db_param_list_new(const char *db_filename)
 	if(!e->database.s)
 		goto error;
 	strcpy(e->database.s, db_filename);
+	e->busy_timeout = -1;
 
 	db_param_list_add(e);
 	return e;
@@ -163,7 +164,8 @@ int db_set_journal_mode(modparam_t type, void *val)
 		goto error;
 	// PRAGMA schema.journal_mode = DELETE | TRUNCATE | PERSIST | MEMORY | WAL | OFF
 	for(pit = params_list; pit; pit = pit->next) {
-		LM_DBG("[param][%.*s]\n", pit->name.len, pit->name.s);
+		LM_DBG("parsing journal mode [param][%.*s][%.*s]\n", pit->name.len,
+				pit->name.s, pit->body.len, pit->body.s);
 		if(pit->body.len == 3 && strncasecmp(pit->body.s, "WAL", 3)) {
 			db_set_journal_mode_entry(pit->name, pit->body);
 		} else if(pit->body.len == 6 && strncasecmp(pit->body.s, "DELETE", 6)) {
@@ -206,11 +208,59 @@ int db_set_readonly(modparam_t type, void *val)
 	return 1;
 }
 
+int db_set_busy_timeout(modparam_t type, void *val)
+{
+	param_t *params_list = NULL;
+	param_hooks_t phooks;
+	param_t *pit = NULL;
+	str s;
+
+	if(val == NULL)
+		return -1;
+
+	s.s = (char *)val;
+	s.len = strlen(s.s);
+	if(s.len <= 0)
+		return -1;
+	if(s.s[s.len - 1] == ';')
+		s.len--;
+
+	if(parse_params(&s, CLASS_ANY, &phooks, &params_list) < 0)
+		goto error;
+	for(pit = params_list; pit; pit = pit->next) {
+		LM_DBG("parsing busy timeout [%.*s][%.*s]\n", pit->name.len,
+				pit->name.s, pit->body.len, pit->body.s);
+
+		db_param_list_t *e = db_param_list_search(pit->name);
+		if(!e)
+			e = db_param_list_new(pit->name.s);
+		if(!e) {
+			LM_ERR("can't create a new db_param for [%s]\n", pit->name.s);
+			return -1;
+		}
+		if(str2int(&(pit->body), (unsigned int *)&(e->busy_timeout)) != 0) {
+			LM_ERR("can't convert db_param busy_timeout to int\n");
+			goto error;
+		}
+		LM_DBG("parsed busy_timeout value '%d'\n", e->busy_timeout);
+	}
+
+	if(params_list != NULL)
+		free_params(params_list);
+	return 1;
+error:
+	if(params_list != NULL)
+		free_params(params_list);
+	return -1;
+}
+
 static param_export_t params[] = {
 		{"db_set_readonly", PARAM_STRING | USE_FUNC_PARAM,
 				(void *)db_set_readonly},
 		{"db_set_journal_mode", PARAM_STRING | USE_FUNC_PARAM,
 				(void *)db_set_journal_mode},
+		{"db_set_busy_timeout", PARAM_STRING | USE_FUNC_PARAM,
+				(void *)db_set_busy_timeout},
 		{0, 0, 0}};
 
 static cmd_export_t cmds[] = {

--- a/src/modules/db_sqlite/db_sqlite.h
+++ b/src/modules/db_sqlite/db_sqlite.h
@@ -32,6 +32,7 @@ typedef struct db_param_list
 	str database;
 	int readonly;
 	str journal_mode;
+	int busy_timeout;
 } db_param_list_t;
 
 db_param_list_t *db_param_list_search(str db_filename);

--- a/src/modules/db_sqlite/doc/db_sqlite.xml
+++ b/src/modules/db_sqlite/doc/db_sqlite.xml
@@ -48,6 +48,22 @@
 	<copyright>
 	    <year>2017</year>
 	</copyright>
+	<authorgroup>
+	    <editor>
+		<firstname>Andreas</firstname>
+		<surname>Granig</surname>
+		<affiliation><orgname>sipfront.com</orgname></affiliation>
+		<email>agranig@sipfront.com</email>
+		<address>
+		<otheraddr>
+		<ulink></ulink>
+		</otheraddr>
+		</address>
+	    </editor>
+	</authorgroup>
+	<copyright>
+	    <year>2024</year>
+	</copyright>
     </bookinfo>
     <toc></toc>
 

--- a/src/modules/db_sqlite/doc/db_sqlite_admin.xml
+++ b/src/modules/db_sqlite/doc/db_sqlite_admin.xml
@@ -80,8 +80,9 @@
 		<title>Set <varname>db_set_readonly</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("db_sqlite","db_set_readonly","/var/mydb.sqlite")
-modparam("sqlops","sqlcon","lrn=>sqlite:////var/mydb.sqlite") # Example if using the sqlops module
+# Don't use trailing slashes for db_sqlite params
+modparam("db_sqlite","db_set_readonly","var/mydb.sqlite")
+modparam("sqlops","sqlcon","lrn=>sqlite:///var/mydb.sqlite") # Example if using the sqlops module
 ...
 		</programlisting>
 		</example>
@@ -94,6 +95,10 @@ modparam("sqlops","sqlcon","lrn=>sqlite:////var/mydb.sqlite") # Example if using
 
 		Other journal mode are : DELETE | TRUNCATE | PERSIST | MEMORY | WAL | OFF
 
+		When setting this option, you must also set db_set_busy_timeout, because all kamailio sub-processes
+		will set this option individually and simultaneously, causing "database locked" errors on startup
+		if no busy timeout is set.
+
 		This parameter may be set multiple times to set many DB connections to readonly in the same configuration file.
 		</para>
 		<para>
@@ -105,11 +110,46 @@ modparam("sqlops","sqlcon","lrn=>sqlite:////var/mydb.sqlite") # Example if using
 		<title>Set <varname>db_set_journal_mode</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-# In this example we are using Write-Ahead Logging in order to update the database from another process(external to Kamailio) without facing any locking.
+# In this example we are using Write-Ahead Logging in order to update the database
+# from another process(external to Kamailio) without facing any locking.
 
-#!subst "!DB_FILE!/var/mydb.sqlite!"
+# Don't use trailing slashes for db_sqlite params
+#!subst "!DB_FILE!var/mydb.sqlite!"
 modparam("db_sqlite","db_set_readonly","DB_FILE")   # We are also opening the database in readonly
 modparam("db_sqlite","db_set_journal_mode","DB_FILE=WAL;")
+modparam("db_sqlite","db_set_busy_timeout","DB_FILE=300;") # wait 300ms max for locks to release
+modparam("sqlops","sqlcon","lrn=>sqlite:///DB_FILE")
+...
+		</programlisting>
+		</example>
+	</section>
+	<section id="db_sqlite.p.db_set_busy_timeout">
+		<title><varname>db_set_busy_timeout</varname> (int)</title>
+		<para>
+		This will set the db connection busy timeout to let it wait for the given milliseconds for
+		database locks to be released by other processes before giving up. Use this with the WAL
+		journaling mode if you run into "database locked" errors.
+		The value is the full path to the sqlite file used for example in any db_url or sqlops/sqlcon
+
+		This parameter may be set multiple times to set the busy-timeout for different DB connections
+		in the same configuration file.
+		</para>
+		<para>
+		<emphasis>
+			By default all the db connections are NOT using any busy timeout, causing them to immediately
+			give up and return a "databased locked" error if another process is locking it at the same time.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>db_set_busy_timeout</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+# In this example we are using Write-Ahead Logging in combination with a busy-timeout to prevent
+"database locked" errors. Note that you have to leave out the leading slash in the DB file!
+
+#!subst "!DB_FILE!var/mydb.sqlite!"
+modparam("db_sqlite","db_set_journal_mode","DB_FILE=WAL;")
+modparam("db_sqlite","db_set_busy_timeout","DB_FILE=300;") # wait 300ms max for locks to release
 modparam("sqlops","sqlcon","lrn=>sqlite:///DB_FILE")
 ...
 		</programlisting>
@@ -164,4 +204,3 @@ modparam("auth_db", "db_url", "sqlite:///etc/kamailio/kamailio.db")
 		</example>
 	</section>
 </chapter>
-


### PR DESCRIPTION
It's needed specifically when setting WAL, because on module loading, each child creates its own DB connection and sets the WAL (or other options you might set), and it all happens roughly at the same time.

Without setting the busy-timeout, starting of kamailio will fail due to locking issues with sqlite.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
