### PR TITLE
pv_headers: Add remove all headers function 

### DIFF
--- a/src/modules/pv_headers/doc/functions.xml
+++ b/src/modules/pv_headers/doc/functions.xml
@@ -128,6 +128,18 @@
 		pvh_collect_headers()</link> or with <quote>auto_msg</quote> parameter enabled.
 		</para>
 	</section>
+	<section id="pv_headers.f.pvh_remove_all_headers">
+		<title>
+		<function moreinfo="none">pvh_remove_all_headers()</function>
+		</title>
+		<para>
+		Removes all sip message headers. 
+		</para>
+		<para>
+		This function can be used from ANY_ROUTE but only after <link linked="pv_headers.f.pvh_collect_headers">
+		pvh_collect_headers()</link> or with <quote>auto_msg</quote> parameter enabled.
+		</para>
+	</section>
 	<section id="pv_headers.f.pvh_header_param_exists">
 		<title>
 			<function moreinfo="none">pvh_value_exists(hname, hparameter)</function>

--- a/src/modules/pv_headers/pv_headers.c
+++ b/src/modules/pv_headers/pv_headers.c
@@ -211,6 +211,12 @@ static int w_pvh_remove_header(
 	return pvh_remove_header(msg, &hname, indx);
 }
 
+static int w_pvh_remove_all_headers(struct sip_msg *msg, char *p1, char *p2)
+{
+	int indx = -1;
+	return pvh_remove_all_headers(msg, indx);
+}
+
 static int w_pvh_header_param_exists(struct sip_msg *msg, char *p1, char *p2)
 {
 	str hname = STR_NULL;
@@ -311,6 +317,8 @@ static cmd_export_t mod_cmds[] = {
 			fixup_spve_null, fixup_free_spve_null, ANY_ROUTE},
 	{"pvh_remove_header", (cmd_function)w_pvh_remove_header, 2,
 			fixup_spve_spve, fixup_free_spve_spve, ANY_ROUTE},
+	{"pvh_remove_all_headers", (cmd_function)w_pvh_remove_all_headers, 0,
+			0, 0, ANY_ROUTE},
 	{"pvh_header_param_exists", (cmd_function)w_pvh_header_param_exists, 2,
 			fixup_spve_spve, fixup_free_spve_spve, ANY_ROUTE},
 	{"pvh_remove_header_param", (cmd_function)w_pvh_remove_header_param, 2,

--- a/src/modules/pv_headers/pvh_func.c
+++ b/src/modules/pv_headers/pvh_func.c
@@ -374,6 +374,22 @@ int pvh_remove_header(struct sip_msg *msg, str *hname, int indx)
 	return 1;
 }
 
+int pvh_remove_all_headers(struct sip_msg *msg, int indx)
+{
+	str name = STR_NULL;
+	struct hdr_field *hf = NULL;
+
+	for(hf = msg->headers; hf; hf = hf->next) {
+		name.len = hf->name.len;
+		name.s = hf->name.s;
+		if(pvh_remove_header(msg, &name, indx) < 0) {
+			LM_ERR("could not remove %.*s header", name.len, name.s);
+			return -1;
+		}
+	}
+	return 1;
+}
+
 int pvh_header_param_exists(struct sip_msg *msg, str *hname, str *hvalue)
 {
 	sr_xavp_t *avi = NULL;

--- a/src/modules/pv_headers/pvh_func.h
+++ b/src/modules/pv_headers/pvh_func.h
@@ -40,6 +40,7 @@ int pvh_check_header(struct sip_msg *msg, str *hname);
 int pvh_append_header(struct sip_msg *msg, str *hname, str *hvalue);
 int pvh_modify_header(struct sip_msg *msg, str *hname, str *hvalue, int indx);
 int pvh_remove_header(struct sip_msg *msg, str *hname, int indx);
+int pvh_remove_all_headers(struct sip_msg *msg, int indx);
 int pvh_header_param_exists(struct sip_msg *msg, str *hname, str *hvalue);
 int pvh_remove_header_param_helper(str *orig, const str *toRemove, str *dst);
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This function removes all the headers. it is useful when calling it and setting `skip_headers` modparam. `pvh_apply_headers()` function remove all the headers except those specified in the `skip_headers` .