### PR TITLE
htable: Fix expiry on assignment

### DIFF
--- a/src/modules/htable/ht_api.c
+++ b/src/modules/htable/ht_api.c
@@ -496,9 +496,7 @@ int ht_set_cell_ex(
 						it->value.s.s[it->value.s.len] = '\0';
 
 						if(exv <= 0) {
-							if(ht->updateexpire) {
-								it->expire = now + ht->htexpire;
-							}
+							HT_UPDATE_EXPIRE(ht, it, now);
 						} else {
 							it->expire = now + exv;
 						}
@@ -514,11 +512,7 @@ int ht_set_cell_ex(
 						cell->next = it->next;
 						cell->prev = it->prev;
 						if(exv <= 0) {
-							if(ht->updateexpire) {
-								cell->expire = now + ht->htexpire;
-							} else {
-								cell->expire = it->expire;
-							}
+							HT_COPY_EXPIRE(ht, cell, now, it);
 						} else {
 							it->expire = now + exv;
 						}
@@ -535,9 +529,7 @@ int ht_set_cell_ex(
 					it->value.n = val->n;
 
 					if(exv <= 0) {
-						if(ht->updateexpire) {
-							it->expire = now + ht->htexpire;
-						}
+						HT_UPDATE_EXPIRE(ht, it, now);
 					} else {
 						it->expire = now + exv;
 					}
@@ -556,11 +548,7 @@ int ht_set_cell_ex(
 						return -1;
 					}
 					if(exv <= 0) {
-						if(ht->updateexpire) {
-							cell->expire = now + ht->htexpire;
-						} else {
-							cell->expire = it->expire;
-						}
+						HT_COPY_EXPIRE(ht, cell, now, it);
 					} else {
 						it->expire = now + exv;
 					}
@@ -578,9 +566,7 @@ int ht_set_cell_ex(
 					it->value.n = val->n;
 
 					if(exv <= 0) {
-						if(ht->updateexpire) {
-							it->expire = now + ht->htexpire;
-						}
+						HT_UPDATE_EXPIRE(ht, it, now);
 					} else {
 						it->expire = now + exv;
 					}

--- a/src/modules/htable/ht_api.h
+++ b/src/modules/htable/ht_api.h
@@ -143,4 +143,11 @@ ht_cell_t *ht_iterator_get_current(str *iname);
 
 void ht_slot_lock(ht_t *ht, int idx);
 void ht_slot_unlock(ht_t *ht, int idx);
+
+#define HT_UPDATE_EXPIRE(ht, it, now)                               \
+	if(ht->updateexpire || (now && it->expire && it->expire < now)) \
+	it->expire = now + ht->htexpire
+#define HT_COPY_EXPIRE(ht, it, now, src) \
+	HT_UPDATE_EXPIRE(ht, it, now);       \
+	else it->expire = src->expire
 #endif


### PR DESCRIPTION
Update cell expiry on assignment for htables w/o updateexpiry (analogue to #4079).

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4079

#### Description
<!-- Describe your changes in detail -->
Currently Kamailio does not update expiry when assigning a value to an expired cell if htable's `updateexpire` equals `0`. So expired cells aren't usable as long htable timer cleans up these cells.
Reproduction 1:
```
#!KAMAILIO

listen=udp:127.0.0.1:9999

log_stderror=yes

loadmodule "xlog.so"
loadmodule "pv.so"
loadmodule "sl.so"
loadmodule "htable.so"

modparam("htable", "htable", "foo=>autoexpire=1;updateexpire=0;initval=0")

request_route {
        if ($sht(foo=>bar) == $null) {
                xlog("it's null, init it\n");
        }
        $sht(foo=>bar) = $sht(foo=>bar) + 1;
        xlog("$Ts value $sht(foo=>bar)\texpire $shtex(foo=>bar)\n");
        sl_send_reply("200", "Hello");
}
```
output:
```
 0(787651) ERROR: <script>: 1736855046 value 1  expire 1
 0(787651) ERROR: <script>: 1736855046 value 2  expire 1
 0(787651) ERROR: <script>: 1736855047 value 3  expire 0
 0(787651) ERROR: <script>: 1736855048 value 0  expire 4294967295
 0(787651) ERROR: <script>: 1736855048 value 0  expire 4294967295
 0(787651) ERROR: <script>: 1736855049 value 0  expire 4294967294
 0(787651) ERROR: <script>: 1736855050 value 0  expire 4294967293
SNIP expire decreases while value stays 0
 0(787651) ERROR: <script>: 1736855066 value 1  expire 1
 0(787651) ERROR: <script>: 1736855066 value 2  expire 1
 0(787651) ERROR: <script>: 1736855067 value 3  expire 0
```
Reproduction 2:
```
#!KAMAILIO

listen=udp:127.0.0.1:9999

log_stderror=yes

loadmodule "xlog.so"
loadmodule "pv.so"
loadmodule "sl.so"
loadmodule "htable.so"

modparam("htable", "htable", "baz=>")
modparam("htable", "htable", "foo=>autoexpire=1;updateexpire=0")

request_route {
        if ($sht(foo=>bar) == $null) {
                xlog("it's null, init it\n");
        }
        $sht(foo=>bar) = $_s($shtinc(baz=>cnt));
        xlog("$Ts value $sht(foo=>bar)\texpire $shtex(foo=>bar)\n");
        sl_send_reply("200", "Hello");
}

event_route[htable:mod-init] {
        xlog("htable:mod-init\n");
        # $sht(foo=>bar) = 0;
        $sht(baz=>cnt) = 0;
}
```
output:
```
 0(789709) ERROR: <script>: it's null, init it
 0(789709) ERROR: <script>: 1736855379 value 1  expire 1
 0(789709) ERROR: <script>: 1736855379 value 2  expire 1
 0(789709) ERROR: <script>: 1736855380 value 3  expire 0
 0(789709) ERROR: <script>: 1736855380 value 4  expire 0
 0(789709) ERROR: <script>: it's null, init it
 0(789709) ERROR: <script>: 1736855381 value <null>     expire 4294967295
 0(789709) ERROR: <script>: it's null, init it
 0(789709) ERROR: <script>: 1736855382 value <null>     expire 4294967294
SNIP expire decreases value stays null
 0(789709) ERROR: <script>: it's null, init it
 0(789709) ERROR: <script>: 1736855399 value 33 expire 1
 0(789709) ERROR: <script>: 1736855399 value 34 expire 1
 0(789709) ERROR: <script>: 1736855400 value 35 expire 0
 0(789709) ERROR: <script>: 1736855400 value 36 expire 0
```