### PR TITLE
cdp: fixed issues discovered during static code analysis

### DIFF
--- a/src/modules/cdp/authstatemachine.c
+++ b/src/modules/cdp/authstatemachine.c
@@ -114,7 +114,7 @@ void update_auth_session_timers(cdp_auth_session_t *x, AAAMessage *msg)
 	} else {
 		if(!avp) {
 			LM_DBG("using timers from our request as there is nothing in the "
-				   "response (lifetime) - last requested lifetime was [%d]\n",
+				   "response (lifetime) - last requested lifetime was [%ld]\n",
 					x->last_requested_lifetime);
 			if(x->last_requested_lifetime > 0) {
 				update_lifetime = 1;

--- a/src/modules/cdp/common.c
+++ b/src/modules/cdp/common.c
@@ -20,7 +20,7 @@ int get_accounting_record_type(AAAMessage *msg)
 
 int get_result_code(AAAMessage *msg)
 {
-	AAA_AVP *avp;
+	AAA_AVP *avp, *avp2;
 	AAA_AVP_LIST list;
 	list.head = 0;
 	list.tail = 0;
@@ -36,9 +36,9 @@ int get_result_code(AAAMessage *msg)
 			goto finish;
 		} else if(avp->code == AVP_Experimental_Result) {
 			list = AAAUngroupAVPS(avp->data);
-			for(avp = list.head; avp; avp = avp->next) {
-				if(avp->code == AVP_IMS_Experimental_Result_Code) {
-					rc = get_4bytes(avp->data.s);
+			for(avp2 = list.head; avp2; avp2 = avp2->next) {
+				if(avp2->code == AVP_IMS_Experimental_Result_Code) {
+					rc = get_4bytes(avp2->data.s);
 					AAAFreeAVPList(&list);
 					goto finish;
 				}

--- a/src/modules/cdp/diameter_peer.c
+++ b/src/modules/cdp/diameter_peer.c
@@ -233,10 +233,8 @@ int diameter_peer_start(int blocking)
 {
 	int pid;
 	int k = 0;
-	int seed;
 	peer *p;
 
-	seed = random();
 	/* fork workers */
 	for(k = 0; k < config->workers; k++) {
 		pid = fork_process(1001 + k, "cdp_worker", 1);
@@ -245,7 +243,6 @@ int diameter_peer_start(int blocking)
 			return 0;
 		}
 		if(pid == 0) {
-			srandom(seed * k);
 			snprintf(
 					pt[process_no].desc, MAX_PT_DESC, "cdp worker child=%d", k);
 			if(cfg_child_init())
@@ -266,7 +263,6 @@ int diameter_peer_start(int blocking)
 
 
 	/* fork receiver for unknown peers */
-	seed = random();
 	pid = fork_process(1001 + k, "cdp_receiver_peer_unknown", 1);
 
 	if(pid == -1) {
@@ -275,7 +271,6 @@ int diameter_peer_start(int blocking)
 		return 0;
 	}
 	if(pid == 0) {
-		srandom(seed * k);
 		snprintf(pt[process_no].desc, MAX_PT_DESC, "cdp receiver peer unknown");
 		if(cfg_child_init())
 			return 0;
@@ -288,7 +283,6 @@ int diameter_peer_start(int blocking)
 	}
 
 	/* fork receivers for each pre-configured peers */
-	seed = random();
 	lock_get(peer_list_lock);
 	for(p = peer_list->head, k = -1; p; p = p->next, k--) {
 		pid = fork_process(1001 + k, "cdp_receiver_peer", 1);
@@ -298,7 +292,6 @@ int diameter_peer_start(int blocking)
 			return 0;
 		}
 		if(pid == 0) {
-			srandom(seed * k);
 			snprintf(pt[process_no].desc, MAX_PT_DESC, "cdp_receiver_peer=%.*s",
 					p->fqdn.len, p->fqdn.s);
 			if(cfg_child_init())

--- a/src/modules/cdp/receiver.c
+++ b/src/modules/cdp/receiver.c
@@ -830,7 +830,7 @@ int receive_loop(peer *original_peer)
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 							if(enable_tls) {
 								to_ssl(&sp2->tls_ctx, &sp2->tls_conn,
-										sp->tcp_socket, method);
+										sp2->tcp_socket, method);
 							}
 #endif
 						} else {
@@ -843,7 +843,7 @@ int receive_loop(peer *original_peer)
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 							if(enable_tls) {
 								to_ssl(&sp2->tls_ctx, &sp2->tls_conn,
-										sp->tcp_socket, method);
+										sp2->tcp_socket, method);
 							}
 #endif
 						}

--- a/src/modules/cdp/session.c
+++ b/src/modules/cdp/session.c
@@ -428,7 +428,7 @@ void cdp_sessions_log()
 								x->u.auth.generic_data, x->u.auth.class);
 						break;
 					case ACCT_CC_CLIENT:
-						LM_DBG("CCAcct State [%d] Charging Active [%c (%d)s] "
+						LM_DBG("CCAcct State [%d] Charging Active [%c (%ld)s] "
 							   "Reserved Units(valid=%ds) [%d] Generic [%p]\n",
 								x->u.cc_acc.state,
 								(x->u.cc_acc.charging_start_time
@@ -436,11 +436,11 @@ void cdp_sessions_log()
 												   != ACC_CC_ST_DISCON)
 										? 'Y'
 										: 'N',
-								x->u.cc_acc.charging_start_time
-										? (int)((int)time(0)
-												- (int)x->u.cc_acc
+								x->u.cc_acc.charging_start_time ? (
+										time_t)(time(0)
+												- (time_t)x->u.cc_acc
 														  .charging_start_time)
-										: -1,
+																: -1,
 								x->u.cc_acc.reserved_units
 										? (int)((int)x->u.cc_acc
 														  .last_reservation_request_time
@@ -482,7 +482,7 @@ int cdp_sessions_timer(time_t now, void *ptr)
 									x, ACC_CC_EV_SESSION_STALE, 0);
 						}
 						//check reservation timers - again here we are assuming CC-Time applications
-						int last_res_timestamp =
+						time_t last_res_timestamp =
 								x->u.cc_acc.last_reservation_request_time;
 						int res_valid_for =
 								x->u.cc_acc.reserved_units_validity_time;

--- a/src/modules/cdp/session.h
+++ b/src/modules/cdp/session.h
@@ -130,12 +130,13 @@ typedef struct _cdp_auth_session_t
 	time_t timeout;	 /**< absolute time for session timeout  -1 means forever */
 	time_t lifetime; /**< absolute time for auth lifetime -1 means forever */
 	time_t grace_period; /**< grace_period in seconds 	*/
-	unsigned int
-			last_requested_lifetime; /**< the following 3 timers are used to store what we are */
-	unsigned int
-			last_requested_timeout; /**<requesting in a request, if the answer does not have anything */
-	unsigned int
-			last_requested_grace; /**<different then we will use these values */
+
+	/** the following 3 timers are used to store what we are */
+	time_t last_requested_lifetime;
+	/** requesting in a request, if the answer does not have anything */
+	time_t last_requested_timeout;
+	/** different then we will use these values */
+	time_t last_requested_grace;
 
 	void *generic_data;
 } cdp_auth_session_t;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

This fixes:
- 4-bytes (typically uint32_t) used for time_t storage (Y2K38)
- print of time_t with %d instead of %ld
- reuse of same loop index variable in a sub-loop
- use of random(), when kam_rand() could theoretically be better
- copy-paste mistake in sp2/sp parameter, where sp2 was meant and sp is probably NULL