### PR TITLE
dispatcher: update the default value and docs of ds_latency_estimator…

### DIFF
--- a/src/modules/dispatcher/dispatcher.c
+++ b/src/modules/dispatcher/dispatcher.c
@@ -105,8 +105,8 @@ static int ds_ping_interval = 0;
 int ds_ping_latency_stats = 0;
 int ds_ping_fr_timeout = 0;
 int ds_retain_latency_stats = 0;
-int ds_latency_estimator_alpha_i = 900;
-float ds_latency_estimator_alpha = 0.9f;
+int ds_latency_estimator_alpha_i = 100;
+float ds_latency_estimator_alpha = 0.1f;
 int ds_probing_mode = DS_PROBE_NONE;
 
 static str ds_ping_reply_codes_str= STR_NULL;

--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -813,15 +813,14 @@ modparam("dispatcher", "ds_retain_latency_stats", 1)
 	<section id="dispatcher.p.ds_latency_estimator_alpha">
 		<title><varname>ds_latency_estimator_alpha</varname> (int)</title>
 		<para>
-		The value to be used to control the memory of the estimator EWMA "exponential weighted moving average" or
-		"the speed at which the older samples are dampened"
-		a good explanation can be found here : http://www.itl.nist.gov/div898/handbook/pmc/section3/pmc324.htm
+		The parameter decides how important each latency ping observation is in the calculation of the EWMA.
+		The higher the value of alpha, the more closely the EWMA tracks the original time series.
 		Because Kamailio doesn't support float parameter types, the value in the parameter is divided by 1000 and stored as float.
-		For example, if you want to set the alpha to be 0.75, use value 750 here.
+		For example, if you want to set the alpha to be 0.25, use value 250 here.
 		</para>
 		<para>
 		<emphasis>
-			Default value is <quote>900 => 0.9</quote>.
+			Default value is <quote>100 => 0.1</quote>.
 		</emphasis>
 		</para>
 		<example>


### PR DESCRIPTION
…_alpha

This is to match the recent adjustement made in "dispatcher: fix ds_latency_estimator_alpha meaning"

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] Related to issue #4331

#### Description
See

https://github.com/kamailio/kamailio/pull/4358