### PR TITLE
htable: Fix de-/increment w/ auto expire

### DIFF
--- a/src/modules/htable/ht_api.c
+++ b/src/modules/htable/ht_api.c
@@ -743,6 +743,10 @@ ht_cell_t *ht_cell_value_add(ht_t *ht, str *name, int val, ht_cell_t *old)
 			if(now > 0 && it->expire != 0 && it->expire < now) {
 				/* entry has expired */
 
+				it->expire = ht->htexpire;
+				if(it->expire) {
+					it->expire += now;
+				}
 				if(ht->flags == PV_VAL_INT) {
 					/* initval is integer, use it to create a fresh entry */
 					it->flags &= ~AVP_VAL_STR;


### PR DESCRIPTION
Update item expiration value during de-/incrementation for htables that are configured with autoexpire and updateexpire disabled. Otherwise an item cannot be used until timer cleaned it up.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Using following configuration
```
#!KAMAILIO

listen=udp:127.0.0.1:9999

log_stderror=yes

loadmodule "xlog.so"
loadmodule "pv.so"
loadmodule "sl.so"
loadmodule "htable.so"

modparam("htable", "htable", "foo=>autoexpire=1;updateexpire=0")

request_route {
        if ($sht(foo=>bar) == $null) {
                $sht(foo=>bar) = 0;
        }
        $var(foo) = $shtdec(foo=>bar);
        xlog("$Ts single value $sht(foo=>bar)\texpire $shtex(foo=>bar)\n");
        sl_send_reply("200", "Hello");
}
```
running
```
while true; do sleep 0.3; sipsak -vs sip:localhost:9999 ; done
```
produces following output
```
 0(1414153) ERROR: <script>: 1734539304 single value -1 expire 1
 0(1414153) ERROR: <script>: 1734539305 single value -2 expire 0
 0(1414153) ERROR: <script>: 1734539305 single value -3 expire 0
 0(1414153) ERROR: <script>: 1734539305 single value -4 expire 0
 0(1414153) ERROR: <script>: 1734539306 single value <null>     expire 4294967295
 0(1414153) ERROR: <script>: 1734539306 single value <null>     expire 4294967295
 0(1414153) ERROR: <script>: 1734539306 single value <null>     expire 4294967295
 0(1414153) ERROR: <script>: 1734539306 single value <null>     expire 4294967295
 0(1414153) ERROR: <script>: 1734539307 single value <null>     expire 4294967294
 0(1414153) ERROR: <script>: 1734539307 single value <null>     expire 4294967294
 0(1414153) ERROR: <script>: 1734539307 single value <null>     expire 4294967294
 0(1414153) ERROR: <script>: 1734539308 single value <null>     expire 4294967293
 0(1414153) ERROR: <script>: 1734539308 single value <null>     expire 4294967293
 0(1414153) ERROR: <script>: 1734539308 single value <null>     expire 4294967293
 0(1414153) ERROR: <script>: 1734539309 single value <null>     expire 4294967292
 0(1414153) ERROR: <script>: 1734539309 single value <null>     expire 4294967292
 0(1414153) ERROR: <script>: 1734539309 single value <null>     expire 4294967292
 0(1414153) ERROR: <script>: 1734539310 single value <null>     expire 4294967291
 0(1414153) ERROR: <script>: 1734539310 single value <null>     expire 4294967291
 0(1414153) ERROR: <script>: 1734539310 single value <null>     expire 4294967291
 0(1414153) ERROR: <script>: 1734539311 single value <null>     expire 4294967290
 0(1414153) ERROR: <script>: 1734539311 single value <null>     expire 4294967290
 0(1414153) ERROR: <script>: 1734539311 single value <null>     expire 4294967290
 0(1414153) ERROR: <script>: 1734539312 single value <null>     expire 4294967289
 0(1414153) ERROR: <script>: 1734539312 single value <null>     expire 4294967289
 0(1414153) ERROR: <script>: 1734539312 single value <null>     expire 4294967289
 0(1414153) ERROR: <script>: 1734539313 single value <null>     expire 4294967288
 0(1414153) ERROR: <script>: 1734539313 single value <null>     expire 4294967288
 0(1414153) ERROR: <script>: 1734539313 single value <null>     expire 4294967288
 0(1414153) ERROR: <script>: 1734539314 single value <null>     expire 4294967287
 0(1414153) ERROR: <script>: 1734539314 single value <null>     expire 4294967287
 0(1414153) ERROR: <script>: 1734539314 single value <null>     expire 4294967287
 0(1414153) ERROR: <script>: 1734539315 single value <null>     expire 4294967286
 0(1414153) ERROR: <script>: 1734539315 single value <null>     expire 4294967286
 0(1414153) ERROR: <script>: 1734539315 single value <null>     expire 4294967286
 0(1414153) ERROR: <script>: 1734539316 single value <null>     expire 4294967285
 0(1414153) ERROR: <script>: 1734539316 single value <null>     expire 4294967285
 0(1414153) ERROR: <script>: 1734539316 single value <null>     expire 4294967285
 0(1414153) ERROR: <script>: 1734539316 single value <null>     expire 4294967285
 0(1414153) ERROR: <script>: 1734539317 single value <null>     expire 4294967284
 0(1414153) ERROR: <script>: 1734539317 single value <null>     expire 4294967284
 0(1414153) ERROR: <script>: 1734539317 single value <null>     expire 4294967284
 0(1414153) ERROR: <script>: 1734539318 single value <null>     expire 4294967283
 0(1414153) ERROR: <script>: 1734539318 single value <null>     expire 4294967283
 0(1414153) ERROR: <script>: 1734539318 single value <null>     expire 4294967283
 0(1414153) ERROR: <script>: 1734539319 single value <null>     expire 4294967282
 0(1414153) ERROR: <script>: 1734539319 single value <null>     expire 4294967282
 0(1414153) ERROR: <script>: 1734539319 single value <null>     expire 4294967282
 0(1414153) ERROR: <script>: 1734539320 single value <null>     expire 4294967281
 0(1414153) ERROR: <script>: 1734539320 single value <null>     expire 4294967281
 0(1414153) ERROR: <script>: 1734539320 single value <null>     expire 4294967281
 0(1414153) ERROR: <script>: 1734539321 single value <null>     expire 4294967280
 0(1414153) ERROR: <script>: 1734539321 single value <null>     expire 4294967280
 0(1414153) ERROR: <script>: 1734539321 single value <null>     expire 4294967280
 0(1414153) ERROR: <script>: 1734539322 single value <null>     expire 4294967279
 0(1414153) ERROR: <script>: 1734539322 single value <null>     expire 4294967279
 0(1414153) ERROR: <script>: 1734539322 single value <null>     expire 4294967279
 0(1414153) ERROR: <script>: 1734539323 single value <null>     expire 4294967278
 0(1414153) ERROR: <script>: 1734539323 single value <null>     expire 4294967278
 0(1414153) ERROR: <script>: 1734539323 single value <null>     expire 4294967278
 0(1414153) ERROR: <script>: 1734539324 single value <null>     expire 4294967277
 0(1414153) ERROR: <script>: 1734539324 single value <null>     expire 4294967277
 0(1414153) ERROR: <script>: 1734539324 single value -1 expire 1
 0(1414153) ERROR: <script>: 1734539325 single value -2 expire 0
 0(1414153) ERROR: <script>: 1734539325 single value -3 expire 0
 0(1414153) ERROR: <script>: 1734539325 single value -4 expire 0
```
When adding `initval=0` to `htable` configuration log output changes `<null>` to `0`