### PR TITLE
Chore/ipsec logging

### DIFF
--- a/src/modules/ims_ipsec_pcscf/cmd.c
+++ b/src/modules/ims_ipsec_pcscf/cmd.c
@@ -809,6 +809,7 @@ int ipsec_create(struct sip_msg *m, udomain_t *d, int _cflags)
 	pcontact_t *pcontact = NULL;
 	struct pcontact_info ci;
 	int ret = IPSEC_CMD_FAIL; // FAIL by default
+	int fun_ret_c; // Used to store return codes of some functions
 	tm_cell_t *t = NULL;
 	sip_msg_t *req = NULL;
 	security_t *req_sec_params = NULL;
@@ -893,10 +894,13 @@ int ipsec_create(struct sip_msg *m, udomain_t *d, int _cflags)
 	}
 
 	if(update_contact_ipsec_params(s, m, old_s) != 0) {
+		LM_ERR("Could not update ipsec params in contact.\n");
 		goto cleanup;
 	}
 
-	if(create_ipsec_tunnel(&req->rcv.src_ip, s) != 0) {
+	fun_ret_c = create_ipsec_tunnel(&req->rcv.src_ip, s);
+	if(fun_ret_c != 0) {
+		LM_ERR("IPSEC tunnel creation failed.\n");
 		goto cleanup;
 	}
 
@@ -917,11 +921,15 @@ int ipsec_create(struct sip_msg *m, udomain_t *d, int _cflags)
 		goto cleanup;
 	}
 
-	if(add_supported_secagree_header(m) != 0) {
+	fun_ret_c = add_supported_secagree_header(m);
+	if(fun_ret_c != 0) {
+		LM_ERR("Could not add secagree header. Failed with code: %d\n", fun_ret_c);
 		goto cleanup;
 	}
 
-	if(add_security_server_header(m, s) != 0) {
+	fun_ret_c = add_security_server_header(m, s);
+	if(fun_ret_c != 0) {
+		LM_ERR("Could not add security server header. Code: %d\n", fun_ret_c);
 		goto cleanup;
 	}
 

--- a/src/modules/ims_ipsec_pcscf/ims_ipsec_pcscf_mod.c
+++ b/src/modules/ims_ipsec_pcscf/ims_ipsec_pcscf_mod.c
@@ -364,6 +364,7 @@ static int ipsec_add_listen_ifaces()
 static int mod_init(void)
 {
 	bind_usrloc_t bind_usrloc;
+	int ret;
 
 	bind_usrloc = (bind_usrloc_t)find_export("ul_bind_ims_usrloc_pcscf", 1, 0);
 	if(!bind_usrloc) {
@@ -371,7 +372,9 @@ static int mod_init(void)
 		return -1;
 	}
 
-	if(bind_usrloc(&ul) < 0) {
+	ret = bind_usrloc(&ul);
+	if(ret < 0) {
+		LM_ERR("bind_userloc() has failed with code %d", ret);
 		return -1;
 	}
 	LM_INFO("Successfully bound to PCSCF Usrloc module\n");
@@ -383,7 +386,9 @@ static int mod_init(void)
 	}
 	LM_INFO("Successfully bound to TM module\n");
 
-	if(ipsec_add_listen_ifaces() != 0) {
+	ret = ipsec_add_listen_ifaces();
+	if(ret != 0) {
+		LM_ERR("Failed to add ipsec listen interface. Code: %d", ret);
 		return -1;
 	}
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally

#### Description

While working on an IMS setup, I and @lynxis encountered some cases where it was unclear why some of the related modules would not load. They just did not without printing any messages as to why. I have identified a few cases where logging was missing and added it, in the hope that it might be helpful.