### PR TITLE
cmake: add FreeBSD support

### DIFF
--- a/cmake/compiler-specific.cmake
+++ b/cmake/compiler-specific.cmake
@@ -8,7 +8,7 @@ option(PROFILE "Enable profiling" OFF)
 add_library(common_compiler_flags INTERFACE)
 
 # Define the flags for the C compiler
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
 
   if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     target_compile_definitions(common_compiler_flags INTERFACE CC_GCC_LIKE_ASM)

--- a/cmake/defs.cmake
+++ b/cmake/defs.cmake
@@ -14,6 +14,8 @@ message(STATUS "OS version: ${OSREL}")
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "i386|i486|i586|i686")
   set(TARGET_ARCH "i386")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
+  set(TARGET_ARCH "x86_64")
 else()
   set(TARGET_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
 endif()
@@ -139,7 +141,7 @@ option(USE_FAST_LOCK "Use fast locking if available" ON)
 # Check the system processor type and set USE_FAST_LOCK accordingly
 if(USE_FAST_LOCK)
   if(CMAKE_SYSTEM_PROCESSOR MATCHES
-     "i386|i486|i586|i686|x86_64|sparc64|sparc|ppc|ppc64|alpha|mips2|mips64")
+     "i386|i486|i586|i686|x86_64|amd64|sparc64|sparc|ppc|ppc64|alpha|mips2|mips64")
     set(USE_FAST_LOCK YES)
   elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
     set(USE_FAST_LOCK NO)

--- a/cmake/os-specific.cmake
+++ b/cmake/os-specific.cmake
@@ -12,6 +12,9 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "DragonFly")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   # Mac OS X specific flags
   include(${OS_SPECIFIC_DIR}/darwin.cmake)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  # FreeBSD specific flags
+  include(${OS_SPECIFIC_DIR}/freebsd.cmake)
 elseif()
   message(FATAL_ERROR "Unsupported system: ${CMAKE_SYSTEM_NAME}")
 endif()

--- a/cmake/os-specific/freebsd.cmake
+++ b/cmake/os-specific/freebsd.cmake
@@ -1,0 +1,37 @@
+message(
+  STATUS
+    "Configuring for FreeBSD"
+)
+
+target_compile_definitions(
+  common
+  INTERFACE HAVE_SOCKADDR_SA_LEN
+            HAVE_GETHOSTBYNAME2
+            HAVE_UNION_SEMUN
+            HAVE_SCHED_YIELD
+            HAVE_MSGHDR_MSG_CONTROL
+            HAVE_CONNECT_ECONNRESET_BUG
+            HAVE_TIMEGM
+            HAVE_IP_MREQN
+)
+
+if(${RAW_SOCKS})
+  target_compile_definitions(common INTERFACE USE_RAW_SOCKS)
+endif()
+
+message(STATUS "USE_FAST_LOCK = ${USE_FAST_LOCK}")
+if(NOT ${USE_FAST_LOCK})
+  target_compile_definitions(common INTERFACE USE_PTHREAD_MUTEX)
+endif()
+
+if(NOT DEFINED ${NO_SELECT})
+  target_compile_definitions(common INTERFACE HAVE_SELECT)
+endif()
+
+if(NOT DEFINED ${NO_KQUEUE})
+  target_compile_definitions(common INTERFACE HAVE_KQUEUE)
+endif()
+
+if(NOT DEFINED RUN_PREFIX)
+  set(RUN_PREFIX "/var")
+endif()


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
I've tested cmake-build in the FreeBSD environment, as requested by @miconda in #4099.
And founded some troubles.
First of all are: specific flags for FreeBSD and arch-name for FreeBSD cmake-environment. I've fixed it in the PR.

But there're some unresolved problems I want to discuss...

A `LOCK_METHOD` problem:
There's a `LOCK_METHOD` variable in defs.cmake:
https://github.com/kamailio/kamailio/blob/6b0b8cb84b7d0e965d50bdf0dfa5423004879f55/cmake/defs.cmake#L171-L179
And the explicit usage `LOCK_METHOD` as `USE_FUTEX` in a compile_definitions:
https://github.com/kamailio/kamailio/blob/6b0b8cb84b7d0e965d50bdf0dfa5423004879f55/cmake/defs.cmake#L304-L327
I suppose it's incorrect while some OSs (FreeBSD, ex.) doesn't tested with futexlock.h earlier.

A resolv-link problem:
There're an explicit links of the resolv library:
https://github.com/kamailio/kamailio/blob/6b0b8cb84b7d0e965d50bdf0dfa5423004879f55/src/CMakeLists.txt#L116-L124
https://github.com/kamailio/kamailio/blob/6b0b8cb84b7d0e965d50bdf0dfa5423004879f55/utils/kamcmd/CMakeLists.txt#L32
I think it's incorrect while some OSs (FreeBSD, ex.) uses builtin resolv (libc, etc).

Initially сmake is built successful after the above fixes.