### PR TITLE
xhttp_prom: add support for `TYPE` and `HELP` metadata output

### DIFF
--- a/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
+++ b/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
@@ -255,6 +255,91 @@ modparam("xhttp_prom", "xhttp_prom_beginning", "");
 		</programlisting>
 	  </example>
 	</section>
+	<section id="xhttp_prom.p.xhttp_prom_metadata_flags">
+	  <title><varname>xhttp_prom_metadata_flags</varname> (integer)</title>
+	  <para>
+		Flags to enable Prometheus metadata lines in the output. The
+		flags are defined as a bitmask on an integer value. Bits have the
+		following meaning:
+	  </para>
+	  <itemizedlist>
+		<listitem>
+		  <para>
+			<emphasis>1</emphasis> - include TYPE metadata string for
+			user defined metrics. Metrics generated from Kamailio statistics are
+			untyped and can't have TYPE metadata.
+			<example><title><varname>xhttp_prom_metadata_flags</varname> TYPE example</title>
+			<programlisting format="linespecific">
+# Enable TYPE metadata and define some metrics.
+modparam("xhttp_prom", "xhttp_prom_beginning", "my_metric_")
+modparam("xhttp_prom", "xhttp_prom_metadata_flags", 1)
+modparam("xhttp_prom", "prom_counter", "name=cnt01")
+modparam("xhttp_prom", "prom_gauge", "name=gg01")
+modparam("xhttp_prom", "prom_histogram", "name=histo01")
+
+In this case the generated Prometheus output may look something like this:
+
+# TYPE my_metric_cnt01 counter
+my_metric_cnt01 0
+# TYPE my_metric_gg01 gauge
+my_metric_gg01 0
+# TYPE my_metric_hist01 histogram
+my_metric_hist01_sum 0.0
+my_metric_hist01_count 0
+			</programlisting>
+			</example>
+		  </para>
+		</listitem>
+		<listitem>
+		  <para>
+			<emphasis>2</emphasis> - include HELP metadata string for
+			user defined metrics. HELP metadata for a metric will only be
+			generated if the help string is defined in metric specification. See
+			description of the help attribute in <varname>prom_counter</varname>.
+			<example><title><varname>xhttp_prom_metadata_flags</varname> HELP example</title>
+			<programlisting format="linespecific">
+# Enable TYPE and HELP metadata and define some metrics (with and without HELP).
+modparam("xhttp_prom", "xhttp_prom_beginning", "my_metric_")
+modparam("xhttp_prom", "xhttp_prom_metadata_flags", 3)
+modparam("xhttp_prom", "prom_counter", "name=cnt01")
+modparam("xhttp_prom", "prom_gauge", "name=gg01; help='Some help string for the gauge'")
+
+In this case the generated Prometheus output may look something like this:
+
+# TYPE my_metric_cnt01 counter
+my_metric_cnt01 0
+# HELP my_metric_gg01 Some help string for the gauge
+# TYPE my_metric_gg01 gauge
+my_metric_gg01 0
+			</programlisting>
+			</example>
+		  </para>
+		</listitem>
+	  </itemizedlist>
+	  <para>
+		<emphasis>
+		  Default value is 0 (no metadata in the output).
+		</emphasis>
+	  </para>
+	  <example>
+		<title>Set <varname>xhttp_prom_metadata_flags</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+# There will be no metadata in the output (it's the default)
+modparam("xhttp_prom", "xhttp_prom_metadata_flags", 0)
+
+# Only the TYPE metadata entry will be included in the output.
+modparam("xhttp_prom", "xhttp_prom_metadata_flags", 1)
+
+# If there's HELP metadata defined for the metric, it will be included in the output.
+modparam("xhttp_prom", "xhttp_prom_metadata_flags", 2)
+
+# Both TYPE and HELP metadata lines are allowed in the output.
+modparam("xhttp_prom", "xhttp_prom_metadata_flags", 3)
+...
+		</programlisting>
+	  </example>
+	</section>
 	<section id="xhttp_prom.p.xhttp_prom_tags">
 	  <title><varname>xhttp_prom_tags</varname> (str)</title>
 	  <para>
@@ -317,6 +402,18 @@ the metric.
 			</example>
 		  </para>
 		</listitem>
+		<listitem>
+		  <para>
+			<emphasis>help</emphasis> - HELP metadata string for the counter. Optional.
+			If HELP string is defined for the metric and metadata
+			generation is enabled (see <varname>xhttp_prom_metadata_flags</varname> parameter),
+			then it will be included in the generated output. Be careful using special
+			characters in the help string. Prometheus requires some characters in
+			the HELP to be quoted, but this module doesn't process the provided
+			HELP string in any way. The provided HELP string will be included in
+			the output as is.
+		  </para>
+		</listitem>
 	  </itemizedlist>
 	  <example>
 		<title>Set <varname>prom_counter</varname> parameter</title>
@@ -332,6 +429,9 @@ modparam("xhttp_prom", "prom_counter", "name=cnt_second;");
 
 # Create cnt_third counter with label method
 modparam("xhttp_prom", "prom_counter", "name=cnt_third; label=method");
