### PR TITLE
core: sdp - update start pointer only after len adjustment

### DIFF
--- a/src/core/parser/sdp/sdp_helpr_funcs.c
+++ b/src/core/parser/sdp/sdp_helpr_funcs.c
@@ -330,8 +330,8 @@ int extract_candidate(str *body, sdp_stream_cell_t *stream)
 
 	fl = space - start;
 
-	start = space + 1;
 	len = len - (space - start + 1);
+	start = space + 1;
 
 	space = memchr(start, 32, len);
 	if(space == NULL) {


### PR DESCRIPTION
- `len` is first adjusted by the amount of chars consumed so far
- `start` pointer is then adjusted to begin new search

#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #4229

#### Description
Small logic tweak — we adjust `len` by the amount of chars consumed first, then adjust the `start` pointer to begin the new search.

Existing:
```
        start = space + 1;
        len = len - (space - start + 1);
        // this is a no-op as the pointer was adjusted first
```

Changed:
```
        len = len - (space - start + 1);
        start = space + 1;
```
