### PR TITLE
dmq: added remove_inactive parameter

### DIFF
--- a/src/modules/dmq/dmq.c
+++ b/src/modules/dmq/dmq.c
@@ -68,6 +68,7 @@ str dmq_notification_channel = str_init("notification_peer");
 int dmq_multi_notify = 0;
 static sip_uri_t dmq_notification_uri = {0};
 int dmq_ping_interval = 60;
+int dmq_remove_inactive = 1;
 
 /* TM bind */
 struct tm_binds _dmq_tmb = {0};
@@ -125,6 +126,7 @@ static param_export_t params[] = {
 	{"notification_channel", PARAM_STR, &dmq_notification_channel},
 	{"multi_notify", PARAM_INT, &dmq_multi_notify},
 	{"worker_usleep", PARAM_INT, &dmq_worker_usleep},
+	{"remove_inactive", PARAM_INT, &dmq_remove_inactive},
 	{0, 0, 0}
 };
 

--- a/src/modules/dmq/dmq.h
+++ b/src/modules/dmq/dmq.h
@@ -50,6 +50,7 @@ extern str dmq_server_socket;
 extern sip_uri_t dmq_server_uri;
 extern str_list_t *dmq_notification_address_list;
 extern int dmq_multi_notify;
+extern int dmq_remove_inactive;
 /* sl and tm */
 extern struct tm_binds _dmq_tmb;
 extern sl_api_t _dmq_slb;

--- a/src/modules/dmq/doc/dmq_admin.xml
+++ b/src/modules/dmq/doc/dmq_admin.xml
@@ -297,6 +297,26 @@ modparam("dmq", "ping_interval", 90)
 </programlisting>
                 </example>
         </section>
+	<section id="dmq.p.remove_inactive">
+		<title><varname>remove_inactive</varname>(int)</title>
+		<para>
+		A value of zero disable removing dmq nodes. Node status will be changed to pending.
+		A non-zero value (default is 1) enable removing nodes.
+		For node that is defined as notification address status will be changed to pending.
+		Otherwise it will be marked as disabled and then will be removed.
+		</para>
+		<para>
+		<emphasis>Default value is <quote>1</quote>.</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>remove_inactive</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dmq", "remove_inactive", 0)
+...
+</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>

--- a/src/modules/dmq/notification_peer.c
+++ b/src/modules/dmq/notification_peer.c
@@ -628,6 +628,11 @@ int notification_resp_callback_f(
 			run_init_callbacks();
 		}
 	} else if(code == 408) {
+		if(!dmq_remove_inactive) {
+			/* put the node in pending state */
+			update_dmq_node_status(dmq_node_list, node, DMQ_NODE_PENDING);
+			return 0;
+		}
 		/* TODO this probably do not work for dmq_multi_notify */
 		slp = dmq_notification_address_list;
 		while(slp != NULL) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Add new parameter for dmq module "remove_inactive" that controls removing nodes behavior. Default value is 1, so the behavior will not changed by default. 
This is useful especially with notification peers that are defined as dns record together with enabled multi_notify option.  