### PR TITLE
dispatcher: fixed memory leak when avp is indirectly used

### DIFF
--- a/src/modules/dispatcher/dispatch.c
+++ b/src/modules/dispatcher/dispatch.c
@@ -4247,6 +4247,7 @@ void ds_check_timer(unsigned int ticks, void *param)
 	}
 
 	ds_ping_set(_ds_list);
+	reset_avps();
 }
 
 /*! \brief


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ x] Commit message has the format required by CONTRIBUTING guide
- [ x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ x] Each component has a single commit (if not, squash them into one commit)
- [ x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x ] Tested changes locally
- [x ] Related to issue #4257

#### Description
When the dispatcher module sends ping requests then these requests are executed in a dedicated process, which handles timers and called `slow timer`. If during this ping request AVP variables are allocated, then these vars are allocated within `slow timer` process and this memory is never released and continiously accumulates in/by this process.
This change makes AVP vars being reset for every iteration of the `dispatcher` timer procedure (`ds_check_timer`  function).
