### PR TITLE
ims_auth|ims_registrar_pcscf: Fix Build for CentOS 7

### DIFF
--- a/src/modules/ims_auth/auth_vector.c
+++ b/src/modules/ims_auth/auth_vector.c
@@ -40,6 +40,8 @@ auth_vector *auth_vector_make_local(uint8_t k[16], uint8_t op[16], int opIsOPc,
 	uint8_t ak[6];
 	uint8_t authenticate[16 + 6 + 2 + 8];
 
+	int i = 0;
+
 	// f0 - generate random
 	f0(rand);
 
@@ -58,7 +60,7 @@ auth_vector *auth_vector_make_local(uint8_t k[16], uint8_t op[16], int opIsOPc,
 	// AUTN = SQN ^ AK || AMF || MAC-A
 	// Authenticate = RAND || AUTN
 	memcpy(authenticate, rand, 16);
-	for(int i = 0; i < 6; i++)
+	for(i = 0; i < 6; i++)
 		authenticate[16 + i] = sqn[i] ^ ak[i];
 	memcpy(authenticate + 22, amf, 2);
 	memcpy(authenticate + 24, mac_a, 8);
@@ -90,6 +92,8 @@ int auth_vector_resync_local(uint8_t sqnMSout[6], auth_vector *av,
 	uint8_t mac_s[8];
 	uint8_t xmac_s[8];
 
+	int i = 0;
+
 	if(!av->is_locally_generated) {
 		LM_ERR("auth_vector is not locally generated - let the HSS handle "
 			   "resync\n");
@@ -114,7 +118,6 @@ int auth_vector_resync_local(uint8_t sqnMSout[6], auth_vector *av,
 	f5star(ak, k, op_c, rand);
 
 	// Unpack the AUTS = (SQN_MS ^ AK) || MAC-S
-	int i = 0;
 	for(i = 0; i < 6; i++)
 		sqnMS[i] = auts[i] ^ ak[i];
 	memcpy(mac_s, auts + 6, 8);

--- a/src/modules/ims_auth/auth_vector.c
+++ b/src/modules/ims_auth/auth_vector.c
@@ -114,7 +114,8 @@ int auth_vector_resync_local(uint8_t sqnMSout[6], auth_vector *av,
 	f5star(ak, k, op_c, rand);
 
 	// Unpack the AUTS = (SQN_MS ^ AK) || MAC-S
-	for(int i = 0; i < 6; i++)
+	int i = 0;
+	for(i = 0; i < 6; i++)
 		sqnMS[i] = auts[i] ^ ak[i];
 	memcpy(mac_s, auts + 6, 8);
 
@@ -135,7 +136,8 @@ int auth_vector_resync_local(uint8_t sqnMSout[6], auth_vector *av,
 
 void sqn_increment(uint8_t sqn[6])
 {
-	for(int i = 5; i >= 0; i--) {
+	int i = 0;
+	for(i = 5; i >= 0; i--) {
 		if(sqn[i] == 0xFF) {
 			sqn[i] = 0;
 		} else {

--- a/src/modules/ims_registrar_pcscf/subscribe.c
+++ b/src/modules/ims_registrar_pcscf/subscribe.c
@@ -56,12 +56,13 @@ int reginfo_subscribe_real(struct sip_msg *msg, pv_elem_t *uri,
 	str extra_headers = {0};
 	reginfo_event_t *new_event;
 	str *subs_outbound_proxy = 0;
+	int i = 0;
 
 	int len = strlen(P_ASSERTED_IDENTITY_HDR_PREFIX) + pcscf_uri.len + 1
 			  + CRLF_LEN;
 	if(service_routes != NULL) {
 		len += strlen(ROUTE_HDR_PREFIX) + strlen(ROUTE_HDR_END);
-		for(int i = 0; i < num_service_routes; i++) {
+		for(i = 0; i < num_service_routes; i++) {
 			len += service_routes[i].len + strlen(ROUTE_HDR_SEPARATOR);
 		}
 	}
@@ -87,7 +88,7 @@ int reginfo_subscribe_real(struct sip_msg *msg, pv_elem_t *uri,
 		memcpy(extra_headers.s + extra_headers.len, ROUTE_HDR_PREFIX,
 				strlen(ROUTE_HDR_PREFIX));
 		extra_headers.len += strlen(ROUTE_HDR_PREFIX);
-		for(int i = 0; i < num_service_routes; i++) {
+		for(i = 0; i < num_service_routes; i++) {
 			memcpy(extra_headers.s + extra_headers.len, service_routes[i].s,
 					service_routes[i].len);
 			extra_headers.len += service_routes[i].len;


### PR DESCRIPTION
### Description

At this time, it's not possible to build Kamailio on `CentOS 7` on `master` or `6.0.0`.
Some code on `ims_auth` and `ims_registrar_pcscf` is not compliant with old `gcc`.

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Additional Information

Tested on my own, and build now works just fine.
