### PR TITLE
dmq and dmq_usrloc additions

### DIFF
--- a/src/modules/dmq/bind_dmq.c
+++ b/src/modules/dmq/bind_dmq.c
@@ -37,5 +37,6 @@ int bind_dmq(dmq_api_t *api)
 	api->send_message = dmq_send_message;
 	api->bcast_message = bcast_dmq_message;
 	api->find_dmq_node_uri = find_dmq_node_uri2;
+	api->get_dmq_server_socket = get_dmq_server_socket;
 	return 0;
 }

--- a/src/modules/dmq/bind_dmq.h
+++ b/src/modules/dmq/bind_dmq.h
@@ -36,6 +36,7 @@ typedef int (*bcast_message_t)(dmq_peer_t *peer, str *body, dmq_node_t *except,
 typedef int (*send_message_t)(dmq_peer_t *peer, str *body, dmq_node_t *node,
 		dmq_resp_cback_t *resp_cback, int max_forwards, str *content_type);
 typedef dmq_node_t *(*find_dmq_node_uri_t)(str *uri);
+typedef str (*get_dmq_server_socket_t)();
 
 typedef struct dmq_api
 {
@@ -43,6 +44,7 @@ typedef struct dmq_api
 	bcast_message_t bcast_message;
 	send_message_t send_message;
 	find_dmq_node_uri_t find_dmq_node_uri;
+	get_dmq_server_socket_t get_dmq_server_socket;
 } dmq_api_t;
 
 typedef int (*bind_dmq_f)(dmq_api_t *api);

--- a/src/modules/dmq/dmq_funcs.c
+++ b/src/modules/dmq/dmq_funcs.c
@@ -566,3 +566,8 @@ void ping_servers(unsigned int ticks, void *param)
 		LM_ERR("error broadcasting message\n");
 	}
 }
+
+str get_dmq_server_socket()
+{
+	return dmq_server_socket;
+}

--- a/src/modules/dmq/dmq_funcs.h
+++ b/src/modules/dmq/dmq_funcs.h
@@ -70,5 +70,6 @@ int ki_dmq_bcast_message(
 int is_from_remote_node(sip_msg_t *msg);
 int ki_dmq_t_replicate(struct sip_msg *msg);
 int ki_dmq_t_replicate_mode(struct sip_msg *msg, int mode);
+str get_dmq_server_socket();
 
 #endif

--- a/src/modules/dmq_usrloc/dmq_usrloc.c
+++ b/src/modules/dmq_usrloc/dmq_usrloc.c
@@ -37,6 +37,7 @@ static int child_init(int);
 int dmq_usrloc_enable = 0;
 int _dmq_usrloc_sync = 1;
 int _dmq_usrloc_replicate_socket_info = 0;
+int _dmq_usrloc_replicate_cflags = 1;
 int _dmq_usrloc_batch_size = 0;
 int _dmq_usrloc_batch_msg_contacts = 1;
 int _dmq_usrloc_batch_msg_size = 60000;
@@ -54,6 +55,7 @@ static param_export_t params[] = {
 	{"enable", PARAM_INT, &dmq_usrloc_enable},
 	{"sync", PARAM_INT, &_dmq_usrloc_sync},
 	{"replicate_socket_info", PARAM_INT, &_dmq_usrloc_replicate_socket_info},
+	{"replicate_cflags", PARAM_INT, &_dmq_usrloc_replicate_cflags},
 	{"batch_msg_contacts", PARAM_INT, &_dmq_usrloc_batch_msg_contacts},
 	{"batch_msg_size", PARAM_INT, &_dmq_usrloc_batch_msg_size},
 	{"batch_size", PARAM_INT, &_dmq_usrloc_batch_size},

--- a/src/modules/dmq_usrloc/dmq_usrloc.c
+++ b/src/modules/dmq_usrloc/dmq_usrloc.c
@@ -43,6 +43,7 @@ int _dmq_usrloc_batch_msg_size = 60000;
 int _dmq_usrloc_batch_usleep = 0;
 str _dmq_usrloc_domain = str_init("location");
 int _dmq_usrloc_delete = 1;
+int _dmq_usrloc_delete_expired = 0;
 
 usrloc_api_t dmq_ul;
 
@@ -59,6 +60,7 @@ static param_export_t params[] = {
 	{"batch_usleep", PARAM_INT, &_dmq_usrloc_batch_usleep},
 	{"usrloc_domain", PARAM_STR, &_dmq_usrloc_domain},
 	{"usrloc_delete", PARAM_INT, &_dmq_usrloc_delete},
+	{"usrloc_delete_expired", PARAM_INT, &_dmq_usrloc_delete_expired},
 	{0, 0, 0}
 };
 
@@ -116,6 +118,7 @@ static int mod_init(void)
 			LM_ERR("Error in dmq_usrloc_initialize()\n");
 		}
 	}
