### PR TITLE
ims_qos: fix getaddrinfo input and update Specific-Action handling in AAR-RX

### DIFF
--- a/src/modules/ims_qos/doc/ims_qos_admin.xml
+++ b/src/modules/ims_qos/doc/ims_qos_admin.xml
@@ -620,6 +620,29 @@ modparam("ims_qos", "trust_bottom_via", 1)
       </example>
     </section>
 
+    <section>
+      <title><varname>rx_add_alloc_result_indications</varname> (int)</title>
+
+      <para>When set to 1, the module adds the following Specific-Action AVPs to AAR:
+              - 8  (INDICATION_OF_SUCCESSFUL_RESOURCES_ALLOCATION)
+              - 9  (INDICATION_OF_FAILED_RESOURCES_ALLOCATION)
+            This enables the PCRF to report resource allocation success/failure back to the AF.</para>
+
+      <para><emphasis> Default value is 0</emphasis></para>
+
+      <example>
+        <title><varname>af_signaling_port_pc</varname> parameter
+        usage</title>
+
+        <programlisting format="linespecific">
+...
+modparam("ims_qos", "rx_add_alloc_result_indications", "1")
+...
+        </programlisting>
+      </example>
+    </section>
+
+
   </section>
 
   <section>

--- a/src/modules/ims_qos/rx_aar.c
+++ b/src/modules/ims_qos/rx_aar.c
@@ -79,6 +79,7 @@ extern struct ims_qos_counters_h ims_qos_cnts_h;
 
 extern int authorize_video_flow;
 extern int _ims_qos_suspend_transaction;
+extern int rx_include_alloc_result_indications;
 
 extern str af_signaling_ip;
 extern str af_signaling_ip6;
