### PR TITLE
 Fix Makefile.defs and influxdbc for build on FreeBSD

### DIFF
--- a/src/Makefile.defs
+++ b/src/Makefile.defs
@@ -492,7 +492,7 @@ endif
 
 ifeq ($(OS), freebsd)
 	doc_dir = share/doc/$(MAIN_NAME)/
-	man_dir = man/
+	man_dir = share/man/
 	data_dir = share/$(MAIN_NAME)/
 	LOCALBASE ?= /usr/local
 endif

--- a/src/modules/influxdbc/ic.c
+++ b/src/modules/influxdbc/ic.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <sys/errno.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
 


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Not related to issues

#### Description
`Makefile.defs` is incorrect (`man_dir` should contain `share`) and `influxdbc` is not built (`sockaddr_in` is undefined) on FreeBSD environment.
The proposed patch fixes it and makes the module is consistent with the rest of modules.