### PR TITLE
pua_reginfo: use expires from contact for publish request

### DIFF
--- a/src/modules/pua_reginfo/usrloc_cb.c
+++ b/src/modules/pua_reginfo/usrloc_cb.c
@@ -257,6 +257,33 @@ error:
 	return NULL;
 }
 
+int reginfo_get_expires(urecord_t *record)
+{
+	// Loop through all record contacts and set the publish Expire value
+	// to the max expire of the contacts
+	ucontact_t *ptr;
+	time_t cur_time = time(0);
+	int expires = -1;
+	int tmp_expires;
+
+	ptr = record->contacts;
+	while(ptr) {
+		if(VALID_CONTACT(ptr, cur_time)) {
+			tmp_expires = (int)(ptr->expires - cur_time);
+			if(tmp_expires > expires) {
+				expires = tmp_expires;
+			}
+		}
+		ptr = ptr->next;
+	}
+	if(expires < 0) {
+		/* if we cannot calc expire from reg contacts, just use this default */
+		expires = 3600;
+	}
+
+	return expires;
+}
+
 void reginfo_usrloc_cb(ucontact_t *c, int type, void *param)
 {
 	str *body = NULL;
@@ -371,7 +398,7 @@ void reginfo_usrloc_cb(ucontact_t *c, int type, void *param)
 	publ.id.s = id_buf;
 	publ.id.len = id_buf_len;
 	publ.content_type = content_type;
-	publ.expires = 3600;
+	publ.expires = reginfo_get_expires(record);
 
 	/* make UPDATE_TYPE, as if this "publish dialog" is not found
 	   by pua it will fallback to INSERT_TYPE anyway */


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Current implementation of pua_reginfo, when `publish_reginfo` is used, sets a fixed `Expires` value of `3600` in the PUBLISH message, which may lead to many entries in pua db for the same reginfo data if the client registers sin an expiration < 1hr.

For example: a device registers every 2 minutes, in one hour pua db will have 30 entries for the same reg, because they're set to expire after 1hr.

In addition if this info is subscribed by another entity, the entity will receive notifies with a lot of entries for the same reg.

Instead, like is done with the pua_dialoginfo, the Expires of the publish should follow the expire of the registration.

This patch does exactly that, it sets the PUBLISH Expire to the reg expire value.

There's only one caveat: that each usrloc record can have many contacts with different expires, so the approach followed here is to set the PUBLISH Expire value to the max reg expire value of all contacts of the same aor.
