### PR TITLE
Cmake: small bugfixes (lib/ims, dialplan, sctp)

### DIFF
--- a/src/lib/ims/CMakeLists.txt
+++ b/src/lib/ims/CMakeLists.txt
@@ -1,4 +1,2 @@
-find_package(LibXml2 REQUIRED)
-
 file(GLOB SRC_FILES "*.c")
 target_sources(kamailio PUBLIC ${SRC_FILES})

--- a/src/modules/dialplan/CMakeLists.txt
+++ b/src/modules/dialplan/CMakeLists.txt
@@ -1,3 +1,14 @@
 file(GLOB MODULE_SOURCES "*.c")
 
 add_library(${module_name} SHARED ${MODULE_SOURCES})
+
+find_package(pcre2 QUIET)
+if(NOT pcre2_FOUND)
+  message(STATUS "PCRE2 library not found... looking with pkg-config")
+  find_package(PkgConfig REQUIRED)
+  # TODO: verify we want 8-bit libpcre2
+  pkg_check_modules(pcre2 REQUIRED IMPORTED_TARGET libpcre2-8)
+  add_library(PCRE2::8BIT ALIAS PkgConfig::pcre2)
+endif()
+
+target_link_libraries(${module_name} PRIVATE PCRE2::8BIT)

--- a/src/modules/sctp/CMakeLists.txt
+++ b/src/modules/sctp/CMakeLists.txt
@@ -14,11 +14,11 @@ endif()
 
 target_include_directories(${module_name} PRIVATE ${SCTP_INCLUDE_DIR})
 
-find_library(
-  SCTP_LIBRARY
-  NAMES sctp
-  PATHS /usr/lib /usr/local/lib)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  find_library(
+    SCTP_LIBRARY
+    NAMES sctp
+    PATHS /usr/lib /usr/local/lib)
 
-if(UNIX)
   target_link_libraries(${module_name} PRIVATE ${SCTP_LIBRARY})
 endif()


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Suggest small bugfixes for CMakeLists.txt for modules and libs.

- `lib/ims` - remove libxml2 as not needed as in 5eac8fd5356cc424d87cac4b4102c99e97054414.
- `dialplan` - added pcre2 lib as a depend.
- `sctp` - switched searching for libsctp for linux only after 9b7719a61ab02c93939e3681cb90e9fa04f3ac5d. There's no libsctp in FreeBSD while kernel module exists, example.
