### PR TITLE
pdb: added KEMI support for PDB module

### DIFF
--- a/src/modules/pdb/doc/pdb_admin.xml
+++ b/src/modules/pdb/doc/pdb_admin.xml
@@ -130,11 +130,11 @@ modparam("pdb", "ll_info", 3)
 				Sends the query string to all configured servers and stores the answer in
 				dstavp. If it takes more than the configured timeout, false is returned.
 
-				Pseudo-variables or AVPs can be used for the query string.
+				In addition to a string, any pseudo-variable can be used as query.
 
 				The answer must consist of the null terminated query string followed by
 				a two byte integer value in network byte order. The integer value will
-				be stored in the given AVP.
+				be stored in the given pseudo-variable dstavp.
 	    </para>
 			<example>
 				<title><function>pdb_query</function> usage</title>

--- a/src/modules/pdb/pdb.c
+++ b/src/modules/pdb/pdb.c
@@ -57,33 +57,6 @@ static uint16_t *global_id = NULL;
 
 ksr_loglevels_t _ksr_loglevels_pdb = KSR_LOGLEVELS_DEFAULTS;
 
-/*!
- * Generic parameter that holds a string, an int or a pseudo-variable
- * @todo replace this with gparam_t
- */
-struct multiparam_t
-{
-	enum
-	{
-		MP_INT,
-		MP_STR,
-		MP_AVP,
-		MP_PVE,
-	} type;
-	union
-	{
-		int n;
-		str s;
-		struct
-		{
-			avp_flags_t flags;
-			avp_name_t name;
-		} a;
-		pv_elem_t *p;
-	} u;
-};
-
-
 /* ---- exported commands: */
 int pdb_query(sip_msg_t *_msg, str *_number, str *_dstvar);
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Added support for KEMI API in PDB module.

Here is example usage in KEMI Python.

```
            if not (KSR.pdb.pdb_query(KSR.pv.gete("$var(pdb_user)"), "$avp(carrier_id)") > 0):
                KSR.err(F"""[{HERE()}]: PDB query failed for user '{KSR.pv.get("$var(pdb_user)")}' \n""")
            else:
                KSR.info(F""" PDB query return carrier_id = '{KSR.pv.getw("$avp(carrier_id)")}' \n""")
```
