### PR TITLE
tm: Update docs of fr_timer to match the implementation

### DIFF
--- a/src/modules/tm/doc/params.xml
+++ b/src/modules/tm/doc/params.xml
@@ -18,8 +18,12 @@
     <section id="tm.p.fr_timer">
 	<title><varname>fr_timer</varname> (integer)</title>
 	<para>
-	    Timer which hits if no final reply for a request or ACK for a
-	    negative INVITE reply arrives (in milliseconds).
+		This timer is used for all SIP requests. It hits if no reply for an
+		request INVITE request or other request has been received
+		within (F in milliseconds). If a provisional reply is received for an
+		INVITE (any 1xx), then the fr_inv_timer will be used instead. And if
+		no replies (at all) for an INVITE are received before fr_timer hits,
+		the transaction is terminated with a 408 in failure route.
 	</para>
 	<para>
 	    Default value is 30000 ms (30 seconds).


### PR DESCRIPTION
- Use description found in https://sip-router.org/wiki/ref_manual/timers

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [ ] Tested changes locally
- [x] Related to issue #3939 

#### Description
<!-- Describe your changes in detail -->

Fix documentation according to the description found in https://sip-router.org/wiki/ref_manual/timers. They better reflect the actual procedure.