### PR TITLE
nathelper: Add modparam to not send ping to Path

### DIFF
--- a/src/modules/nathelper/doc/nathelper_admin.xml
+++ b/src/modules/nathelper/doc/nathelper_admin.xml
@@ -428,6 +428,26 @@ modparam("nathelper", "udpping_from_path", 1)
 </programlisting>
 		</example>
 	</section>
+	<section id="nathelper.p.ignore_path">
+		<title><varname>ignore_path</varname> (int)</title>
+		<para>
+		Enable ignore of Path header address when sending UDP pings (keepalives).
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote> (feature disabled).
+			UDP pings are sent to Path header if header is present.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>ignore_path</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("nathelper", "ignore_path", 1)
+...
+		</programlisting>
+		</example>
+	</section>
 	<section id="nathelper.p.append_sdp_oldmediaip">
 		<title><varname>append_sdp_oldmediaip</varname> (int)</title>
 		<para>

--- a/src/modules/nathelper/nathelper.c
+++ b/src/modules/nathelper/nathelper.c
@@ -193,6 +193,7 @@ static avp_name_t rcv_avp_name;
 
 static char *natping_socket = NULL;
 static int udpping_from_path = 0;
+static int ignore_path = 0;
 static int sdp_oldmediaip = 1;
 static int raw_sock = -1;
 static unsigned int raw_ip = 0;
@@ -277,6 +278,7 @@ static param_export_t params[] = {
 	{"natping_socket",        PARAM_STRING, &natping_socket        },
 	{"keepalive_timeout",     PARAM_INT, &nh_keepalive_timeout  },
 	{"udpping_from_path",     PARAM_INT, &udpping_from_path     },
+	{"ignore_path",           PARAM_INT, &ignore_path},
 	{"append_sdp_oldmediaip", PARAM_INT, &sdp_oldmediaip        },
 	{"filter_server_id",      PARAM_INT, &nh_filter_srvid },
 	{"nat_addr_mode",         PARAM_INT, &nh_nat_addr_mode },
@@ -2387,7 +2389,7 @@ static void nh_timer(unsigned int ticks, void *timer_idx)
 			dst_uri = &c;
 
 		/* determine the destination */
-		if(path.len && (flags & sipping_flag) != 0) {
+		if(path.len && (flags & sipping_flag) != 0 && !ignore_path) {
 			/* send to first URI in path */
 			if(get_path_dst_uri(&path, &opt) < 0) {
 				LM_ERR("failed to get dst_uri for Path\n");
@@ -2398,7 +2400,7 @@ static void nh_timer(unsigned int ticks, void *timer_idx)
 				LM_ERR("can't parse contact dst_uri\n");
 				continue;
 			}
-		} else if(path.len && udpping_from_path) {
+		} else if(path.len && udpping_from_path && !ignore_path) {
 			path_ip_str = extract_last_path_ip(path);
 			if(path_ip_str == NULL) {
 				LM_ERR("unable to parse path from location\n");


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
OPTIONS ping is always sent to Path uri, if contact has it set. Add option to ignore this and still send OPTIONS to contact.