+
 	return 0;
 }
 

--- a/src/modules/dmq_usrloc/doc/dmq_usrloc_admin.xml
+++ b/src/modules/dmq_usrloc/doc/dmq_usrloc_admin.xml
@@ -292,6 +292,44 @@ modparam("dmq_usrloc", "replicate_socket_info", 1)
 </programlisting>
 	</example>
 	</section>
+	<section id="usrloc_dmq.p.replicate_cflags">
+		<title><varname>replicate_cflags</varname> (int)</title>
+		<para>
+			The parameter controls whether the cflags replication is active or not.
+			This is important for anycast scenarios.
+			The value can be:
+			<itemizedlist>
+			<listitem>
+			<para>
+				0 - disabled
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				1 - enabled, replicate cflags
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				> 1 - enabled, set cflags corresponding to this value, on replicated peers
+			</para>
+			</listitem>
+			</itemizedlist>
+		</para>
+		<para>
+		<emphasis>
+			Default value is 1.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>replicate_cflags</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dmq_usrloc", "replicate_cflags", 97) # will set cflags corresponding to 1 + 32 + 64
+...
+		</programlisting>
+		</example>
+	</section>
 	<section id="usrloc_dmq.p.usrloc_delete">
 		<title><varname>usrloc_delete</varname> (int)</title>
 		<para>

--- a/src/modules/dmq_usrloc/doc/dmq_usrloc_admin.xml
+++ b/src/modules/dmq_usrloc/doc/dmq_usrloc_admin.xml
@@ -303,10 +303,29 @@ modparam("dmq_usrloc", "replicate_socket_info", 1)
 		</emphasis>
 		</para>
 		<example>
-		<title>Set <varname>usrloc_domain</varname> parameter</title>
+		<title>Set <varname>usrloc_delete</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
 modparam("dmq_usrloc", "usrloc_delete", 0)
+...
+</programlisting>
+		</example>
+	</section>
+	<section id="usrloc_dmq.p.usrloc_delete_expired">
+		<title><varname>usrloc_delete_expired</varname> (int)</title>
+		<para>
+			Enable (1) or disable (0) synchronizing usrloc expire actions using delete actions. In other words, sync delete of (UL_CONTACT_EXPIRE) expired contacts.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>usrloc_delete_expired</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dmq_usrloc", "usrloc_delete_expired", 1)
 ...
 </programlisting>
 		</example>

--- a/src/modules/dmq_usrloc/doc/dmq_usrloc_admin.xml
+++ b/src/modules/dmq_usrloc/doc/dmq_usrloc_admin.xml
@@ -271,6 +271,11 @@ modparam("dmq_usrloc", "usrloc_domain", "my_domain")
 				2 - enabled, replicate socket by socket name
 			</para>
 			</listitem>
+			<listitem>
+			<para>
+				3 - enabled, use local socket from dmq server_socket modparam
+			</para>
+			</listitem>
 			</itemizedlist>
 		</para>
 		<para>

