### PR TITLE
rtpengine: Removed the legacy Hash Algorithm-RTP_HASH_CALLID

### DIFF
--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -2338,9 +2338,10 @@ modparam("rtpengine", "control_cmd_tos", 144)
 	<section id="rtpengine.p.hash_algo">
 		<title><varname>hash_algo</varname> (integer)</title>
 		<para>
-			Hashing algorithm to be used in node selection algorithm. Now there are 3 possibilities: legacy
-			algorithm - 0 (very basic hash over callid), SHA1 - 1 (apply sha1 over the callid and calculate hash) or
+			The hashing algorithm to be used in node selection algorithm. There are two possibilities:
+			SHA1 - 1 (calculate SHA1 hash over the Call-ID) or
 			CRC32 - 2 (calculate crc32 sum over the callid).
+			The legacy algorithm - 0 is not available anymore. If 0 is specified the default CRC32 will be used.
 		</para>
 		<para>
 			Default value is 2, CRC32.
@@ -2352,9 +2353,6 @@ modparam("rtpengine", "control_cmd_tos", 144)
 		<title>Set <varname>hash_algo</varname> parameter</title>
 <programlisting format="linespecific">
 ...
-### use SHA1 instead of legacy algorithm
-modparam("rtpengine", "hash_algo", 1)
-
 ### use CRC32 instead of legacy algorithm
 modparam("rtpengine", "hash_algo", 2)
 ...

--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -4485,10 +4485,6 @@ static struct rtpp_node *select_rtpp_node_new(str callid, str viabranch,
 	str hash_data = STR_NULL;
 
 	switch(hash_algo) {
-		case RTP_HASH_CALLID:
-			hash_data = callid;
-
-			break;
 		case RTP_HASH_SHA1_CALLID:
 			if(callid.len <= 0 || callid.s == NULL) {
 				LM_ERR("Invalid callid for SHA1 hashing\n");
@@ -4498,6 +4494,7 @@ static struct rtpp_node *select_rtpp_node_new(str callid, str viabranch,
 			hash_data.s = (char *)sha1;
 			hash_data.len = SHA1_DIGEST_LENGTH;
 			break;
+		case RTP_HASH_CALLID:
 		case RTP_HASH_CRC32_CALLID:
 			crc32_uint(&callid, &sum);
 			goto retry;
@@ -4505,18 +4502,10 @@ static struct rtpp_node *select_rtpp_node_new(str callid, str viabranch,
 			LM_ERR("unknown hashing algo %d\n", hash_algo);
 			return NULL;
 	}
-
 	/* XXX Use quick-and-dirty hashing algo */
 	sum = 0;
 	for(i = 0; i < hash_data.len; i++)
 		sum += hash_data.s[i];
-
-	/* FIXME this seems to affect the algorithm in a negative way
-	 * legacy code uses it; disable it for other algos */
-	if(hash_algo == RTP_HASH_CALLID) {
-		sum &= 0xff;
-	}
-
 retry:
 	LM_DBG("sum is = %u\n", sum);
 	weight_sum = 0;


### PR DESCRIPTION
rtpengine: Removed the legacy Hash Algorithm from the code and documentation updated. The legacy algorithm is left for backward compatibility but adopts the behavior of the default (CRC32) 