### PR TITLE
CMakeLists.txt: drop EXTRAVERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ project(
   HOMEPAGE_URL "https://www.kamailio.org")
 
 # Set the version number
-set(EXTRAVERSION "-rc0")
+set(EXTRAVERSION "")
 set(RELEASE "${PROJECT_VERSION}${EXTRAVERSION}")
 
 message(STATUS "PROJECT_VERSION: ${PROJECT_VERSION}")


### PR DESCRIPTION
I think stable branch does not need EXTRAVERSION string after MAJOR.MINOR.0 is released.

This patch sets EXTRAVERSION to empty value.