### PR TITLE
dmq: Fix DNS resolution corruption when search list is used

### DIFF
--- a/src/modules/dmq/notification_peer.c
+++ b/src/modules/dmq/notification_peer.c
@@ -228,6 +228,7 @@ int get_dmq_host_list(
 	for(prec = phead; prec; prec = prec->next) {
 		/**********
 		* o check max
+		* o skip non-A records (e.g., CNAME)
 		* o create URI
 		**********/
 
@@ -235,6 +236,11 @@ int get_dmq_host_list(
 			LM_WARN("notification host count reached max!\n");
 			free_rdata_list(phead);
 			return host_cnt;
+		}
+		/* Skip non-A records - get_record may return CNAME records
+		 * when DNS search list expansion is used */
+		if(prec->type != T_A) {
+			continue;
 		}
 		len = ip4tosbuf(
 				((struct a_rdata *)prec->rdata)->ip, pIP, IP4_MAX_STR_SIZE);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

When `dns_use_search_list=1` (the default), `get_record()` may prepend a "fake CNAME" record to map short hostnames to their expanded form. The DMQ module's `get_dmq_host_list()` function was iterating through all returned records and casting `rdata` to `struct a_rdata *` without checking the record type. This caused CNAME record data (hostname bytes) to be interpreted as IP address bytes, resulting in bogus IP addresses.

For example, a hostname containing `.ord` would produce the IP `43.111.114.100` (the ASCII bytes `+ord` = 0x2B 0x6F 0x72 0x64).

This has been tested and fixed with Kamailio 6.0.x, backported also to master.

#### Fix

Add a type check to skip non-A records in the iteration loop:

```c
if(prec->type != T_A) {
    continue;
}
```

#### Affected Environments
This bug affects Kamailio deployments using the following setup:
* DMQ module with dmq_notification_address containing partial hostnames
* DNS search lists (common in Kubernetes environments)
* Default dns_use_search_list=1 setting

#### Workarounds
Before this fix, users could work around the issue by:
* Using fully qualified domain names in dmq_notification_address
* Setting dns_use_search_list=0 in kamailio.cfg