### PR TITLE
tm: allow pending forked REGISTER auths being handled the same way as…

### DIFF
--- a/src/modules/tm/t_reply.c
+++ b/src/modules/tm/t_reply.c
@@ -1365,7 +1365,7 @@ static enum rps t_should_relay_response( struct cell *Trans , int new_code,
 	*/
 	LM_DBG("->>>>>>>>> T_code=%d, new_code=%d\n", Trans->uas.status,new_code);
 	inv_through=new_code>=200 && new_code<300 && is_invite(Trans);
-	/* if final response sent out, allow only INVITE 2xx  */
+	/* if final response sent out, allow only INVITE 2xx && REGISTER > 299 */
 	if ( Trans->uas.status >= 200 ) {
 		if (inv_through) {
 			LM_DBG("200 INV after final sent\n");
@@ -1373,11 +1373,18 @@ static enum rps t_should_relay_response( struct cell *Trans , int new_code,
 			Trans->uac[branch].last_received=new_code;
 			*should_relay=branch;
 			return RPS_PUSHED_AFTER_COMPLETION;
-		} else {
+		} 		
+		/* Do not discard negative replies for REGSITER messages 
+		 * after 200 for the initial trasaction already been sent.
+		 * In case of forking REGISGER requests to multiple Registrars
+		 * some of registrars may reply later than others being authenticated.
+		 * This lests late forked transactions being finalised correctly
+		*/
+		if (!(strncmp(Trans->method.s, "REGISTER", 8) == 0 && new_code >= 300)) {
+			/*Except the exceptions above, too late  messages will be discarded */
 			LM_DBG("final reply already sent\n");
+			goto discard;
 		}
-		/* except the exception above, too late  messages will be discarded */
-		goto discard;
 	}
 
 	/* if final response received at this branch, allow only INVITE 2xx */


### PR DESCRIPTION
… forked INVITEs auths

#### Pre-Submission Checklist
- [*] Commit message has the format required by CONTRIBUTING guide
- [*] Commits are split per component (core, individual modules, libs, utils, ...)
- [*] Each component has a single commit (if not, squash them into one commit)
- [*] No commits to README files for modules (changes must be done to docbook files


#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ *] Tested changes locally
- [ ]* Related to issue #[4266](https://github.com/kamailio/kamailio/issues/4266)

#### Description
If a Negative reply for forked REGISTER comes after the first 200 response, it won't be ignored by Kamailio and will be processed the same way as replies processed for the INVITEs