+
+# Create cnt_fourth counter with label method and HELP string
+modparam("xhttp_prom", "prom_counter", "name=cnt_fourth; label=method; help='Total number of SIP requests'");
 
 These lines declare the counter but the actual metric will be created when
 using it by prom_counter_inc or prom_counter_reset functions.
@@ -375,6 +475,13 @@ This would generate  {method="whatever", handler="whatever2"} when building
 the metric.
 			</programlisting>
 			</example>
+		  </para>
+		</listitem>
+		<listitem>
+		  <para>
+			<emphasis>help</emphasis> - HELP metadata string for the gauge. Optional.
+			See description for the help attribute in <varname>prom_counter</varname> parameter.
+			Everything is the same for <varname>prom_gauge</varname> help.
 		  </para>
 		</listitem>
 	  </itemizedlist>
@@ -450,6 +557,13 @@ the metric.
 		  <para>
 			If no buckets specified, default bucket list is set to these values:
 			<para>[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]</para>
+		  </para>
+		</listitem>
+		<listitem>
+		  <para>
+			<emphasis>help</emphasis> - HELP metadata string for the histogram. Optional.
+			See description for the help attribute in <varname>prom_counter</varname> parameter.
+			Everything is the same for <varname>prom_histogram</varname> help.
 		  </para>
 		</listitem>
 	  </itemizedlist>

