### PR TITLE
pua_reginfo: handle_notify - fix AoR key parsing

### DIFF
--- a/src/modules/pua_reginfo/notify.c
+++ b/src/modules/pua_reginfo/notify.c
@@ -305,10 +305,10 @@ int process_body(str notify_body, udomain_t *domain)
 
 		if(reginfo_use_domain) {
 			aor_key.s = uri;
+			aor_key.len = strlen(uri);
 		} else {
-			aor_key.s = parsed_aor.user.s;
+			aor_key = parsed_aor.user;
 		}
-		aor_key.len = strlen(aor_key.s);
 		/* Now let's lock that domain for this AOR: */
 		ul.lock_udomain(domain, &aor_key);
 		/* and retrieve the user-record for this user: */


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

This PR aims to fix what seems like a discrepancy in the generated AoR key when using `handle_notify` from the `pua_reginfo` module.

I'm not familiar with the codebase but it seems like the AoR key should not include the domain when usrloc's `use_domain` isn't enabled. This seems to match with usrloc documentation and with the fact that the address is being parsed and the username selected from the parse result. However, the string length is then set with `strlen` and since `parse_uri` doesn't allocate strings but simply slices the input string, the result is that the everything after (and including) the username is set as the AoR key.

For example the uri `sip:bob@domain` currently generates the AoR key `bob@domain`, when it seems like it should generate a key with only `bob`.

This PR fixes it by inheriting both the pointer and length of the username part of the parsed uri.

#### Additional notes

There also seems to be a problem with multi domain support, as it uses the `uri` variable, but this variable isn't set anywhere except for a null byte. This causes all AoR keys to be empty strings. I've confirmed this in practice.