### PR TITLE
core/parser: minor bugfix for URI_ENCLOSED

### DIFF
--- a/src/core/parser/parse_addr_spec.c
+++ b/src/core/parser/parse_addr_spec.c
@@ -784,6 +784,8 @@ char *parse_addr_spec(char *const buffer, const char *const end,
 						to_b->display.s = tmp;
 						status = DISPLAY_QUOTED;
 						break;
+					case URI_ENCLOSED:
+						break;
 					case DISPLAY_QUOTED:
 						status = E_DISPLAY_QUOTED;
 						to_b->display.len = tmp - to_b->display.s + 1;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Two small bugfixes improving parser stability and PCSCF reliability.

- **core/parser**: added missing `URI_ENCLOSED` case in `parse_addr_spec()`  
  → prevents `LM_ERR("unexpected char ...")` when parsing `<...>` segments.
- **ims_registrar_pcscf**: fixed incorrect `memset()` target in `pcscf_unregister()`  
  → ensures `search_ci` is properly zero-initialized, preventing undefined behavior.