### PR TITLE
rr: loose_route_mode: add vmode bit 2 to skip outbound

### DIFF
--- a/src/modules/rr/doc/rr_admin.xml
+++ b/src/modules/rr/doc/rr_admin.xml
@@ -446,11 +446,16 @@ if(!loose_route_preloaded()) {
 	<section id="rr.f.loose_route_mode">
       <title><function moreinfo="none">loose_route_mode(vmode)</function></title>
 
-	  <para>The function is similar to `loose_route()`, but it does only
-	  loose routing processing if vmode==1, skipping the testing of r-uri==myself
-	  for performing strict routing. If vmode==0, it behaves like loose_route().
+      <para>The function is similar to `loose_route()`,
+      but it accepts route mode bitmask as <emphasis>vmode</emphasis> parameter.
       </para>
-      <para>It is a convenient function to use with application servers that
+      <para>
+      If bit one is set, then do only loose routing processing, skipping the testing of r-uri==myself
+	  for performing strict routing. If not, behave like loose_route().
+      If bit two is set, then skip flow tokens processing.
+      </para>
+      <para>
+      First bit is convenient to use with application servers that
       set the Contact URI to SIP server address.
       </para>
       <para>This function can be used from REQUEST_ROUTE.</para>

--- a/src/modules/rr/rr_mod.h
+++ b/src/modules/rr/rr_mod.h
@@ -36,6 +36,11 @@
 extern str i_user;
 #endif
 
+/*! bit to force loose mode in loose_route_mode() */
+#define RR_LR_MODE_LOOSE_ONLY 1
+/*! bit to skip outbound processing in after_loose() */
+#define RR_LR_MODE_SKIP_OUTBOUND 2
+
 /*! should request's from-tag is appended to record-route */
 extern int append_fromtag;
 /*! insert two record-route header instead of one */


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

`loose_route()` in `rr` checks request src ip/port against ip/port in flow tokens to detect direction and decide whether to apply flow tokens routing:
```
static inline int process_outbound(struct sip_msg *_m, str flow_token)
{
...
	} else if(!ip_addr_cmp(&rcv->src_ip, &_m->rcv.src_ip)
			  || rcv->src_port != _m->rcv.src_port) {
		LM_DBG("\"incoming\" request found. Using flow-token for "
			   "routing\n");
...
```

there are cases when remote UA changes ip/port for in-dialog messages and this approach does not work.
incoming message has route set with flow tokens and src ip/port different from ones in the flow tokens.
as a result, `loose_route()` routes message back to the client using flow tokens instead of using the normal part of the Route headers as expected.

new `force_lr_no_outbound_flag` allows to control flow tokens usage in the `loose_route()` when we know direction based on the some high level config logic (for example: by the result of `ds_is_from_list()` call)
UPD:
changed to use new _vmode_ value in `loose_route_mode(vmode)` instead of the `force_lr_no_outbound_flag` param

