### PR TITLE
core: parser - set URI type to TELS_URI_T for user=phone SIPS R-URI

### DIFF
--- a/src/core/parser/parse_uri.c
+++ b/src/core/parser/parse_uri.c
@@ -1277,7 +1277,7 @@ int parse_uri(char *buf, int len, struct sip_uri *uri)
 			uri->sip_params = uri->params;
 			if((phone2tel) && (uri->user_param_val.len == 5)
 					&& (strncmp(uri->user_param_val.s, "phone", 5) == 0)) {
-				uri->type = TEL_URI_T;
+				uri->type = uri->type == SIPS_URI_T ? TELS_URI_T : TEL_URI_T;
 				uri->flags |= URI_SIP_USER_PHONE;
 				/* move params from user into uri->params */
 				p = q_memchr(uri->user.s, ';', uri->user.len);


### PR DESCRIPTION
#### Pre-Submission Checklist

- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change

- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:

- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Fixes an issue where setting the ``$rU`` for a SIPS R-URI containing ``user=phone`` would overwrite the scheme to ``sip``.