### PR TITLE
pv: Always convert int to string in {s.int} transformation

### DIFF
--- a/src/modules/pv/pv_trans.c
+++ b/src/modules/pv/pv_trans.c
@@ -223,8 +223,8 @@ int tr_eval_string(
 				if(str2slong(&val->rs, &val->ri) != 0)
 					return -1;
 			} else {
-				if(!(val->flags & PV_VAL_STR))
-					val->rs.s = int2str(val->ri, &val->rs.len);
+				// Replace string as an existing string value may not be equal to the int
+				val->rs.s = int2str(val->ri, &val->rs.len);
 			}
 
 			val->flags = PV_TYPE_INT | PV_VAL_INT | PV_VAL_STR;


### PR DESCRIPTION
PV's may hold a string as well as an integer, and the s.int transformation always assumes that an existing string value always represents the integer. This is not the case for some PV's such as $rP where the string value is not equal to the integer (ie, string "tls" and integer 3).

By ignoring the existing string value and always creating a new string from the integer value, it is guaranteed that s.int always returns an numerical value.

Fixes #4444


N.B. I first tried removing the `PV_VAL_STR` flag and removing the int2str altogether so conversion would be "on demand", but other code seem to contain a bug and blindly use the string value even if `PV_VAL_STR` is not set.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4444

#### Description
