### PR TITLE
uac: Export two new functions for reg/unreg and rpc for reg

### DIFF
--- a/src/modules/uac/doc/uac_admin.xml
+++ b/src/modules/uac/doc/uac_admin.xml
@@ -1024,6 +1024,55 @@ uac_req_send();
 				</programlisting>
 			</example>
 		</section>
+
+		<section id="uac.f.uac_reg_send_register">
+			<title>
+				<function moreinfo="none">uac_reg_send_register(atttr,value)</function>
+			</title>
+			<para>
+			This function sends a REGISTER request for the registration
+			based on a filter specified by attribute and value. The attribute can be: l_uuid, l_username,
+			r_username or auth_username. The value is what should be matched
+			against the value of the attribute in the remote registration record.
+			</para>
+			<para>
+			This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
+			BRANCH_ROUTE, ONREPLY_ROUTE, LOCAL_ROUTE.
+			</para>
+			<example>
+				<title><function>uac_reg_send_register</function> usage</title>
+				<programlisting format="linespecific">
+...
+uac_reg_send_register("l_uuid", "account123");
+...
+				</programlisting>
+			</example>
+		</section>
+
+		<section id="uac.f.uac_reg_send_unregister">
+			<title>
+				<function moreinfo="none">uac_reg_send_unregister(atttr,value)</function>
+			</title>
+			<para>
+			This function sends a REGISTER request with expires 0 for the registration
+			based on a filter specified by attribute and value. The attribute can be: l_uuid, l_username,
+			r_username or auth_username. The value is what should be matched
+			against the value of the attribute in the remote registration record.
+			</para>
+			<para>
+			This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
+			BRANCH_ROUTE, ONREPLY_ROUTE, LOCAL_ROUTE.
+			</para>
+			<example>
+				<title><function>uac_reg_send_unregister</function> usage</title>
+				<programlisting format="linespecific">
+...
+uac_reg_send_unregister("l_uuid", "account123");
+...
+				</programlisting>
+			</example>
+		</section>
+
 		<section id="uac.f.uac_reg_lookup">
 			<title>
 				<function moreinfo="none">uac_reg_lookup(uuid, dst)</function>
@@ -1420,6 +1469,28 @@ event_route[uac:reply] {
 		</example>
 		</section>
 
+		<section id="uac.r.uac.reg_register">
+			<title>
+				<function moreinfo="none">uac.reg_register</function>
+			</title>
+		<para>
+			Send a REGISTER for the matching record based on a filter.
+			The command has two parameters: attribute and value.
+			The attribute can be: l_uuid, l_username, r_username or auth_username.
+			The value is what should be matched against the value of the attribute
+			in the remote registration record.
+		</para>
+		<example>
+		<title><function>uac.reg_register</function> usage</title>
+			<programlisting format="linespecific">
+...
+   kamcmd uac.reg_register l_uuid account123
+   kamcmd uac.reg_register l_uuid s:12345678
+...
+			</programlisting>
+		</example>
+		</section>
+
 		<section id="uac.r.uac.reg_unregister">
 			<title>
 				<function moreinfo="none">uac.reg_unregister</function>
@@ -1686,4 +1757,3 @@ event_route[uac:reply] {
 		</example>
 	</section>
 </chapter>
-

--- a/src/modules/uac/uac_reg.h
+++ b/src/modules/uac/uac_reg.h
@@ -28,6 +28,55 @@
 #define UACREG_REQTO_MASK_USER 1
 #define UACREG_REQTO_MASK_AUTH 2
 
+typedef struct _reg_uac
+{
+	unsigned int h_uuid;
+	unsigned int h_user;
+	str l_uuid;
+	str l_username;
+	str l_domain;
+	str r_username;
+	str r_domain;
+	str realm;
+	str auth_proxy;
+	str auth_username;
+	str auth_password;
+	str auth_ha1;
+	str callid;
+	str contact_addr;
+	str socket;
+	unsigned int cseq;
+	unsigned int flags;
+	unsigned int expires;
+	time_t timer_expires;
+	unsigned int reg_delay;
+	time_t reg_init;
+	gen_lock_t *lock;
+} reg_uac_t;
+
+typedef struct _reg_item
+{
+	reg_uac_t *r;
+	struct _reg_item *next;
+} reg_item_t;
+
+
+typedef struct _reg_entry
+{
+	unsigned int isize;
+	unsigned int usize;
+	reg_item_t *byuser;
+	reg_item_t *byuuid;
+	gen_lock_t lock;
+} reg_entry_t;
+
+typedef struct _reg_ht
+{
+	unsigned int htsize;
+	time_t stime;
+	reg_entry_t *entries;
+} reg_ht_t;
+
 extern int reg_timer_interval;
 extern int reg_retry_interval;
 extern int reg_htable_size;
@@ -60,6 +109,7 @@ int uac_reg_free_ht(void);
 void uac_reg_timer(unsigned int ticks);
 int uac_reg_init_rpc(void);
 
+int uac_reg_send(reg_uac_t *reg, time_t tn);
 int uac_reg_lookup(struct sip_msg *msg, str *src, pv_spec_t *dst, int mode);
 int uac_reg_status(struct sip_msg *msg, str *src, int mode);
 int uac_reg_request_to(struct sip_msg *msg, str *src, unsigned int mode);
@@ -69,5 +119,6 @@ int uac_reg_disable(sip_msg_t *msg, str *attr, str *val);
 int uac_reg_refresh(sip_msg_t *msg, str *l_uuid);
 
 int reg_active_init(int mode);
+int reg_ht_get_byfilter(reg_uac_t **reg, str *attr, str *val);
 
 #endif


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This PR exports some new functions for handling registration and deregistration in the uac table without waiting for timer to fire.

All of the following function require the parameters of the already available RPC function call `reg_unregister`:

- `kamcmd uac.reg_register`: Register for kamcmd similar to `uac.reg_unregister`
- `uac_reg_send_register`: Config function to register immediately without waiting for timer
- `uac_reg_send_unregister`: Config funtion to unregister immediately without waiting for timer
- Move required structures/functions to .h