### PR TITLE
dispatcher: weight documentation and workaround for limitations

### DIFF
--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -2558,6 +2558,34 @@ setid(int) destination(sip uri) flags(int,opt) priority(int,opt) attrs(str,opt)
 	</section>
 	</section>
 
+	<section id="dispatcher.weight.info">
+		<title>
+		<function moreinfo="none">Limitation on the weight parameter</function>
+		</title>
+		<para>
+			The weight is implemented as an internal table with 100 entries. Each entry points to one dispatcher target.
+			This means that approaching 100 entries the distribution will become more and more uneven.
+			Weights also need to add up to 100.
+		</para>
+		<para>
+			In order to get around these issues, you can write your own distribution algorithm.
+		</para>
+		<para>
+			Example for dispatching based on rweight. The functions in this example perform dispatching based on random while taking the rweight parameter into account.
+			This should work regardless of the number of destinations. However run-time increases linearly with the number of dispatcher destinations.
+		</para>
+		<para>
+			This works by first adding up the rweights, then selecting a random number between 0 and that sum.
+			It then goes through the targets one at a time, adds up the rweights again.
+			The target where the new sum is above the previously selected random number will be selected.
+		</para>
+<programlisting  format="linespecific">
+
+<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="weights.cfg" parse="text"/>
+
+</programlisting>
+	</section>
+
         <section id="dispatcher.ex.event_routes">
         <title>Event routes</title>
         <section>

--- a/src/modules/dispatcher/doc/weights.cfg
+++ b/src/modules/dispatcher/doc/weights.cfg
@@ -1,0 +1,49 @@
+# This replaces ds_select_dst
+route[own_ds_select_dst] {
+        if (!ds_select($var(dispatcherSet),"4")) {
+                xlog("L_ERR", "getDispatcheDestinations $var(dispatcherSet) FAILED, no destinations");
+                return(-1);
+        }
+        #Select random entry from list
+        if (route(own_ds_next_dst)) {
+                return(1);
+        } 
+        return(-1);
+}
+
+
+# This replaces ds_next_dst
+route [own_ds_next_dst] {
+        #Add up all the rweight parameters of all active dispatcher targets
+        $var(len)=$cnt($xavp(_dsdst_[*]));
+        $var(i)=0;
+        $var(sum)=0;
+        # Sum up the rweights of the dispatcher tables
+        while($var(i)<$var(len)) {
+                $var(attrs)=$xavp(_dsdst_[$var(i)]=>attrs);
+                $var(wi)=0;
+                if ($var(attrs)==0) { # No attributes => $var(attrs)=0 🤷
+                        $var(wi)=1;
+                } else {
+                        # In this example we use the rweight parameter
+                        $var(rweight)=$(var(attrs){param.value,rweight}); 
+                        $var(wi)=$(var(rweight){s.int}); #Transform to integer
+                }
+                $var(sum)=$var(sum)+$var(wi);
+                $var(i)=$var(i)+1;
+        }
+
+        # If sum of weights is 0, we have no active dispatcher targets
+        if ($var(sum)<=0) {
+                xlog("L_ERR", "own_ds_next_dst weight-sum: $var(sum) is to low; $var(len) dispatchers in list  => likely no active gateways left");
+                return(-1);
+        }
+
+        # Use a random value for dispatching, you could also use a hash over the call-id. The s.corehash transformation is usefull for this
+        $var(rand)=$RANDOM mod $var(sum);
+
+        #Add up all the rweight parameters for all active dispacther targets...
+        # ... and take the dispatcher if it is larger than $var(rand)
+        $var(selected)=0;
+        $var(sum)=0;
+        $var(i)=0;


### PR DESCRIPTION
- describe limitation of weight parameter
- describe a potential workaround against those limitations

<!-- Kamailio Pull Request Template -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
We had problems understanding the weight parameter of the dispatcher module and wrote a little workaround against the problems we have found. This workaround in the configuration file improves behavior for setups with many dispatcher targets at the cost of more CPU load.