### PR TITLE
outbound: encode bind address into flow token as destination

### DIFF
--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1739,7 +1739,8 @@ struct tcp_connection *_tcpconn_find(int id, struct ip_addr *ip, int port,
 			print_ip("ip=", &a->parent->rcv.src_ip, "\n");
 #endif
 			if((a->parent->state != S_CONN_BAD) && (port == a->port)
-					&& ((l_port == 0) || (l_port == a->parent->rcv.dst_port))
+					&& ((l_port == 0) || (l_port == a->parent->rcv.dst_port)
+							|| (l_port == a->parent->cinfo.dst_port))
 					&& (ip_addr_cmp(ip, &a->parent->rcv.src_ip))
 					&& (is_local_ip_any
 							|| ip_addr_cmp(l_ip, &a->parent->rcv.dst_ip)


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

This is an attempt to fix the combination of the outbound/rr modules and ``tcp_accept_haproxy=yes``. This combination is currently broken, as previously reported on the mailing list: https://www.mail-archive.com/sr-users@lists.kamailio.org/msg21854.html

The issue is that the destination address/port combo of the haproxy side is encoded into the flow token. When the rr module decodes the flow token and tries to look up the listening socket using ``find_si``, it cannot be found, because it is given the destination address/port combo of the connection of the haproxy side, not the address/port combo that Kamailio is actually listening on.

This patch fixes the issue by encoding the ``bind_address`` of the socket the connection was received on into the flow token as the destination address. The source address remains unchanged, as it *can* be used to look up the TCP connection (with a minor patch to ``_tcpconn_find`` in ``tcp_main.c``)

While I've done quite a bit of testing with this patchset, I find it difficult to oversee the full impact of this change in Kamailio's large codebase. Any feedback is welcome.