### PR TITLE
dispatcher: added ping socket configuration

### DIFF
--- a/src/modules/dispatcher/dispatch.h
+++ b/src/modules/dispatcher/dispatch.h
@@ -137,6 +137,7 @@ extern int ds_probing_mode;
 extern str ds_outbound_proxy;
 extern str ds_default_socket;
 extern str ds_default_sockname;
+extern str ds_ping_socket;
 extern struct socket_info *ds_default_sockinfo;
 
 int ds_init_data(void);
@@ -198,6 +199,7 @@ typedef struct _ds_attrs {
 	str body;
 	str duid;
 	str socket;
+	str ping_socket;
 	str sockname;
 	int maxload;
 	int weight;

--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -965,6 +965,22 @@ modparam("dispatcher", "ds_default_sockname", "sock1")
 		</example>
 	</section>
 
+	<section id="dispatcher.p.ds_ping_socket">
+		<title><varname>ds_ping_socket</varname> (str)</title>
+		<para>
+			Default socket to be used for sending ping requests
+			when a gateway has no "ping_socket" configured.
+		</para>
+		<example>
+		<title>Set the <quote>ds_ping_socket</quote> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("dispatcher", "ds_ping_socket", "udp:192.168.0.125:5060")
+...
+</programlisting>
+		</example>
+	</section>
+
 	<section id="dispatcher.p.ds_timer_mode">
 		<title><varname>ds_timer_mode</varname> (int)</title>
 		<para>
@@ -2479,6 +2495,10 @@ kamcli dispatcher.oclist 1
 							<para>'socket' - used to set the sending socket for the gateway. It is
 								used for sending the SIP traffic as well as OPTIONS
 								keepalives.</para>
+						</listitem>
+						<listitem>
+							<para>'ping_socket' - used to set the sending socket for ping requests.
+								It overwrites the general ds_ping_socket parameter.</para>
 						</listitem>
 						<listitem>
 							<para>'sockname' - used to set by name the sending socket for the


### PR DESCRIPTION
- add dispatcher modparam `ds_ping_socket`
- add gateway param `ping_socket`

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

could be useful for HA use cases where multiple kamailio nodes share a common Virtual IP (e.g.: managed by the VRRP).

we need to route requests using Virtual IP socket configured with `ds_default_sockname`/`socket` and to perform destinations probing using self-IP socket configured with `ds_ping_socket`/`ping_socket`.