### PR TITLE
rtp_media_server: fix incorrect function return value

### DIFF
--- a/src/modules/rtp_media_server/rms_sdp.c
+++ b/src/modules/rtp_media_server/rms_sdp.c
@@ -205,15 +205,15 @@ PayloadType *rms_sdp_check_payload_type(PayloadType *pt, rms_sdp_info_t *sdp)
 	pt->channels = 1;
 	pt->mime_type = NULL;
 	if(pt->type > 127) {
-		return NULL;
+		return pt;
 	} else if(pt->type >= 96) {
 		char *rtpmap = rms_sdp_get_rtpmap(sdp->recv_body, pt->type);
 		if(!rtpmap)
-			return NULL;
+			return pt;
 		char *s_mime_type = strtok(rtpmap, "/");
 		if(!s_mime_type) {
 			shm_free(rtpmap);
-			return NULL;
+			return pt;
 		}
 		if(strcasecmp(s_mime_type, "opus") == 0) {
 			int payload_type = pt->type;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit
- [x] No commits to README files for modules

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

#### Checklist:
- [ ] PR should be backported to stable branches (please check if maintainers want this)
- [x] Tested changes locally
- [ ] Related to issue #XXXX (add issue number if exists)

#### Description
This PR fixes an issue in the rtp_media_server module where the function could attempt to access non-existent data when no codec matches are found. The fix properly handles this edge case.

Changes:
- Return proper value when no matches are found

The bug could cause segmentation faults when negotiating codecs in certain scenarios. The fix maintains backward compatibility while preventing the crash condition.
