### PR TITLE
remove deprecated xmlMemoryDump() calls

### DIFF
--- a/src/modules/presence/notify.c
+++ b/src/modules/presence/notify.c
@@ -189,7 +189,7 @@ int build_str_hdr(subs_t *subs, int is_body, str *hdr)
 			+ (subs->reason.len > expires.len ? subs->reason.len : expires.len)
 			+ CRLF_LEN
 			+ (is_body ? (14 /*Content-Type: */ + subs->event->content_type.len
-						  + CRLF_LEN)
+								 + CRLF_LEN)
 					   : 0)
 			+ 1;
 
@@ -2149,8 +2149,6 @@ str *create_winfo_xml(watcher_t *watchers, char *version, str resource,
 	xmlFreeDoc(doc);
 
 	xmlCleanupParser();
-
-	xmlMemoryDump();
 
 	return body;
 

--- a/src/modules/presence/publish.c
+++ b/src/modules/presence/publish.c
@@ -671,12 +671,10 @@ int update_hard_presentity(
 			LM_ERR("bad body format\n");
 			xmlFreeDoc(doc);
 			xmlCleanupParser();
-			xmlMemoryDump();
 			goto done;
 		}
 		xmlFreeDoc(doc);
 		xmlCleanupParser();
-		xmlMemoryDump();
 
 		new_t = 1;
 	} else {

--- a/src/modules/presence_dfks/add_events.c
+++ b/src/modules/presence_dfks/add_events.c
@@ -104,13 +104,11 @@ int dfks_publ_handler(struct sip_msg *msg)
 	}
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 	return 1;
 
 error:
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 	return -1;
 }
 
@@ -328,12 +326,10 @@ int dfks_subs_handler(struct sip_msg *msg)
 
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 	return 1;
 
 error:
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 	return -1;
 }

--- a/src/modules/presence_dialoginfo/notify_body.c
+++ b/src/modules/presence_dialoginfo/notify_body.c
@@ -115,7 +115,6 @@ str *dlginfo_agg_nbody_empty(str *pres_user, str *pres_domain)
 
 
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return n_body;
 }
@@ -144,7 +143,6 @@ str *dlginfo_agg_nbody(str *pres_user, str *pres_domain, str **body_array,
 	}
 
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return n_body;
 }
@@ -423,7 +421,6 @@ str *aggregate_xmls(str *pres_user, str *pres_domain, str **body_array, int n)
 		pkg_free(xml_array);
 
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return body;
 
@@ -617,7 +614,6 @@ str *dlginfo_body_setversion(subs_t *subs, str *body)
 			doc, (xmlChar **)(void *)&aux_body->s, &aux_body->len, 1);
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return aux_body;
 }

--- a/src/modules/presence_reginfo/notify_body.c
+++ b/src/modules/presence_reginfo/notify_body.c
@@ -74,7 +74,6 @@ str *reginfo_agg_nbody(str *pres_user, str *pres_domain, str **body_array,
 	}
 
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return n_body;
 }
@@ -211,7 +210,6 @@ str *aggregate_xmls(str *pres_user, str *pres_domain, str **body_array, int n)
 		pkg_free(xml_array);
 
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return body;
 
@@ -310,7 +308,6 @@ str *reginfo_body_setversion(subs_t *subs, str *body)
 			doc, (xmlChar **)(void *)&aux_body->s, &aux_body->len, 1);
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return aux_body;
 }

--- a/src/modules/presence_xml/add_events.c
+++ b/src/modules/presence_xml/add_events.c
@@ -166,12 +166,10 @@ int xml_publ_handl(struct sip_msg *msg)
 	}
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 	return 1;
 
 error:
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 	return -1;
 }

--- a/src/modules/presence_xml/notify_body.c
+++ b/src/modules/presence_xml/notify_body.c
@@ -131,7 +131,6 @@ str *pres_agg_nbody_empty(str *pres_user, str *pres_domain)
 
 
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return n_body;
 }
