### PR TITLE
sca: reserve subscription.rr.s separately since it could be updated

### DIFF
--- a/src/modules/sca/sca_subscribe.c
+++ b/src/modules/sca/sca_subscribe.c
@@ -626,9 +626,6 @@ sca_subscription *sca_subscription_create(str *aor, int event, str *subscriber,
 
 	len += sizeof(sca_subscription);
 	len += sizeof(char) * (aor->len + subscriber->len);
-	if(!SCA_STR_EMPTY(rr)) {
-		len += sizeof(char) * rr->len;
-	}
 
 	sub = (sca_subscription *)shm_malloc(len);
 	if(sub == NULL) {
@@ -660,18 +657,20 @@ sca_subscription *sca_subscription_create(str *aor, int event, str *subscriber,
 	SCA_STR_COPY(&sub->target_aor, aor);
 	len += aor->len;
 
+	// we shm_malloc this parts separately in case we need to update in-memory
+	// info for this subscriber. This is likely to happen if the
+	// subscriber goes off-line for some reason.
 	if(!SCA_STR_EMPTY(rr)) {
-		sub->rr.s = (char *)sub + len;
+		sub->rr.s = (char *)shm_malloc(rr->len);
+		if(sub->rr.s == NULL) {
+			SHM_MEM_ERROR;
+			goto error;
+		}
 		SCA_STR_COPY(&sub->rr, rr);
-		len += rr->len;
 	}
 	// dialog.id holds call-id + from-tag + to-tag; dialog.call_id,
 	// dialog.from_tag, and dialog.to_tag point to offsets within
 	// dialog.id.
-	//
-	// we shm_malloc this separately in case we need to update in-memory
-	// dialog saved for this subscriber. This is likely to happen if the
-	// subscriber goes off-line for some reason.
 	len = sizeof(char) * (call_id->len + from_tag->len + to_tag->len);
 	sub->dialog.id.s = (char *)shm_malloc(len);
 	if(sub->dialog.id.s == NULL) {
@@ -702,6 +701,9 @@ sca_subscription *sca_subscription_create(str *aor, int event, str *subscriber,
 
 error:
 	if(sub != NULL) {
+		if(sub->rr.s != NULL) {
+			shm_free(sub->rr.s);
+		}
 		if(sub->dialog.id.s != NULL) {
 			shm_free(sub->dialog.id.s);
 		}
@@ -733,6 +735,10 @@ void sca_subscription_free(void *value)
 
 	LM_DBG("Freeing %s subscription from %.*s\n",
 			sca_event_name_from_type(sub->event), STR_FMT(&sub->subscriber));
+
+	if(!SCA_STR_EMPTY(&sub->rr)) {
+		shm_free(sub->rr.s);
+	}
 
 	if(!SCA_STR_EMPTY(&sub->dialog.id)) {
 		shm_free(sub->dialog.id.s);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally

#### Description

sca was generating a crash since it is trying to shm_free a part of a bigger block at:
https://github.com/kamailio/kamailio/blob/master/src/modules/sca/sca_subscribe.c#L909-L920

So, let's reserve memory for that field separately. 
