### PR TITLE
core: Include parameter skip_record in dns_cache_print_entry

### DIFF
--- a/src/core/dns_cache.c
+++ b/src/core/dns_cache.c
@@ -3898,6 +3898,15 @@ int dns_cache_print_entry(rpc_t *rpc, void *ctx, struct dns_hash_entry *e)
 					rpc->fault(ctx, 500, "Internal error adding naptr order");
 					return -1;
 				}
+				if(rpc->struct_add(sh, "s", "rr_skip_record",
+						   ((struct naptr_rdata *)(rr->rdata))->skip_record
+								   ? "yes"
+								   : "no")
+						< 0) {
+					rpc->fault(ctx, 500,
+							"Internal error adding naptr rr_skip_record");
+					return -1;
+				}
 				s.s = ((struct naptr_rdata *)(rr->rdata))->flags;
 				s.len = ((struct naptr_rdata *)(rr->rdata))->flags_len;
 				if(rpc->struct_add(sh, "S", "rr_flags", &s) < 0) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4174

#### Description
Extend the return value of dns_cache_print_entry with the parameter `rr_skip_record` for NAPTR records. The parameter `rr_skip_record` indicates, whether the NAPTR record is skipped due to issues reaching the destinations. Once a NAPTR record is marked as skipped, it will no longer be used.
