### PR TITLE
tls: add WSS to RPC funtions

### DIFF
--- a/src/modules/tls/tls_rpc.c
+++ b/src/modules/tls/tls_rpc.c
@@ -118,7 +118,7 @@ static void tls_list(rpc_t *rpc, void *c)
 	TCPCONN_LOCK;
 	for(i = 0; i < TCP_ID_HASH_SIZE; i++) {
 		for(con = tcpconn_id_hash[i]; con; con = con->id_next) {
-			if(con->rcv.proto != PROTO_TLS)
+			if(con->rcv.proto != PROTO_TLS && con->rcv.proto != PROTO_WSS)
 				continue;
 			tls_d = con->extra_data;
 			rpc->add(c, "{", &handle);
@@ -276,7 +276,7 @@ static void tls_kill(rpc_t *rpc, void *c)
 	TCPCONN_LOCK;
 	for(i = 0; i < TCP_ID_HASH_SIZE; i++) {
 		for(con = tcpconn_id_hash[i]; con; con = con->id_next) {
-			if(con->rcv.proto != PROTO_TLS)
+			if(con->rcv.proto != PROTO_TLS && con->rcv.proto != PROTO_WSS)
 				continue;
 			if(con->id == kill_id) {
 				con->state = -2;


### PR DESCRIPTION
- tls_list() add PROTO_WSS to TLS_LIST RPC call to include WSS connections in tls.list

- tls_kill() add PROTO_WSS to handle WSS connections

Co-authored-by: Andreas Tarp <tarp@sipgate.de>

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4167

#### Description
WSS connection is not shown in tls.list RPC command like all other TLS connections.
Also tls_kill does not handle WSS connections. 
This is related to the issue 4167.