@@ -1000,9 +1001,13 @@ int rx_send_aar(struct sip_msg *req, struct sip_msg *res, AAASession *auth,
 	rx_add_specific_action_avp(aar, 2); // INDICATION_OF_LOSS_OF_BEARER
 	rx_add_specific_action_avp(aar, 3); // INDICATION_RECOVERY_OF_BEARER
 	rx_add_specific_action_avp(aar, 4); // INDICATION_RELEASE_OF_BEARER
-	rx_add_specific_action_avp(
-			aar, 5); // INDICATION_ESTABLISHMENT_OF_BEARER (now void)
 	rx_add_specific_action_avp(aar, 6);	 // IP-CAN_CHANGE
+	if(rx_include_alloc_result_indications) {
+		rx_add_specific_action_avp(
+				aar, 8); // INDICATION_OF_SUCCESSFUL_RESOURCES_ALLOCATION
+		rx_add_specific_action_avp(
+				aar, 9); // INDICATION_OF_FAILED_RESOURCES_ALLOCATION
+	}
 	rx_add_specific_action_avp(aar, 12); // ACCESS_NETWORK_INFO_REPORT
 
 	show_callsessiondata(p_session_data);
@@ -1139,9 +1144,13 @@ int rx_send_aar_register(struct sip_msg *msg, AAASession *auth,
 	rx_add_specific_action_avp(aar, 2); // INDICATION_OF_LOSS_OF_BEARER
 	rx_add_specific_action_avp(aar, 3); // INDICATION_RECOVERY_OF_BEARER
 	rx_add_specific_action_avp(aar, 4); // INDICATION_RELEASE_OF_BEARER
-	rx_add_specific_action_avp(
-			aar, 5); // INDICATION_ESTABLISHMENT_OF_BEARER (now void)
 	rx_add_specific_action_avp(aar, 6);	 // IP-CAN_CHANGE
+	if(rx_include_alloc_result_indications) {
+		rx_add_specific_action_avp(
+				aar, 8); // INDICATION_OF_SUCCESSFUL_RESOURCES_ALLOCATION
+		rx_add_specific_action_avp(
+				aar, 9); // INDICATION_OF_FAILED_RESOURCES_ALLOCATION
+	}
 	rx_add_specific_action_avp(aar, 12); // ACCESS_NETWORK_INFO_REPORT
 
 	/* Add Framed IP address AVP*/

--- a/src/modules/ims_qos_npn/doc/ims_qos_npn_admin.xml
+++ b/src/modules/ims_qos_npn/doc/ims_qos_npn_admin.xml
@@ -659,6 +659,29 @@ modparam("ims_qos", "af_signaling_port_ps", "5063")
       </example>
     </section>
 
+    <section>
+      <title><varname>rx_add_alloc_result_indications</varname> (int)</title>
+
+      <para>When set to 1, the module adds the following Specific-Action AVPs to AAR:
+              - 8  (INDICATION_OF_SUCCESSFUL_RESOURCES_ALLOCATION)
+              - 9  (INDICATION_OF_FAILED_RESOURCES_ALLOCATION)
+            This enables the PCRF to report resource allocation success/failure back to the AF.</para>
+
+      <para><emphasis> Default value is 0</emphasis></para>
+
+      <example>
+        <title><varname>af_signaling_port_pc</varname> parameter
+        usage</title>
+
+        <programlisting format="linespecific">
+...
+modparam("ims_qos", "rx_add_alloc_result_indications", "1")
+...
+        </programlisting>
+      </example>
+    </section>
+
+
   </section>
 
   <section>

--- a/src/modules/ims_qos_npn/ims_qos_mod.c
+++ b/src/modules/ims_qos_npn/ims_qos_mod.c
@@ -124,6 +124,10 @@ int trust_bottom_via = 0;
 int cdp_event_list_size_threshold =
 		0; /**Threshold for size of cdp event list after which a warning is logged */
 
+int rx_include_alloc_result_indications =
+		0; /* When set to 1, adds Specific-Action AVPs 8 (successful) and 9 (failed) to AAR so the PCRF
+			reports resource-allocation results to the AF.*/
+
 stat_var *aars;
 stat_var *strs;
 stat_var *asrs;
@@ -297,6 +301,8 @@ static param_export_t params[] = {
 		{"af_signaling_ip6", PARAM_STR, &af_signaling_ip6},
 		{"af_signaling_port_pc", PARAM_STR, &af_signaling_port_pc},
 		{"af_signaling_port_ps", PARAM_STR, &af_signaling_port_ps},
+		{"rx_include_alloc_result_indications", PARAM_INT,
+				&rx_include_alloc_result_indications},
 		{0, 0, 0},
 };
 
@@ -759,10 +765,19 @@ static int get_identifier(str *src)
 uint16_t check_ip_version(str ip)
 {
 	struct addrinfo hint, *res = NULL;
+	char *s = shm_malloc(ip.len + 1);
+	if(!s) {
+		LM_ERR("Memory allocation failed!\n");
+		return 0;
+	}
+	memcpy(s, ip.s, ip.len);
+	s[ip.len] = '\0';
+
 	memset(&hint, '\0', sizeof(hint));
 	hint.ai_family = AF_UNSPEC;
 	hint.ai_flags = AI_NUMERICHOST;
-	int getaddrret = getaddrinfo(ip.s, NULL, &hint, &res);
+	int getaddrret = getaddrinfo(s, NULL, &hint, &res);
+	shm_free(s);
 	if(getaddrret) {
 		LM_ERR("GetAddrInfo returned an error !\n");
 		return 0;
@@ -1249,6 +1264,8 @@ static int w_rx_aar(struct sip_msg *msg, char *route, char *dir, char *c_id,
 					LM_ERR("Reply SDP IP information could not be retrieved");
 					goto error;
 				}
+				LM_DBG("IP retrieved from Reply sdp_stream: [%.*s]", ip.len,
+						ip.s);
 				ip_version = check_ip_version(ip);
 				if(!ip_version) {
 					LM_ERR("check_ip_version returned 0 \n");

--- a/src/modules/ims_qos_npn/rx_aar.c
+++ b/src/modules/ims_qos_npn/rx_aar.c
@@ -80,6 +80,7 @@ extern struct ims_qos_counters_h ims_qos_cnts_h;
 
 extern int authorize_video_flow;
 extern int _ims_qos_suspend_transaction;
+extern int rx_include_alloc_result_indications;
 
 extern str af_signaling_ip;
 extern str af_signaling_ip6;
@@ -1057,9 +1058,13 @@ int rx_send_aar(struct sip_msg *req, struct sip_msg *res, AAASession *auth,
 	rx_add_specific_action_avp(aar, 2); // INDICATION_OF_LOSS_OF_BEARER
 	rx_add_specific_action_avp(aar, 3); // INDICATION_RECOVERY_OF_BEARER
 	rx_add_specific_action_avp(aar, 4); // INDICATION_RELEASE_OF_BEARER
-	rx_add_specific_action_avp(
-			aar, 5); // INDICATION_ESTABLISHMENT_OF_BEARER (now void)
 	rx_add_specific_action_avp(aar, 6);	 // IP-CAN_CHANGE
+	if(rx_include_alloc_result_indications) {
+		rx_add_specific_action_avp(
+				aar, 8); // INDICATION_OF_SUCCESSFUL_RESOURCES_ALLOCATION
+		rx_add_specific_action_avp(
+				aar, 9); // INDICATION_OF_FAILED_RESOURCES_ALLOCATION
+	}
 	rx_add_specific_action_avp(aar, 12); // ACCESS_NETWORK_INFO_REPORT
 
 	show_callsessiondata(p_session_data);
@@ -1200,8 +1205,13 @@ int rx_send_aar_register(struct sip_msg *msg, AAASession *auth,
 	rx_add_specific_action_avp(aar, 2); // INDICATION_OF_LOSS_OF_BEARER
 	rx_add_specific_action_avp(aar, 3); // INDICATION_RECOVERY_OF_BEARER
 	rx_add_specific_action_avp(aar, 4); // INDICATION_RELEASE_OF_BEARER
-	//rx_add_specific_action_avp(aar, 5); // INDICATION_ESTABLISHMENT_OF_BEARER (now void)
 	rx_add_specific_action_avp(aar, 6);	 // IP-CAN_CHANGE
+	if(rx_include_alloc_result_indications) {
+		rx_add_specific_action_avp(
+				aar, 8); // INDICATION_OF_SUCCESSFUL_RESOURCES_ALLOCATION
+		rx_add_specific_action_avp(
+				aar, 9); // INDICATION_OF_FAILED_RESOURCES_ALLOCATION
+	}
 	rx_add_specific_action_avp(aar, 12); // ACCESS_NETWORK_INFO_REPORT
 
 	/* Add Framed IP address AVP*/


### PR DESCRIPTION
ims_qos, ims_qos_npn: fix getaddrinfo input and update Specific-Action handling in AAR-RX
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This PR includes several improvements and cleanups to both ims_qos and ims_qos_npn modules:

- Fixed input parameters for getaddrinfo().
- Added new module parameter `rx_include_alloc_result_indications`; when enabled, the module adds
  Specific-Action(513) AVPs INDICATION_OF_SUCCESSFUL_RESOURCES_ALLOCATION(8) and
  INDICATION_OF_FAILED_RESOURCES_ALLOCATION(9) to AAR-RX messages.
- Removed deprecated Specific-Action(513) AVP INDICATION_ESTABLISHMENT_OF_BEARER(5),
  which is now void according to 3GPP specifications.
- The changes are mirrored in ims_qos and ims_qos_npn modules to maintain consistency.
