### PR TITLE
PDB: new RPC command to get/set the PDB query timeout value

### DIFF
--- a/src/modules/pdb/doc/pdb.xml
+++ b/src/modules/pdb/doc/pdb.xml
@@ -24,6 +24,12 @@
 		<affiliation><orgname>1&amp;1 Internet AG</orgname></affiliation>
 		<email>pawel.kuzak@1und1.de</email>
 		</editor>
+		<editor>
+		<firstname>Muhammad Shahzad</firstname>
+		<surname>Shafi</surname>
+		<affiliation><orgname>1&amp;1 Internet AG</orgname></affiliation>
+		<email>muhammad.shafi@1und1.de</email>
+		</editor>
 	</authorgroup>
 	<copyright>
 		<year>2009</year>

--- a/src/modules/pdb/doc/pdb_admin.xml
+++ b/src/modules/pdb/doc/pdb_admin.xml
@@ -167,6 +167,24 @@ cr_route("$avp(i:82)", "$rd", "$rU", "$rU", "call_id");
 				</programlisting>
 	    </example>
 		</section>
+		<section id="pdb.r.timeout">
+	    <title>pdb.timeout</title>
+	    <para>
+				Prints the current PDB query timeout value.
+				This can also be used to set the PDB query timeout.
+	    </para>
+			<example>
+				<title><function>pdb.timeout</function> usage</title>
+				<programlisting format="linespecific">
+...
+# get the PDB query timeout
+&kamcmd; pdb.timeout
+# set the PDB query timeout to 10ms
+&kamcmd; pdb.timeout 10
+...
+				</programlisting>
+	    </example>
+		</section>
 		<section id="pdb.r.activate">
 	    <title>pdb.activate</title>
 	    <para>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Adds RPC command to view and/or change the timeout value for PDB queries. The documentation is also updated accordingly.