--- a/src/modules/dmq_usrloc/usrloc_sync.c
+++ b/src/modules/dmq_usrloc/usrloc_sync.c
@@ -60,6 +60,7 @@ static void srjson_to_xavp(srjson_t *json, sr_xavp_t **xavp);
 
 extern int _dmq_usrloc_sync;
 extern int _dmq_usrloc_replicate_socket_info;
+extern int _dmq_usrloc_replicate_cflags;
 extern int _dmq_usrloc_batch_msg_contacts;
 extern int _dmq_usrloc_batch_msg_size;
 extern int _dmq_usrloc_batch_size;
@@ -421,7 +422,12 @@ static int usrloc_dmq_execute_action(srjson_t *jdoc_action, dmq_node_t *node)
 		} else if(strcmp(it->string, "flags") == 0) {
 			flags = SRJSON_GET_UINT(it);
 		} else if(strcmp(it->string, "cflags") == 0) {
-			cflags = SRJSON_GET_UINT(it);
+			if(_dmq_usrloc_replicate_cflags == 1) {
+				cflags = SRJSON_GET_UINT(it);
+			} else if(_dmq_usrloc_replicate_cflags > 1) {
+				cflags = _dmq_usrloc_replicate_cflags;
+			}
+			// else don't replicate cflags
 		} else if(strcmp(it->string, "q") == 0) {
 			q = SRJSON_GET_UINT(it);
 		} else if(strcmp(it->string, "last_modified") == 0) {

--- a/src/modules/dmq_usrloc/usrloc_sync.c
+++ b/src/modules/dmq_usrloc/usrloc_sync.c
@@ -317,7 +317,7 @@ int usrloc_dmq_initialize()
 	dmq_server_socket = usrloc_dmqb.get_dmq_server_socket();
 	dmq_server_socket_local = lookup_local_socket(&dmq_server_socket);
 	if(dmq_server_socket_local == 0) {
-		LM_DBG("dmq local server socket <%.*s> not found ...ignoring\n",
+		LM_WARN("dmq local server socket <%.*s> not found ...ignoring\n",
 				dmq_server_socket.len, dmq_server_socket.s);
 	}
 

--- a/src/modules/dmq_usrloc/usrloc_sync.c
+++ b/src/modules/dmq_usrloc/usrloc_sync.c
@@ -66,6 +66,7 @@ extern int _dmq_usrloc_batch_size;
 extern int _dmq_usrloc_batch_usleep;
 extern str _dmq_usrloc_domain;
 extern int _dmq_usrloc_delete;
+extern int _dmq_usrloc_delete_expired;
 
 static int add_contact(str aor, ucontact_info_t *ci)
 {
@@ -1043,7 +1044,9 @@ void dmq_ul_cb_contact(ucontact_t *ptr, int type, void *param)
 				}
 				break;
 			case UL_CONTACT_EXPIRE:
-				//usrloc_dmq_send_contact(ptr, aor, DMQ_UPDATE);
+				if(_dmq_usrloc_delete_expired >= 1) {
+					usrloc_dmq_send_contact(ptr, aor, DMQ_RM, 0);
+				}
 				LM_DBG("Contact <%.*s> expired\n", aor.len, aor.s);
 				break;
 		}

--- a/src/modules/dmq_usrloc/usrloc_sync.h
+++ b/src/modules/dmq_usrloc/usrloc_sync.h
@@ -31,6 +31,7 @@
 
 #define DMQ_USRLOC_REPLICATE_SOCKET 1
 #define DMQ_USRLOC_REPLICATE_SOCKNAME 2
+#define DMQ_USRLOC_REPLICATE_SOCKET_LOCAL 3
 
 extern usrloc_api_t dmq_ul;
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each  component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Add new api function to dmq to get local socket. Use that in dmq_usrloc.
Sync dmq_usrloc UL_CONTACT_EXPIRE. Very useful for lost TCP connections, so contacts will be expired on all dmq nodes.