### PR TITLE
db_redis: Support build C89

### DIFF
--- a/src/modules/db_redis/redis_sentinels.c
+++ b/src/modules/db_redis/redis_sentinels.c
@@ -41,12 +41,14 @@ static int str_eq_reply(const redisReply *r, const char *s)
 
 static redisReply *get_field(redisReply *r, const char *field)
 {
+	size_t i;
+
 	if(!r)
 		return NULL;
 
 	if(r->type == REDIS_REPLY_ARRAY) {
 		// Treat as alternating field/value list
-		for(size_t i = 0; i + 1 < r->elements; i += 2) {
+		for(i = 0; i + 1 < r->elements; i += 2) {
 			redisReply *k = r->element[i];
 			redisReply *v = r->element[i + 1];
 			if(str_eq_reply(k, field))
@@ -74,7 +76,8 @@ static int replica_list_init(redisReply *reply, struct reply_list *list)
 	list->head = NULL;
 	list->tail = NULL;
 
-	for(size_t i = 0; i < reply->elements; i++) {
+	size_t i;
+	for(i = 0; i < reply->elements; i++) {
 		struct reply_node *node;
 
 		/*


### PR DESCRIPTION
### Description

In the past i have included support to build on `c89` based compilers, but after `6.1.0` this problem happened again.
The required change its only on `db_redis` and quiet simple and not intrusive.

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Additional Information

Tested on my own, and build now works just fine.
