### PR TITLE
secfilter‌: support remove rule in Whitelist and Blacklist

### DIFF
--- a/src/modules/secfilter/secfilter.c
+++ b/src/modules/secfilter/secfilter.c
@@ -128,10 +128,12 @@ static const char *rpc_reload_doc[2] = {"Reload values from database", NULL};
 static const char *rpc_print_doc[2] = {"Print values from database", NULL};
 static const char *rpc_stats_doc[2] = {"Print statistics of blocked and allowed messages", NULL};
 static const char *rpc_stats_reset_doc[2] = {"Reset statistics", NULL};
-static const char *rpc_add_dst_doc[2] = {
-		"Add new values to destination blacklist", NULL};
+static const char *rpc_add_dst_doc[2] = {"Add new values to destination blacklist", NULL};
+static const char *rpc_del_dst_doc[2] = {"Delete a value from destination blacklist", NULL};
 static const char *rpc_add_bl_doc[2] = {"Add new values to blacklist", NULL};
+static const char *rpc_del_bl_doc[2] = {"Delete a value from blacklist", NULL};
 static const char *rpc_add_wl_doc[2] = {"Add new values to whitelist", NULL};
+static const char *rpc_del_wl_doc[2] = {"Delete a value from whitelist", NULL};
 
 rpc_export_t secfilter_rpc[] = {
 	{"secfilter.reload", secf_rpc_reload, rpc_reload_doc, 0},
@@ -139,7 +141,9 @@ rpc_export_t secfilter_rpc[] = {
 	{"secfilter.stats", secf_rpc_stats, rpc_stats_doc, 0},
 	{"secfilter.stats_reset", secf_rpc_stats_reset, rpc_stats_reset_doc, 0},
 	{"secfilter.add_dst", secf_rpc_add_dst, rpc_add_dst_doc, 0},
+	{"secfilter.del_dst", secf_rpc_del_dst, rpc_del_dst_doc, 0},
 	{"secfilter.add_bl", secf_rpc_add_bl, rpc_add_bl_doc, 0},
+	{"secfilter.del_bl", secf_rpc_del_bl, rpc_del_bl_doc, 0},
 	{"secfilter.add_wl", secf_rpc_add_wl, rpc_add_wl_doc, 0},
 	{0, 0, 0, 0}
 };

--- a/src/modules/secfilter/secfilter.h
+++ b/src/modules/secfilter/secfilter.h
@@ -88,7 +88,10 @@ void secf_rpc_print(rpc_t *rpc, void *ctx);
 void secf_rpc_stats(rpc_t *rpc, void *ctx);
 void secf_rpc_stats_reset(rpc_t *rpc, void *ctx);
 void secf_rpc_add_dst(rpc_t *rpc, void *ctx);
+void secf_rpc_del_dst(rpc_t *rpc, void *ctx);
 void secf_rpc_add_bl(rpc_t *rpc, void *ctx);
+void secf_rpc_del_bl(rpc_t *rpc, void *ctx);
 void secf_rpc_add_wl(rpc_t *rpc, void *ctx);
+void secf_rpc_del_wl(rpc_t *rpc, void *ctx);
 
 #endif

--- a/src/modules/secfilter/secfilter.h
+++ b/src/modules/secfilter/secfilter.h
@@ -58,6 +58,7 @@ extern int *secf_stats;
 void secf_reset_stats(void);
 
 int secf_append_rule(int action, int type, str *value);
+int secf_remove_rule(int action, int type, str *value);
 
 /* Get header values from message */
 int secf_get_ua(struct sip_msg *msg, str *ua);

--- a/src/modules/secfilter/secfilter_db.c
+++ b/src/modules/secfilter/secfilter_db.c
@@ -284,7 +284,7 @@ int secf_remove_rule(int action, int type, str *value)
 		LM_DBG("Total matches removed: %d", total);
 		return 0; // Return the total number of removed items
 	} else {
-		LM_DGB("No matching values found in the list.");
+		LM_DBG("No matching values found in the list.");
 		return -1; // Return -1 on no matches
 	}
 }

--- a/src/modules/secfilter/secfilter_db.c
+++ b/src/modules/secfilter/secfilter_db.c
@@ -182,6 +182,112 @@ int secf_append_rule(int action, int type, str *value)
 	return 0;
 }
 
