### PR TITLE
uac: fix memory corruption from shared tp being freed by another tran…

### DIFF
--- a/src/modules/uac/uac_send.c
+++ b/src/modules/uac/uac_send.c
@@ -807,7 +807,7 @@ void uac_send_tm_callback(struct cell *t, int type, struct tmcb_params *ps)
 		/* Callback function */
 		uac_r.cb = uac_resend_tm_callback;
 		/* Callback parameter */
-		uac_r.cbp = (void *)tp;
+		uac_r.cbp = (void *)uac_send_info_clone(tp);
 	}
 	ret = _uac_send_tmb.t_request_within(&uac_r);
 
@@ -816,13 +816,18 @@ void uac_send_tm_callback(struct cell *t, int type, struct tmcb_params *ps)
 		goto error;
 	}
 	if(uac_r.cb_flags & TMCB_LOCAL_REQUEST_DROP) {
+		if(uac_r.cbp != NULL)
+			shm_free(uac_r.cbp);
+
 		shm_free(tp);
 		*ps->param = NULL;
 		tp = NULL;
 	}
 
-	if(tp->evroute != 0) {
-		return;
+	if(tp != NULL) {
+		if(tp->evroute != 0) {
+			return;
+		}
 	}
 
 done:


### PR DESCRIPTION
…saction

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

When the UAC is used to send an outbound REGISTER message to an endpoint and has an incorrect password resulting in all messages with or without an authorization header being responded to with a 401/407 it is possible and likely that shared memory will be corrupted resulting in core dumps.

The response to the initial register calls into the uac modules uac_send_tm_callback where it generates the authorization constructs a a new request info that has a reference to the existing tp.   As a result the 2 transactions and associated timers will have race conditions and ultimately can both attempt to deallocate the shared tp object in either uac_send_tm_callback or uac_resend_tm_callback.

As a solution I use the existing clone function uac_r.cbp = (void *)uac_send_info_clone(tp); which allows each transaction to use and deallocate only their own copy.

In addition to this a sanity check was also added around the to object where it was being used after a possible deallocation.
