### PR TITLE
kex: add KDMQ to request statistic

### DIFF
--- a/src/modules/kex/core_stats.c
+++ b/src/modules/kex/core_stats.c
@@ -70,6 +70,7 @@ stat_var *rcv_reqs_prack;
 stat_var *rcv_reqs_update;
 stat_var *rcv_reqs_refer;
 stat_var *rcv_reqs_publish;
+stat_var *rcv_reqs_kdmq;
 /*! extended received replies */
 stat_var *rcv_rpls_1xx;
 stat_var *rcv_rpls_18x;
@@ -148,7 +149,8 @@ stat_export_t core_stats[] = {{"rcv_requests", 0, &rcv_reqs},
 		{"rcv_requests_update", 0, &rcv_reqs_update},
 		{"rcv_requests_refer", 0, &rcv_reqs_refer},
 		{"rcv_requests_publish", 0, &rcv_reqs_publish},
-		{"rcv_replies", 0, &rcv_rpls}, {"rcv_replies_1xx", 0, &rcv_rpls_1xx},
+		{"rcv_requests_kdmq", 0, &rcv_reqs_kdmq}, {"rcv_replies", 0, &rcv_rpls},
+		{"rcv_replies_1xx", 0, &rcv_rpls_1xx},
 		{"rcv_replies_18x", 0, &rcv_rpls_18x},
 		{"rcv_replies_2xx", 0, &rcv_rpls_2xx},
 		{"rcv_replies_3xx", 0, &rcv_rpls_3xx},
@@ -258,6 +260,9 @@ static int km_cb_req_stats(struct sip_msg *msg, unsigned int flags, void *param)
 			break;
 		case METHOD_PUBLISH:
 			update_stat(rcv_reqs_publish, 1);
+			break;
+		case METHOD_KDMQ:
+			update_stat(rcv_reqs_kdmq, 1);
 			break;
 		case METHOD_OTHER:
 			update_stat(unsupported_methods, 1);

--- a/src/modules/kex/core_stats.h
+++ b/src/modules/kex/core_stats.h
@@ -54,6 +54,7 @@ extern stat_var *rcv_reqs_prack;
 extern stat_var *rcv_reqs_update;
 extern stat_var *rcv_reqs_refer;
 extern stat_var *rcv_reqs_publish;
+extern stat_var *rcv_reqs_kdmq;
 
 /*! \brief received replies */
 extern stat_var *rcv_rpls;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
KDMQ messages were added as a separate received request method in the statistic. 
