### PR TITLE
dialog: fix sflags database persistence for dlg_setflag/dlg_resetflag

### DIFF
--- a/src/modules/dialog/dlg_hash.h
+++ b/src/modules/dialog/dlg_hash.h
@@ -73,6 +73,9 @@
 #define DLG_FLAG_CHANGED_PROF (1 << 11)	 /*!< dialog-profiles changed - DMQ */
 #define DLG_FLAG_DB_LOAD_EXTRA (1 << 12) /*!< dialog loaded extra from db */
 
+#define DLG_FLAG_CHANGED_SFLAGS \
+	(1 << 13) /*!< sflags changed - needs db update */
+
 /* internal flags stored in db */
 #define DLG_IFLAG_TIMEOUTBYE (1 << 0) /*!< send bye on time-out */
 #define DLG_IFLAG_KA_SRC (1 << 1)	  /*!< send keep alive to src */


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Dialog script flags (sflags) were not persisting to database, causing 
inconsistent behavior in cluster deployments and after restarts. This 
fix ensures sflags are properly saved when dlg_setflag()/dlg_resetflag() 
are called, making them truly "persistent" as documented.

- Add DLG_FLAG_CHANGED_SFLAGS flag to track sflags changes
- Trigger immediate DB updates in realtime mode
- Support delayed and shutdown database modes
- Fix database update parameters to target sflags column correctly
