### PR TITLE
stirshaken: removed repeated x509 certification path check

### DIFF
--- a/src/modules/stirshaken/doc/stirshaken_admin.xml
+++ b/src/modules/stirshaken/doc/stirshaken_admin.xml
@@ -528,6 +528,10 @@ request_route {
 ...
 </programlisting>
 		</example>
+	<para>
+		To ensure proper functionality, the Kamailio stirshaken module requires a minimum version of libstirshaken that includes the stir_shaken_verify_cert_path function for performing the x509 certificate path check. This functionality was added to libstirshaken around 2020 (<![CDATA[https://github.com/signalwire/libstirshaken/commit/58e740b897ae40e2bb02ada2231a051a7eb55137]]>). 
+		If you're using an older version of libstirshaken that predates this commit, the stirshaken module may not function correctly.
+	</para>
 	</section>
 
 </chapter>

--- a/src/modules/stirshaken/stirshaken_mod.c
+++ b/src/modules/stirshaken/stirshaken_mod.c
@@ -613,23 +613,6 @@ static int ki_stirshaken_check_identity(sip_msg_t *msg)
 		goto fail;
 	}
 
-	if(stirshaken_vs_verify_x509_cert_path) {
-
-		LM_DBG("Running X509 certificate path verification\n");
-
-		if(!vs) {
-			LM_ERR("Verification Service not started\n");
-			goto fail;
-		}
-
-		if(STIR_SHAKEN_STATUS_OK
-				!= stir_shaken_verify_cert_path(&ss, cert_out, vs->store)) {
-			LM_ERR("Cert did not pass X509 path validation\n");
-			stirshaken_print_error_details(&ss);
-			goto fail;
-		}
-	}
-
 	if(stirshaken_vs_pptg_pvname.s != 0) {
 		memset(&val, 0, sizeof(pv_value_t));
 		val.flags = PV_VAL_STR;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Currently `stirshaken` module performs x509 certificate path check twice (when enabled): 
- first by calling `stir_shaken_verify_cert_path` directly from the [`stirshaken_mod.c`](https://github.com/kamailio/kamailio/blob/330543f46cbb6bf815ebf77c98378314091197ce/src/modules/stirshaken/stirshaken_mod.c#L626)
- second time from the [`libstirshaken`](https://github.com/signalwire/libstirshaken/blame/cb6ede40b3ce12ab76e370186a14dc141839ef07/src/stir_shaken_verify.c#L445)

`libstirshaken` had the path check built in since approx 2020 ([last commit mentioning it as TODO](https://github.com/signalwire/libstirshaken/blame/552650e31e3dc66806944b6495490bbb98bae4af/src/stir_shaken_verify.c#L362) before the `stir_shaken_verify_cert_path` function was introduced). This shouldn't be an issue since `stirshaken` module was added to Kamailio in 2021. 

This PR removes the x509 certificate path check from the `stirshaken_mod.c` by passing the responsibility to perform certificate path check to the `libstirshaken`.
