### PR TITLE
core: support tls connection domain matching

### DIFF
--- a/src/core/cfg.lex
+++ b/src/core/cfg.lex
@@ -447,6 +447,7 @@ TCP_CLONE_RCVBUF	"tcp_clone_rcvbuf"
 TCP_REUSE_PORT		"tcp_reuse_port"
 TCP_WAIT_DATA	"tcp_wait_data"
 TCP_SCRIPT_MODE	"tcp_script_mode"
+TLS_CONNECTION_MATCH_DOMAIN "tls_connection_match_domain"
 DISABLE_TLS		"disable_tls"|"tls_disable"
 ENABLE_TLS		"enable_tls"|"tls_enable"
 TLS_THREADS_MODE	"tls_threads_mode"
@@ -971,6 +972,8 @@ IMPORTFILE      "import_file"
 <INITIAL>{TCP_WAIT_DATA}	{ count(); yylval.strval=yytext;
 									return TCP_WAIT_DATA; }
 <INITIAL>{TCP_SCRIPT_MODE}	{ count(); yylval.strval=yytext; return TCP_SCRIPT_MODE; }
+<INITIAL>{TLS_CONNECTION_MATCH_DOMAIN}	{ count(); yylval.strval=yytext;
+									return TLS_CONNECTION_MATCH_DOMAIN; }
 <INITIAL>{DISABLE_TLS}	{ count(); yylval.strval=yytext; return DISABLE_TLS; }
 <INITIAL>{ENABLE_TLS}	{ count(); yylval.strval=yytext; return ENABLE_TLS; }
 <INITIAL>{TLS_THREADS_MODE}	{ count(); yylval.strval=yytext; return TLS_THREADS_MODE; }

--- a/src/core/cfg.y
+++ b/src/core/cfg.y
@@ -478,6 +478,7 @@ extern char *default_routename;
 %token TCP_REUSE_PORT
 %token TCP_WAIT_DATA
 %token TCP_SCRIPT_MODE
+%token TLS_CONNECTION_MATCH_DOMAIN
 %token DISABLE_TLS
 %token ENABLE_TLS
 %token TLS_THREADS_MODE
@@ -1488,6 +1489,14 @@ assign_stm:
 		#endif
 	}
 	| TCP_SCRIPT_MODE EQUAL error { yyerror("number expected"); }
+	| TLS_CONNECTION_MATCH_DOMAIN EQUAL NUMBER {
+		#ifdef USE_TLS
+			tls_connection_match_domain=$3;
+		#else
+			warn("tls support not compiled in");
+		#endif
+	}
+	| TLS_CONNECTION_MATCH_DOMAIN EQUAL error { yyerror("number expected"); }
 	| DISABLE_TLS EQUAL NUMBER {
 		#ifdef USE_TLS
 			tls_disable=$3;

--- a/src/core/globals.h
+++ b/src/core/globals.h
@@ -109,6 +109,7 @@ extern int ksr_tcp_accept_hep3;
 extern int ksr_tcp_accept_haproxy;
 extern int ksr_tcp_script_mode;
 #ifdef USE_TLS
+extern int tls_connection_match_domain;
 extern int tls_disable;
 extern unsigned short tls_port_no;
 #define KSR_TLS_THREADS_MNONE 0 /* no set of set thread-local variables */

--- a/src/core/tls_hooks.h
+++ b/src/core/tls_hooks.h
@@ -76,6 +76,15 @@ typedef struct tls_hooks
 	/* generic pre-init function (called at kamailio start, before module
 	 * initialization (after modparams) */
 	int (*pre_init)(void);
+	/* match the given connection TLS domain
+	 * with the TLS domain looked up by ip:port
+	 * see: _tcpconn_find */
+	int (*match_domain)(
+			struct tcp_connection *c, struct ip_addr *ip, unsigned short port);
+	/* match connections TLS domain
+	 * see: _tcpconn_add_alias_unsafe */
+	int (*match_connections_domain)(
+			struct tcp_connection *l_c, struct tcp_connection *r_c);
 } tls_hooks_t;
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -497,6 +497,10 @@ unsigned short port_no = 0; /* default port*/
 unsigned short tls_port_no = 0; /* default port */
 #endif
 
