### PR TITLE
Fix Subscription-State in NOTIFY to registered subscribers

### DIFF
--- a/src/modules/ims_registrar_scscf/registrar_notify.c
+++ b/src/modules/ims_registrar_scscf/registrar_notify.c
@@ -282,12 +282,14 @@ int can_publish_reg(struct sip_msg *msg, char *_t, char *str2)
 
 done:
 	if(presentity_uri.s)
-		shm_free(presentity_uri
+		shm_free(
+				presentity_uri
 						.s); // shm_malloc in cscf_get_public_identity_from_requri
 	return ret;
 error:
 	if(presentity_uri.s)
-		shm_free(presentity_uri
+		shm_free(
+				presentity_uri
 						.s); // shm_malloc in cscf_get_public_identity_from_requri
 	ret = CSCF_RETURN_ERROR;
 	return ret;
@@ -459,13 +461,15 @@ int can_subscribe_to_reg(struct sip_msg *msg, char *_t, char *str2)
 
 done:
 	if(presentity_uri.s)
-		shm_free(presentity_uri
+		shm_free(
+				presentity_uri
 						.s); // shm_malloc in cscf_get_public_identity_from_requri or get_presentity_from_subscriber_dialog
 	return ret;
 error:
 	ret = CSCF_RETURN_ERROR;
 	if(presentity_uri.s)
-		shm_free(presentity_uri
+		shm_free(
+				presentity_uri
 						.s); // shm_malloc in cscf_get_public_identity_from_requri or get_presentity_from_subscriber_dialog
 	return ret;
 }
@@ -1705,7 +1709,9 @@ void create_notifications(udomain_t *_t, impurecord_t *r_passed,
 
 		create_notification = 0;
 
-		if(r->reg_state == IMPU_REGISTERED && s->expires > act_time) {
+		if((event_type != IMS_REGISTRAR_CONTACT_EXPIRED
+				   && event_type != IMS_REGISTRAR_CONTACT_UNREGISTERED)
+				&& s->expires > act_time) {
 			subscription_state.s = (char *)pkg_malloc(32 * sizeof(char *));
 			subscription_state.len = 0;
 			if(subscription_state.s) {
@@ -1722,8 +1728,8 @@ void create_notifications(udomain_t *_t, impurecord_t *r_passed,
 
 		} else {
 			STR_PKG_DUP(subscription_state, subs_terminated, "pkg subs state");
-			LM_DBG("Expires is past than current time or impu is not registered! Subscription state: "
-				   "[%.*s]\n",
+			LM_DBG("Expires is past than current time or UE deregistered! "
+				   "Subscription state: [%.*s]\n",
 					subscription_state.len, subscription_state.s);
 		}
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

In this PR I am address an issue where SIP NOTIFY from S-CSCF to registered subscribers was sent with Subscription-State set to active and expires > 0 when UE deregisters from the IMS.

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4296

#### Description
<!-- Describe your changes in detail -->