+/**
+ * @brief Removes entries from a whitelist or blacklist based on action, type, and value.
+ *
+ * The function validates the action and type, locates the relevant list, and iterates 
+ * through its nodes to find and remove all matches for the given value. If matches are found, 
+ * the corresponding memory is freed, and the list pointers are updated. Logs are generated 
+ * for each removal and at the end of the process to summarize the result.
+ * @param action: Specifies the target list (0 = blacklist, 1 = whitelist, 2 = destination blacklist).
+ * @param type: Indicates the type of rule to be removed (e.g., domain, IP, user, etc.).
+ * @param value: The specific value to be matched and removed from the list.
+ * @returns 0 if one or more entries are successfully removed or -1 if no matches are found or if an invalid action or type is specified.
+**/
+int secf_remove_rule(int action, int type, str *value)
+{
+	secf_info_p ini = NULL;
+	secf_info_p last = NULL;
+	struct str_list **ini_node = NULL;
+	struct str_list **last_node = NULL;
+	struct str_list *current = NULL;
+	struct str_list *previous = NULL;
+	int total = 0;
+
+	if(action < 0 || action > 2) {
+		LM_ERR("Unknown action value %d", action);
+		return -1;
+	}
+
+	if(action == 1) {
+		ini = &(*secf_data)->wl;
+		last = &(*secf_data)->wl_last;
+	} else {
+		ini = &(*secf_data)->bl;
+		last = &(*secf_data)->bl_last;
+	}
+
+	switch(type) {
+		case 0:
+			if(action == 2) {
+				ini_node = &ini->dst;
+				last_node = &last->dst;
+			} else {
+				ini_node = &ini->ua;
+				last_node = &last->ua;
+			}
+			break;
+		case 1:
+			ini_node = &ini->country;
+			last_node = &last->country;
+			break;
+		case 2:
+			ini_node = &ini->domain;
+			last_node = &last->domain;
+			break;
+		case 3:
+			ini_node = &ini->ip;
+			last_node = &last->ip;
+			break;
+		case 4:
+			ini_node = &ini->user;
+			last_node = &last->user;
+			break;
+		default:
+			LM_ERR("Unknown type value %d", type);
+			return -1;
+	}
+
+	current = *ini_node;
+	previous = NULL;
+	// Iterate through the list and remove matching nodes
+	while(current) {
+		if(strncmp(current->s.s, value->s, value->len) == 0) {
+			LM_DBG("Match found: %.*s\n", current->s.len, current->s.s);
+			total++;
+			struct str_list *temp = current;
+			if(previous) {
+				previous->next = current->next;
+				if(!previous->next) {
+					*last_node = previous;
+				}
+			} else {
+				*ini_node = current->next;
+				if(!(*ini_node)) {
+					*last_node = NULL;
+				}
+			}
+			shm_free(temp->s.s);
+			shm_free(temp);
+			LM_DBG("Match removed.\n");
+			if(previous) {
+				current = previous->next;
+			} else {
+				current = *ini_node;
+			}
+			continue;
+		}
+		previous = current;
+		current = current->next;
+	}
+	if(total > 0) {
+		LM_DBG("Total matches removed: %d", total);
+		return 0; // Return the total number of removed items
+	} else {
+		LM_DGB("No matching values found in the list.");
+		return -1; // Return -1 on no matches
+	}
+}
 
 /* Load data from database */
 int secf_load_db(void)


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

##### **Summary**

This update introduces new functionality to the `secfilter` module, enabling the removal of entries from both the Blacklist and Whitelist. It also includes automatic detection and removal of duplicate values from these lists.

##### **Details**

   * Users can now remove specific entries from the Blacklist or Whitelist based on type (e.g., IP, domain, user) and a given value.
   * Supports removal of single or multiple matching entries in one operation.


##### **Benefits**

- Improves the usability and flexibility of the `secfilter` module by allowing fine-grained control over list management.
- Ensures that the Blacklist and Whitelist are kept clean and free from redundant entries.
- Enhances performance by reducing unnecessary duplication in the lists.

##### Testing
This feature was tested using `kamcmd` commands in various scenarios:
- Removing the **first element** in the list.
- Removing an element from the **middle** of the list.
- Removing the **last element** in the list.
- Removing **all matching elements** in the list.

In all cases, the commands worked correctly, and the lists were updated and cleaned as expected.