--- a/src/modules/xhttp_prom/prom_metric.c
+++ b/src/modules/xhttp_prom/prom_metric.c
@@ -120,6 +120,7 @@ struct prom_metric_s
 {
 	metric_type_t type;		   /**< Metric type. */
 	str name;				   /**< Name of the metric. */
+	str help;				   /**< Help metadata string for the metric. */
 	struct prom_lb_s *lb_name; /**< Names of labels. */
 	struct prom_buckets_upper_s
 			*buckets_upper; /**< Upper bounds for buckets. */
@@ -291,6 +292,10 @@ static void prom_counter_free(prom_metric_t *m_cnt)
 	assert(m_cnt);
 
 	assert(m_cnt->type == M_COUNTER);
+
+	if(m_cnt->help.s) {
+		shm_free(m_cnt->help.s);
+	}
 
 	if(m_cnt->name.s) {
 		shm_free(m_cnt->name.s);
@@ -1017,6 +1022,15 @@ int prom_counter_create(char *spec)
 			}
 			LM_DBG("name = %.*s\n", m_cnt->name.len, m_cnt->name.s);
 
+		} else if(p->name.len == 4 && strncmp(p->name.s, "help", 4) == 0) {
+			/* Fill counter help metadata. */
+			if(shm_str_dup(&m_cnt->help, &p->body)) {
+				LM_ERR("Error creating counter help: %.*s\n", p->body.len,
+						p->body.s);
+				goto error;
+			}
+			LM_DBG("help = %.*s\n", m_cnt->help.len, m_cnt->help.s);
+
 		} else {
 			LM_ERR("Unknown field: %.*s (%.*s)\n", p->name.len, p->name.s,
 					p->body.len, p->body.s);
@@ -1058,6 +1072,10 @@ static void prom_gauge_free(prom_metric_t *m_gg)
 	assert(m_gg);
 
 	assert(m_gg->type == M_GAUGE);
+
+	if(m_gg->help.s) {
+		shm_free(m_gg->help.s);
+	}
 
 	if(m_gg->name.s) {
 		shm_free(m_gg->name.s);
@@ -1114,6 +1132,15 @@ int prom_gauge_create(char *spec)
 				goto error;
 			}
 			LM_DBG("name = %.*s\n", m_gg->name.len, m_gg->name.s);
+
+		} else if(p->name.len == 4 && strncmp(p->name.s, "help", 4) == 0) {
+			/* Fill gauge help metadata. */
+			if(shm_str_dup(&m_gg->help, &p->body)) {
+				LM_ERR("Error creating gauge help: %.*s\n", p->body.len,
+						p->body.s);
+				goto error;
+			}
+			LM_DBG("help = %.*s\n", m_gg->help.len, m_gg->help.s);
 
 		} else {
 			LM_ERR("Unknown field: %.*s (%.*s)\n", p->name.len, p->name.s,
@@ -1395,6 +1422,10 @@ static void prom_histogram_free(prom_metric_t *m_hist)
 
 	assert(m_hist->type == M_HISTOGRAM);
 
+	if(m_hist->help.s) {
+		shm_free(m_hist->help.s);
+	}
+
 	if(m_hist->name.s) {
 		shm_free(m_hist->name.s);
 	}
@@ -1469,6 +1500,15 @@ int prom_histogram_create(char *spec)
 				goto error;
 			}
 			LM_DBG("buckets = %.*s\n", p->body.len, p->body.s);
+
+		} else if(p->name.len == 4 && strncmp(p->name.s, "help", 4) == 0) {
+			/* Fill histogram help metadata. */
+			if(shm_str_dup(&m_hist->help, &p->body)) {
+				LM_ERR("Error creating histogram help: %.*s\n", p->body.len,
+						p->body.s);
+				goto error;
+			}
+			LM_DBG("help = %.*s\n", m_hist->help.len, m_hist->help.s);
 
 		} else {
 			LM_ERR("Unknown field: %.*s (%.*s)\n", p->name.len, p->name.s,
@@ -2000,6 +2040,50 @@ error:
 	return -1;
 }
 
+static int prom_metric_metadata_print(
+		prom_ctx_t *ctx, prom_metric_t *p, int flags)
+{
+	if(!ctx) {
+		LM_ERR("No context\n");
+		return -1;
+	}
+
+	if(!p) {
+		LM_ERR("No metric\n");
+		return -1;
+	}
+
+	if((flags & METADATA_FLAGS_HELP) && STR_WITHVAL(&p->help)) {
+		if(prom_body_printf(ctx, "# HELP %.*s%.*s %.*s\n",
+				   xhttp_prom_beginning.len, xhttp_prom_beginning.s,
+				   p->name.len, p->name.s, p->help.len, p->help.s)
+				== -1) {
+			LM_ERR("Fail to print\n");
+			return -1;
+		}
+	}
+
+	if(flags & METADATA_FLAGS_TYPE) {
+		const char *type_descr = (p->type == M_COUNTER)		? "counter"
+								 : (p->type == M_GAUGE)		? "gauge"
+								 : (p->type == M_HISTOGRAM) ? "histogram"
+															: NULL;
+		if(type_descr) {
+			if(prom_body_printf(ctx, "# TYPE %.*s%.*s %s\n",
+					   xhttp_prom_beginning.len, xhttp_prom_beginning.s,
+					   p->name.len, p->name.s, type_descr)
+					== -1) {
+				LM_ERR("Fail to print\n");
+				return -1;
+			}
+		} else {
+			LM_DBG("Unknown metric type: %d\n", p->type);
+		}
+	}
+
+	return 0;
+}
+
 /**
  * @brief Print user defined metrics.
  *
@@ -2025,6 +2109,13 @@ int prom_metric_list_print(prom_ctx_t *ctx)
 	while(p) {
 
 		prom_lvalue_t *pvl = p->lval_list;
+
+		if(metadata_flags) {
+			if(prom_metric_metadata_print(ctx, p, metadata_flags)) {
+				LM_ERR("Failed to print metric metadata\n");
+				goto error;
+			}
+		}
 
 		while(pvl) {
 			if(prom_metric_lvalue_print(ctx, p, pvl)) {

--- a/src/modules/xhttp_prom/xhttp_prom.c
+++ b/src/modules/xhttp_prom/xhttp_prom.c
@@ -176,6 +176,8 @@ int uptime_stat_enabled = 0; /**< enable or disable uptime statistic. */
 
 int pkgmem_stats_enabled = 0; /**< enable or disable pkgmem statistics. */
 
+int metadata_flags = 0; /**< include metrics metadata in text output. */
+
 char error_buf[ERROR_REASON_BUF_LEN];
 
 /* clang-format off */
@@ -217,6 +219,7 @@ static param_export_t params[] = {
 	{"xhttp_prom_timeout", PARAM_INT, &timeout_minutes},
 	{"xhttp_prom_uptime_stat", PARAM_INT, &uptime_stat_enabled},
 	{"xhttp_prom_pkg_stats", PARAM_INT, &pkgmem_stats_enabled},
+	{"xhttp_prom_metadata_flags", PARAM_INT, &metadata_flags},
 	{0, 0, 0}
 };
 

--- a/src/modules/xhttp_prom/xhttp_prom.h
+++ b/src/modules/xhttp_prom/xhttp_prom.h
@@ -121,4 +121,15 @@ extern pkg_proc_stats_t *pkg_proc_stats;
  */
 extern int pkg_proc_stats_no;
 
+/**
+ * @brief include metrics metadata in text output.
+ */
+extern int metadata_flags;
+
+enum
+{
+	METADATA_FLAGS_TYPE = (1 << 0),
+	METADATA_FLAGS_HELP = (1 << 1)
+};
+
 #endif /* _XHTTP_PROM_H */


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #3001

#### Description
<!-- Describe your changes in detail -->
This adds support for conditionally generating `HELP` and `TYPE` Prometheus metadata strings into the output.

It may be a waste of bytes most of the time, but sometimes it may be useful (e.g., see #3001).

I noticed that most of the module parameters are prefixed with module name. Is there a reason it can't be just `metadata_flags` (`uptime_stat`, etc) instead of `xhttp_prom_metadata_flags` (`xhttp_prom_uptime_stat`, etc)? 

While working on this I've also tried to reduce code duplication in functions to create and free metrics. The related changes (in their current state) are in [a separate branch](/a12n/kamailio/tree/xhttp_prom_code_dedup). It's significant refactoring of code that seems to be working fine, so I'm not sure about it. Let me know if I should open another PR for this.