### PR TITLE
Python exception handling fixes

### DIFF
--- a/src/modules/app_python3/apy_kemi.c
+++ b/src/modules/app_python3/apy_kemi.c
@@ -281,7 +281,7 @@ PyObject *sr_apy_kemi_exec_func_ex(
 		if(pobj == NULL) {
 			LM_ERR("null parameter - func: %.*s idx: %d argc: %d\n", fname.len,
 					fname.s, i, (int)alen);
-			return sr_kemi_apy_return_false();
+			return NULL;
 		}
 		if(ket->ptypes[i] == SR_KEMIP_STR) {
 			if(!PyUnicode_Check(pobj)) {
@@ -293,7 +293,7 @@ PyObject *sr_apy_kemi_exec_func_ex(
 			if(vps[i].v.s.s == NULL) {
 				LM_ERR("null-string parameter - func: %.*s idx: %d argc: %d\n",
 						fname.len, fname.s, i, (int)alen);
-				return sr_kemi_apy_return_false();
+				return NULL;
 			}
 			vps[i].v.s.len = (int)slen;
 			vps[i].vtype = SR_KEMIP_STR;

--- a/src/modules/app_python3s/apy3s_kemi.c
+++ b/src/modules/app_python3s/apy3s_kemi.c
@@ -409,7 +409,7 @@ PyObject *sr_apy_kemi_exec_func_ex(
 		if(pobj == NULL) {
 			LM_ERR("null parameter - func: %.*s idx: %d argc: %d\n", fname.len,
 					fname.s, i, (int)alen);
-			return sr_kemi_apy_return_false();
+			return NULL;
 		}
 		if(ket->ptypes[i] == SR_KEMIP_STR) {
 			if(!PyUnicode_Check(pobj)) {
@@ -421,7 +421,7 @@ PyObject *sr_apy_kemi_exec_func_ex(
 			if(vps[i].v.s.s == NULL) {
 				LM_ERR("null-string parameter - func: %.*s idx: %d argc: %d\n",
 						fname.len, fname.s, i, (int)alen);
-				return sr_kemi_apy_return_false();
+				return NULL;
 			}
 			vps[i].v.s.len = (int)slen;
 			vps[i].vtype = SR_KEMIP_STR;


### PR DESCRIPTION

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #4045

#### Description
<!-- Describe your changes in detail -->

Python's C interface contract states that C code must *either* raise an exception and return NULL, *or* return a Python object.

Doing both will raise a `SystemError` exception which obscures the original problem. It may also cause a memory leak.