### PR TITLE
ims_diameter_server: fix retrieval ``$diameter_response`` value

### DIFF
--- a/src/modules/ims_diameter_server/avp_helper.c
+++ b/src/modules/ims_diameter_server/avp_helper.c
@@ -48,7 +48,6 @@
 
 // ID of current message
 static unsigned int current_msg_id = 0;
-static unsigned int current_msg_id_repl = 0;
 
 cJSON *avp2json(AAA_AVP *avp_t)
 {
@@ -488,7 +487,7 @@ int pv_get_application(struct sip_msg *msg, pv_param_t *param, pv_value_t *res)
 
 int pv_get_response(struct sip_msg *msg, pv_param_t *param, pv_value_t *res)
 {
-	if((msg->id != current_msg_id_repl) || (responsejson.len < 0)) {
+	if(responsejson.len < 0) {
 		return pv_get_null(msg, param, res);
 	}
 	return pv_get_strval(msg, param, res, &responsejson);
@@ -504,7 +503,6 @@ int pv_set_response(
 				val->rs.s);
 		responsejson.s = val->rs.s;
 		responsejson.len = val->rs.len;
-		current_msg_id_repl = msg->id;
 		return 0;
 	}
 	return 0;


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [ ] Tested changes locally
- [x] Related to issue https://lists.kamailio.org/mailman3/hyperkitty/list/sr-users@lists.kamailio.org/thread/CZM47Y5ODFPCJCOCX3PQ4FWKHFNNZGV2/

#### Description
``current_msg_id_repl is only`` changed if ``$diameter_reponse`` is changed by via ``pv_set_response()``. The event_route is executed with a ``fake_msg`` so it will not match if is setted outside anyways.
