### PR TITLE
PDB: new RPC command to view/change PDB query timeout value

### DIFF
--- a/src/modules/pdb/doc/pdb.xml
+++ b/src/modules/pdb/doc/pdb.xml
@@ -24,6 +24,12 @@
 		<affiliation><orgname>1&amp;1 Internet AG</orgname></affiliation>
 		<email>pawel.kuzak@1und1.de</email>
 		</editor>
+		<editor>
+		<firstname>Muhammad Shahzad</firstname>
+		<surname>Shafi</surname>
+		<affiliation><orgname>1&amp;1 Internet AG</orgname></affiliation>
+		<email>muhammad.shafi@1und1.de</email>
+		</editor>
 	</authorgroup>
 	<copyright>
 		<year>2009</year>

--- a/src/modules/pdb/doc/pdb_admin.xml
+++ b/src/modules/pdb/doc/pdb_admin.xml
@@ -167,6 +167,24 @@ cr_route("$avp(i:82)", "$rd", "$rU", "$rU", "call_id");
 				</programlisting>
 	    </example>
 		</section>
+		<section id="pdb.r.timeout">
+	    <title>pdb.timeout</title>
+	    <para>
+				Prints the current PDB query timeout value.
+				This can also be used to set the PDB query timeout.
+	    </para>
+			<example>
+				<title><function>pdb.timeout</function> usage</title>
+				<programlisting format="linespecific">
+...
+# get the PDB query timeout
+&kamcmd; pdb.timeout
+# set the PDB query timeout to 10ms
+&kamcmd; pdb.timeout 10
+...
+				</programlisting>
+	    </example>
+		</section>
 		<section id="pdb.r.activate">
 	    <title>pdb.activate</title>
 	    <para>

--- a/src/modules/pdb/pdb.c
+++ b/src/modules/pdb/pdb.c
@@ -829,7 +829,8 @@ static void pdb_rpc_timeout(rpc_t *rpc, void *ctx)
 		return;
 	}
 
-	if(rpc->struct_add(vh, "dd", "old_timeout", old_val, "new_timeout", new_val) < 0) {
+	if(rpc->struct_add(vh, "dd", "old_timeout", old_val, "new_timeout", new_val)
+			< 0) {
 		rpc->fault(ctx, 500, "Internal error reply structure");
 		return;
 	}

--- a/src/modules/pdb/pdb.c
+++ b/src/modules/pdb/pdb.c
@@ -27,6 +27,8 @@
 
 
 #include "../../core/sr_module.h"
+#include "../../core/cfg/cfg.h"
+#include "../../core/cfg/cfg_ctx.h"
 #include "../../core/mem/mem.h"
 #include "../../core/mem/shm_mem.h"
 #include "../../core/rpc_lookup.h"
@@ -806,6 +808,35 @@ static void pdb_rpc_status(rpc_t *rpc, void *ctx)
 			(*active) ? "active" : "inactive");
 }
 
+static void pdb_rpc_timeout(rpc_t *rpc, void *ctx)
+{
+	void *vh;
+	int new_val = -1;
+	int old_val = cfg_get(pdb, pdb_cfg, timeout);
+
+	str gname = str_init("pdb");
+	str vname = str_init("timeout");
+
+	if(rpc->add(ctx, "{", &vh) < 0) {
+		rpc->fault(ctx, 500, "Server error");
+		return;
+	}
+
+	if(rpc->scan(ctx, "*d", &new_val) < 1) {
+		if(rpc->struct_add(vh, "d", "timeout", old_val) < 0) {
+			rpc->fault(ctx, 500, "Internal error reply structure");
+		}
+		return;
+	}
+
+	if(rpc->struct_add(vh, "dd", "old_timeout", old_val, "new_timeout", new_val) < 0) {
+		rpc->fault(ctx, 500, "Internal error reply structure");
+		return;
+	}
+
+	cfg_set_now_int(ctx, &gname, NULL, &vname, new_val);
+}
+
 static void pdb_rpc_activate(rpc_t *rpc, void *ctx)
 {
 	if(active == NULL) {
@@ -826,11 +857,14 @@ static void pdb_rpc_deactivate(rpc_t *rpc, void *ctx)
 
 static const char *pdb_rpc_status_doc[2] = {"Get the pdb status.", 0};
 
+static const char *pdb_rpc_timeout_doc[2] = {"Set the pdb_query timeout.", 0};
+
 static const char *pdb_rpc_activate_doc[2] = {"Activate pdb.", 0};
 
 static const char *pdb_rpc_deactivate_doc[2] = {"Deactivate pdb.", 0};
 
 rpc_export_t pdb_rpc[] = {{"pdb.status", pdb_rpc_status, pdb_rpc_status_doc, 0},
+		{"pdb.timeout", pdb_rpc_timeout, pdb_rpc_timeout_doc, 0},
 		{"pdb.activate", pdb_rpc_activate, pdb_rpc_activate_doc, 0},
 		{"pdb.deactivate", pdb_rpc_deactivate, pdb_rpc_deactivate_doc, 0},
 		{0, 0, 0, 0}};


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This adds RPC command to view and/or change the timeout value for PDB queries. The documentation is also updated accordingly.