### PR TITLE
peerstate: Add peer state tracking module

### DIFF
--- a/src/modules/peerstate/CMakeLists.txt
+++ b/src/modules/peerstate/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB MODULE_SOURCES "*.c")
+
+add_library(${module_name} SHARED ${MODULE_SOURCES})

--- a/src/modules/peerstate/Makefile
+++ b/src/modules/peerstate/Makefile
@@ -1,0 +1,12 @@
+#
+# Domain module makefile
+#
+#
+# WARNING: do not run this directly, it should be run by the main Makefile
+
+include ../../Makefile.defs
+auto_gen=
+NAME=peerstate.so
+LIBS=
+
+include ../../Makefile.modules

--- a/src/modules/peerstate/README
+++ b/src/modules/peerstate/README
@@ -1,0 +1,618 @@
+Peerstate Module
+
+Serdar GÜÇLÜER
+
+   Netgsm ICT Inc.
+   <serdar.gucluuer@hotmail.com>
+
+   Copyright © 2024 Netgsm ICT Inc., http://www.netgsm.com.tr
+     __________________________________________________________________
+
+   Table of Contents
+
+   1. Admin Guide
+
+        1. Overview
+        2. How it works
+        3. Peer states
+        4. Dependencies
+
+              4.1. Kamailio Modules
+              4.2. External Libraries or Applications
+
+        5. Parameters
+
+              5.1. cache_hash_size (integer)
+              5.2. cache_expire (integer)
+              5.3. cache_cleanup_interval (integer)
+              5.4. use_avps (integer)
+              5.5. caller_avp (string)
+              5.6. callee_avp (string)
+              5.7. reg_avp (string)
+              5.8. enable_notify_on_trying (integer)
+              5.9. disable_caller_notify_flag (integer)
+              5.10. disable_callee_notify_flag (integer)
+              5.11. disable_reg_notify (integer)
+              5.12. disable_dlg_notify (integer)
+
+        6. RPC Commands
+
+              6.1. peerstate.get_peer
+              6.2. peerstate.stats
+              6.3. peerstate.list
+              6.4. peerstate.dump
+
+        7. Event Routes
+
+              7.1. event_route[peerstate:state_changed]
+
+   2. Developer Guide
+
+        1. Available Functions
+
+              1.1. bind_peerstate(peerstate_api_t *api)
+              1.2. register_peerstate_callback(int event_types, 
+                   peerstate_cb_f callback, void *param)
+
+   List of Examples
+
+   1.1. Set cache_hash_size parameter
+   1.2. Set cache_expire parameter
+   1.3. Set cache_cleanup_interval parameter
+   1.4. Set use_avps parameter
+   1.5. Set caller_avp parameter
+   1.6. Set callee_avp parameter
+   1.7. Set reg_avp parameter
+   1.8. Set enable_notify_on_trying parameter
+   1.9. Set disable_caller_notify_flag parameter
+   1.10. Set disable_callee_notify_flag parameter
+   1.11. Set disable_reg_notify parameter
+   1.12. Set disable_dlg_notify parameter
+   1.13. peerstate.get_peer RPC command
+   1.14. peerstate.stats RPC command
+   1.15. peerstate.list RPC command
+   1.16. peerstate.dump RPC command
+   1.17. event_route[peerstate:state_changed] usage
+   1.18. Callback registration example
+
+Chapter 1. Admin Guide
+
+   Table of Contents
+
+   1. Overview
+   2. How it works
+   3. Peer states
+   4. Dependencies
+
+        4.1. Kamailio Modules
+        4.2. External Libraries or Applications
+
+   5. Parameters
+
+        5.1. cache_hash_size (integer)
+        5.2. cache_expire (integer)
+        5.3. cache_cleanup_interval (integer)
+        5.4. use_avps (integer)
+        5.5. caller_avp (string)
+        5.6. callee_avp (string)
+        5.7. reg_avp (string)
+        5.8. enable_notify_on_trying (integer)
+        5.9. disable_caller_notify_flag (integer)
+        5.10. disable_callee_notify_flag (integer)
+        5.11. disable_reg_notify (integer)
+        5.12. disable_dlg_notify (integer)
+
+   6. RPC Commands
+
+        6.1. peerstate.get_peer
+        6.2. peerstate.stats
+        6.3. peerstate.list
+        6.4. peerstate.dump
+
+   7. Event Routes
+
+        7.1. event_route[peerstate:state_changed]
+
+1. Overview
+
+   The peerstate module provides peer state tracking for the 
+   Kamailio SIP proxy. It monitors both dialog events (call states) 
+   and registration events (usrloc) to maintain an accurate view of 
+   each peer's current status.
+
+   For example, a common need in call center applications is to track 
+   agent availability in real-time. In order to monitor agent states, 
+   it is necessary for the proxy to be aware of both call activity and 
+   registration status. This is just one common application; there are 
+   many others such as presence services, load balancing, and 
+   concurrent call limiting.
+
+   The module exports RPC commands for monitoring and management, 
+   provides an event route mechanism for custom logic execution, and 
+   offers a callback API for other Kamailio modules.
+
+2. How it works
+
+   The peerstate module registers callbacks with the dialog and usrloc 
+   modules. When dialog state changes (EARLY, CONFIRMED, TERMINATED) 
+   or registration events (REGISTER/UNREGISTER) occur, the module 
+   updates its internal cache and determines if a peer's state has 
+   changed.
+
+   Peer state is maintained in a shared memory hash table. Each peer 
+   entry contains current state, active call count, registration flag, 
+   and timestamp.
+
+   State transitions:
+     * EARLY events increment call count and set peer to RINGING (or 
+       keep INUSE if already in call)
+     * CONFIRMED events set peer to INUSE
+     * TERMINATED events decrement call count; peer returns to 
+       NOT_INUSE (if registered) or UNAVAILABLE (if not registered) 
+       when call count reaches zero
+     * REGISTER events set registration flag and may transition from 
+       UNAVAILABLE to NOT_INUSE
+     * UNREGISTER events clear registration flag and may transition 
+       from NOT_INUSE to UNAVAILABLE (if no active calls)
+
+   When a peer's state changes, the module triggers notifications via 
+   event routes and callback functions.
+
+3. Peer states
+
+   Peer states tracked by the module:
+     * 0 : NOT_INUSE - Peer is registered and idle (no active calls)
+     * 1 : INUSE - Peer is in an active call (dialog confirmed)
+     * 2 : RINGING - Peer has incoming or outgoing call ringing (early 
+       dialog)
+     * 3 : UNAVAILABLE - Peer is not registered
+     * 4 : NA - Not applicable or unknown state
+
+   State transitions are designed to accurately reflect the peer's 
+   availability:
+     * A peer transitions to RINGING when receiving or making a call
+     * A peer transitions to INUSE when the call is answered
+     * A peer returns to NOT_INUSE when all calls end and the peer is 
+       still registered
+     * A peer transitions to UNAVAILABLE when unregistering with no 
+       active calls
+     * Active calls are preserved during registration changes
+
+4. Dependencies
+
+   4.1. Kamailio Modules
+   4.2. External Libraries or Applications
+
+4.1. Kamailio Modules
+
+   The following modules must be loaded before this module:
+     * Dialog - Dialog tracking module
+     * Usrloc - User location module
+
+4.2. External Libraries or Applications
+
+   The following libraries or applications must be installed before 
+   running Kamailio with this module loaded:
+     * None.
+
+5. Parameters
+
+   5.1. cache_hash_size (integer)
+   5.2. cache_expire (integer)
+   5.3. cache_cleanup_interval (integer)
+   5.4. use_avps (integer)
+   5.5. caller_avp (string)
+   5.6. callee_avp (string)
+   5.7. reg_avp (string)
+   5.8. enable_notify_on_trying (integer)
+   5.9. disable_caller_notify_flag (integer)
+   5.10. disable_callee_notify_flag (integer)
+   5.11. disable_reg_notify (integer)
+   5.12. disable_dlg_notify (integer)
+
+5.1. cache_hash_size (integer)
+
+   The size of the hash table internally used to keep the peer state 
+   information. A larger table is much faster but consumes more 
+   memory. The hash size must be a power of two.
+
+   Default value is "4096".
+
+   Example 1.1. Set cache_hash_size parameter
+...
+modparam("peerstate", "cache_hash_size", 8192)
+...
+
+5.2. cache_expire (integer)
+
+   The time in seconds after which inactive peer entries are removed 
+   from the cache. Set to 0 to disable automatic expiration. This 
+   helps conserve memory by removing stale peer information.
+
+   Default value is "3600" (1 hour).
+
+   Example 1.2. Set cache_expire parameter
+...
+modparam("peerstate", "cache_expire", 7200)
+...
+
+5.3. cache_cleanup_interval (integer)
+
+   The interval in seconds between automatic cache cleanup runs. Must 
+   be less than or equal to cache_expire. Set to 0 to disable 
+   automatic cleanup. During cleanup, expired entries are removed from 
+   the cache.
+
+   Default value is "300" (5 minutes).
+
+   Example 1.3. Set cache_cleanup_interval parameter
+...
+modparam("peerstate", "cache_cleanup_interval", 600)
+...
+
+5.4. use_avps (integer)
+
+   Enable or disable the use of AVPs for peer identification instead 
+   of extracting peer information from SIP headers. When enabled, the 
+   module will use the AVPs specified by caller_avp, callee_avp, and 
+   reg_avp parameters to identify peers.
+   
+
+   If set to 0, the module extracts peer information from From/To 
+   headers. If set to 1, AVPs must be set by the routing script.
+
+   Default value is "0" (disabled).
+
+   Example 1.4. Set use_avps parameter
+...
+modparam("peerstate", "use_avps", 1)
+...
+
+5.5. caller_avp (string)
+
+   The specification of an AVP that contains the caller's peer 
+   identifier. Only used when use_avps is set to 1. The AVP should 
+   contain the peer identifier in the format "peer@domain".
+
+   Default value is "NULL".
+
+   Example 1.5. Set caller_avp parameter
+...
+modparam("peerstate", "caller_avp", "$avp(caller_peer)")
+...
+
+5.6. callee_avp (string)
+
+   The specification of an AVP that contains the callee's peer 
+   identifier. Only used when use_avps is set to 1. The AVP should 
+   contain the peer identifier in the format "peer@domain".
+
+   Default value is "NULL".
+
+   Example 1.6. Set callee_avp parameter
+...
+modparam("peerstate", "callee_avp", "$avp(callee_peer)")
+...
+
+5.7. reg_avp (string)
+
+   The specification of an AVP that contains the registered peer 
+   identifier for usrloc events. Only used when use_avps is set to 1.
+
+   Default value is "NULL".
+
+   Example 1.7. Set reg_avp parameter
+...
+modparam("peerstate", "reg_avp", "$avp(reg_peer)")
+...
+
+5.8. enable_notify_on_trying (integer)
+
+   Enable state change notifications for dialog TRYING state. By 
+   default, only EARLY, CONFIRMED, and TERMINATED states trigger 
+   notifications. When enabled, TRYING state will also trigger 
+   notifications.
+
+   Default value is "0" (disabled).
+
+   Example 1.8. Set enable_notify_on_trying parameter
+...
+modparam("peerstate", "enable_notify_on_trying", 1)
+...
+
+5.9. disable_caller_notify_flag (integer)
+
+   Message flag to disable caller state change notifications for 
+   specific calls. When this flag is set on a message, state changes 
+   for the caller will not trigger notifications. Set to -1 to disable 
+   this feature.
+
+   Default value is "-1" (feature disabled).
+
+   Example 1.9. Set disable_caller_notify_flag parameter
+...
+modparam("peerstate", "disable_caller_notify_flag", 10)
+...
+# In routing script:
+if ($rU == "1234567890") {
+    setflag(10);  # Don't notify about emergency call callers
+}
+...
+
+5.10. disable_callee_notify_flag (integer)
+
+   Message flag to disable callee state change notifications for 
+   specific calls. When this flag is set on a message, state changes 
+   for the callee will not trigger notifications. Set to -1 to disable 
+   this feature.
+
+   Default value is "-1" (feature disabled).
+
+   Example 1.10. Set disable_callee_notify_flag parameter
+...
+modparam("peerstate", "disable_callee_notify_flag", 11)
+...
+
+5.11. disable_reg_notify (integer)
+
+   Globally disable registration event processing. When set to 1, the 
+   module will not register callbacks with the usrloc module and will 
+   not process registration events.
+
+   Default value is "0" (process registration events).
+
+   Example 1.11. Set disable_reg_notify parameter
+...
+modparam("peerstate", "disable_reg_notify", 1)
+...
+
+5.12. disable_dlg_notify (integer)
+
+   Globally disable dialog event processing. When set to 1, the module 
+   will not register callbacks with the dialog module and will not 
+   process dialog events.
+
+   Default value is "0" (process dialog events).
+
+   Example 1.12. Set disable_dlg_notify parameter
+...
+modparam("peerstate", "disable_dlg_notify", 1)
+...
+
+6. RPC Commands
+
+   6.1. peerstate.get_peer
+   6.2. peerstate.stats
+   6.3. peerstate.list
+   6.4. peerstate.dump
+
+6.1. peerstate.get_peer
+
+   Get detailed state information for a specific peer. Returns the 
+   peer's current state, active call count, and registration status.
+
+   Name: peerstate.get_peer
+
+   Parameters:
+     * peer - peer identifier in the format "peer@domain"
+
+   RPC Command Format:
+
+   Example 1.13. peerstate.get_peer RPC command
+...
+kamctl rpc peerstate.get_peer 1000@192.168.1.100
+...
+
+   The command returns a structure containing:
+     * peer - peer identifier
+     * state - current state (NOT_INUSE, INUSE, RINGING, UNAVAILABLE)
+     * call_count - number of active calls
+     * registered - registration status ("yes" or "no")
+
+7.2. peerstate.stats
+
+   Get global cache statistics including total number of peers, number 
+   of peers in active calls, and number of registered peers.
+
+   Name: peerstate.stats
+
+   Parameters: none
+
+   RPC Command Format:
+
+   Example 1.14. peerstate.stats RPC command
+...
+kamctl rpc peerstate.stats
+...
+
+   The command returns a structure containing:
+     * total_peers - total number of peers in cache
+     * incall_peers - number of peers in INUSE or RINGING state
+     * registered_peers - number of registered peers
+
+7.3. peerstate.list
+
+   List all peers in a specific state. This command is useful for 
+   monitoring which peers are currently in a particular state.
+
+   Name: peerstate.list
+
+   Parameters:
+     * state - state filter (NOT_INUSE, INUSE, RINGING, or 
+       UNAVAILABLE)
+
+   RPC Command Format:
+
+   Example 1.15. peerstate.list RPC command
+...
+kamctl rpc peerstate.list INUSE
+...
+
+   The command returns a structure containing:
+     * count - number of peers in the specified state
+     * state - the state filter used
+     * Peer - array of peer objects, each containing:
+          + name - peer identifier
+          + state - current state
+          + call_count - number of active calls
+          + registered - registration status
+
+7.4. peerstate.dump
+
+   Dump all peers from the cache regardless of state. This command 
+   provides a complete view of all tracked peers.
+
+   Name: peerstate.dump
+
+   Parameters: none
+
+   RPC Command Format:
+
+   Example 1.16. peerstate.dump RPC command
+...
+kamctl rpc peerstate.dump
+...
+
+   The command returns a structure containing:
+     * count - total number of peers
+     * Peer - array of peer objects, each containing:
+          + name - peer identifier
+          + state - current state
+          + call_count - number of active calls
+          + registered - registration status
+
+7. Event Routes
+
+   7.1. event_route[peerstate:state_changed]
+
+7.1. event_route[peerstate:state_changed]
+
+   Executed when a peer's state changes. Provides access to state 
+   change information through AVP pseudo-variables.
+
+   Available pseudo-variables:
+     * $avp(ps_peer) - Peer identifier
+     * $avp(ps_state) - Current state (NOT_INUSE, INUSE, RINGING, 
+       UNAVAILABLE)
+     * $avp(ps_prev_state) - Previous state
+     * $avp(ps_uniq_id) - Call-ID or RUID
+
+   Example 1.17. event_route[peerstate:state_changed] usage
+...
+event_route[peerstate:state_changed] {
+    xlog("L_INFO", "Peer $avp(ps_peer): $avp(ps_prev_state) -> $avp(ps_state)");
+
+    # HTTP notification
+    if ($avp(ps_state) == "INUSE") {
+        http_async_query("http://api.local/state", "peer=$avp(ps_peer)&state=b
+usy", "HTTP_REPLY");
+    }
+}
+...
+
+Chapter 2. Developer Guide
+
+   Table of Contents
+
+   1. Available Functions
+
+        1.1. bind_peerstate(peerstate_api_t *api)
+        1.2. register_peerstate_callback(int event_types, 
+             peerstate_cb_f callback, void *param)
+
+1. Available Functions
+
+   1.1. bind_peerstate(peerstate_api_t *api)
+   1.2. register_peerstate_callback(int event_types, peerstate_cb_f 
+        callback, void *param)
+
+1.1.  bind_peerstate(peerstate_api_t *api)
+
+   Bind to the peerstate API and fill the provided structure with 
+   function pointers.
+
+   Meaning of the parameters is as follows:
+     * peerstate_api_t *api - pointer to API structure
+
+   The API structure:
+     typedef struct peerstate_api {
+         register_peerstate_cb_f register_callback;
+     } peerstate_api_t;
+
+   Return value:
+     * 0 - success
+     * -1 - error
+
+1.2.  register_peerstate_callback(int event_types, peerstate_cb_f callback, 
+void *param)
+
+   Register a callback function for peer state change notifications.
+
+   Meaning of the parameters is as follows:
+     * int event_types - Bitmask of event types:
+          + PEERSTATE_EVENT_DIALOG (1) - Dialog events
+          + PEERSTATE_EVENT_REGISTRATION (2) - Registration events
+     * peerstate_cb_f callback - Callback function with signature:
+       void callback(peerstate_cb_ctx_t *ctx, void *param);
+     * void *param - User parameter (can be NULL)
+
+   The callback context structure:
+     typedef struct peerstate_cb_ctx {
+         str peer;                      /* Peer identifier */
+         ps_state_t current_state;        /* Current state */
+         ps_state_t previous_state;       /* Previous state */
+         int call_count;                /* Active call count */
+         int is_registered;             /* Registration status */
+         str uniq_id;                   /* Call-ID or RUID */
+         peerstate_event_type_t event_type;  /* Event type */
+     } peerstate_cb_ctx_t;
+
+   State enumeration:
+     typedef enum ps_state {
+         NOT_INUSE,      /* Registered and idle */
+         INUSE,          /* In active call */
+         RINGING,        /* Ringing */
+         UNAVAILABLE,    /* Not registered */
+         NA              /* Unknown */
+     } ps_state_t;
+
+   Return value:
+     * 0 - success
+     * -1 - error
+
+   Example 1.18. Callback registration example
+...
+#include "../peerstate/peerstate_cb.h"
+
+static peerstate_api_t peerstate_api;
+
+/* Callback function */
+static void my_state_callback(peerstate_cb_ctx_t *ctx, void *param) {
+    LM_INFO("Peer %.*s: %s -> %s (calls=%d, reg=%s)\n",
+            ctx->peer.len, ctx->peer.s,
+            PS_STATE_TO_STR(ctx->previous_state),
+            PS_STATE_TO_STR(ctx->current_state),
+            ctx->call_count,
+            ctx->is_registered ? "yes" : "no");
+}
+
+/* Module initialization */
+static int mod_init(void) {
+    bind_peerstate_f bind_peerstate;
+    
+    bind_peerstate = (bind_peerstate_f)find_export("bind_peerstate", 1, 0);
+    if (!bind_peerstate || bind_peerstate(&peerstate_api) < 0) {
+        LM_ERR("Cannot bind to peerstate module\n");
+        return -1;
+    }
+    
+    if (peerstate_api.register_callback(
+            PEERSTATE_EVENT_DIALOG | PEERSTATE_EVENT_REGISTRATION,
+            my_state_callback, NULL) < 0) {
+        LM_ERR("Failed to register callback\n");
+        return -1;
+    }
+    
+    return 0;
+}
+...

--- a/src/modules/peerstate/docs/Makefile
+++ b/src/modules/peerstate/docs/Makefile
@@ -1,0 +1,4 @@
+docs = peerstate.xml
+
+docbook_dir = ../../../../doc/docbook
+include $(docbook_dir)/Makefile.module

--- a/src/modules/peerstate/docs/peerstate.xml
+++ b/src/modules/peerstate/docs/peerstate.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<book xmlns:xi="http://www.w3.org/2001/XInclude">
+    <bookinfo>
+	<title>Peerstate Module</title>
+	<productname class="trade">&kamailioname;</productname>
+	<authorgroup>
+	    <author>
+		<firstname>Serdar</firstname>
+		<surname>GÜÇLÜER</surname>
+		<affiliation><orgname>Netgsm ICT Inc.</orgname></affiliation>
+		<email>serdar.gucluer@hotmail.com</email>
+	    </author>
+	</authorgroup>
+	<copyright>
+	    <year>2025</year>
+	    <holder>Netgsm ICT Inc., http://www.netgsm.com.tr</holder>
+	</copyright>
+    </bookinfo>
+    <toc></toc>
+
+    <xi:include href="peerstate_admin.xml"/>
+    <xi:include href="peerstate_devel.xml"/>
+</book>

--- a/src/modules/peerstate/docs/peerstate_admin.xml
+++ b/src/modules/peerstate/docs/peerstate_admin.xml
@@ -1,0 +1,596 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<chapter>
+    
+    <title>&adminguide;</title>
+    
+    <section>
+	<title>Overview</title>
+	<para>
+	    The peerstate module provides peer state tracking for the 
+	    Kamailio SIP proxy. It monitors both dialog events (call states) 
+	    and registration events (usrloc) to maintain an accurate view of 
+	    each peer's current status.
+	</para>
+	<para>
+	    For example, a common need in call center applications is to track 
+	    agent availability in real-time. In order to monitor agent states, 
+	    it is necessary for the proxy to be aware of both call activity and 
+	    registration status. This is just one common application; there are 
+	    many others such as presence services, load balancing, and 
+	    concurrent call limiting.
+	</para>
+	<para>
+	    The module exports RPC commands for monitoring and management, 
+	    provides an event route mechanism for custom logic execution, and 
+	    offers a callback API for other Kamailio modules.
+	</para>
+    </section>
+    
+    <section>
+	<title>How it works</title>
+	<para>
+	    The peerstate module registers callbacks with the dialog and usrloc 
+	    modules. When dialog state changes (EARLY, CONFIRMED, TERMINATED) 
+	    or registration events (REGISTER/UNREGISTER) occur, the module 
+	    updates its internal cache and determines if a peer's state has 
+	    changed.
+	</para>
+	<para>
+	    Peer state is maintained in a shared memory hash table. Each peer 
+	    entry contains current state, active call count, registration flag, 
+	    and timestamp.
+	</para>
+	<para>
+	    State transitions:
+	    <itemizedlist>
+		<listitem>
+		    <para>EARLY events increment call count and set peer to RINGING (or 
+		    keep INUSE if already in call)</para>
+		</listitem>
+		<listitem>
+		    <para>CONFIRMED events set peer to INUSE</para>
+		</listitem>
+		<listitem>
+		    <para>TERMINATED events decrement call count; peer returns to 
+		    NOT_INUSE (if registered) or UNAVAILABLE (if not registered) 
+		    when call count reaches zero</para>
+		</listitem>
+		<listitem>
+		    <para>REGISTER events set registration flag and may transition from 
+		    UNAVAILABLE to NOT_INUSE</para>
+		</listitem>
+		<listitem>
+		    <para>UNREGISTER events clear registration flag and may transition 
+		    from NOT_INUSE to UNAVAILABLE (if no active calls)</para>
+		</listitem>
+	    </itemizedlist>
+	</para>
+	<para>
+	    When a peer's state changes, the module triggers notifications via 
+	    event routes and callback functions.
+	</para>
+    </section>
+    
+    <section>
+	<title>Peer states</title>
+	<para>
+	    Peer states tracked by the module:
+	    <itemizedlist>
+		<listitem>
+		    <para>0 : NOT_INUSE - Peer is registered and idle (no active calls)</para>
+		</listitem>
+		<listitem>
+		    <para>1 : INUSE - Peer is in an active call (dialog confirmed)</para>
+		</listitem>
+		<listitem>
+		    <para>2 : RINGING - Peer has incoming or outgoing call ringing (early dialog)</para>
+		</listitem>
+		<listitem>
+		    <para>3 : UNAVAILABLE - Peer is not registered</para>
+		</listitem>
+		<listitem>
+		    <para>4 : NA - Not applicable or unknown state</para>
+		</listitem>
+	    </itemizedlist>
+	</para>
+	<para>
+	    State transitions are designed to accurately reflect the peer's availability:
+	    <itemizedlist>
+		<listitem>
+		    <para>A peer transitions to RINGING when receiving or making a call</para>
+		</listitem>
+		<listitem>
+		    <para>A peer transitions to INUSE when the call is answered</para>
+		</listitem>
+		<listitem>
+		    <para>A peer returns to NOT_INUSE when all calls end and the peer is still registered</para>
+		</listitem>
+		<listitem>
+		    <para>A peer transitions to UNAVAILABLE when unregistering with no active calls</para>
+		</listitem>
+		<listitem>
+		    <para>Active calls are preserved during registration changes</para>
+		</listitem>
+	    </itemizedlist>
+	</para>
+    </section>
+    
+    <section>
+	<title>Dependencies</title>
+	<section>
+	    <title>&kamailio; Modules</title>
+	    <para>
+		The following modules must be loaded before this module:
+		<itemizedlist>
+		    <listitem>
+			<para><emphasis>Dialog</emphasis> - Dialog tracking module</para>
+		    </listitem>
+		    <listitem>
+			<para><emphasis>Usrloc</emphasis> - User location module</para>
+		    </listitem>
+		</itemizedlist>
+	    </para>
+	</section>
+	<section>
+	    <title>External Libraries or Applications</title>
+	    <para>
+		The following libraries or applications must be installed before 
+		running &kamailio; with this module loaded:
+		<itemizedlist>
+		    <listitem>
+			<para><emphasis>None</emphasis>.</para>
+		    </listitem>
+		</itemizedlist>
+	    </para>
+	</section>
+    </section>
+    
+    <section>
+	<title>Parameters</title>
+	<section id="peerstate.p.cache_hash_size">
+	    <title><varname>cache_hash_size</varname> (integer)</title>
+	    <para>
+		The size of the hash table internally used to keep the peer state 
+		information. A larger table is much faster but consumes more 
+		memory. The hash size must be a power of two.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>4096</quote>.
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>cache_hash_size</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("peerstate", "cache_hash_size", 8192)
+...
+</programlisting>
+	    </example>
+	</section>
+	
+	<section id="peerstate.p.cache_expire">
+	    <title><varname>cache_expire</varname> (integer)</title>
+	    <para>
+		The time in seconds after which inactive peer entries are removed 
+		from the cache. Set to 0 to disable automatic expiration. This 
+		helps conserve memory by removing stale peer information.
+		Minimum allowed value is 60 seconds (when enabled).
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>3600</quote> (1 hour).
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>cache_expire</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("peerstate", "cache_expire", 7200)
+...
+</programlisting>
+	    </example>
+	</section>
+	
+	<section id="peerstate.p.cache_cleanup_interval">
+	    <title><varname>cache_cleanup_interval</varname> (integer)</title>
+	    <para>
+		The interval in seconds between automatic cache cleanup runs. Must 
+		be less than or equal to cache_expire. Set to 0 to disable 
+		automatic cleanup. During cleanup, expired entries are removed from 
+		the cache. Minimum allowed value is 10 seconds (when enabled).
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>300</quote> (5 minutes).
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>cache_cleanup_interval</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("peerstate", "cache_cleanup_interval", 600)
+...
+</programlisting>
+	    </example>
+	</section>
+	
+	<section id="peerstate.p.use_avps">
+	    <title><varname>use_avps</varname> (integer)</title>
+	    <para>
+		Enable or disable the use of AVPs for peer identification instead 
+		of extracting peer information from SIP headers. When enabled, the 
+		module will use the AVPs specified by caller_avp, callee_avp, and 
+		reg_avp parameters to identify peers.
+	    </para>
+	    <para>
+		If set to 0, the module extracts peer information from From/To 
+		headers. If set to 1, AVPs must be set by the routing script.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>0</quote> (disabled).
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>use_avps</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("peerstate", "use_avps", 1)
+...
+</programlisting>
+	    </example>
+	</section>
+	
+	<section id="peerstate.p.caller_avp">
+	    <title><varname>caller_avp</varname> (string)</title>
+	    <para>
+		The specification of an AVP that contains the caller's peer 
+		identifier. Only used when use_avps is set to 1. The AVP should 
+		contain the peer identifier in the format "peer@domain".
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>NULL</quote>.
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>caller_avp</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("peerstate", "caller_avp", "$avp(caller_peer)")
+...
+</programlisting>
+	    </example>
+	</section>
+	
+	<section id="peerstate.p.callee_avp">
+	    <title><varname>callee_avp</varname> (string)</title>
+	    <para>
+		The specification of an AVP that contains the callee's peer 
+		identifier. Only used when use_avps is set to 1. The AVP should 
+		contain the peer identifier in the format "peer@domain".
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>NULL</quote>.
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>callee_avp</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("peerstate", "callee_avp", "$avp(callee_peer)")
+...
+</programlisting>
+	    </example>
+	</section>
+	
+	<section id="peerstate.p.reg_avp">
+	    <title><varname>reg_avp</varname> (string)</title>
+	    <para>
+		The specification of an AVP that contains the registered peer 
+		identifier for usrloc events. Only used when use_avps is set to 1.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>NULL</quote>.
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>reg_avp</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("peerstate", "reg_avp", "$avp(reg_peer)")
+...
+</programlisting>
+	    </example>
+	</section>
+	
+	<section id="peerstate.p.enable_notify_on_trying">
+	    <title><varname>enable_notify_on_trying</varname> (integer)</title>
+	    <para>
+		Enable state change notifications for dialog TRYING state. By 
+		default, only EARLY, CONFIRMED, and TERMINATED states trigger 
+		notifications. When enabled, TRYING state will also trigger 
+		notifications.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>0</quote> (disabled).
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>enable_notify_on_trying</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("peerstate", "enable_notify_on_trying", 1)
+...
+</programlisting>
+	    </example>
+	</section>
+	
+	<section id="peerstate.p.disable_caller_notify_flag">
+	    <title><varname>disable_caller_notify_flag</varname> (integer)</title>
+	    <para>
+		Message flag to disable caller state change notifications for 
+		specific calls. When this flag is set on a message, state changes 
+		for the caller will not trigger notifications. Set to -1 to disable 
+		this feature.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>-1</quote> (feature disabled).
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>disable_caller_notify_flag</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("peerstate", "disable_caller_notify_flag", 10)
+...
+# In routing script:
+if ($rU == "1234567890") {
+    setflag(10);  # Don't notify about emergency call callers
+}
+...
+</programlisting>
+	    </example>
+	</section>
+	
+	<section id="peerstate.p.disable_callee_notify_flag">
+	    <title><varname>disable_callee_notify_flag</varname> (integer)</title>
+	    <para>
+		Message flag to disable callee state change notifications for 
+		specific calls. When this flag is set on a message, state changes 
+		for the callee will not trigger notifications. Set to -1 to disable 
+		this feature.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>-1</quote> (feature disabled).
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>disable_callee_notify_flag</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("peerstate", "disable_callee_notify_flag", 11)
+...
+</programlisting>
+	    </example>
+	</section>
+	
+	<section id="peerstate.p.disable_reg_notify">
+	    <title><varname>disable_reg_notify</varname> (integer)</title>
+	    <para>
+		Globally disable registration event processing. When set to 1, the 
+		module will not register callbacks with the usrloc module and will 
+		not process registration events.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>0</quote> (process registration events).
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>disable_reg_notify</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("peerstate", "disable_reg_notify", 1)
+...
+</programlisting>
+	    </example>
+	</section>
+	
+	<section id="peerstate.p.disable_dlg_notify">
+	    <title><varname>disable_dlg_notify</varname> (integer)</title>
+	    <para>
+		Globally disable dialog event processing. When set to 1, the module 
+		will not register callbacks with the dialog module and will not 
+		process dialog events.
+	    </para>
+	    <para>
+		<emphasis>
+		    Default value is <quote>0</quote> (process dialog events).
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>disable_dlg_notify</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("peerstate", "disable_dlg_notify", 1)
+...
+</programlisting>
+	    </example>
+	</section>
+	
+    </section>
+    
+    <section>
+	<title>RPC Commands</title>
+	<section id="peerstate.r.get_peer">
+	    <title>
+		<function moreinfo="none">peerstate.get_peer</function>
+	    </title>
+	    <para>
+		Get detailed state information for a specific peer. Returns the 
+		peer's current state, active call count, and registration status.
+	    </para>
+	    <para>
+		Name: <emphasis>peerstate.get_peer</emphasis>
+	    </para>
+	    <para>Parameters:</para>
+	    <itemizedlist>
+		<listitem><para>peer - peer identifier in the format "peer@domain"</para></listitem>
+	    </itemizedlist>
+	    <para>RPC Command Format:</para>
+	    <programlisting  format="linespecific">
+...
+kamctl rpc peerstate.get_peer 1000@192.168.1.100
+...
+	    </programlisting>
+	    <para>
+		The command returns a structure containing:
+		<itemizedlist>
+		    <listitem><para>peer - peer identifier</para></listitem>
+		    <listitem><para>state - current state (NOT_INUSE, INUSE, RINGING, UNAVAILABLE)</para></listitem>
+		    <listitem><para>call_count - number of active calls</para></listitem>
+		    <listitem><para>registered - registration status ("yes" or "no")</para></listitem>
+		</itemizedlist>
+	    </para>
+	</section>
+	
+	<section id="peerstate.r.stats">
+	    <title>
+		<function moreinfo="none">peerstate.stats</function>
+	    </title>
+	    <para>
+		Get global cache statistics including total number of peers, number 
+		of peers in active calls, and number of registered peers.
+	    </para>
+	    <para>
+		Name: <emphasis>peerstate.stats</emphasis>
+	    </para>
+	    <para>Parameters: none</para>
+	    <para>RPC Command Format:</para>
+	    <programlisting  format="linespecific">
+...
+kamctl rpc peerstate.stats
+...
+	    </programlisting>
+	    <para>
+		The command returns a structure containing:
+		<itemizedlist>
+		    <listitem><para>total_peers - total number of peers in cache</para></listitem>
+		    <listitem><para>incall_peers - number of peers in INUSE or RINGING state</para></listitem>
+		    <listitem><para>registered_peers - number of registered peers</para></listitem>
+		</itemizedlist>
+	    </para>
+	</section>
+	
+	<section id="peerstate.r.list">
+	    <title>
+		<function moreinfo="none">peerstate.list</function>
+	    </title>
+	    <para>
+		List all peers in a specific state. This command is useful for 
+		monitoring which peers are currently in a particular state.
+	    </para>
+	    <para>
+		Name: <emphasis>peerstate.list</emphasis>
+	    </para>
+	    <para>Parameters:</para>
+	    <itemizedlist>
+		<listitem><para>state - state filter (NOT_INUSE, INUSE, RINGING, or UNAVAILABLE)</para></listitem>
+	    </itemizedlist>
+	    <para>RPC Command Format:</para>
+	    <programlisting  format="linespecific">
+...
+kamctl rpc peerstate.list INUSE
+...
+	    </programlisting>
+	    <para>
+		The command returns a structure containing:
+		<itemizedlist>
+		    <listitem><para>count - number of peers in the specified state</para></listitem>
+		    <listitem><para>state - the state filter used</para></listitem>
+		    <listitem><para>Peer - array of peer objects with name, state, call_count, and registered status</para></listitem>
+		</itemizedlist>
+	    </para>
+	</section>
+	
+	<section id="peerstate.r.dump">
+	    <title>
+		<function moreinfo="none">peerstate.dump</function>
+	    </title>
+	    <para>
+		Dump all peers from the cache regardless of state. This command 
+		provides a complete view of all tracked peers.
+	    </para>
+	    <para>
+		Name: <emphasis>peerstate.dump</emphasis>
+	    </para>
+	    <para>Parameters: none</para>
+	    <para>RPC Command Format:</para>
+	    <programlisting  format="linespecific">
+...
+kamctl rpc peerstate.dump
+...
+	    </programlisting>
+	    <para>
+		The command returns a structure containing:
+		<itemizedlist>
+		    <listitem><para>count - total number of peers</para></listitem>
+		    <listitem><para>Peer - array of peer objects with name, state, call_count, and registered status</para></listitem>
+		</itemizedlist>
+	    </para>
+	</section>
+    </section>
+    
+    <section>
+	<title>Event Routes</title>
+	<section id="peerstate.evr.peerstate_state_changed">
+	    <title>
+		<function moreinfo="none">event_route[peerstate:state_changed]</function>
+	    </title>
+	    <para>
+		Executed when a peer's state changes. Provides access to state 
+		change information through AVP pseudo-variables.
+	    </para>
+	    <para>
+		Available pseudo-variables:
+		<itemizedlist>
+		    <listitem><para>$avp(ps_peer) - Peer identifier</para></listitem>
+		    <listitem><para>$avp(ps_state) - Current state (NOT_INUSE, INUSE, RINGING, UNAVAILABLE)</para></listitem>
+		    <listitem><para>$avp(ps_prev_state) - Previous state</para></listitem>
+		    <listitem><para>$avp(ps_uniq_id) - Call-ID or RUID</para></listitem>
+		</itemizedlist>
+	    </para>
+	    <example>
+		<title><function>event_route[peerstate:state_changed]</function> usage</title>
+		<programlisting format="linespecific">
+...
+event_route[peerstate:state_changed] {
+    xlog("L_INFO", "Peer $avp(ps_peer): $avp(ps_prev_state) -> $avp(ps_state)");
+
+    # HTTP notification
+    if ($avp(ps_state) == "INUSE") {
+        http_async_query("http://api.local/state", "peer=$avp(ps_peer)&amp;state=busy", "HTTP_REPLY");
+    }
+}
+...
+</programlisting>
+	    </example>
+	</section>
+    </section>
+    
+</chapter>

--- a/src/modules/peerstate/docs/peerstate_devel.xml
+++ b/src/modules/peerstate/docs/peerstate_devel.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<chapter>
+    
+    <title>&develguide;</title>
+    
+    <section>
+	<title>Available Functions</title>
+	
+	<section id="peerstate.f.bind_peerstate">
+	    <title>
+		<function moreinfo="none">bind_peerstate(peerstate_api_t *api)</function>
+	    </title>
+	    <para>
+		Bind to the peerstate API and fill the provided structure with 
+		function pointers.
+	    </para>
+	    <para>
+		Meaning of the parameters is as follows:
+		<itemizedlist>
+		    <listitem>
+			<para><emphasis>peerstate_api_t *api</emphasis> - pointer to API structure</para>
+		    </listitem>
+		</itemizedlist>
+	    </para>
+	    <para>
+		The API structure:
+		<programlisting format="linespecific">
+typedef struct peerstate_api {
+    register_peerstate_cb_f register_callback;
+} peerstate_api_t;
+		</programlisting>
+	    </para>
+	    <para>
+		Return value:
+		<itemizedlist>
+		    <listitem>
+			<para>0 - success</para>
+		    </listitem>
+		    <listitem>
+			<para>-1 - error</para>
+		    </listitem>
+		</itemizedlist>
+	    </para>
+	</section>
+	
+	<section id="peerstate.f.register_peerstate_callback">
+	    <title>
+		<function moreinfo="none">register_peerstate_callback(int event_types, peerstate_cb_f callback, void *param)</function>
+	    </title>
+	    <para>
+		Register a callback function for peer state change notifications.
+	    </para>
+	    <para>
+		Meaning of the parameters is as follows:
+		<itemizedlist>
+		    <listitem>
+			<para><emphasis>int event_types</emphasis> - Bitmask of event types:</para>
+			<itemizedlist>
+			    <listitem>
+				<para>PEERSTATE_EVENT_DIALOG (1) - Dialog events</para>
+			    </listitem>
+			    <listitem>
+				<para>PEERSTATE_EVENT_REGISTRATION (2) - Registration events</para>
+			    </listitem>
+			</itemizedlist>
+		    </listitem>
+		    <listitem>
+			<para><emphasis>peerstate_cb_f callback</emphasis> - Callback function with signature:</para>
+			<para>void callback(peerstate_cb_ctx_t *ctx, void *param);</para>
+		    </listitem>
+		    <listitem>
+			<para><emphasis>void *param</emphasis> - User parameter (can be NULL)</para>
+		    </listitem>
+		</itemizedlist>
+	    </para>
+	    <para>
+		The callback context structure:
+		<programlisting format="linespecific">
+typedef struct peerstate_cb_ctx {
+    str peer;                      /* Peer identifier */
+    ps_state_t current_state;        /* Current state */
+    ps_state_t previous_state;       /* Previous state */
+    int call_count;                /* Active call count */
+    int is_registered;             /* Registration status */
+    str uniq_id;                   /* Call-ID or RUID */
+    peerstate_event_type_t event_type;  /* Event type */
+} peerstate_cb_ctx_t;
+		</programlisting>
+	    </para>
+	    <para>
+		State enumeration:
+		<programlisting format="linespecific">
+typedef enum ps_state {
+    NOT_INUSE,      /* Registered and idle */
+    INUSE,          /* In active call */
+    RINGING,        /* Ringing */
+    UNAVAILABLE,    /* Not registered */
+    NA              /* Unknown */
+} ps_state_t;
+		</programlisting>
+	    </para>
+	    <para>
+		Return value:
+		<itemizedlist>
+		    <listitem>
+			<para>0 - success</para>
+		    </listitem>
+		    <listitem>
+			<para>-1 - error</para>
+		    </listitem>
+		</itemizedlist>
+	    </para>
+	    <example>
+		<title>Callback registration example</title>
+		<programlisting format="linespecific">
+<![CDATA[
+#include "../peerstate/peerstate_cb.h"
+
+static peerstate_api_t peerstate_api;
+
+/* Callback function */
+static void my_state_callback(peerstate_cb_ctx_t *ctx, void *param) {
+    LM_INFO("Peer %.*s: %s -> %s (calls=%d, reg=%s)\n",
+            ctx->peer.len, ctx->peer.s,
+            PS_STATE_TO_STR(ctx->previous_state),
+            PS_STATE_TO_STR(ctx->current_state),
+            ctx->call_count,
+            ctx->is_registered ? "yes" : "no");
+}
+
+/* Module initialization */
+static int mod_init(void) {
+    bind_peerstate_f bind_peerstate;
+    
+    bind_peerstate = (bind_peerstate_f)find_export("bind_peerstate", 1, 0);
+    if (!bind_peerstate || bind_peerstate(&peerstate_api) < 0) {
+        LM_ERR("Cannot bind to peerstate module\n");
+        return -1;
+    }
+    
+    if (peerstate_api.register_callback(
+            PEERSTATE_EVENT_DIALOG | PEERSTATE_EVENT_REGISTRATION,
+            my_state_callback, NULL) < 0) {
+        LM_ERR("Failed to register callback\n");
+        return -1;
+    }
+    
+    return 0;
+}
+]]>
+		</programlisting>
+	    </example>
+	</section>
+	
+    </section>
+    
+</chapter>

--- a/src/modules/peerstate/peerstate.h
+++ b/src/modules/peerstate/peerstate.h
@@ -1,0 +1,63 @@
+/*
+ *
+ * Peerstate Module - Peer State Tracking
+ *
+ * Copyright (C) 2025 Serdar Gucluer (Netgsm ICT Inc. - www.netgsm.com.tr)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef _PEERSTATE_H
+#define _PEERSTATE_H
+
+#include "../../core/parser/parse_uri.h"
+struct str_list;
+
+#define PEERSTATE_EVENT_ROUTE "peerstate:state_changed"
+
+typedef enum ps_state
+{
+	NOT_INUSE,	 // according to dialog state
+	INUSE,		 // according to dialog and register state
+	RINGING,	 // according to dialog state
+	UNAVAILABLE, // according to register state
+	NA
+} ps_state_t;
+
+static const char *ps_state_strs[] __attribute__((unused)) = {
+		"NOT_INUSE", "INUSE", "RINGING", "UNAVAILABLE", "N/A"};
+
+#define PS_STATE_TO_STR(s)                                                     \
+	((s) >= 0 && (s) < (int)(sizeof(ps_state_strs) / sizeof(ps_state_strs[0])) \
+					? ps_state_strs[s]                                         \
+					: "UNKNOWN")
+
+struct ps_dlginfo_cell
+{
+	struct sip_uri *from;
+	struct sip_uri *to;
+	str callid;
+	struct str_list *caller_peers;
+	struct str_list *callee_peers;
+	int disable_caller_notify;
+	int disable_callee_notify;
+};
+
+#endif /* _PEERSTATE_H */

--- a/src/modules/peerstate/peerstate_cache.c
+++ b/src/modules/peerstate/peerstate_cache.c
@@ -1,0 +1,712 @@
+/*
+ *
+ * Peerstate Module - Peer State Tracking
+ *
+ * Copyright (C) 2025 Serdar Gucluer (Netgsm ICT Inc. - www.netgsm.com.tr)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include <string.h>
+#include <time.h>
+
+#include "../../core/mem/shm_mem.h"
+#include "../../core/locking.h"
+#include "../../core/str_hash.h"
+#include "../../core/dprint.h"
+#include "../../core/timer.h"
+#include "../../core/timer_proc.h"
+#include "peerstate_cache.h"
+
+struct ps_peer_state
+{
+	str peer;
+	ps_state_t state;
+	int call_count;
+	unsigned char is_registered;
+	time_t timestamp;
+	struct ps_peer_state *next;
+};
+
+static int peer_state_hash_size = 0;
+
+static struct ps_peer_state **peer_state_hash_table = NULL;
+static gen_lock_t *peer_state_lock = NULL;
+
+static int cache_expire_time = 0;
+static int cache_cleanup_interval = 0;
+
+static void cleanup_expired_entries(unsigned int ticks, void *param)
+{
+	int i;
+	int removed = 0;
+	struct ps_peer_state *p, *prev, *next;
+	time_t now = time(NULL);
+
+	if(!peer_state_hash_table || cache_expire_time == 0)
+		return;
+	lock_get(peer_state_lock);
+
+	for(i = 0; i < peer_state_hash_size; i++) {
+		prev = NULL;
+		p = peer_state_hash_table[i];
+
+		while(p) {
+			next = p->next;
+			if((now - p->timestamp) > cache_expire_time) {
+				LM_DBG("Removing expired peer '%.*s'\n", p->peer.len,
+						p->peer.s);
+				if(prev)
+					prev->next = next;
+				else
+					peer_state_hash_table[i] = next;
+				shm_free(p);
+				removed++;
+			} else
+				prev = p;
+			p = next;
+		}
+	}
+
+	lock_release(peer_state_lock);
+	if(removed > 0)
+		LM_INFO("Cleanup: removed %d expired entries\n", removed);
+}
+
+int init_peerstate_cache(int expire_time, int cleanup_interval, int hash_size)
+{
+	if(expire_time < 0) {
+		LM_ERR("invalid expire_time: %d\n", expire_time);
+		return -1;
+	} else if(expire_time > 0 && expire_time < 60) {
+		LM_WARN("expire_time too small, setting to 60 seconds for performance "
+				"concerns\n");
+		expire_time = 60;
+	}
+
+	if(cleanup_interval < 0) {
+		LM_ERR("invalid cleanup_interval: %d\n", cleanup_interval);
+		return -1;
+	} else if(cleanup_interval > 0 && cleanup_interval < 10) {
+		LM_WARN("cleanup_interval too small, setting to 10 seconds for "
+				"performance concerns\n");
+		cleanup_interval = 10;
+	}
+
+	if(expire_time > 0 && cleanup_interval > expire_time) {
+		LM_WARN("cleanup_interval (%d) > expire_time (%d), adjusting to %d\n",
+				cleanup_interval, expire_time, expire_time);
+		cleanup_interval = expire_time;
+	}
+
+	cache_expire_time = expire_time;
+	cache_cleanup_interval = cleanup_interval;
+	peer_state_hash_size = hash_size;
+
+	peer_state_hash_table = (struct ps_peer_state **)shm_malloc(
+			peer_state_hash_size * sizeof(struct ps_peer_state *));
+	if(!peer_state_hash_table) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+
+	int i;
+	for(i = 0; i < peer_state_hash_size; i++) {
+		peer_state_hash_table[i] = NULL;
+	}
+
+	peer_state_lock = lock_alloc();
+	if(!peer_state_lock) {
+		LM_ERR("failed to allocate lock\n");
+		shm_free(peer_state_hash_table);
+		return -1;
+	}
+
+	if(!lock_init(peer_state_lock)) {
+		LM_ERR("failed to initialize lock\n");
+		lock_dealloc(peer_state_lock);
+		shm_free(peer_state_hash_table);
+		return -1;
+	}
+
+	if(cache_expire_time > 0 && cache_cleanup_interval > 0) {
+		if(register_timer(cleanup_expired_entries, NULL, cache_cleanup_interval)
+				< 0)
+			LM_WARN("failed to register cleanup timer\n");
+		else
+			LM_DBG("Cleanup timer registered (expire=%ds, interval=%ds)\n",
+					cache_expire_time, cache_cleanup_interval);
+	}
+
+	LM_DBG("Peerstate cache initialized (size=%d, expire=%ds, cleanup=%ds)\n",
+			peer_state_hash_size, cache_expire_time, cache_cleanup_interval);
+	return 0;
+}
+
+/**
+ * @brief Update peer state based on dialog event
+ */
+int update_peer_state_dialog(str *peer, ps_state_t candidate_state,
+		int early_enabled, ps_state_t *prev_state)
+{
+	unsigned int hash;
+	struct ps_peer_state *p;
+	ps_state_t old_state, new_state;
+	int old_count, new_count;
+	int state_changed = 0;
+
+	if(!peer || !peer->s || peer->len == 0) {
+		LM_ERR("invalid peer parameter\n");
+		return -1;
+	}
+
+	if(!peer_state_hash_table) {
+		LM_ERR("cache not initialized\n");
+		return -1;
+	}
+
+	hash = get_hash1_raw(peer->s, peer->len) % peer_state_hash_size;
+	lock_get(peer_state_lock);
+
+	// Find or create peer entry
+	p = peer_state_hash_table[hash];
+	while(p) {
+		if(p->peer.len == peer->len
+				&& memcmp(p->peer.s, peer->s, peer->len) == 0)
+			break;
+		p = p->next;
+	}
+
+	// Create new entry if not found
+	if(!p) {
+		p = (struct ps_peer_state *)shm_malloc(
+				sizeof(struct ps_peer_state) + peer->len);
+		if(!p) {
+			SHM_MEM_ERROR;
+			lock_release(peer_state_lock);
+			return -1;
+		}
+
+		p->peer.s = (char *)p + sizeof(struct ps_peer_state);
+		p->peer.len = peer->len;
+		memcpy(p->peer.s, peer->s, peer->len);
+		p->state = NOT_INUSE;
+		p->call_count = 0;
+		p->timestamp = time(NULL);
+		p->next = peer_state_hash_table[hash];
+		peer_state_hash_table[hash] = p;
+
+		LM_DBG("Created new peer entry '%.*s'\n", peer->len, peer->s);
+	}
+
+	// Save old values
+	old_state = p->state;
+	old_count = p->call_count;
+
+	// Process based on candidate state
+	if(candidate_state == RINGING) {
+		// EARLY event occurred
+		// Always increment counter for new dialog
+		p->call_count++;
+		new_count = p->call_count;
+
+		// Update state based on priority: INUSE > RINGING > NOT_INUSE
+		switch(old_state) {
+			case INUSE:
+				// Don't downgrade from INUSE to RINGING
+				new_state = INUSE;
+				break;
+			case RINGING:
+				// Already ringing, stay ringing
+				new_state = RINGING;
+				break;
+			case NOT_INUSE:
+			case UNAVAILABLE:
+			default:
+				// NOT_INUSE or UNAVAILABLE -> upgrade to RINGING
+				new_state = RINGING;
+				break;
+		}
+
+		p->state = new_state;
+		p->timestamp = time(NULL);
+
+		LM_DBG("EARLY: peer='%.*s', old_state=%s, new_state=%s, old_count=%d, "
+			   "new_count=%d, is_registered=%d\n",
+				peer->len, peer->s, PS_STATE_TO_STR(old_state),
+				PS_STATE_TO_STR(new_state), old_count, new_count,
+				p->is_registered);
+	} else if(candidate_state == INUSE) {
+		// CONFIRMED event occurred
+		// Check if EARLY was enabled
+		if(early_enabled)
+			new_count =
+					p->call_count; // EARLY was enabled, count already incremented, Don't increment again (same dialog transitioning)
+		else {
+			// EARLY was disabled, this is first event for this dialog
+			if(p->call_count == 0) {
+				// First dialog event, increment
+				p->call_count++;
+				new_count = p->call_count;
+			} else {
+				// Already has calls, don't increment
+				// (shouldn't happen but safety check)
+				new_count = p->call_count;
+			}
+		}
+
+		// Always upgrade to INUSE
+		new_state = INUSE;
+
+		p->state = new_state;
+		p->timestamp = time(NULL);
+
+		LM_DBG("CONFIRMED: peer='%.*s', old_state=%s, new_state=%s, "
+			   "old_count=%d, new_count=%d, early_enabled=%d, "
+			   "is_registered=%d\n",
+				peer->len, peer->s, PS_STATE_TO_STR(old_state),
+				PS_STATE_TO_STR(new_state), old_count, new_count, early_enabled,
+				p->is_registered);
+	} else if(candidate_state == NOT_INUSE) {
+		// FAILED / EXPIRED / TERMINATED event occurred
+		// Always decrement counter
+		if(p->call_count > 0)
+			p->call_count--;
+		else
+			LM_WARN("BUG: call_count already zero for peer '%.*s'\n", peer->len,
+					peer->s);
+
+		new_count = p->call_count;
+
+		// Determine new state based on remaining calls and registration
+		if(new_count > 0)
+			new_state = old_state; // Still has active calls, keep current state
+		else {
+			// No more active calls, Check registration flag
+			if(p->is_registered)
+				new_state = NOT_INUSE;
+			else
+				new_state = UNAVAILABLE;
+		}
+
+		p->state = new_state;
+		p->timestamp = time(NULL);
+
+		LM_DBG("ENDED: peer='%.*s', old_state=%s, new_state=%s, old_count=%d, "
+			   "new_count=%d, is_registered=%d\n",
+				peer->len, peer->s, PS_STATE_TO_STR(old_state),
+				PS_STATE_TO_STR(new_state), old_count, new_count,
+				p->is_registered);
+	} else {
+		// Invalid candidate state
+		LM_ERR("Invalid candidate_state=%d for peer '%.*s'\n", candidate_state,
+				peer->len, peer->s);
+		lock_release(peer_state_lock);
+		return -1;
+	}
+
+	// Check if state actually changed
+	if(old_state != new_state) {
+		state_changed = 1;
+		if(prev_state)
+			*prev_state = old_state;
+	} else
+		state_changed = 0;
+
+	lock_release(peer_state_lock);
+
+	return state_changed;
+}
+
+/**
+ * @brief Update peer state based on usrloc event
+ */
+int update_peer_state_usrloc(
+		str *peer, ps_state_t candidate_state, ps_state_t *prev_state)
+{
+	unsigned int hash;
+	struct ps_peer_state *p;
+	ps_state_t old_state, new_state;
+	int call_count;
+	int state_changed = 0;
+
+	if(!peer || !peer->s || peer->len == 0) {
+		LM_ERR("invalid peer parameter\n");
+		return -1;
+	}
+
+	if(!peer_state_hash_table) {
+		LM_ERR("cache not initialized\n");
+		return -1;
+	}
+
+	hash = get_hash1_raw(peer->s, peer->len) % peer_state_hash_size;
+	lock_get(peer_state_lock);
+
+	// Find or create peer entry
+	p = peer_state_hash_table[hash];
+	while(p) {
+		if(p->peer.len == peer->len
+				&& memcmp(p->peer.s, peer->s, peer->len) == 0)
+			break;
+		p = p->next;
+	}
+
+	// Create new entry if not found
+	if(!p) {
+		p = (struct ps_peer_state *)shm_malloc(
+				sizeof(struct ps_peer_state) + peer->len);
+		if(!p) {
+			SHM_MEM_ERROR;
+			lock_release(peer_state_lock);
+			return -1;
+		}
+
+		p->peer.s = (char *)p + sizeof(struct ps_peer_state);
+		p->peer.len = peer->len;
+		memcpy(p->peer.s, peer->s, peer->len);
+		p->state = NOT_INUSE;
+		p->call_count = 0;
+		p->timestamp = time(NULL);
+		p->next = peer_state_hash_table[hash];
+		peer_state_hash_table[hash] = p;
+
+		LM_DBG("Created new peer entry '%.*s'\n", peer->len, peer->s);
+	}
+
+	// Save old values
+	old_state = p->state;
+	call_count = p->call_count;
+
+	if(candidate_state == NOT_INUSE) {
+		// REGISTERED event occurred
+		// Update registration flag
+		p->is_registered = 1;
+
+		if(old_state == UNAVAILABLE)
+			new_state = NOT_INUSE; // Peer was unavailable, now registered
+		else
+			new_state =
+					old_state; // Registration doesn't interrupt active calls, NOT_INUSE, INUSE, or RINGING - no change
+		p->state = new_state;
+		p->timestamp = time(NULL);
+
+		LM_DBG("REGISTERED: peer='%.*s', old_state=%s, new_state=%s, count=%d, "
+			   "is_registered=%d\n",
+				peer->len, peer->s, PS_STATE_TO_STR(old_state),
+				PS_STATE_TO_STR(new_state), call_count, p->is_registered);
+	} else if(candidate_state == UNAVAILABLE) {
+		// UNREGISTERED event occurred
+		// Update registration flag
+		p->is_registered = 0;
+
+		switch(old_state) {
+			case INUSE:
+			case RINGING:
+				// Keep current state during active call or ringing
+				new_state = old_state;
+				break;
+			case NOT_INUSE:
+			case UNAVAILABLE:
+			default:
+				// Mark as unavailable
+				new_state = UNAVAILABLE;
+				break;
+		}
+
+		p->state = new_state;
+		p->timestamp = time(NULL);
+
+		LM_DBG("UNREGISTERED: peer='%.*s', old_state=%s, new_state=%s, "
+			   "count=%d, is_registered=%d\n",
+				peer->len, peer->s, PS_STATE_TO_STR(old_state),
+				PS_STATE_TO_STR(new_state), call_count, p->is_registered);
+	} else {
+		// Invalid candidate state for usrloc event
+		LM_ERR("Invalid usrloc candidate_state=%d for peer '%.*s'\n",
+				candidate_state, peer->len, peer->s);
+		lock_release(peer_state_lock);
+		return -1;
+	}
+
+	if(old_state != new_state) {
+		state_changed = 1;
+		if(prev_state)
+			*prev_state = old_state;
+	} else
+		state_changed = 0;
+
+	lock_release(peer_state_lock);
+
+	return state_changed;
+}
+
+/**
+ * @brief Get peer info from cache
+ */
+int get_peer_info(
+		str *peer, ps_state_t *state, int *call_count, int *is_registered)
+{
+	unsigned int hash;
+	struct ps_peer_state *p;
+
+	if(!peer || !peer->s || peer->len == 0)
+		return -1;
+	if(!peer_state_hash_table)
+		return -1;
+
+	hash = get_hash1_raw(peer->s, peer->len) % peer_state_hash_size;
+
+	lock_get(peer_state_lock);
+
+	p = peer_state_hash_table[hash];
+	while(p) {
+		if(p->peer.len == peer->len
+				&& memcmp(p->peer.s, peer->s, peer->len) == 0) {
+			if(state)
+				*state = p->state;
+			if(call_count)
+				*call_count = p->call_count;
+			if(is_registered)
+				*is_registered = p->is_registered;
+			lock_release(peer_state_lock);
+			return 0;
+		}
+		p = p->next;
+	}
+
+	lock_release(peer_state_lock);
+	return -1;
+}
+
+/**
+ * @brief Get cache statistics
+ */
+void get_cache_stats(int *total_peers, int *incall_count, int *registered_count)
+{
+	int i;
+	int total = 0, incall = 0, registered = 0;
+	struct ps_peer_state *p;
+
+	if(!peer_state_hash_table) {
+		if(total_peers)
+			*total_peers = 0;
+		if(incall_count)
+			*incall_count = 0;
+		if(registered_count)
+			*registered_count = 0;
+		return;
+	}
+
+	lock_get(peer_state_lock);
+
+	for(i = 0; i < peer_state_hash_size; i++) {
+		p = peer_state_hash_table[i];
+		while(p) {
+			total++;
+			if(p->state == INUSE || p->state == RINGING)
+				incall++;
+			if(p->is_registered)
+				registered++;
+			p = p->next;
+		}
+	}
+
+	lock_release(peer_state_lock);
+
+	if(total_peers)
+		*total_peers = total;
+	if(incall_count)
+		*incall_count = incall;
+	if(registered_count)
+		*registered_count = registered;
+}
+
+/**
+ * @brief Get list of peers by state
+ */
+int get_peers_by_state(ps_state_t target_state, str **peers, int *count)
+{
+	int i, found = 0;
+	struct ps_peer_state *p;
+	str *result = NULL;
+	int capacity = 100;
+
+	if(!peer_state_hash_table || !peers || !count)
+		return -1;
+
+	result = (str *)pkg_malloc(capacity * sizeof(str));
+	if(!result) {
+		PKG_MEM_ERROR;
+		return -1;
+	}
+
+	lock_get(peer_state_lock);
+
+	for(i = 0; i < peer_state_hash_size; i++) {
+		p = peer_state_hash_table[i];
+		while(p) {
+			if(p->state == target_state) {
+				if(found >= capacity) {
+					capacity *= 2;
+					str *new_result =
+							(str *)pkg_realloc(result, capacity * sizeof(str));
+					if(!new_result) {
+						PKG_MEM_ERROR;
+						lock_release(peer_state_lock);
+						pkg_free(result);
+						return -1;
+					}
+					result = new_result;
+				}
+
+				result[found].s = (char *)pkg_malloc(p->peer.len + 1);
+				if(!result[found].s) {
+					PKG_MEM_ERROR;
+					lock_release(peer_state_lock);
+					for(int j = 0; j < found; j++)
+						pkg_free(result[j].s);
+					pkg_free(result);
+					return -1;
+				}
+
+				memcpy(result[found].s, p->peer.s, p->peer.len);
+				result[found].s[p->peer.len] = '\0';
+				result[found].len = p->peer.len;
+				found++;
+			}
+			p = p->next;
+		}
+	}
+
+	lock_release(peer_state_lock);
+
+	*peers = result;
+	*count = found;
+	return 0;
+}
+
+/**
+ * @brief Get list of all peers
+ */
+int get_all_peers(str **peers, int *count)
+{
+	int i, found = 0;
+	struct ps_peer_state *p;
+	str *result = NULL;
+	int capacity = 100;
+
+	if(!peer_state_hash_table || !peers || !count)
+		return -1;
+
+	result = (str *)pkg_malloc(capacity * sizeof(str));
+	if(!result) {
+		PKG_MEM_ERROR;
+		return -1;
+	}
+
+	lock_get(peer_state_lock);
+
+	for(i = 0; i < peer_state_hash_size; i++) {
+		p = peer_state_hash_table[i];
+		while(p) {
+			if(found >= capacity) {
+				capacity *= 2;
+				str *new_result =
+						(str *)pkg_realloc(result, capacity * sizeof(str));
+				if(!new_result) {
+					PKG_MEM_ERROR;
+					lock_release(peer_state_lock);
+					pkg_free(result);
+					return -1;
+				}
+				result = new_result;
+			}
+
+			result[found].s = (char *)pkg_malloc(p->peer.len + 1);
+			if(!result[found].s) {
+				PKG_MEM_ERROR;
+				lock_release(peer_state_lock);
+				for(int j = 0; j < found; j++)
+					pkg_free(result[j].s);
+				pkg_free(result);
+				return -1;
+			}
+
+			memcpy(result[found].s, p->peer.s, p->peer.len);
+			result[found].s[p->peer.len] = '\0';
+			result[found].len = p->peer.len;
+			found++;
+
+			p = p->next;
+		}
+	}
+
+	lock_release(peer_state_lock);
+
+	*peers = result;
+	*count = found;
+	return 0;
+}
+
+/**
+ * @brief Destroy cache system
+ */
+void destroy_peerstate_cache(void)
+{
+	int i;
+	struct ps_peer_state *p, *next;
+
+	if(!peer_state_hash_table) {
+		LM_DBG("Cache not initialized, nothing to destroy\n");
+		return;
+	}
+
+	if(!peer_state_lock) {
+		LM_DBG("Cache lock not initialized\n");
+		return;
+	}
+
+	lock_get(peer_state_lock);
+
+	/* Free all peer state entries */
+	for(i = 0; i < peer_state_hash_size; i++) {
+		p = peer_state_hash_table[i];
+		while(p) {
+			next = p->next;
+			shm_free(p);
+			p = next;
+		}
+		peer_state_hash_table[i] = NULL;
+	}
+
+	lock_release(peer_state_lock);
+
+	/* Free hash table */
+	shm_free(peer_state_hash_table);
+	peer_state_hash_table = NULL;
+
+	/* Destroy and free lock */
+	lock_destroy(peer_state_lock);
+	lock_dealloc(peer_state_lock);
+	peer_state_lock = NULL;
+
+	LM_DBG("Cache system destroyed\n");
+}

--- a/src/modules/peerstate/peerstate_cache.h
+++ b/src/modules/peerstate/peerstate_cache.h
@@ -1,0 +1,105 @@
+/*
+ *
+ * Peerstate Module - Peer State Tracking
+ *
+ * Copyright (C) 2025 Serdar Gucluer (Netgsm ICT Inc. - www.netgsm.com.tr)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef _PEERSTATE_CACHE_H
+#define _PEERSTATE_CACHE_H
+
+#include "../../core/str.h"
+#include "peerstate.h"
+
+int init_peerstate_cache(int expire_time, int cleanup_interval, int hash_size);
+
+/**
+ * @brief Update peer state based on dialog event
+ * 
+ * @param peer Peer identifier
+ * @param candidate_state Next candidate state (RINGING, INUSE, or NOT_INUSE)
+ * @param early_enabled Whether EARLY event is processed (1) or not (0)
+ * @param old_state Output: previous state (only valid if return > 0)
+ * @return int 1 if state changed, 0 if no change, -1 on error
+ */
+int update_peer_state_dialog(str *peer, ps_state_t candidate_state,
+		int early_enabled, ps_state_t *prev_state);
+
+/**
+ * @brief Update peer state based on usrloc event
+ * 
+ * @param peer Peer identifier
+ * @param candidate_state Next candidate state (NOT_INUSE for register, UNAVAILABLE for unregister)
+ * @param old_state Output: previous state (only valid if return > 0)
+ * @return int 1 if state changed, 0 if no change, -1 on error
+ */
+int update_peer_state_usrloc(
+		str *peer, ps_state_t candidate_state, ps_state_t *prev_state);
+
+/**
+ * @brief Get peer state from cache
+ * 
+ * @param peer Peer identifier
+ * @param state Output: peer state
+ * @param call_count Output: active call count
+ * @param is_registered Output: registration status
+ * @return int 0 on success, -1 if not found
+ */
+int get_peer_info(
+		str *peer, ps_state_t *state, int *call_count, int *is_registered);
+
+/**
+ * @brief Get cache statistics
+ * 
+ * @param total_peers Output: total number of peers
+ * @param incall_count Output: peers in call (INUSE or RINGING)
+ * @param registered_count Output: registered peers
+ */
+void get_cache_stats(
+		int *total_peers, int *incall_count, int *registered_count);
+
+/**
+ * @brief Get list of all peers in specific state
+ * 
+ * @param state Target state
+ * @param peers Output: array of peer strings
+ * @param count Output: number of peers
+ * @return int 0 on success, -1 on error
+ */
+int get_peers_by_state(ps_state_t state, str **peers, int *count);
+
+/**
+ * @brief Get list of all peers (state independent)
+ *
+ * @param peers Output: array of peer strings
+ * @param count Output: number of peers
+ * @return int 0 on success, -1 on error
+ */
+int get_all_peers(str **peers, int *count);
+
+/**
+ * @brief Destroy cache system and free all resources
+ */
+void destroy_peerstate_cache(void);
+
+
+#endif /* _PEERSTATE_CACHE_H */

--- a/src/modules/peerstate/peerstate_cb.c
+++ b/src/modules/peerstate/peerstate_cb.c
@@ -1,0 +1,187 @@
+/*
+ *
+ * Peerstate Module - Peer State Tracking
+ *
+ * Copyright (C) 2025 Serdar Gucluer (Netgsm ICT Inc. - www.netgsm.com.tr)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include <string.h>
+
+#include "../../core/mem/shm_mem.h"
+#include "../../core/locking.h"
+#include "../../core/dprint.h"
+#include "peerstate_cb.h"
+
+/**
+ * @brief Callback list node
+ */
+struct peerstate_cb_node
+{
+	int event_types;		 /* Bitmask of subscribed event types */
+	peerstate_cb_f callback; /* Callback function */
+	void *param;			 /* User parameter */
+	struct peerstate_cb_node *next;
+};
+
+static struct peerstate_cb_node *callback_list = NULL;
+static gen_lock_t *callback_lock = NULL;
+
+/**
+ * @brief Initialize callback system
+ */
+int init_peerstate_callbacks(void)
+{
+	callback_lock = lock_alloc();
+	if(!callback_lock) {
+		LM_ERR("failed to allocate callback lock\n");
+		return -1;
+	}
+
+	if(!lock_init(callback_lock)) {
+		LM_ERR("failed to initialize callback lock\n");
+		lock_dealloc(callback_lock);
+		return -1;
+	}
+
+	callback_list = NULL;
+	LM_DBG("Callback system initialized\n");
+	return 0;
+}
+
+/**
+ * @brief Register a callback
+ */
+int register_peerstate_callback(
+		int event_types, peerstate_cb_f callback, void *param)
+{
+	struct peerstate_cb_node *node;
+
+	if(!callback) {
+		LM_ERR("callback function is NULL\n");
+		return -1;
+	}
+
+	if(event_types == 0) {
+		LM_ERR("event_types cannot be 0\n");
+		return -1;
+	}
+
+	if(!callback_lock) {
+		LM_ERR("callback system not initialized - load peerstate module "
+			   "first!\n");
+		return -1;
+	}
+
+	node = (struct peerstate_cb_node *)shm_malloc(
+			sizeof(struct peerstate_cb_node));
+	if(!node) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+
+	node->event_types = event_types;
+	node->callback = callback;
+	node->param = param;
+
+	lock_get(callback_lock);
+	node->next = callback_list;
+	callback_list = node;
+	lock_release(callback_lock);
+
+	LM_INFO("Peerstate callback registered (event_types=0x%x)\n", event_types);
+	return 0;
+}
+
+/**
+ * @brief Trigger callbacks for an event
+ */
+void trigger_peerstate_callbacks(peerstate_cb_ctx_t *ctx)
+{
+	struct peerstate_cb_node *node;
+
+	if(!ctx || !callback_list)
+		return;
+
+	lock_get(callback_lock);
+	node = callback_list;
+
+	while(node) {
+		/* Check if callback is interested in this event type */
+		if(node->event_types & ctx->event_type) {
+			/* Release lock before callback to avoid deadlocks */
+			lock_release(callback_lock);
+
+			/* Call the callback */
+			node->callback(ctx, node->param);
+
+			/* Re-acquire lock for next iteration */
+			lock_get(callback_lock);
+			node = node->next;
+		} else {
+			node = node->next;
+		}
+	}
+
+	lock_release(callback_lock);
+}
+
+/**
+ * @brief Destroy callback system
+ */
+void destroy_peerstate_callbacks(void)
+{
+	struct peerstate_cb_node *node, *next;
+
+	if(!callback_lock)
+		return;
+
+	lock_get(callback_lock);
+
+	node = callback_list;
+	while(node) {
+		next = node->next;
+		shm_free(node);
+		node = next;
+	}
+	callback_list = NULL;
+
+	lock_release(callback_lock);
+	lock_destroy(callback_lock);
+	lock_dealloc(callback_lock);
+	callback_lock = NULL;
+
+	LM_DBG("Callback system destroyed\n");
+}
+
+/**
+ * @brief Bind function for other modules
+ */
+int bind_peerstate(peerstate_api_t *api)
+{
+	if(!api) {
+		LM_ERR("invalid parameter\n");
+		return -1;
+	}
+
+	api->register_callback = register_peerstate_callback;
+	return 0;
+}

--- a/src/modules/peerstate/peerstate_cb.h
+++ b/src/modules/peerstate/peerstate_cb.h
@@ -1,0 +1,126 @@
+/*
+ *
+ * Peerstate Module - Peer State Tracking
+ *
+ * Copyright (C) 2025 Serdar Gucluer (Netgsm ICT Inc. - www.netgsm.com.tr)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#ifndef _PEERSTATE_CB_H
+#define _PEERSTATE_CB_H
+
+#include "peerstate.h"
+
+/**
+ * @brief Callback event types
+ */
+typedef enum peerstate_event_type
+{
+	PEERSTATE_EVENT_DIALOG = 1, /* Dialog event (EARLY/CONFIRMED/ENDED) */
+	PEERSTATE_EVENT_REGISTRATION =
+			2 /* Registration event (REGISTER/UNREGISTER) */
+} peerstate_event_type_t;
+
+/**
+ * @brief Callback context for state change events
+ */
+typedef struct peerstate_cb_ctx
+{
+	str peer;						   /* Peer identifier */
+	ps_state_t current_state;		   /* Current state */
+	ps_state_t previous_state;		   /* Previous state */
+	int call_count;					   /* Active call count */
+	int is_registered;				   /* Registration status */
+	str uniq_id;					   /* Call-ID or RUID */
+	peerstate_event_type_t event_type; /* Event source type */
+} peerstate_cb_ctx_t;
+
+/**
+ * @brief Callback function signature
+ * 
+ * @param ctx Event context
+ * @param param User-provided parameter during registration
+ */
+typedef void (*peerstate_cb_f)(peerstate_cb_ctx_t *ctx, void *param);
+
+/**
+ * @brief Register a callback for peerstate events
+ * 
+ * @param event_types Bitmask of event types (PEERSTATE_EVENT_*)
+ * @param callback Callback function
+ * @param param User parameter passed to callback
+ * @return int 0 on success, -1 on error
+ */
+typedef int (*register_peerstate_cb_f)(
+		int event_types, peerstate_cb_f callback, void *param);
+
+/**
+ * @brief Peerstate notify API structure
+ */
+typedef struct peerstate_api
+{
+	register_peerstate_cb_f register_callback;
+} peerstate_api_t;
+
+/**
+ * @brief Bind function for other modules
+ */
+typedef int (*bind_peerstate_f)(peerstate_api_t *api);
+
+/**
+ * @brief Initialize callback system
+ * @return int 0 on success, -1 on error
+ */
+int init_peerstate_callbacks(void);
+
+/**
+ * @brief Destroy callback system
+ */
+void destroy_peerstate_callbacks(void);
+
+/**
+ * @brief Register a callback (internal)
+ * 
+ * @param event_types Bitmask of event types
+ * @param callback Callback function
+ * @param param User parameter
+ * @return int 0 on success, -1 on error
+ */
+int register_peerstate_callback(
+		int event_types, peerstate_cb_f callback, void *param);
+
+/**
+ * @brief Trigger callbacks for an event
+ * 
+ * @param ctx Event context
+ */
+void trigger_peerstate_callbacks(peerstate_cb_ctx_t *ctx);
+
+/**
+ * @brief Bind to peerstate API
+ * 
+ * @param api API structure to fill
+ * @return int 0 on success, -1 on error
+ */
+int bind_peerstate(peerstate_api_t *api);
+
+
+#endif /* _PEERSTATE_CB_H */

--- a/src/modules/peerstate/peerstate_mod.c
+++ b/src/modules/peerstate/peerstate_mod.c
@@ -1,0 +1,1338 @@
+/*
+ *
+ * Peerstate Module - Peer State Tracking
+ *
+ * Copyright (C) 2025 Serdar Gucluer (Netgsm ICT Inc. - www.netgsm.com.tr)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "../../core/mem/shm_mem.h"
+#include "../../core/shm_init.h"
+#include "../../core/mem/mem.h"
+#include "../../core/script_cb.h"
+#include "../../core/sr_module.h"
+#include "../../core/parser/parse_expires.h"
+#include "../../core/parser/msg_parser.h"
+#include "../../core/parser/parse_param.h"
+#include "../../core/parser/parse_to.h"
+#include "../../core/parser/contact/parse_contact.h"
+#include "../../core/dprint.h"
+#include "../../core/pt.h"
+#include "../../core/ut.h"
+#include "../../core/str.h"
+#include "../../core/str_list.h"
+#include "../../core/timer_proc.h"
+#include "../../core/timer.h"
+#include "../../core/utils/sruid.h"
+#include "../dialog/dlg_load.h"
+#include "../dialog/dlg_hash.h"
+#include "../usrloc/usrloc.h"
+#include "../../core/route.h"
+#include "../../core/kemi.h"
+#include "../../core/fmsg.h"
+#include "../../core/rpc.h"
+#include "../../core/rpc_lookup.h"
+
+#include "peerstate.h"
+#include "peerstate_cache.h"
+#include "peerstate_cb.h"
+
+MODULE_VERSION
+
+/* Default module parameter values */
+#define DEF_CALLER_ALWAYS_CONFIRMED 0
+#define DEF_USE_AVPS 0
+#define DEF_CALLER_AVP 0
+#define DEF_CALLEE_AVP 0
+#define DEF_REG_AVP 0
+
+#define DEF_ENABLE_NOTIFY_ON_TRYING 0
+#define DEF_DISABLE_CALLER_NOTIFY_FLAG -1
+#define DEF_DISABLE_CALLEE_NOTIFY_FLAG -1
+#define DEF_DISABLE_REG_NOTIFY -1
+#define DEF_DISABLE_DLG_NOTIFY -1
+#define DEF_CACHE_EXPIRE 3600
+#define DEF_CACHE_CLEANUP_INTERVAL 300
+#define DEF_CACHE_HASH_SIZE 4096
+
+static struct dlg_binds dlg_api;
+static usrloc_api_t ul_api;
+
+avp_flags_t caller_avp_type;
+avp_name_t caller_avp_name;
+avp_flags_t callee_avp_type;
+avp_name_t callee_avp_name;
+avp_flags_t reg_avp_type;
+avp_name_t reg_avp_name;
+
+static char *DLG_VAR_SEP = ",";
+static str caller_dlg_var = {"caller_var", strlen("caller_var")};
+static str callee_dlg_var = {"callee_var", strlen("callee_var")};
+static int peerstate_event_rt = -1;
+
+/* Module parameter variables */
+int use_avps = DEF_USE_AVPS;
+int enable_notify_on_trying = DEF_ENABLE_NOTIFY_ON_TRYING;
+int disable_caller_notify_flag = DEF_DISABLE_CALLER_NOTIFY_FLAG;
+int disable_callee_notify_flag = DEF_DISABLE_CALLEE_NOTIFY_FLAG;
+int disable_reg_notify = DEF_DISABLE_REG_NOTIFY;
+int disable_dlg_notify = DEF_DISABLE_DLG_NOTIFY;
+char *caller_avp = DEF_CALLER_AVP;
+char *callee_avp = DEF_CALLEE_AVP;
+char *reg_avp = DEF_REG_AVP;
+int dialog_event_types = DLGCB_FAILED | DLGCB_CONFIRMED | DLGCB_TERMINATED
+						 | DLGCB_EXPIRED | DLGCB_EARLY;
+int cache_expire = DEF_CACHE_EXPIRE; /* Default: 1 hour */
+int cache_cleanup_interval =
+		DEF_CACHE_CLEANUP_INTERVAL;		   /* Default: 5 minutes */
+int cache_hash_size = DEF_CACHE_HASH_SIZE; /* Default: 4096 entries */
+
+static int mod_init(void);
+static int child_init(int rank);
+static void mod_destroy(void);
+static inline void print_ucontact(ucontact_t *c);
+static inline int should_notify(
+		int disable_notify, int disable_flag, struct sip_msg *request);
+static void process_dialog_peers(struct str_list *peers, ps_state_t new_state,
+		int early_enabled, str *callid);
+static struct str_list *peer_at_host_list(struct sip_uri *uri);
+static inline void free_ps_dlginfo_cell(void *param);
+static inline void free_str_list_all(struct str_list *del_current);
+static struct str_list *get_avp_str_list(
+		unsigned short avp_flags, int_str avp_name);
+static inline int get_avp_first_str(
+		unsigned short avp_flags, int_str avp_name, str *result);
+static int set_dlg_var(struct dlg_cell *dlg, str *key, struct str_list *lst);
+static int get_dlg_var(struct dlg_cell *dlg, str *key, struct str_list **lst);
+static struct ps_dlginfo_cell *get_dialog_data(struct dlg_cell *dlg, int type,
+		int disable_caller_notify, int disable_callee_notify);
+static void rpc_dump(rpc_t *rpc, void *ctx);
+static void rpc_list(rpc_t *rpc, void *ctx);
+static void rpc_stats(rpc_t *rpc, void *ctx);
+static void rpc_get_peer(rpc_t *rpc, void *ctx);
+
+
+/* clang-format off */
+static cmd_export_t cmds[] = {
+	{"bind_peerstate", (cmd_function)bind_peerstate, 1, 0, 0, 0},
+	{0, 0, 0, 0, 0, 0}
+};
+
+static const char *rpc_dump_doc[2] = {
+	"Dump all cache entries",
+	0
+};
+
+static const char *rpc_get_peer_doc[2] = {
+	"Get state information for specific peer",
+	0
+};
+
+static const char *rpc_stats_doc[2] = {
+	"Get cache statistics",
+	0
+};
+
+static const char *rpc_list_doc[2] = {
+	"List all peers in specific state (NOT_INUSE, INUSE, RINGING, UNAVAILABLE)",
+	0
+};
+
+static rpc_export_t peerstate_rpc[] = {
+	{"peerstate.get_peer", rpc_get_peer, rpc_get_peer_doc, 0},
+	{"peerstate.stats", rpc_stats, rpc_stats_doc, 0},
+	{"peerstate.list", rpc_list, rpc_list_doc, 0},
+	{"peerstate.dump", rpc_dump, rpc_dump_doc, 0},
+	{0, 0, 0, 0}
+};
+
+static param_export_t params[] = {
+	{"use_avps", PARAM_INT, &use_avps},
+	{"caller_avp", PARAM_STRING, &caller_avp},
+	{"callee_avp", PARAM_STRING, &callee_avp},
+	{"reg_avp", PARAM_STRING, &reg_avp},
+	{"enable_notify_on_trying", PARAM_INT, &enable_notify_on_trying},
+	{"disable_caller_notify_flag", PARAM_INT, &disable_caller_notify_flag},
+	{"disable_callee_notify_flag", PARAM_INT, &disable_callee_notify_flag},
+	{"disable_reg_notify", PARAM_INT, &disable_reg_notify},
+	{"disable_dlg_notify", PARAM_INT, &disable_dlg_notify},
+	{"cache_expire", PARAM_INT, &cache_expire},
+	{"cache_cleanup_interval", PARAM_INT, &cache_cleanup_interval},
+	{"cache_hash_size", PARAM_INT, &cache_hash_size},
+	{0, 0, 0}
+};
+
+struct module_exports exports = {
+	"peerstate", 			/* module name */
+	DEFAULT_DLFLAGS,  		/* dlopen flags */
+	cmds,			  	/* exported functions */
+	params,			  	/* exported parameters */
+	peerstate_rpc,			/* RPC method exports */
+	0,			 	/* exported pseudo-variables */
+	0,				/* response handling function */
+	mod_init,		  	/* module initialization function */
+	child_init,		  	/* per-child init function */
+	mod_destroy		  	/* module destroy function */
+};
+/* clang-format on */
+
+static void trigger_event_route(
+		ps_state_t ps_state, ps_state_t prev_state, str *peer, str *uniq_id)
+{
+	struct run_act_ctx ra_ctx;
+	struct sip_msg *fmsg = NULL;
+	sr_kemi_eng_t *keng = NULL;
+	str evname = str_init(PEERSTATE_EVENT_ROUTE);
+	int_str avp_name, avp_val;
+
+	if(peerstate_event_rt < 0)
+		return;
+
+	// Create fake message for event route execution
+	fmsg = faked_msg_get_next();
+	if(fmsg == NULL) {
+		LM_ERR("failed to get faked message\n");
+		return;
+	}
+
+	avp_name.s.s = "ps_peer";
+	avp_name.s.len = 7;
+	avp_val.s = *peer;
+	if(add_avp(AVP_NAME_STR | AVP_VAL_STR, avp_name, avp_val) < 0) {
+		LM_ERR("failed to set peer AVP\n");
+		goto error;
+	}
+
+	avp_name.s.s = "ps_state";
+	avp_name.s.len = 8;
+	avp_val.s.s = (char *)PS_STATE_TO_STR(ps_state);
+	avp_val.s.len = strlen(avp_val.s.s);
+	if(add_avp(AVP_NAME_STR | AVP_VAL_STR, avp_name, avp_val) < 0) {
+		LM_ERR("failed to set state AVP\n");
+		goto error;
+	}
+
+	avp_name.s.s = "ps_prev_state";
+	avp_name.s.len = 13;
+	avp_val.s.s = (char *)PS_STATE_TO_STR(prev_state);
+	avp_val.s.len = strlen(avp_val.s.s);
+	if(add_avp(AVP_NAME_STR | AVP_VAL_STR, avp_name, avp_val) < 0) {
+		LM_ERR("failed to set previous state AVP\n");
+		goto error;
+	}
+
+	avp_name.s.s = "ps_uniq_id";
+	avp_name.s.len = 10;
+	avp_val.s = *uniq_id;
+	if(add_avp(AVP_NAME_STR | AVP_VAL_STR, avp_name, avp_val) < 0) {
+		LM_ERR("failed to set callid AVP\n");
+		goto error;
+	}
+
+	keng = sr_kemi_eng_get();
+	if(keng == NULL) {
+		init_run_actions_ctx(&ra_ctx);
+		run_top_route(event_rt.rlist[peerstate_event_rt], fmsg, &ra_ctx);
+	} else if(keng->froute(fmsg, EVENT_ROUTE, &evname, &evname) < 0)
+		LM_ERR("error executing event route kemi callback\n");
+
+	LM_DBG("event_route[%s] executed: peer=%.*s, state=%s, id=%.*s\n",
+			PEERSTATE_EVENT_ROUTE, peer->len, peer->s,
+			PS_STATE_TO_STR(ps_state), uniq_id->len, uniq_id->s);
+	return;
+
+error:
+	LM_ERR("failed to execute event route\n");
+}
+
+/**
+ * @brief Helper to trigger callbacks with event type
+ */
+static inline void notify_with_callbacks(ps_state_t ps_state,
+		ps_state_t prev_state, str *peer, str *uniq_id,
+		peerstate_event_type_t event_type)
+{
+	peerstate_cb_ctx_t ctx;
+	int call_count = 0, is_registered = 0;
+
+	LM_DBG("[%.*s] notify for peer: %.*s with state: %s (event_type=%d)\n",
+			uniq_id->len, uniq_id->s, peer->len, peer->s,
+			PS_STATE_TO_STR(ps_state), event_type);
+
+	/* Trigger event route */
+	trigger_event_route(ps_state, prev_state, peer, uniq_id);
+	/* Prepare callback context */
+	memset(&ctx, 0, sizeof(peerstate_cb_ctx_t));
+	ctx.peer = *peer;
+	ctx.current_state = ps_state;
+	ctx.previous_state = prev_state;
+	ctx.uniq_id = *uniq_id;
+	ctx.event_type = event_type;
+
+	/* Get additional info from cache */
+	if(get_peer_info(peer, NULL, &call_count, &is_registered) == 0) {
+		ctx.call_count = call_count;
+		ctx.is_registered = is_registered;
+	} else {
+		LM_WARN("[%.*s] failed to get peer info for callbacks: %.*s, check "
+				"cache_expire time may be too short\n",
+				uniq_id->len, uniq_id->s, peer->len, peer->s);
+	}
+
+	/* Trigger callbacks */
+	trigger_peerstate_callbacks(&ctx);
+}
+
+static void __dialog_callback(
+		struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
+{
+	struct ps_dlginfo_cell *dlginfo = (struct ps_dlginfo_cell *)*_params->param;
+	struct sip_msg *request = _params->req;
+	ps_state_t new_state;
+	int notify_caller, notify_callee;
+	const char *event_name;
+
+	if(!dlg || !dlginfo)
+		return;
+
+	if(request && (request->REQ_METHOD & (METHOD_PRACK | METHOD_UPDATE)))
+		return;
+
+	if(disable_dlg_notify > 0)
+		return;
+
+	switch(type) {
+		case DLGCB_FAILED:
+		case DLGCB_TERMINATED:
+		case DLGCB_EXPIRED:
+			new_state = NOT_INUSE;
+			event_name = "ENDED";
+			break;
+
+		case DLGCB_CONFIRMED:
+		case DLGCB_REQ_WITHIN:
+		case DLGCB_CONFIRMED_NA:
+			new_state = INUSE;
+			event_name = "CONFIRMED";
+			break;
+
+		case DLGCB_EARLY:
+			new_state = RINGING;
+			event_name = "EARLY";
+			break;
+
+		default:
+			LM_DBG("[%.*s] Unhandled dialog type: %d\n", dlginfo->callid.len,
+					dlginfo->callid.s, type);
+			return;
+	}
+
+	LM_DBG("[%.*s] Dialog %s: %.*s -> %.*s\n", dlginfo->callid.len,
+			dlginfo->callid.s, event_name, dlginfo->from->user.len,
+			dlginfo->from->user.s, dlginfo->to->user.len, dlginfo->to->user.s);
+
+	notify_caller = should_notify(dlginfo->disable_caller_notify,
+			disable_caller_notify_flag, request);
+	notify_callee = should_notify(dlginfo->disable_callee_notify,
+			disable_callee_notify_flag, request);
+
+	if(notify_caller && dlginfo->caller_peers)
+		process_dialog_peers(dlginfo->caller_peers, new_state,
+				enable_notify_on_trying, &dlginfo->callid);
+
+	if(notify_callee && dlginfo->callee_peers)
+		process_dialog_peers(dlginfo->callee_peers, new_state,
+				enable_notify_on_trying, &dlginfo->callid);
+}
+
+static void __dialog_created(
+		struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
+{
+	struct sip_msg *request = _params->req;
+	struct ps_dlginfo_cell *dlginfo;
+
+	int disable_caller_notify = 0;
+	int disable_callee_notify = 0;
+
+	if(request == NULL || request->REQ_METHOD != METHOD_INVITE)
+		return;
+
+	LM_DBG("new INVITE dialog created: from=%.*s\n", dlg->from_uri.len,
+			dlg->from_uri.s);
+
+	if(disable_caller_notify_flag != -1
+			&& (request
+					&& (request->flags & (1 << disable_caller_notify_flag))))
+		disable_caller_notify = 1;
+
+	if(disable_callee_notify_flag != -1
+			&& (request
+					&& (request->flags & (1 << disable_callee_notify_flag))))
+		disable_callee_notify = 1;
+
+	dlginfo = get_dialog_data(
+			dlg, type, disable_caller_notify, disable_callee_notify);
+
+	if(dlginfo == NULL) {
+		LM_WARN("failed to get dialog data for new dialog\n");
+		return;
+	}
+}
+
+static void __dialog_loaded(
+		struct dlg_cell *dlg, int type, struct dlg_cb_params *_params)
+{
+	struct sip_msg *request = _params->req;
+	struct ps_dlginfo_cell *dlginfo;
+
+	if(request == NULL || request->REQ_METHOD != METHOD_INVITE)
+		return;
+
+	LM_INFO("INVITE dialog loaded: from=%.*s\n", dlg->from_uri.len,
+			dlg->from_uri.s);
+
+	dlginfo = get_dialog_data(dlg, type, 0, 0);
+
+	if(dlginfo == NULL) {
+		LM_WARN("failed to load dialog data for existing dialog\n");
+		return;
+	}
+}
+
+static void __usrloc_changed(ucontact_t *c, int type, void *param)
+{
+	str peer = {NULL, 0};
+
+	peer.len = c->aor->len;
+	peer.s = c->aor->s;
+
+	if(disable_reg_notify > 0) {
+		LM_DBG("Reginfo notify disabled for peer(%.*s)\n", peer.len, peer.s);
+		return;
+	}
+
+	int res;
+	udomain_t *domain;
+	urecord_t *record = NULL;
+	int state_changed;
+	char *state_meaning = NULL;
+	ps_state_t prev_state;
+
+	if(type & UL_CONTACT_INSERT)
+		state_meaning = "UL_CONTACT_INSERT";
+	else if(type & UL_CONTACT_EXPIRE)
+		state_meaning = "UL_CONTACT_EXPIRE";
+	else if(type & UL_CONTACT_UPDATE)
+		state_meaning = "UL_CONTACT_UPDATE";
+	else if(type & UL_CONTACT_DELETE)
+		state_meaning = "UL_CONTACT_DELETE";
+	else
+		return;
+
+	LM_DBG("Current Contact Ruid : %.*s, Peer: %.*s, State Meaning : %s\n",
+			c->ruid.len, c->ruid.s, peer.len, peer.s,
+			state_meaning ? state_meaning : "Unknown");
+
+	/* Get the UDomain for this account */
+	res = ul_api.get_udomain(c->domain->s, &domain);
+	if(res < 0) {
+		LM_ERR("no domain found\n");
+		return;
+	}
+
+	/* Get the URecord for this AOR */
+	res = ul_api.get_urecord(domain, &peer, &record);
+	if(res > 0) {
+		LM_ERR("' %.*s (%.*s)' Not found in usrloc\n", c->aor->len, c->aor->s,
+				c->domain->len, c->domain->s);
+		return;
+	}
+
+	if(!record)
+		return;
+
+	str cur_ruid = c->ruid;
+
+	int valid_contact_counter = 0;
+	time_t cur_time = time(0);
+	ucontact_t *ptr;
+	ptr = record->contacts;
+	ps_state_t ps_state = NA;
+
+	if(type & (UL_CONTACT_INSERT)) {
+		while(ptr) {
+			if(STR_EQ(c->ruid, ptr->ruid) || !(VALID_CONTACT(ptr, cur_time))) {
+				// ptr null or itself or not valid contact
+				ptr = ptr->next;
+				continue;
+			}
+
+			print_ucontact(ptr);
+			valid_contact_counter++;
+			ptr = ptr->next;
+		}
+		ps_state = NOT_INUSE;
+	} else if(type & (UL_CONTACT_UPDATE)) {
+		while(ptr) {
+			if(STR_EQ(c->ruid, ptr->ruid)) {
+				if(!(VALID_CONTACT(ptr, cur_time))) {
+					print_ucontact(ptr);
+					valid_contact_counter++;
+					ptr = ptr->next;
+					continue;
+				}
+				ptr = ptr->next;
+				continue;
+			}
+
+			if(!(VALID_CONTACT(ptr, cur_time))) {
+				ptr = ptr->next;
+				continue;
+			}
+
+			print_ucontact(ptr);
+			valid_contact_counter++;
+			ptr = ptr->next;
+		}
+		ps_state = NOT_INUSE;
+	} else if(type & (UL_CONTACT_DELETE)) {
+		while(ptr) {
+			if(STR_EQ(c->ruid, ptr->ruid) || !(VALID_CONTACT(ptr, cur_time))) {
+				ptr = ptr->next;
+				continue;
+			}
+
+			print_ucontact(ptr);
+			valid_contact_counter++;
+			ptr = ptr->next;
+		}
+		ps_state = UNAVAILABLE;
+	} else if(type & (UL_CONTACT_EXPIRE)) {
+		while(ptr) {
+			if(STR_EQ(c->ruid, ptr->ruid) || !(VALID_CONTACT(ptr, cur_time))) {
+				ptr = ptr->next;
+				continue;
+			}
+
+			print_ucontact(ptr);
+			valid_contact_counter++;
+			ptr = ptr->next;
+		}
+		ps_state = UNAVAILABLE;
+	}
+
+	if(use_avps && get_avp_first_str(reg_avp_type, reg_avp_name, &peer) != 0)
+		LM_WARN("Failed to get reg_avp(%s) for peer(%.*s)\n", reg_avp, peer.len,
+				peer.s);
+
+	if(valid_contact_counter == 0) {
+		state_changed = update_peer_state_usrloc(&peer, ps_state, &prev_state);
+		if(state_changed > 0) {
+			LM_INFO("Peer '%.*s' state changed from %s to %s\n", peer.len,
+					peer.s, PS_STATE_TO_STR(prev_state),
+					PS_STATE_TO_STR(ps_state));
+			notify_with_callbacks(ps_state, prev_state, &peer, &cur_ruid,
+					PEERSTATE_EVENT_REGISTRATION);
+		}
+	} else
+		LM_DBG("Reginfo state(%s) notify disabled (multiple active contacts) "
+			   "for peer(%.*s) with ruid(%.*s)\n",
+				state_meaning ? state_meaning : "Unknown", peer.len, peer.s,
+				cur_ruid.len, cur_ruid.s);
+
+	ul_api.release_urecord(record);
+}
+
+static struct ps_dlginfo_cell *get_dialog_data(struct dlg_cell *dlg, int type,
+		int disable_caller_notify, int disable_callee_notify)
+{
+	struct ps_dlginfo_cell *dlginfo;
+	int len;
+
+	// create dlginfo structure to store important data inside the module
+	len = sizeof(struct ps_dlginfo_cell) + dlg->from_uri.len + dlg->to_uri.len
+		  + dlg->callid.len;
+	dlginfo = (struct ps_dlginfo_cell *)shm_malloc(len);
+
+	if(dlginfo == 0) {
+		SHM_MEM_ERROR;
+		return NULL;
+	}
+	memset(dlginfo, 0, len);
+
+	// copy from dlg structure to dlginfo structure
+	dlginfo->disable_caller_notify = disable_caller_notify;
+	dlginfo->disable_callee_notify = disable_callee_notify;
+	dlginfo->callid.s = (char *)dlginfo + sizeof(struct ps_dlginfo_cell);
+	dlginfo->callid.len = dlg->callid.len;
+
+	memcpy(dlginfo->callid.s, dlg->callid.s, dlg->callid.len);
+
+	struct sip_uri *furi = (struct sip_uri *)shm_malloc(sizeof(struct sip_uri));
+	if(!furi) {
+		LM_ERR("failed to allocate From URI\n");
+		SHM_MEM_ERROR;
+		free_ps_dlginfo_cell(dlginfo);
+		return NULL;
+	}
+
+	if(parse_uri(dlg->from_uri.s, dlg->from_uri.len, furi) < 0) {
+		LM_ERR("failed to parse From URI\n");
+		free_ps_dlginfo_cell(dlginfo);
+		shm_free(furi);
+		return NULL;
+	}
+
+	struct sip_uri *turi = (struct sip_uri *)shm_malloc(sizeof(struct sip_uri));
+
+	if(!turi) {
+		LM_ERR("failed to allocate To URI\n");
+		SHM_MEM_ERROR;
+		free_ps_dlginfo_cell(dlginfo);
+		shm_free(furi);
+		return NULL;
+	}
+
+	if(parse_uri(dlg->to_uri.s, dlg->to_uri.len, turi) < 0) {
+		LM_ERR("failed to parse To URI\n");
+		free_ps_dlginfo_cell(dlginfo);
+		shm_free(turi);
+		shm_free(furi);
+		return NULL;
+	}
+
+	dlginfo->from = furi;
+	dlginfo->to = turi;
+
+	if(type == DLGCB_CREATED) {
+		if(use_avps) {
+			struct str_list *caller_peers_from_avp =
+					get_avp_str_list(caller_avp_type, caller_avp_name);
+			struct str_list *callee_peers_from_avp =
+					get_avp_str_list(callee_avp_type, callee_avp_name);
+
+			if(caller_peers_from_avp)
+				dlginfo->caller_peers = caller_peers_from_avp;
+			else {
+				LM_WARN("failed to get caller peers from AVP\n");
+				// build "peer@host" from from/to uri
+				dlginfo->caller_peers = peer_at_host_list(dlginfo->from);
+				if(!dlginfo->caller_peers) {
+					LM_ERR("failed to build caller peer@host\n");
+					free_ps_dlginfo_cell(dlginfo);
+					return NULL;
+				}
+			}
+
+			if(callee_peers_from_avp)
+				dlginfo->callee_peers = callee_peers_from_avp;
+			else {
+				LM_WARN("failed to get callee peers from AVP\n");
+				// build "peer@host" from from/to uri
+				dlginfo->callee_peers = peer_at_host_list(dlginfo->to);
+				if(!dlginfo->callee_peers) {
+					LM_ERR("failed to build callee peer@host\n");
+					free_ps_dlginfo_cell(dlginfo);
+					return NULL;
+				}
+			}
+		} else {
+			// build "peer@host" from from/to uri
+			dlginfo->caller_peers = peer_at_host_list(dlginfo->from);
+			if(!dlginfo->caller_peers) {
+				LM_ERR("failed to build caller peer@host\n");
+				free_ps_dlginfo_cell(dlginfo);
+				return NULL;
+			}
+
+			dlginfo->callee_peers = peer_at_host_list(dlginfo->to);
+			if(!dlginfo->callee_peers) {
+				LM_ERR("failed to build callee peer@host\n");
+				free_ps_dlginfo_cell(dlginfo);
+				return NULL;
+			}
+		}
+
+		if(caller_dlg_var.len > 0) {
+			if(set_dlg_var(dlg, &caller_dlg_var, dlginfo->caller_peers) < 0) {
+				free_str_list_all(dlginfo->caller_peers);
+				dlginfo->caller_peers = NULL;
+			}
+		}
+
+		if(callee_dlg_var.len > 0) {
+			if(set_dlg_var(dlg, &callee_dlg_var, dlginfo->callee_peers) < 0) {
+				free_str_list_all(dlginfo->callee_peers);
+				dlginfo->callee_peers = NULL;
+			}
+		}
+	} else {
+		// no need to init caller_peers and callee_peers, will be taken from dlg var.
+		if(caller_dlg_var.len > 0) {
+			if(get_dlg_var(dlg, &caller_dlg_var, &dlginfo->caller_peers) < 0) {
+				free_ps_dlginfo_cell(dlginfo);
+				return NULL;
+			}
+		}
+
+		if(callee_dlg_var.len > 0) {
+			if(get_dlg_var(dlg, &callee_dlg_var, &dlginfo->callee_peers) < 0) {
+				free_ps_dlginfo_cell(dlginfo);
+				return NULL;
+			}
+		}
+	}
+
+	// register dialog callbacks to handle changing dialog state
+	if(dlg_api.register_dlgcb(dlg, dialog_event_types, __dialog_callback,
+			   dlginfo, free_ps_dlginfo_cell)
+			!= 0) {
+		LM_ERR("cannot register callback for interesting dialog types\n");
+		free_ps_dlginfo_cell(dlginfo);
+		return NULL;
+	}
+
+	return (dlginfo);
+}
+
+static inline void free_ps_dlginfo_cell(void *param)
+{
+	struct ps_dlginfo_cell *cell = NULL;
+
+	if(param == NULL)
+		return;
+
+	cell = param;
+	if(cell->from)
+		shm_free(cell->from);
+	if(cell->to)
+		shm_free(cell->to);
+	free_str_list_all(cell->caller_peers);
+	free_str_list_all(cell->callee_peers);
+
+	shm_free(param);
+}
+
+static inline void free_str_list_all(struct str_list *del_current)
+{
+	struct str_list *del_next;
+	while(del_current) {
+		del_next = del_current->next;
+
+		if(del_current->s.s)
+			shm_free(del_current->s.s);
+
+		shm_free(del_current);
+		del_current = del_next;
+	}
+}
+
+static inline int get_avp_first_str(
+		unsigned short avp_flags, int_str avp_name, str *result)
+{
+	int_str avp_value;
+	struct search_state st;
+
+	if(!result)
+		return -1;
+
+	LM_DBG("AVP Name received '%.*s'\n", avp_name.s.len, avp_name.s.s);
+
+	if(!search_first_avp(avp_flags, avp_name, &avp_value, &st)) {
+		return -1;
+	}
+
+	LM_DBG("AVP found '%.*s'\n", avp_value.s.len, avp_value.s.s);
+
+	result->s = avp_value.s.s;
+	result->len = avp_value.s.len;
+
+	return 0;
+}
+
+static struct str_list *get_avp_str_list(
+		unsigned short avp_flags, int_str avp_name)
+{
+	int_str avp_value;
+	struct str_list *list_first = NULL;
+	struct str_list *list_current = NULL;
+	struct str_list *new_node = NULL;
+	struct search_state st;
+
+	LM_DBG("AVP Name received '%.*s'\n", avp_name.s.len, avp_name.s.s);
+
+	if(!search_first_avp(avp_flags, avp_name, &avp_value, &st)) {
+		LM_DBG("AVP '%.*s' not found\n", avp_name.s.len, avp_name.s.s);
+		return NULL;
+	}
+
+	do {
+		LM_DBG("AVP found '%.*s'\n", avp_value.s.len, avp_value.s.s);
+		new_node = (struct str_list *)shm_malloc(sizeof(struct str_list));
+		if(!new_node) {
+			SHM_MEM_ERROR;
+			free_str_list_all(list_first);
+			return NULL;
+		}
+
+		memset(new_node, 0, sizeof(struct str_list));
+
+		new_node->s.s = shm_str2char_dup(&avp_value.s);
+		if(!new_node->s.s) {
+			shm_free(new_node); /* Free the newly allocated node */
+			free_str_list_all(list_first);
+			return NULL;
+		}
+
+		new_node->s.len = avp_value.s.len;
+
+		if(list_current)
+			list_current->next = new_node;
+		else
+			list_first = new_node;
+
+		list_current = new_node;
+	} while(search_next_avp(&st, &avp_value));
+	return list_first;
+}
+
+static int set_dlg_var(struct dlg_cell *dlg, str *key, struct str_list *lst)
+{
+	str buf = STR_NULL;
+	struct str_list *it = lst;
+	int res;
+	int count = 0;
+
+	if(!lst)
+		return -1;
+
+	buf.len = 0;
+	while(it) {
+		buf.len += it->s.len;
+		count++;
+		it = it->next;
+	}
+	if(count > 1)
+		buf.len += (count - 1);
+
+	buf.s = (char *)pkg_malloc(buf.len + 1);
+	if(!buf.s) {
+		PKG_MEM_ERROR;
+		return -1;
+	}
+
+	it = lst;
+	int pos = 0;
+	while(it) {
+		memcpy(buf.s + pos, it->s.s, it->s.len);
+		pos += it->s.len;
+		if(it->next)
+			buf.s[pos++] = *DLG_VAR_SEP;
+		it = it->next;
+	}
+	buf.s[buf.len] = '\0';
+
+	res = dlg_api.set_dlg_var(dlg, key, &buf);
+	pkg_free(buf.s);
+	return res;
+}
+
+static int get_dlg_var(struct dlg_cell *dlg, str *key, struct str_list **lst)
+{
+	str dval = STR_NULL;
+	str val = STR_NULL;
+	struct str_list *it, *prev;
+	char *sep, *ini, *end;
+
+	if(dlg_api.get_dlg_varval(dlg, key, &dval) != 0 || dval.s == NULL)
+		return 0;
+
+	if(*lst)
+		free_str_list_all(*lst);
+
+	*lst = prev = NULL;
+	ini = dval.s;
+	end = dval.s + dval.len - 1;
+
+	while(ini <= end) {
+		sep = stre_search_strz(ini, end, DLG_VAR_SEP);
+
+		if(!sep || sep > end) {
+			val.s = ini;
+			val.len = end - ini + 1;
+		} else {
+			val.s = ini;
+			val.len = sep - ini;
+		}
+
+		if(val.len <= 0) {
+			if(!sep || sep > end)
+				break;
+			ini = sep + 1;
+			continue;
+		}
+
+		it = (struct str_list *)shm_malloc(sizeof(struct str_list));
+		if(!it) {
+			SHM_MEM_ERROR;
+			free_str_list_all(*lst);
+			return -1;
+		}
+
+		memset(it, 0, sizeof(struct str_list));
+		it->s.s = shm_str2char_dup(&val);
+		if(!it->s.s) {
+			shm_free(it);
+			free_str_list_all(*lst);
+			return -1;
+		}
+
+		it->s.len = val.len;
+
+		if(!*lst)
+			*lst = prev = it;
+		else {
+			prev->next = it;
+			prev = it;
+		}
+
+		if(!sep || sep > end)
+			break;
+		ini = sep + 1;
+	}
+	return 0;
+}
+
+/**
+ * init module function
+ */
+static int mod_init(void)
+{
+	LM_DBG("mod_init worked!\n");
+	str s;
+	pv_spec_t avp_spec;
+	bind_usrloc_t bind_usrloc;
+
+	if(init_peerstate_callbacks() < 0) {
+		LM_ERR("failed to initialize callback system\n");
+		return -1;
+	}
+
+	if(init_peerstate_cache(
+			   cache_expire, cache_cleanup_interval, cache_hash_size)
+			< 0) {
+		LM_ERR("failed to initialize peerstate cache\n");
+		return -1;
+	}
+	LM_DBG("Peerstate cache enabled\n");
+
+	if(caller_dlg_var.len <= 0)
+		LM_WARN("pubruri_caller_dlg_var is not set - restore on restart "
+				"disabled\n");
+
+	if(callee_dlg_var.len <= 0)
+		LM_WARN("pubruri_callee_dlg_var is not set - restore on restart "
+				"disabled\n");
+
+	/* bind to the dialog API */
+	if(load_dlg_api(&dlg_api) != 0) {
+		LM_ERR("failed to find dialog API - is dialog module loaded?\n");
+		return -1;
+	}
+
+	bind_usrloc = (bind_usrloc_t)find_export("ul_bind_usrloc", 1, 0);
+	if(!bind_usrloc) {
+		LM_ERR("Failed to bind usrloc - is usrloc module loaded?\n");
+		return -1;
+	}
+
+	if(bind_usrloc(&ul_api) < 0) {
+		LM_ERR("Failed to bind usrloc - is usrloc module loaded?\n");
+		return -1;
+	}
+
+	peerstate_event_rt = route_lookup(&event_rt, PEERSTATE_EVENT_ROUTE);
+	if(peerstate_event_rt < 0)
+		LM_INFO("event_route[%s] not defined, notifications via event route "
+				"disabled\n",
+				PEERSTATE_EVENT_ROUTE);
+	else
+		LM_INFO("event_route[%s] registered\n", PEERSTATE_EVENT_ROUTE);
+
+	if(disable_dlg_notify <= 0) {
+		/* register dialog creation callback */
+		if(dlg_api.register_dlgcb(
+				   NULL, DLGCB_CREATED, __dialog_created, NULL, NULL)
+				!= 0) {
+			LM_ERR("cannot register callback for dialog creation\n");
+			return -1;
+		}
+
+		/* register dialog loaded callback */
+		if(dlg_api.register_dlgcb(
+				   NULL, DLGCB_LOADED, __dialog_loaded, NULL, NULL)
+				!= 0) {
+			LM_ERR("cannot register callback for dialog loaded\n");
+			return -1;
+		}
+	}
+
+	if(disable_reg_notify <= 0) {
+		if(ul_api.register_ulcb(UL_CONTACT_INSERT | UL_CONTACT_EXPIRE
+										| UL_CONTACT_UPDATE | UL_CONTACT_DELETE,
+				   __usrloc_changed, 0)
+				< 0) {
+			LM_ERR("cannot register usrloc callbacks\n");
+			return -1;
+		}
+	}
+
+	if(use_avps) {
+		LM_INFO("configured to use avps for uri values\n");
+		if((caller_avp == NULL || *caller_avp == 0)
+				|| (callee_avp == NULL || *callee_avp == 0)) {
+			LM_ERR("caller_avp and callee_avp must be set, if use_avps is "
+				   "enabled\n");
+			return -1;
+		}
+
+		s.s = caller_avp;
+		s.len = strlen(s.s);
+		if(pv_parse_spec(&s, &avp_spec) == 0 || avp_spec.type != PVT_AVP) {
+			LM_ERR("malformed or non AVP %s AVP definition\n", caller_avp);
+			return -1;
+		}
+
+		if(pv_get_avp_name(0, &avp_spec.pvp, &caller_avp_name, &caller_avp_type)
+				!= 0) {
+			LM_ERR("[%s]- invalid AVP definition\n", caller_avp);
+			return -1;
+		}
+
+		s.s = callee_avp;
+		s.len = strlen(s.s);
+		if(pv_parse_spec(&s, &avp_spec) == 0 || avp_spec.type != PVT_AVP) {
+			LM_ERR("malformed or non AVP %s AVP definition\n", callee_avp);
+			return -1;
+		}
+		if(pv_get_avp_name(0, &avp_spec.pvp, &callee_avp_name, &callee_avp_type)
+				!= 0) {
+			LM_ERR("[%s]- invalid AVP definition\n", callee_avp);
+			return -1;
+		}
+
+		s.s = reg_avp;
+		s.len = strlen(s.s);
+		if(pv_parse_spec(&s, &avp_spec) == 0 || avp_spec.type != PVT_AVP) {
+			LM_ERR("malformed or non AVP %s AVP definition\n", reg_avp);
+			return -1;
+		}
+		if(pv_get_avp_name(0, &avp_spec.pvp, &reg_avp_name, &reg_avp_type)
+				!= 0) {
+			LM_ERR("[%s]- invalid AVP definition\n", reg_avp);
+			return -1;
+		}
+	} else
+		LM_INFO("configured to use headers for uri values\n");
+
+	return 0;
+}
+
+/**
+ * @brief Initialize module children
+ */
+static int child_init(int rank)
+{
+	if(rank != PROC_MAIN) {
+		return 0;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Module cleanup function
+ */
+static void mod_destroy(void)
+{
+	LM_INFO("peerstate module cleanup started\n");
+	destroy_peerstate_callbacks();
+	destroy_peerstate_cache();
+	LM_INFO("peerstate module cleanup completed\n");
+}
+
+static inline int should_notify(
+		int disable_notify, int disable_flag, struct sip_msg *request)
+{
+	if(disable_notify)
+		return 0;
+
+	if(disable_flag == -1)
+		return 1;
+
+	if(request && (request->flags & (1 << disable_flag)))
+		return 0;
+
+	return 1;
+}
+
+static void process_dialog_peers(struct str_list *peers, ps_state_t new_state,
+		int early_enabled, str *callid)
+{
+	struct str_list *peer = peers;
+	ps_state_t prev_state;
+	int state_changed;
+
+	while(peer) {
+		state_changed = update_peer_state_dialog(
+				&peer->s, new_state, early_enabled, &prev_state);
+		if(state_changed > 0) {
+			LM_DBG("[%.*s] '%.*s': %s -> %s\n", callid->len, callid->s,
+					peer->s.len, peer->s.s, PS_STATE_TO_STR(prev_state),
+					PS_STATE_TO_STR(new_state));
+			notify_with_callbacks(new_state, prev_state, &peer->s, callid,
+					PEERSTATE_EVENT_DIALOG);
+		}
+		peer = peer->next;
+	}
+}
+
+// helper: build a shm-allocated str_list node with "peer@host"
+static struct str_list *peer_at_host_list(struct sip_uri *uri)
+{
+	struct str_list *n;
+	int len;
+	char *p;
+
+	if(uri == NULL || uri->user.s == NULL || uri->user.len <= 0
+			|| uri->host.s == NULL || uri->host.len <= 0)
+		return NULL;
+
+	n = (struct str_list *)shm_malloc(sizeof(struct str_list));
+	if(!n) {
+		SHM_MEM_ERROR;
+		return NULL;
+	}
+	memset(n, 0, sizeof(struct str_list));
+
+	len = uri->user.len + 1 + uri->host.len; /* peer + '@' + host */
+	n->s.s = (char *)shm_malloc(len + 1);
+	if(!n->s.s) {
+		SHM_MEM_ERROR;
+		shm_free(n);
+		return NULL;
+	}
+
+	p = n->s.s;
+	memcpy(p, uri->user.s, uri->user.len);
+	p += uri->user.len;
+	*p++ = '@';
+	memcpy(p, uri->host.s, uri->host.len);
+	p += uri->host.len;
+	*p = '\0';
+
+	n->s.len = len;
+	n->next = NULL;
+	return n;
+}
+
+static inline void print_ucontact(ucontact_t *c)
+{
+	time_t now = time(NULL);
+	if(!c) {
+		LM_ERR("Contact is NULL\n");
+		return;
+	}
+	LM_DBG("CONTACT: aor=%.*s contact=%.*s ruid=%.*s expires=%lu "
+		   "remaining=%ld(s) callid=%.*s ua=%.*s\n",
+			c->aor ? c->aor->len : 0, c->aor ? c->aor->s : "", c->c.len, c->c.s,
+			c->ruid.len, c->ruid.s, (unsigned long)c->expires,
+			(c->expires > now) ? (long)(c->expires - now) : 0, c->callid.len,
+			c->callid.s, c->user_agent.len, c->user_agent.s);
+}
+
+/**
+ * @brief RPC: peerstate.get_peer <peer>
+ * Get state info for specific peer
+ */
+static void rpc_get_peer(rpc_t *rpc, void *ctx)
+{
+	str peer;
+	ps_state_t state;
+	int call_count, is_registered;
+
+	if(rpc->scan(ctx, "S", &peer) < 1) {
+		rpc->fault(ctx, 400, "Peer parameter required");
+		return;
+	}
+
+	if(get_peer_info(&peer, &state, &call_count, &is_registered) < 0) {
+		rpc->fault(ctx, 404, "Peer not found");
+		return;
+	}
+
+	if(rpc->add(ctx, "{", &ctx) < 0)
+		return;
+	rpc->struct_add(ctx, "Ssds", "peer", &peer, "state", PS_STATE_TO_STR(state),
+			"call_count", call_count, "registered",
+			is_registered ? "yes" : "no");
+}
+
+/**
+ * @brief RPC: peerstate.stats
+ * Get cache statistics
+ */
+static void rpc_stats(rpc_t *rpc, void *ctx)
+{
+	int total, incall, registered;
+
+	get_cache_stats(&total, &incall, &registered);
+
+	if(rpc->add(ctx, "{", &ctx) < 0)
+		return;
+	rpc->struct_add(ctx, "ddd", "total_peers", total, "incall_peers", incall,
+			"registered_peers", registered);
+}
+
+static void rpc_list(rpc_t *rpc, void *ctx)
+{
+	str state_str;
+	ps_state_t state;
+	str *peers = NULL;
+	int count, i;
+
+	void *root_ctx;
+	void *peers_obj_ctx;
+	void *peer_arr_ctx;
+	void *peer_ctx;
+
+	ps_state_t ps_state;
+	int call_count, is_registered;
+
+	if(rpc->scan(ctx, "S", &state_str) < 1) {
+		rpc->fault(ctx, 400,
+				"State parameter required (NOT_INUSE, INUSE, RINGING, "
+				"UNAVAILABLE)");
+		return;
+	}
+
+	if(strncasecmp(state_str.s, "NOT_INUSE", 9) == 0)
+		state = NOT_INUSE;
+	else if(strncasecmp(state_str.s, "INUSE", 5) == 0)
+		state = INUSE;
+	else if(strncasecmp(state_str.s, "RINGING", 7) == 0)
+		state = RINGING;
+	else if(strncasecmp(state_str.s, "UNAVAILABLE", 11) == 0)
+		state = UNAVAILABLE;
+	else {
+		rpc->fault(ctx, 400,
+				"Invalid state (use: NOT_INUSE, INUSE, RINGING, UNAVAILABLE)");
+		return;
+	}
+
+	if(get_peers_by_state(state, &peers, &count) < 0) {
+		rpc->fault(ctx, 500, "Failed to get peers");
+		return;
+	}
+
+	if(rpc->add(ctx, "{", &root_ctx) < 0)
+		goto cleanup;
+
+	rpc->struct_add(root_ctx, "{", "Peers", &peers_obj_ctx);
+
+	rpc->struct_add(peers_obj_ctx, "dS", "count", count, "state", &state_str);
+
+	rpc->struct_add(peers_obj_ctx, "[", "Peer", &peer_arr_ctx);
+
+	for(i = 0; i < count; i++) {
+		rpc->array_add(peer_arr_ctx, "{", &peer_ctx);
+
+		if(get_peer_info(&peers[i], &ps_state, &call_count, &is_registered)
+				< 0) {
+			rpc->struct_add(peer_ctx, "Ssds", "name", &peers[i], "state",
+					"UNKNOWN", "call_count", 0, "registered", "no");
+		} else {
+			rpc->struct_add(peer_ctx, "Ssds", "name", &peers[i], "state",
+					PS_STATE_TO_STR(ps_state), "call_count", call_count,
+					"registered", is_registered ? "yes" : "no");
+		}
+	}
+
+cleanup:
+	for(i = 0; i < count; i++)
+		pkg_free(peers[i].s);
+	pkg_free(peers);
+}
+
+/**
+ * @brief RPC: peerstate.dump
+ * List all peers
+ */
+static void rpc_dump(rpc_t *rpc, void *ctx)
+{
+	str *peers = NULL;
+	int count, i;
+
+	void *root_ctx;
+	void *peers_obj_ctx;
+	void *peer_arr_ctx;
+	void *peer_ctx;
+
+	ps_state_t state;
+	int call_count, is_registered;
+
+	if(get_all_peers(&peers, &count) < 0) {
+		rpc->fault(ctx, 500, "Failed to get peers");
+		return;
+	}
+
+	if(rpc->add(ctx, "{", &root_ctx) < 0)
+		goto cleanup;
+
+	rpc->struct_add(root_ctx, "{", "Peers", &peers_obj_ctx);
+
+	rpc->struct_add(peers_obj_ctx, "d", "count", count);
+
+	rpc->struct_add(peers_obj_ctx, "[", "Peer", &peer_arr_ctx);
+
+	for(i = 0; i < count; i++) {
+		rpc->array_add(peer_arr_ctx, "{", &peer_ctx);
+
+		if(get_peer_info(&peers[i], &state, &call_count, &is_registered) < 0) {
+			rpc->struct_add(peer_ctx, "Ssds", "name", &peers[i], "state",
+					"UNKNOWN", "call_count", 0, "registered", "no");
+		} else {
+			rpc->struct_add(peer_ctx, "Ssds", "name", &peers[i], "state",
+					PS_STATE_TO_STR(state), "call_count", call_count,
+					"registered", is_registered ? "yes" : "no");
+		}
+	}
+
+cleanup:
+	for(i = 0; i < count; i++)
+		pkg_free(peers[i].s);
+	pkg_free(peers);
+}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

This PR introduces a new Kamailio module named `peerstate`.

The peerstate module provides real-time tracking of SIP peer state by
correlating dialog lifecycle events with registration status. It
maintains a shared-memory cache of peer states and supports multiple
simultaneous dialogs and contacts per peer.

The design and behavior of the module are inspired by existing presence
and PUA-related modules such as `pua_reginfo` and `pua_dialoginfo`.
Some concepts and mechanisms used in those modules (dialog and
registration event handling, some parameters) are reused and adapted for peer state tracking without requiring
full SIP presence functionality. 

Peer state changes are exposed through:
- Kamailio event routes (event_route[peerstate:state_changed])
- A callback-based API for other modules
- RPC commands for runtime inspection and monitoring

The module integrates with the `dialog` and `usrloc` modules to receive
dialog and registration events. It supports both URI-derived and
AVP-based peer identification and handles multi-contact registration
scenarios conservatively.

Documentation is provided in DocBook XML format following the standard
Kamailio Admin Guide / Developer Guide structure.
