### PR TITLE
ims_auth: replaced t_continue_skip_timer with t_continue in cxdx_mar.c

### DIFF
--- a/src/modules/ims_auth/cxdx_mar.c
+++ b/src/modules/ims_auth/cxdx_mar.c
@@ -479,7 +479,7 @@ done:
 		adi_list = 0;
 	}
 
-	LM_DBG("DBG:UAR Async CDP callback: ... Done resuming transaction\n");
+	LM_DBG("DBG:MAR Async CDP callback: ... Done resuming transaction\n");
 	set_avp_list(AVP_TRACK_FROM | AVP_CLASS_URI, &t->uri_avps_from);
 	set_avp_list(AVP_TRACK_TO | AVP_CLASS_URI, &t->uri_avps_to);
 	set_avp_list(AVP_TRACK_FROM | AVP_CLASS_USER, &t->user_avps_from);
@@ -493,7 +493,7 @@ done:
 		//del_nonshm_lump_rpl(&req->reply_lump);
 		tmb.unref_cell(t);
 	}
-	tmb.t_continue(data->tindex, data->tlabel, data->act);
+	tmb.t_continue_skip_timer(data->tindex, data->tlabel, data->act);
 	free_saved_transaction_data(data);
 	return;
 
@@ -504,7 +504,7 @@ error:
 		//del_nonshm_lump_rpl(&t->uas.request->reply_lump);
 		tmb.unref_cell(t);
 	}
-	tmb.t_continue(data->tindex, data->tlabel, data->act);
+	tmb.t_continue_skip_timer(data->tindex, data->tlabel, data->act);
 
 error1:
 	free_saved_transaction_data(data);


### PR DESCRIPTION
- fixed log message in MAR Async CDP callback
- fixed executing cfg_action after sending MAR Diameter request
- cfg_action is the callback parameter of the ims_www_challenge function

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4205 (replace XXXX with an open issue number)

#### Description
Based on the description in issue #4205, this PR will fix a bug in ims_auth module related to MAR Diameter request callbacks, by replacing the call to t_continue function with t_continue_skip_timer, after the MAR request is sent, the control will successfully move to the cfg action in Kamailio scripts. Just like what we already have in ims_registrar_scscf module, using t_continue_skip_timer instead of t_continue cause the transaction to be found and resumed.
