### PR TITLE
rtpengine: changed the hash_algo parameter to be by default 2 (CRC32) 

### DIFF
--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -2343,7 +2343,7 @@ modparam("rtpengine", "control_cmd_tos", 144)
 			CRC32 - 2 (calculate crc32 sum over the callid).
 		</para>
 		<para>
-			Default value is 0, legacy algorithm.
+			Default value is 2, CRC32.
 		</para>
 		<para>
 			The values not falling into the range <quote>0-2</quote> are ignored.

--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -418,7 +418,7 @@ int force_send_ip_af = AF_UNSPEC;
 static str _rtpe_wsapi = STR_NULL;
 lwsc_api_t _rtpe_lwscb = {0};
 
-static enum hash_algo_t hash_algo = RTP_HASH_CALLID;
+static enum hash_algo_t hash_algo = RTP_HASH_CRC32_CALLID;
 
 static str rtpengine_dtmf_event_sock;
 static int rtpengine_dtmf_event_fd;


### PR DESCRIPTION
rtpengine: Changed the hash_algo parameter to be by default 2 (CRC32)  instead of 0 (legacy algorithm)