+#ifdef USE_TLS
+int tls_connection_match_domain = 0;
+#endif
+
 struct host_alias *aliases = 0; /* name aliases list */
 
 /* Parameter to child_init */

--- a/src/modules/tls/tls_mod.c
+++ b/src/modules/tls/tls_mod.c
@@ -352,6 +352,8 @@ static struct tls_hooks tls_h = {
 	tls_h_mod_init_f,
 	tls_h_mod_destroy_f,
 	tls_h_mod_pre_init_f,
+	tls_h_match_domain_f,
+	tls_h_match_connections_domain_f,
 };
 /* clang-format on */
 

--- a/src/modules/tls/tls_rpc.c
+++ b/src/modules/tls/tls_rpc.c
@@ -113,7 +113,7 @@ static void tls_list(rpc_t *rpc, void *c)
 	int i, len, timeout;
 	struct tm timestamp;
 	char timestamp_s[128];
-	const char *sni;
+	const char *sni, *dom;
 
 	TCPCONN_LOCK;
 	for(i = 0; i < TCP_ID_HASH_SIZE; i++) {
@@ -146,17 +146,19 @@ static void tls_list(rpc_t *rpc, void *c)
 
 			if(tls_d) {
 				sni = SSL_get_servername(tls_d->ssl, TLSEXT_NAMETYPE_host_name);
+				dom = tls_d->dom.s;
 				if(sni == NULL) {
 					sni = "N/A";
 				}
 			} else {
 				sni = "N/A";
+				dom = "N/A";
 			}
 
-			rpc->struct_add(handle, "dssdsdsd", "id", con->id, "sni", sni,
-					"timestamp", timestamp_s, "timeout", timeout, "src_ip",
-					src_ip, "src_port", con->rcv.src_port, "dst_ip", dst_ip,
-					"dst_port", con->rcv.dst_port);
+			rpc->struct_add(handle, "dsssdsdsd", "id", con->id, "dom", dom,
+					"sni", sni, "timestamp", timestamp_s, "timeout", timeout,
+					"src_ip", src_ip, "src_port", con->rcv.src_port, "dst_ip",
+					dst_ip, "dst_port", con->rcv.dst_port);
 			if(tls_d) {
 				if(SSL_get_current_cipher(tls_d->ssl)) {
 					tls_info = SSL_CIPHER_description(

--- a/src/modules/tls/tls_server.h
+++ b/src/modules/tls/tls_server.h
@@ -57,6 +57,7 @@ typedef struct tls_rd_buf
 typedef struct tls_extra_data
 {
 	tls_domains_cfg_t *cfg; /* Configuration used for this connection */
+	str dom;				/* tls_domain_str() for this connection */
 	SSL *ssl;				/* SSL context used for the connection */
 	BIO *rwbio;				/* bio used for read/write
 							 * (openssl code might add buffering BIOs so
@@ -86,6 +87,13 @@ void tls_h_tcpconn_clean_f(struct tcp_connection *c);
  * shut down the TLS connection
  */
 void tls_h_tcpconn_close_f(struct tcp_connection *c, int fd);
+
+int tls_h_match_domain_f(
+		struct tcp_connection *c, struct ip_addr *ip, unsigned short port);
+
+int tls_h_match_connections_domain_f(
+		struct tcp_connection *l_c, struct tcp_connection *r_c);
+
 
 int tls_h_encode_f(struct tcp_connection *c, const char **pbuf,
 		unsigned int *plen, const char **rest_buf, unsigned int *rest_len,

--- a/src/modules/tls_wolfssl/tls_rpc.c
+++ b/src/modules/tls_wolfssl/tls_rpc.c
@@ -113,7 +113,7 @@ static void tls_list(rpc_t *rpc, void *c)
 	int i, len, timeout;
 	struct tm timestamp;
 	char timestamp_s[128];
-	const char *sni;
+	const char *sni, *dom;
 
 	TCPCONN_LOCK;
 	for(i = 0; i < TCP_ID_HASH_SIZE; i++) {
@@ -150,14 +150,16 @@ static void tls_list(rpc_t *rpc, void *c)
 				if(sni == NULL) {
 					sni = "N/A";
 				}
+				dom = tls_d->dom.s;
 			} else {
 				sni = "N/A";
+				dom = "N/A";
 			}
 
-			rpc->struct_add(handle, "dssdsdsd", "id", con->id, "sni", sni,
-					"timestamp", timestamp_s, "timeout", timeout, "src_ip",
-					src_ip, "src_port", con->rcv.src_port, "dst_ip", dst_ip,
-					"dst_port", con->rcv.dst_port);
+			rpc->struct_add(handle, "dsssdsdsd", "id", con->id, "dom", dom,
+					"sni", sni, "timestamp", timestamp_s, "timeout", timeout,
+					"src_ip", src_ip, "src_port", con->rcv.src_port, "dst_ip",
+					dst_ip, "dst_port", con->rcv.dst_port);
 			if(tls_d) {
 				if(wolfSSL_get_current_cipher(tls_d->ssl)) {
 					tls_info = wolfSSL_CIPHER_description(

--- a/src/modules/tls_wolfssl/tls_server.c
+++ b/src/modules/tls_wolfssl/tls_server.c
@@ -218,6 +218,8 @@ static str *tls_get_connect_server_name(void)
 static int tls_complete_init(struct tcp_connection *c)
 {
 	tls_domain_t *dom;
+	char *dom_str;
+	size_t dom_str_size;
 	struct tls_extra_data *data = 0;
 	tls_domains_cfg_t *cfg;
 	enum tls_conn_states state;
@@ -262,7 +264,11 @@ static int tls_complete_init(struct tcp_connection *c)
 	DBG("Using initial TLS domain %s (dom %p ctx %p sn [%s])\n",
 			tls_domain_str(dom), dom, dom->ctx[0], ZSW(dom->server_name.s));
 
-	data = (struct tls_extra_data *)shm_malloc(sizeof(struct tls_extra_data));
+	dom_str = tls_domain_str(dom);
+	dom_str_size = strlen(dom_str) + 1;
+
+	data = (struct tls_extra_data *)shm_malloc(
+			sizeof(struct tls_extra_data) + dom_str_size);
 	if(!data) {
 		ERR("Not enough shared memory left\n");
 		goto error;
@@ -274,6 +280,9 @@ static int tls_complete_init(struct tcp_connection *c)
 	data->rwbio = rw_bio;
 	data->cfg = cfg;
 	data->state = state;
+	data->dom.s = (char *)data + sizeof(struct tls_extra_data);
+	data->dom.len = dom_str_size - 1;
+	memcpy(data->dom.s, dom_str, dom_str_size);
 
 	if(unlikely(data->ssl == 0 || data->rwbio == 0)) {
 		TLS_ERR_SSL("Failed to create SSL or BIO structure:", data->ssl);
@@ -686,6 +695,89 @@ void tls_h_tcpconn_close_f(struct tcp_connection *c, int fd)
 
 		lock_release(&c->write_lock);
 	}
+}
+
+
+static char *get_tls_domain_str(
+		struct tcp_connection *c, struct ip_addr *ip, unsigned short port)
+{
+	tls_domain_t *dom;
+	char *dom_str;
+	tls_domains_cfg_t *cfg;
+	str *sname = NULL;
+	str *srvid = NULL;
+
+	lock_get(tls_domains_cfg_lock);
+	cfg = *tls_domains_cfg;
+	atomic_inc(&cfg->ref_count);
+	lock_release(tls_domains_cfg_lock);
+
+	if(c->flags & F_CONN_PASSIVE) {
+		dom = tls_lookup_cfg(cfg, TLS_DOMAIN_SRV, ip, port, 0, 0);
+	} else {
+		sname = tls_get_connect_server_name();
+		srvid = tls_get_connect_server_id();
+		dom = tls_lookup_cfg(cfg, TLS_DOMAIN_CLI, ip, port, sname, srvid);
+	}
+
+	dom_str = tls_domain_str(dom);
+	atomic_dec(&cfg->ref_count);
+
+	return dom_str;
+}
+
+
+int tls_h_match_domain_f(
+		struct tcp_connection *c, struct ip_addr *ip, unsigned short port)
+{
+	struct tls_extra_data *tls_c;
+	char *dom_str;
+	str dom;
+
+	if(c->type != PROTO_TLS) {
+		LM_ERR("Connection is not TLS\n");
+		return 0;
+	}
+
+	tls_c = (struct tls_extra_data *)c->extra_data;
+
+	if(!c->extra_data) {
+		LM_ERR("called before tls_complete_init()\n");
+		return 0;
+	}
+
+	dom_str = get_tls_domain_str(c, ip, port);
+	STR_SET(dom, dom_str);
+
+	return STR_EQ(tls_c->dom, dom);
+}
+
+
+int tls_h_match_connections_domain_f(
+		struct tcp_connection *l_c, struct tcp_connection *r_c)
+{
+	struct tls_extra_data *l_tls_c, *r_tls_c;
+	char *l_dom_str;
+	str l_dom;
+
+	l_tls_c = (struct tls_extra_data *)l_c->extra_data;
+	r_tls_c = (struct tls_extra_data *)r_c->extra_data;
+
+	if(!r_tls_c)
+		return 1; //consider connection wihout extra_data as matched to keep old behavior
+
+	if(l_tls_c)
+		return STR_EQ(l_tls_c->dom, r_tls_c->dom);
+
+	if(l_c->type != PROTO_TLS) {
+		LM_ERR("Connection is not TLS\n");
+		return 0;
+	}
+
+	l_dom_str = get_tls_domain_str(l_c, &l_c->rcv.dst_ip, l_c->rcv.dst_port);
+	STR_SET(l_dom, l_dom_str);
+
+	return STR_EQ(l_dom, r_tls_c->dom);
 }
 
 

--- a/src/modules/tls_wolfssl/tls_server.h
+++ b/src/modules/tls_wolfssl/tls_server.h
@@ -57,6 +57,7 @@ typedef struct tls_rd_buf
 typedef struct tls_extra_data
 {
 	tls_domains_cfg_t *cfg; /* Configuration used for this connection */
+	str dom;				/* tls_domain_str() for this connection */
 	SSL *ssl;				/* SSL context used for the connection */
 	BIO *rwbio;				/* bio used for read/write
 							 * (openssl code might add buffering BIOs so
@@ -86,6 +87,12 @@ void tls_h_tcpconn_clean_f(struct tcp_connection *c);
  * shut down the TLS connection
  */
 void tls_h_tcpconn_close_f(struct tcp_connection *c, int fd);
+
+int tls_h_match_domain_f(
+		struct tcp_connection *c, struct ip_addr *ip, unsigned short port);
+
+int tls_h_match_connections_domain_f(
+		struct tcp_connection *l_c, struct tcp_connection *r_c);
 
 int tls_h_encode_f(struct tcp_connection *c, const char **pbuf,
 		unsigned int *plen, const char **rest_buf, unsigned int *rest_len,

--- a/src/modules/tls_wolfssl/tls_wolfssl_mod.c
+++ b/src/modules/tls_wolfssl/tls_wolfssl_mod.c
@@ -259,6 +259,8 @@ static struct tls_hooks tls_h = {
 		tls_h_mod_init_f,
 		tls_h_mod_destroy_f,
 		tls_h_mod_pre_init_f,
+		tls_h_match_domain_f,
+		tls_h_match_connections_domain_f,
 };
 
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

PR adds new core option `tls_connection_match_domain` with the default value 0 (old behavior)
to solve the problem when we need to have multiple TLS connections with different SNI to the same host:port endpoint.
for example: multiple customers authorized by different TLS certificates for MS Teams on the single kamailio instance.

originally, functions `_tcpconn_find` and `_tcpconn_add_alias_unsafe` use only endpoint and protocol to match connections.
setting `tls_connection_match_domain` to `1` will match additionaly with `tls_domain_str()` output for matched TLS domain.
as a result, we will be able to establish new TLS connections if TLS domain is changed instead of reusing of the existent one with the wrong SNI.

i'm not considering this PR as the final version but we need something to start with. looking forward for any input.

FIXME: not found the right place where new core option should be documented.

#### Behavior difference example

* /etc/kamailio/kamailio.cfg
(relays all requests to 127.0.0.1:5081 using TLS domain matched by server_id retreived from RURI-User):
```
#!KAMAILIO

listen=udp:127.0.0.1:5060
listen=tls:127.0.0.1:5061

enable_tls = yes
tls_connection_match_domain = 1

debug = 3

loadmodule "tls.so"
modparam("tls", "config", "/etc/kamailio/tls.cfg")
modparam("tls", "xavp_cfg", "tls")

loadmodule "ctl.so"
loadmodule "pv.so"
loadmodule "tm.so"

route {
    $xavp(tls=>server_id) = $rU;
    t_relay_to_tls("127.0.0.1", 5081);
}
```

* /etc/kamailio/tls.cfg:
```
[server:default]
certificate = /etc/ssl/certs/ssl-cert-snakeoil.pem
private_key = /etc/ssl/private/ssl-cert-snakeoil.key

[client:any]
server_name = server_name_1.invalid
server_id = 1

[client:any]
server_name = server_name_2.invalid
server_id = 2
```

* run tls server:
```bash
$ openssl s_server -port 5081 -cert /etc/ssl/certs/ssl-cert-snakeoil.pem -key /etc/ssl/private/ssl-cert-snakeoil.key
```

* send `INVITE sip:1@127.0.0.1:5060` and `INVITE sip:2@127.0.0.1:5060` using sipp:
```bash
$ for u in 1 2; do sipp -sn uac -m 1 -nd -recv_timeout 1 -bg -s $u 127.0.0.1:5060; done
```

* resulting `tls.list` for kamailio instance WITHOUT `tls_connection_match_domain = 1` (old behavior):
```bash
# kamcmd tls.list
{
        id: 1
        dom: TLSc<any:server_name_1.invalid>
        sni: N/A
        timestamp: 2025-04-24 14:07:20
        timeout: 118
        src_ip: 127.0.0.1
        src_port: 5081
        dst_ip: 127.0.0.1
        dst_port: 58808
        cipher: unknown
        ct_wq_size: 1162
        enc_rd_buf: 0
        flags: 1
        state: tls_connect
}
```

* `tls.list` for kamailio instance WITH `tls_connection_match_domain = 1` (new behavior):
```bash
# kamcmd tls.list
{
        id: 1
        dom: TLSc<any:server_name_1.invalid>
        sni: N/A
        timestamp: 2025-04-24 14:09:10
        timeout: 117
        src_ip: 127.0.0.1
        src_port: 5081
        dst_ip: 127.0.0.1
        dst_port: 55480
        cipher: unknown
        ct_wq_size: 581
        enc_rd_buf: 0
        flags: 1
        state: tls_connect
}
{
        id: 2
        dom: TLSc<any:server_name_2.invalid>
        sni: N/A
        timestamp: 2025-04-24 14:09:10
        timeout: 117
        src_ip: 127.0.0.1
        src_port: 5081
        dst_ip: 127.0.0.1
        dst_port: 55488
        cipher: unknown
        ct_wq_size: 581
        enc_rd_buf: 0
        flags: 1
        state: tls_connect
}
```