### PR TITLE
xhttp_prom: don't sanitize tag values in exported metrics

### DIFF
--- a/src/modules/xhttp_prom/prom.c
+++ b/src/modules/xhttp_prom/prom.c
@@ -191,10 +191,15 @@ static int metric_generate(
 			(uint64_t)ts);
 
 	/* Print metric name. */
-	if(prom_body_name_printf(ctx, "%.*s%.*s_%.*s%s", xhttp_prom_beginning.len,
-			   xhttp_prom_beginning.s, group->len, group->s, name->len, name->s,
-			   xhttp_prom_tags_braces)
+	if(prom_body_name_printf(ctx, "%.*s%.*s_%.*s", xhttp_prom_beginning.len,
+			   xhttp_prom_beginning.s, group->len, group->s, name->len, name->s)
 			== -1) {
+		LM_ERR("Fail to print\n");
+		return -1;
+	}
+
+	/* xhttp_prom_tags_braces is not sanitized any more because UTF-8 characters are allowed */
+	if(prom_body_printf(ctx, "%s", xhttp_prom_tags_braces) == -1) {
 		LM_ERR("Fail to print\n");
 		return -1;
 	}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #4508

#### Description
<!-- Describe your changes in detail -->


This pull request updates the way metric names and tags are printed in the `metric_generate` function to improve UTF-8 compatibility and error handling. The most important changes are:

**Metric Name and Tag Printing Improvements:**

* The `prom_body_name_printf` call was modified to exclude `xhttp_prom_tags_braces` from the metric name, and instead, `xhttp_prom_tags_braces` is now printed separately using `prom_body_printf`. This change allows UTF-8 characters in the tags and avoids unnecessary sanitization.
* Improved error handling: if either `prom_body_name_printf` or `prom_body_printf` fails, an error is logged and the function returns `-1`.

**Code Comments:**

* Added a comment clarifying that `xhttp_prom_tags_braces` is no longer sanitized because UTF-8 characters are now allowed.