### PR TITLE
core: add `xavp_add_value_reserve()`, don't copy `SR_XTYPE_STR` data if it's `NULL`

### DIFF
--- a/src/core/xavp.h
+++ b/src/core/xavp.h
@@ -80,6 +80,7 @@ int xavp_add(sr_xavp_t *xavp, sr_xavp_t **list);
 int xavp_add_last(sr_xavp_t *xavp, sr_xavp_t **list);
 int xavp_add_after(sr_xavp_t *nxavp, sr_xavp_t *pxavp);
 sr_xavp_t *xavp_add_value(str *name, sr_xval_t *val, sr_xavp_t **list);
+sr_xavp_t *xavp_add_value_reserve(str *name, sr_xval_t *val, sr_xavp_t **list);
 sr_xavp_t *xavp_add_value_after(str *name, sr_xval_t *val, sr_xavp_t *pxavp);
 sr_xavp_t *xavp_add_xavp_value(
 		str *rname, str *name, sr_xval_t *val, sr_xavp_t **list);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

This change should allow a small optimization/convenience improvement when building a combined string for XAVP value.

Consider the `xavp_example-1.c`. It builds a semicolon-separated string of parameters out of some data and makes XAVP from this combined string. It has to build the string entirely before passing it to `xavp_add_value()`. It either needs to use some fixed-length pad buffer or has to allocate/deallocate a temporary PKG buffer to build the string.

This change allows `SR_XTYPE_STR` values with `NULL` data (but with non-zero length) into `xavp_add_value()`. In that case `xavp_add_value()` will create a shared memory buffer for the string, but wouldn't try to copy string data into the buffer, leaving it uninitialized. The string content should be filled in-place later through the returned `sr_xavp_t *`. This allows simpler `xavp_example-2.c`.

<details>
<summary>xavp_example-1.c</summary>

```c
struct some_third_party_item
{
	const char *key;
	const char *value;
	size_t key_sz, value_sz;
};

int add_items_xavp1()
{
	struct some_third_party_item **list = some_third_party_func();

	str key = STR_STATIC_INIT("items");
	sr_xval_t value = {.type = SR_XTYPE_STR, .v = {.s = STR_NULL}};

	/* Compute total size of the combined string */
	for(int i = 0; list[i]; ++i) {
		value.v.s.len += (i != 0); /* ; */
		value.v.s.len += (int)list[i]->key_sz;
		value.v.s.len += 1; /* = */
		value.v.s.len += (int)list[i]->value_sz;
	}

	/* Allocate temporary buffer */
	if((value.v.s.s = pkg_malloc(value.v.s.len)) == NULL) {
		LM_ERR("couldn't allocate string value");
		return -1;
	}

	/* Build the string in the temporary buffer */
	char *dest = value.v.s.s;
	for(int i = 0; list[i]; ++i) {
		if(i != 0) {
			*dest++ = ';';
		}
		memcpy(dest, list[i]->key, list[i]->key_sz);
		dest += list[i]->key_sz;
		*dest++ = '=';
		memcpy(dest, list[i]->value, list[i]->value_sz);
		dest += list[i]->value_sz;
	}

	/* Allocate XAVP and its SHM for string, copy into SHM */
	if(!xavp_add_value(&key, &value, NULL)) {
		LM_ERR("couldn't allocate XAVP\n");
		pkg_free(value.v.s.s);
		return -1;
	}

	/* Deallocate the temporary buffer */
	pkg_free(value.v.s.s);

	return 0;
}
```
</details>

<details>
<summary>xavp_example-2.c</summary>

```c
struct some_third_party_item
{
	const char *key;
	const char *value;
	size_t key_sz, value_sz;
};

int add_items_xavp2()
{
	struct some_third_party_item **list = some_third_party_func();

	str key = STR_STATIC_INIT("items");
	sr_xval_t value = {.type = SR_XTYPE_STR, .v = {.s = STR_NULL}};

	/* Compute total size of the combined string */
	for(int i = 0; list[i]; ++i) {
		value.v.s.len += (i != 0); /* ; */
		value.v.s.len += (int)list[i]->key_sz;
		value.v.s.len += 1; /* = */
		value.v.s.len += (int)list[i]->value_sz;
	}

	sr_xavp_t *xavp;

	/* Allocate XAVP and its SHM for string, leave its content uninitialized */
	if(!(xavp = xavp_add_value(&key, &value, NULL))) {
		LM_ERR("couldn't allocate XAVP\n");
		return -1;
	}

	/* Build the string in the XAVP shared memory directly */
	char *dest = xavp->val.v.s.s;
	for(int i = 0; list[i]; ++i) {
		if(i != 0) {
			*dest++ = ';';
		}
		memcpy(dest, list[i]->key, list[i]->key_sz);
		dest += list[i]->key_sz;
		*dest++ = '=';
		memcpy(dest, list[i]->value, list[i]->value_sz);
		dest += list[i]->value_sz;
	}

	return 0;
}
```
</details>
