### PR TITLE
pua_reginfo: add helper to disable publishing for current message

### DIFF
--- a/src/modules/pua_reginfo/doc/pua_reginfo_admin.xml
+++ b/src/modules/pua_reginfo/doc/pua_reginfo_admin.xml
@@ -238,6 +238,33 @@ reply_route[1] {
 				</programlisting>
 			</example>
 		</section>
+		<section id="pua_reginfo.f.reginfo_disable_publish">
+			<title>
+				<function moreinfo="none">reginfo_disable_publish()</function>
+			</title>
+			<para>
+				This function disables sending the PUBLISH request in the registrar
+				callback invocation, for the current message only.
+			</para>
+
+			<example>
+				<title><function>reginfo_disable_publish</function> usage</title>
+				<programlisting format="linespecific">
+...
+if(is_method("REGISTER")) {
+	if (dmq_is_from_node())
+		# coming from a DMQ node, just save without triggering PUBLISH
+		# which may be replicated differently, like with presence DMQ support
+		reginfo_disable_publish();
+		save("location");
+	} else {
+		# coming from end point - authenticate, save contact, etc...
+	}
+}
+...
+				</programlisting>
+			</example>
+		</section>
 	</section>
 
 </chapter>

--- a/src/modules/pua_reginfo/pua_reginfo.c
+++ b/src/modules/pua_reginfo/pua_reginfo.c
@@ -46,6 +46,8 @@ str server_address = {NULL, 0};
 
 int publish_reginfo = 1;
 
+int reginfo_disable_publish = 0; /* Disables publish for current message */
+
 sruid_t _reginfo_sruid;
 
 int reginfo_use_domain = 0;
@@ -65,6 +67,8 @@ static cmd_export_t cmds[] = {
 		fixup_subscribe, 0, REQUEST_ROUTE | ONREPLY_ROUTE},
 	{"reginfo_handle_notify", (cmd_function)reginfo_handle_notify, 1,
 		domain_fixup, 0, REQUEST_ROUTE},
+	{"reginfo_disable_publish", (cmd_function)w_reginfo_disable_publish, 0,
+		0, 0, REQUEST_ROUTE},
 	{0, 0, 0, 0, 0, 0}
 };
 

--- a/src/modules/pua_reginfo/pua_reginfo.h
+++ b/src/modules/pua_reginfo/pua_reginfo.h
@@ -37,5 +37,9 @@ extern usrloc_api_t ul; /*!< Structure containing pointers to usrloc functions*/
 extern pua_api_t pua;	/*!< Structure containing pointers to PUA functions*/
 
 extern int reginfo_use_domain;
+extern int reginfo_disable_publish;
+
+int w_reginfo_disable_publish(sip_msg_t *, char *, char *);
+int ki_reginfo_disable_publish(sip_msg_t *);
 
 #endif

--- a/src/modules/pua_reginfo/usrloc_cb.c
+++ b/src/modules/pua_reginfo/usrloc_cb.c
@@ -53,6 +53,18 @@ Call-ID: 9ad9f89f-164d-bb86-1072-52e7e9eb5025.
 
 static int _pua_reginfo_self_op = 0;
 
+#define BUF_LEN 256
+int ki_reginfo_disable_publish(sip_msg_t *msg)
+{
+	reginfo_disable_publish = 1;
+	return 1;
+}
+
+int w_reginfo_disable_publish(struct sip_msg *msg, char *s1, char *s2)
+{
+	return ki_reginfo_disable_publish(msg);
+}
+
 void pua_reginfo_update_self_op(int v)
 {
 	_pua_reginfo_self_op = v;
@@ -263,6 +275,15 @@ void reginfo_usrloc_cb(ucontact_t *c, int type, void *param)
 	if(_pua_reginfo_self_op == 1) {
 		LM_DBG("operation triggered by own action for aor: %.*s (%d)\n",
 				c->aor->len, c->aor->s, type);
+		return;
+	}
+
+	if(reginfo_disable_publish == 1) {
+		LM_DBG("Not publishing due to reginfo_disable_publish for aor: %.*s "
+			   "(%d)\n",
+				c->aor->len, c->aor->s, type);
+
+		reginfo_disable_publish = 0;
 		return;
 	}
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4252

#### Description
This PR adds a new helper `reginfo_disable_publish` to `pua_reginfo` module which disabled the publishing for the current message, which is useful to control when to actually send it or not (eg in DMQ replication scenarios).

The helper is "negative" (it *disables* not enables) on purpose in order to mantain backward compatibility to current behaviour.
