### PR TITLE
topos: expose rcv data in event routes

### DIFF
--- a/src/modules/topos/doc/topos_admin.xml
+++ b/src/modules/topos/doc/topos_admin.xml
@@ -659,14 +659,12 @@ request_route {
 		<para>
 		It is executed before doing topology stripping processing for an outgoing
 		SIP message. If 'drop' is executed inside the event route, then the
-		module skips doing the topology hiding.
+		module skips doing the <emphasis>out part of</emphasis> topology hiding.
 		</para>
 		<para>
+		Only fake msg is available in this event route.
 		Inside the event route the variables $sndto(ip), $sndto(port) and
-		$sndto(proto) point to the destination. The SIP message is not the one
-		to be sent out, but an internally generated one at startup, to avoid
-		reparsing the outgoing SIP message for the cases when topology hiding
-		is not wanted.
+		$sndto(proto) point to the destination.
 		</para>
 		<example>
 		<title>Usage of event_route[topos:msg-outgoing]</title>
@@ -686,11 +684,13 @@ event_route[topos:msg-outgoing] {
 		<para>
 		It is executed before doing topology stripping processing for a SIP
 		message to be sent out, being executed after event_route[topos:msg-outgoing].
+		If 'drop' is executed inside the event route, then the
+		module skips doing the <emphasis>out part of</emphasis> topology hiding.
 		</para>
 		<para>
+		A copy of the SIP msg to be sent out is available in this event route.
 		Inside the event route the variables $sndto(ip), $sndto(port) and
-		$sndto(proto) point to the destination. The SIP message is the one
-		to be sent out.
+		$sndto(proto) point to the destination.
 		</para>
 		<example>
 		<title>Usage of event_route[topos:msg-sending]</title>
@@ -709,15 +709,12 @@ event_route[topos:msg-sending] {
 		<title>event_route[topos:msg-incoming]</title>
 		<para>
 		It is executed before doing topology stripping processing for an incoming
-		SIP message. If 'drop' is executed inside the event route, then the
-		module skips doing the topology hiding.
+		SIP message. If 'drop' is executed inside this event route, then the
+		module skips doing the <emphasis>in part of</emphasis> topology hiding.
 		</para>
 		<para>
-		Inside the event route the variables $si, $sp and
-		$proto point to the source address. The SIP message is not the one
-		to be sent out, but an internally generated one at startup, to avoid
-		reparsing the outgoing SIP message for the cases when topology hiding
-		is not wanted.
+		Only fake msg is available in this event route.
+		$si, $sp and $proto will have default fake values.
 		</para>
 		<example>
 		<title>Usage of event_route[topos:msg-incoming]</title>
@@ -737,11 +734,13 @@ event_route[topos:msg-incoming] {
 		<para>
 		It is executed before doing topology stripping processing for a SIP
 		message that was received, being executed after event_route[topos:msg-incoing].
+		If 'drop' is executed inside this event route, then the
+		module skips doing the <emphasis>in part of</emphasis> topology hiding.
 		</para>
 		<para>
-		Inside the event route the variables $si, $sp and
-		$proto point to the source address. The SIP message is the one
-		to be sent out.
+		A copy of the received SIP msg is available in this event route.
+		$si, $sp and $proto will have correct, expected values.
+		Also src_port and dst_port can be used here.
 		</para>
 		<example>
 		<title>Usage of event_route[topos:msg-receiving]</title>
@@ -749,6 +748,14 @@ event_route[topos:msg-incoming] {
 ...
 event_route[topos:msg-receiving] {
   if(is_request() and $fU=="alice") {
+    drop;
+  }
+
+  if($sp==5555 || $si=="1.2.3.4") {
+    drop;
+  }
+
+  if(src_port==1234 || dst_port==5678) {
     drop;
   }
 }

--- a/src/modules/topos/topos_mod.c
+++ b/src/modules/topos/topos_mod.c
@@ -524,6 +524,9 @@ int tps_msg_received(sr_event_param_t *evp)
 	memset(&msg, 0, sizeof(sip_msg_t));
 	msg.buf = obuf->s;
 	msg.len = obuf->len;
+	if(evp->rcv) {
+		msg.rcv = *(receive_info_t *)evp->rcv;
+	}
 
 	ret = 0;
 	if(tps_prepare_msg(&msg) != 0) {
@@ -601,6 +604,9 @@ int tps_msg_sent(sr_event_param_t *evp)
 	memset(&msg, 0, sizeof(sip_msg_t));
 	msg.buf = obuf->s;
 	msg.len = obuf->len;
+	if(evp->rcv) {
+		msg.rcv = *(receive_info_t *)evp->rcv;
+	}
 
 	if(tps_prepare_msg(&msg) != 0) {
 		goto done;


### PR DESCRIPTION
Updated documentation.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Right now if I try to log $sp in event_route[topos:msg-receiving], will have value 0.
Updated documentation too, related to those event routes.