### PR TITLE
Fix crash in xhttp_rpc when listing kemi methods

### DIFF
--- a/src/core/kemi.c
+++ b/src/core/kemi.c
@@ -3790,7 +3790,9 @@ typedef struct sr_kemi_param_map
 static sr_kemi_param_map_t _sr_kemi_param_map[] = {
 		{SR_KEMIP_NONE, str_init("none")}, {SR_KEMIP_INT, str_init("int")},
 		{SR_KEMIP_STR, str_init("str")}, {SR_KEMIP_BOOL, str_init("bool")},
-		{SR_KEMIP_XVAL, str_init("xval")}, {0, STR_NULL}};
+		{SR_KEMIP_LONG, str_init("long")}, {SR_KEMIP_XVAL, str_init("xval")},
+		{SR_KEMIP_NULL, str_init("null")}, {SR_KEMIP_DICT, str_init("dict")},
+		{SR_KEMIP_ARRAY, str_init("array")}, {0, STR_NULL}};
 
 /**
  *

--- a/src/modules/xhttp_rpc/xhttp_rpc.c
+++ b/src/modules/xhttp_rpc/xhttp_rpc.c
@@ -322,7 +322,11 @@ static int print_value(rpc_ctx_t *ctx, char fmt, va_list *ap, str *id)
 			break;
 		case 'S':
 			sp = va_arg(*ap, str *);
-			body = *sp;
+			if(sp) {
+				body = *sp;
+			} else {
+				body = (str)str_init("&lt;null&gt;");
+			}
 			break;
 		default:
 			body.len = 0;


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4351

#### Description
- Add strings describing all kemi types
- Add handling of null values to http_rpc module
