### PR TITLE
janssonrpcc: fixed warning var may be used uninitialized

### DIFF
--- a/src/modules/janssonrpcc/janssonrpc_server.c
+++ b/src/modules/janssonrpcc/janssonrpc_server.c
@@ -130,6 +130,7 @@ int jsonrpc_parse_server(char *server_s, jsonrpc_server_group_t **group_ptr)
 	param_t *pit = NULL;
 	param_t *freeme = NULL;
 	str conn;
+	conn.s = NULL;
 	str addr;
 	addr.s = NULL;
 	str srv;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
On CentOS, the present build error var may be used uninitialized.
This fixes this.