@@ -175,7 +174,6 @@ str *pres_agg_nbody(str *pres_user, str *pres_domain, str **body_array, int n,
 	}
 
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return n_body;
 }
@@ -217,7 +215,6 @@ int pres_apply_auth(str *notify_body, subs_t *subs, str **final_nbody)
 
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	*final_nbody = n_body;
 	return 1;
@@ -500,7 +497,6 @@ done:
 	xmlFree(deviceID);
 	xmlFree(service_uri);
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return new_body;
 
@@ -628,7 +624,6 @@ str *aggregate_xmls(str *pres_user, str *pres_domain, str **body_array, int n)
 		pkg_free(xml_array);
 
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return body;
 
@@ -736,7 +731,6 @@ str *aggregate_xmls_priority(
 		pkg_free(xml_array);
 
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return body;
 
@@ -827,7 +821,6 @@ str *offline_nbody(str *body)
 	xmlFreeDoc(doc);
 	xmlFreeDoc(new_doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return new_body;
 

--- a/src/modules/pua/add_events.c
+++ b/src/modules/pua/add_events.c
@@ -240,7 +240,6 @@ int pres_process_body(
 	doc = NULL;
 
 	*fin_body = body;
-	xmlMemoryDump();
 	xmlCleanupParser();
 	return 1;
 
@@ -301,7 +300,6 @@ int bla_process_body(publ_info_t *publ, str **fin_body, int ver, str **tuple)
 	if(*fin_body == NULL)
 		LM_DBG("NULL fin_body\n");
 
-	xmlMemoryDump();
 	xmlCleanupParser();
 	LM_DBG("successful\n");
 	return 1;
@@ -312,7 +310,6 @@ error:
 	if(body)
 		pkg_free(body);
 
-	xmlMemoryDump();
 	xmlCleanupParser();
 	return -1;
 }
@@ -362,7 +359,6 @@ int reginfo_process_body(
 	if(*fin_body == NULL)
 		LM_DBG("NULL fin_body\n");
 
-	xmlMemoryDump();
 	xmlCleanupParser();
 	LM_DBG("successful\n");
 	return 1;
@@ -373,7 +369,6 @@ error:
 	if(body)
 		pkg_free(body);
 
-	xmlMemoryDump();
 	xmlCleanupParser();
 	return -1;
 }

--- a/src/modules/pua_bla/notify.c
+++ b/src/modules/pua_bla/notify.c
@@ -208,7 +208,6 @@ int bla_handle_notify(struct sip_msg *msg, char *s1, char *s2)
 	}
 
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	free_to_params(&TO);
 	return 1;

--- a/src/modules/pua_xmpp/simple2xmpp.c
+++ b/src/modules/pua_xmpp/simple2xmpp.c
@@ -450,7 +450,6 @@ done:
 
 	xmlBufferFree(buffer);
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	if(sip_doc)
 		xmlFreeDoc(sip_doc);
@@ -466,7 +465,6 @@ error:
 	if(buffer)
 		xmlBufferFree(buffer);
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return -1;
 }
@@ -575,7 +573,6 @@ int winfo2xmpp(str *to_uri, str *body, str *id)
 
 	xmlFreeDoc(notify_doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 	return 0;
 
 error:
@@ -589,7 +586,6 @@ error:
 	if(buffer)
 		xmlBufferFree(buffer);
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return -1;
 }

--- a/src/modules/pua_xmpp/xmpp2simple.c
+++ b/src/modules/pua_xmpp/xmpp2simple.c
@@ -117,7 +117,6 @@ void pres_Xmpp2Sip(char *msg, int type, void *param)
 
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 	return;
 
 error:
@@ -125,7 +124,6 @@ error:
 	if(doc)
 		xmlFreeDoc(doc);
 	xmlCleanupParser();
-	xmlMemoryDump();
 
 	return;
 }


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [x] Related to issue #4411

