### PR TITLE
permissions: add locks support

### DIFF
--- a/src/modules/permissions/hash.c
+++ b/src/modules/permissions/hash.c
@@ -357,40 +357,6 @@ struct trusted_hash_table * trusted_table_allocate(unsigned int hash_table_size)
 
 
 /*
- * Create and initialize a hash table
- */
-struct trusted_list **new_hash_table(void)
-{
-	struct trusted_list **ptr;
-
-	/* Initializing hash tables and hash table variable */
-	ptr = (struct trusted_list **)shm_malloc(
-			sizeof(struct trusted_list *) * PERM_HASH_SIZE);
-	if(!ptr) {
-		LM_ERR("no shm memory for hash table\n");
-		return 0;
-	}
-
-	memset(ptr, 0, sizeof(struct trusted_list *) * PERM_HASH_SIZE);
-	return ptr;
-}
-
-
-/*
- * Release all memory allocated for a hash table
- */
-void free_hash_table(struct trusted_list **table)
-{
-	if(!table)
-		return;
-
-	empty_hash_table(table);
-	shm_free(table);
-}
-
-
-
-/*
  * Add <src_ip, proto, pattern, ruri_pattern, tag, priority> into hash table, where proto is integer
  * representation of string argument proto.
  */
@@ -761,34 +727,6 @@ int hash_table_rpc_print(struct trusted_hash_table *trusted_table, rpc_t *rpc, v
 		lock_release(trusted_table->row_locks[i]);
 	}
 	return 0;
-}
-
-/*
- * Free contents of hash table, it doesn't destroy the
- * hash table itself
- */
-void empty_hash_table(struct trusted_list **table)
-{
-	int i;
-	struct trusted_list *np, *next;
-
-	for(i = 0; i < PERM_HASH_SIZE; i++) {
-		np = table[i];
-		while(np) {
-			if(np->src_ip.s)
-				shm_free(np->src_ip.s);
-			if(np->pattern)
-				shm_free(np->pattern);
-			if(np->ruri_pattern)
-				shm_free(np->ruri_pattern);
-			if(np->tag.s)
-				shm_free(np->tag.s);
-			next = np->next;
-			shm_free(np);
-			np = next;
-		}
-		table[i] = 0;
-	}
 }
 
 

--- a/src/modules/permissions/hash.c
+++ b/src/modules/permissions/hash.c
@@ -136,8 +136,7 @@ void trusted_table_free_entries(struct trusted_list *given_entry)
 		return;
 
 	entry = given_entry;
-	while(entry)
-	{
+	while(entry) {
 		last_entry = entry;
 		entry = entry->next;
 		trusted_table_free_entry(last_entry);
@@ -153,8 +152,8 @@ void trusted_table_free_entries(struct trusted_list *given_entry)
  * Locks can be left intact,
  * e.g. in case this is just a table re-initialization.
  */
-void trusted_table_free_buckets(struct trusted_hash_table *trusted_table, bool free_locks,
-		bool keep_dummy_head)
+void trusted_table_free_buckets(struct trusted_hash_table *trusted_table,
+		bool free_locks, bool keep_dummy_head)
 {
 	if(!trusted_table) {
 		LM_ERR("Nothing to de-allocate! Empty trusted table pointer.");
@@ -163,10 +162,11 @@ void trusted_table_free_buckets(struct trusted_hash_table *trusted_table, bool f
 
 	unsigned int orig_size = trusted_table->size;
 
-	for(int i = 0; i < orig_size; i++)
-	{
+	for(int i = 0; i < orig_size; i++) {
 		if(!trusted_table->row_locks[i]) {
-			LM_ERR("Absent table row lock[%d], cannot acquire it and de-allocate members.\n", i);
+			LM_ERR("Absent table row lock[%d], cannot acquire it and "
+				   "de-allocate members.\n",
+					i);
 			continue;
 		} else {
 			lock_get(trusted_table->row_locks[i]);
@@ -174,10 +174,12 @@ void trusted_table_free_buckets(struct trusted_hash_table *trusted_table, bool f
 
 		/* now clean the bucket */
 		if(!trusted_table->row_entry_list[i]) {
-			LM_DBG("Table bucket[%d] is already empty, cannot de-allocate its content.\n", i);
+			LM_DBG("Table bucket[%d] is already empty, cannot de-allocate its "
+				   "content.\n",
+					i);
 		} else {
 			/* in case of bucket re-init, leave the dummy head (list is never NULL when using) */
-			if (keep_dummy_head) {
+			if(keep_dummy_head) {
 				struct trusted_list *dummy = trusted_table->row_entry_list[i];
 				trusted_table_free_entries(dummy->next);
 				dummy->next = NULL;
@@ -201,7 +203,7 @@ void trusted_table_free_buckets(struct trusted_hash_table *trusted_table, bool f
 		lock_release(trusted_table->row_locks[i]);
 
 		/* and accordingly a lock */
-		if (free_locks) {
+		if(free_locks) {
 			trusted_table_free_row_lock(trusted_table->row_locks[i]);
 			trusted_table->row_locks[i] = NULL;
 		}
@@ -221,7 +223,8 @@ int trusted_table_destroy(struct trusted_hash_table *trusted_table)
 
 	/* de-allocate row locks */
 	if(!trusted_table->row_locks) {
-		LM_ERR("Empty row locks, cannot acquire it and de-allocate trusted table members.\n");
+		LM_ERR("Empty row locks, cannot acquire it and de-allocate trusted "
+			   "table members.\n");
 		shm_free(trusted_table);
 		return -1;
 	}
@@ -249,13 +252,13 @@ int trusted_table_destroy(struct trusted_hash_table *trusted_table)
 }
 
 
-int trusted_table_reinit(struct trusted_hash_table * trusted_table,
-		unsigned int hash_table_size)
+int trusted_table_reinit(
+		struct trusted_hash_table *trusted_table, unsigned int hash_table_size)
 {
 	DBG("re-initializing table.\n");
 
 	trusted_table_free_buckets(trusted_table, false, true);
-	if (trusted_table_init(trusted_table, PERM_HASH_SIZE)) {
+	if(trusted_table_init(trusted_table, PERM_HASH_SIZE)) {
 		LM_ERR("failed to re-initialize the new trusted table.\n");
 		return -1;
 	}
@@ -266,8 +269,8 @@ int trusted_table_reinit(struct trusted_hash_table * trusted_table,
 /**
  * Initialize main members and locks.
  */
-int trusted_table_init(struct trusted_hash_table * trusted_table,
-		unsigned int hash_table_size)
+int trusted_table_init(
+		struct trusted_hash_table *trusted_table, unsigned int hash_table_size)
 {
 	if(!trusted_table) {
 		LM_ERR("Cannot initialize this table, empty trusted table pointer.");
@@ -276,33 +279,40 @@ int trusted_table_init(struct trusted_hash_table * trusted_table,
 
 	DBG("init trusted_table size = %d\n", hash_table_size);
 
-	for(unsigned int i = 0; i < hash_table_size; i++)
-	{
+	for(unsigned int i = 0; i < hash_table_size; i++) {
 		/* init locks (can be already in place, e.g. re-init) */
-		if (!trusted_table->row_locks[i]) {
+		if(!trusted_table->row_locks[i]) {
 			trusted_table->row_locks[i] = lock_alloc();
 
 			if(!trusted_table->row_locks[i]) {
-				LM_ERR("no shared memory left to allocate a row lock[%d] for this trusted table\n", i);
+				LM_ERR("no shared memory left to allocate a row lock[%d] for "
+					   "this trusted table\n",
+						i);
 				trusted_table_destroy(trusted_table);
 				return -1;
 			}
 			if(!lock_init(trusted_table->row_locks[i])) {
-				LM_ERR("failed to initialize a row lock[%d] for this trusted table\n", i);
+				LM_ERR("failed to initialize a row lock[%d] for this trusted "
+					   "table\n",
+						i);
 				trusted_table_destroy(trusted_table);
 				return -1;
 			}
 		}
 
 		/* initialize each trusted_list entry (dummy head can already be in place, e.g. re-init) */
-		if (!trusted_table->row_entry_list[i]) {
-			trusted_table->row_entry_list[i] = shm_malloc(sizeof(struct trusted_list));
+		if(!trusted_table->row_entry_list[i]) {
+			trusted_table->row_entry_list[i] =
+					shm_malloc(sizeof(struct trusted_list));
 			if(!trusted_table->row_entry_list[i]) {
-				LM_ERR("no shared memory left to allocate trusted list entry[%d] for this trusted table\n", i);
+				LM_ERR("no shared memory left to allocate trusted list "
+					   "entry[%d] for this trusted table\n",
+						i);
 				trusted_table_destroy(trusted_table);
 				return -1;
 			}
-			memset(trusted_table->row_entry_list[i], 0, sizeof(struct trusted_list));
+			memset(trusted_table->row_entry_list[i], 0,
+					sizeof(struct trusted_list));
 
 			/* track real table size */
 			trusted_table->size++;
@@ -323,10 +333,11 @@ int trusted_table_init(struct trusted_hash_table * trusted_table,
 /**
  * Allocate space (shm) for the table.
  */
-struct trusted_hash_table * trusted_table_allocate(unsigned int hash_table_size)
+struct trusted_hash_table *trusted_table_allocate(unsigned int hash_table_size)
 {
 	/* init the main hash table structure */
-	struct trusted_hash_table * trusted_table = shm_malloc(sizeof(struct trusted_hash_table));
+	struct trusted_hash_table *trusted_table =
+			shm_malloc(sizeof(struct trusted_hash_table));
 	if(!trusted_table) {
 		LM_ERR("no shared memory left to create this trusted table\n");
 		return NULL;
@@ -334,22 +345,27 @@ struct trusted_hash_table * trusted_table_allocate(unsigned int hash_table_size)
 	memset(trusted_table, 0, sizeof(struct trusted_hash_table));
 
 	/* init the row locks for it */
-	trusted_table->row_locks = shm_malloc(hash_table_size * sizeof(gen_lock_t *));
+	trusted_table->row_locks =
+			shm_malloc(hash_table_size * sizeof(gen_lock_t *));
 	if(!trusted_table->row_locks) {
-		LM_ERR("no shared memory left to create row locks for this trusted table\n");
+		LM_ERR("no shared memory left to create row locks for this trusted "
+			   "table\n");
 		trusted_table_destroy(trusted_table);
 		return NULL;
 	}
 	memset(trusted_table->row_locks, 0, hash_table_size * sizeof(gen_lock_t *));
 
 	/* allocate space for the list */
-	trusted_table->row_entry_list = shm_malloc(hash_table_size * sizeof(struct trusted_list *));
+	trusted_table->row_entry_list =
+			shm_malloc(hash_table_size * sizeof(struct trusted_list *));
 	if(!trusted_table->row_entry_list) {
-		LM_ERR("no shared memory left to create entry list for this trusted table\n");
+		LM_ERR("no shared memory left to create entry list for this trusted "
+			   "table\n");
 		trusted_table_destroy(trusted_table);
 		return NULL;
 	}
-	memset(trusted_table->row_entry_list, 0, hash_table_size * sizeof(struct trusted_list *));
+	memset(trusted_table->row_entry_list, 0,
+			hash_table_size * sizeof(struct trusted_list *));
 
 	LM_DBG("successfully allocated new trusted table\n");
 	return trusted_table;
@@ -360,8 +376,8 @@ struct trusted_hash_table * trusted_table_allocate(unsigned int hash_table_size)
  * Add <src_ip, proto, pattern, ruri_pattern, tag, priority> into hash table, where proto is integer
  * representation of string argument proto.
  */
-int hash_table_insert(struct trusted_hash_table *hash_table, char *src_ip, char *proto,
-		char *pattern, char *ruri_pattern, char *tag, int priority)
+int hash_table_insert(struct trusted_hash_table *hash_table, char *src_ip,
+		char *proto, char *pattern, char *ruri_pattern, char *tag, int priority)
 {
 	struct trusted_list *cur_entry, *prev_entry;
 	struct trusted_list *new_entry = NULL;
@@ -462,7 +478,7 @@ int hash_table_insert(struct trusted_hash_table *hash_table, char *src_ip, char 
 	hash_index = perm_hash(new_entry->src_ip);
 
 	/* ensure to have a correct index within boundaries */
-	if (hash_index >= hash_table->size) {
+	if(hash_index >= hash_table->size) {
 		trusted_table_free_entry(new_entry);
 		LM_ERR("hash index out of bounds [%d]\n", hash_index);
 		return -1;
@@ -475,7 +491,8 @@ int hash_table_insert(struct trusted_hash_table *hash_table, char *src_ip, char 
 		lock_get(hash_table->row_locks[hash_index]);
 	} else {
 		trusted_table_free_entry(new_entry);
-		LM_ERR("Cannot acquire the bucket lock, hash table slot[%d]\n", hash_index);
+		LM_ERR("Cannot acquire the bucket lock, hash table slot[%d]\n",
+				hash_index);
 		return -1;
 	}
 
@@ -490,31 +507,37 @@ int hash_table_insert(struct trusted_hash_table *hash_table, char *src_ip, char 
 	new_entry->next = NULL; // for the meanwhile
 	cur_entry = hash_table->row_entry_list[hash_index];
 
-	while(cur_entry)
-	{
+	while(cur_entry) {
 		/* check always if already added before */
-		if(STR_EQ(cur_entry->src_ip, new_entry->src_ip) && /* compare source ip */
-			/* compare From patern (both equal or both null) */
-			((!cur_entry->pattern && !new_entry->pattern) ||
-			(cur_entry->pattern && new_entry->pattern &&
-			strcmp(cur_entry->pattern, new_entry->pattern) == 0)) &&
-			/* compare ruri patern (both equal or both null) */
-			((!cur_entry->ruri_pattern && !new_entry->ruri_pattern) ||
-			(cur_entry->ruri_pattern && new_entry->ruri_pattern &&
-			strcmp(cur_entry->ruri_pattern, new_entry->ruri_pattern) == 0)) &&
-			/* compare protocol */
-			cur_entry->proto == new_entry->proto)
-		{
+		if(STR_EQ(cur_entry->src_ip, new_entry->src_ip)
+				&& /* compare source ip */
+				/* compare From patern (both equal or both null) */
+				((!cur_entry->pattern && !new_entry->pattern)
+						|| (cur_entry->pattern && new_entry->pattern
+								&& strcmp(cur_entry->pattern,
+										   new_entry->pattern)
+										   == 0))
+				&&
+				/* compare ruri patern (both equal or both null) */
+				((!cur_entry->ruri_pattern && !new_entry->ruri_pattern)
+						|| (cur_entry->ruri_pattern && new_entry->ruri_pattern
+								&& strcmp(cur_entry->ruri_pattern,
+										   new_entry->ruri_pattern)
+										   == 0))
+				&&
+				/* compare protocol */
+				cur_entry->proto == new_entry->proto) {
 			lock_release(hash_table->row_locks[hash_index]);
 			trusted_table_free_entry(new_entry);
-			LM_NOTICE("source IP = '%.*s', was already added before, ingore new entry.\n",
+			LM_NOTICE("source IP = '%.*s', was already added before, ingore "
+					  "new entry.\n",
 					cur_entry->src_ip.len, cur_entry->src_ip.s);
 			return 0;
 			/* TODO: we should actually return -1, but the caller is quite strict! */
 		}
 
 		/* stop by the first entry with a lower priority */
-		if (cur_entry->priority < new_entry->priority)
+		if(cur_entry->priority < new_entry->priority)
 			break;
 
 		/* find the next available slot in the list */
@@ -523,7 +546,7 @@ int hash_table_insert(struct trusted_hash_table *hash_table, char *src_ip, char 
 	}
 
 	/* insert new_entry in the right position */
-	if (prev_entry == NULL) {
+	if(prev_entry == NULL) {
 		/* head */
 		new_entry->next = hash_table->row_entry_list[hash_index];
 		hash_table->row_entry_list[hash_index] = new_entry;
@@ -545,8 +568,8 @@ int hash_table_insert(struct trusted_hash_table *hash_table, char *src_ip, char 
  * has been defined, tag of the entry is added as a value to tag_avp.
  * Returns number of matches or -1 if none matched.
  */
-int match_hash_table(struct trusted_hash_table *trusted_table, struct sip_msg *msg,
-		char *src_ip_c_str, int proto, char *from_uri)
+int match_hash_table(struct trusted_hash_table *trusted_table,
+		struct sip_msg *msg, char *src_ip_c_str, int proto, char *from_uri)
 {
 	LM_DBG("match_hash_table src_ip: %s, proto: %d, uri: %s\n", src_ip_c_str,
 			proto, from_uri);
@@ -560,13 +583,13 @@ int match_hash_table(struct trusted_hash_table *trusted_table, struct sip_msg *m
 	unsigned int hash_index;
 	struct trusted_list **table = NULL;
 
-	if (!trusted_table) {
+	if(!trusted_table) {
 		LM_ERR("empty table used for comparison.\n");
 		return -1;
 	}
 
 	/* detect source IP */
-	if (!src_ip_c_str) {
+	if(!src_ip_c_str) {
 		LM_ERR("empty source IP given\n");
 		return -1;
 	}
@@ -589,12 +612,12 @@ int match_hash_table(struct trusted_hash_table *trusted_table, struct sip_msg *m
 	if(trusted_table->row_locks[hash_index]) {
 		lock_get(trusted_table->row_locks[hash_index]);
 	} else {
-		LM_ERR("Cannot acquire the bucket lock, hash table slot[%d]\n", hash_index);
+		LM_ERR("Cannot acquire the bucket lock, hash table slot[%d]\n",
+				hash_index);
 		return -1;
 	}
 
-	if(!trusted_table->row_entry_list[hash_index])
-	{
+	if(!trusted_table->row_entry_list[hash_index]) {
 		LM_ERR("Non-initialized bucket, hash table slot[%d]\n", hash_index);
 		lock_release(trusted_table->row_locks[hash_index]);
 		return -1;
@@ -664,14 +687,15 @@ int match_hash_table(struct trusted_hash_table *trusted_table, struct sip_msg *m
 /*! \brief
  * RPC interface :: Print trusted entries stored in hash table
  */
-int hash_table_rpc_print(struct trusted_hash_table *trusted_table, rpc_t *rpc, void *c)
+int hash_table_rpc_print(
+		struct trusted_hash_table *trusted_table, rpc_t *rpc, void *c)
 {
 	int i;
 	struct trusted_list *np = NULL;
 	void *th;
 	void *ih;
 
-	if (!trusted_table) {
+	if(!trusted_table) {
 		LM_ERR("empty table used for comparison.\n");
 		return -1;
 	}
@@ -683,15 +707,14 @@ int hash_table_rpc_print(struct trusted_hash_table *trusted_table, rpc_t *rpc, v
 
 	for(i = 0; i < PERM_HASH_SIZE; i++) {
 
-		if (trusted_table->row_locks[i]) {
+		if(trusted_table->row_locks[i]) {
 			lock_get(trusted_table->row_locks[i]);
 		} else {
 			LM_ERR("Cannot acquire the bucket lock, hash table slot[%d]\n", i);
 			continue;
 		}
 
-		if (!trusted_table->row_entry_list[i])
-		{
+		if(!trusted_table->row_entry_list[i]) {
 			LM_WARN("Non-initialized bucket, hash table slot[%d]\n", i);
 			lock_release(trusted_table->row_locks[i]);
 			continue;
@@ -716,8 +739,7 @@ int hash_table_rpc_print(struct trusted_hash_table *trusted_table, rpc_t *rpc, v
 					   np->ruri_pattern ? np->ruri_pattern : "NULL", "tag",
 					   np->tag.len ? np->tag.s : "NULL", "priority",
 					   np->priority)
-					< 0)
-			{
+					< 0) {
 				rpc->fault(c, 500, "Internal error creating rpc data");
 				lock_release(trusted_table->row_locks[i]);
 				return -1;

--- a/src/modules/permissions/hash.h
+++ b/src/modules/permissions/hash.h
@@ -86,18 +86,6 @@ void get_tag_avp(int_str *tag_avp_p, int *tag_avp_type_p);
 
 
 /*
- * Create and initialize a hash table
- */
-struct trusted_list **new_hash_table(void);
-
-
-/*
- * Release all memory allocated for a hash table
- */
-void free_hash_table(struct trusted_list **table);
-
-
-/*
  * Add <src_ip, proto, pattern, ruri_pattern, priority> into hash table, where proto is integer
  * representation of string argument proto.
  */
@@ -118,11 +106,6 @@ int match_hash_table(struct trusted_hash_table *trusted_table, struct sip_msg *m
  * Print entries stored in hash table
  */
 int hash_table_rpc_print(struct trusted_hash_table *trusted_table, rpc_t *rpc, void *c);
-
-/*
- * Empty hash table
- */
-void empty_hash_table(struct trusted_list **hash_table);
 
 
 /*

--- a/src/modules/permissions/hash.h
+++ b/src/modules/permissions/hash.h
@@ -56,22 +56,24 @@ struct trusted_list
  */
 struct trusted_hash_table
 {
-	struct trusted_list ** row_entry_list; // entry vector (buckets)
-	gen_lock_t ** row_locks; // locks vector
-	unsigned int size; // table size
+	struct trusted_list **row_entry_list; // entry vector (buckets)
+	gen_lock_t **row_locks;				  // locks vector
+	unsigned int size;					  // table size
 };
 
 void trusted_table_free_row_lock(gen_lock_t *row_lock);
 void trusted_table_free_entry(struct trusted_list *entry);
 void trusted_table_free_entries(struct trusted_list *given_entry);
-void trusted_table_free_buckets(struct trusted_hash_table *trusted_table, bool free_locks,
-		bool keep_dummy_head);
+void trusted_table_free_buckets(struct trusted_hash_table *trusted_table,
+		bool free_locks, bool keep_dummy_head);
 int trusted_table_destroy(struct trusted_hash_table *trusted_table);
-int trusted_table_init(struct trusted_hash_table * trusted_table, unsigned int hash_table_size);
-struct trusted_hash_table * trusted_table_allocate(unsigned int hash_table_size);
+int trusted_table_init(
+		struct trusted_hash_table *trusted_table, unsigned int hash_table_size);
+struct trusted_hash_table *trusted_table_allocate(unsigned int hash_table_size);
 /* same as init, but leaves locks intact
  * and cleans the whole content beforehand */
-int trusted_table_reinit(struct trusted_hash_table * trusted_table, unsigned int hash_table_size);
+int trusted_table_reinit(
+		struct trusted_hash_table *trusted_table, unsigned int hash_table_size);
 
 /*
  * Parse and init tag avp specification
@@ -98,14 +100,15 @@ int hash_table_insert(struct trusted_hash_table *hash_table, char *src_ip,
  * Check if an entry exists in hash table that has given src_ip and protocol
  * value and pattern or ruri_pattern that matches to provided URI.
  */
-int match_hash_table(struct trusted_hash_table *trusted_table, struct sip_msg *msg,
-		char *scr_ip, int proto, char *uri);
+int match_hash_table(struct trusted_hash_table *trusted_table,
+		struct sip_msg *msg, char *scr_ip, int proto, char *uri);
 
 
 /*
  * Print entries stored in hash table
  */
-int hash_table_rpc_print(struct trusted_hash_table *trusted_table, rpc_t *rpc, void *c);
+int hash_table_rpc_print(
+		struct trusted_hash_table *trusted_table, rpc_t *rpc, void *c);
 
 
 /*

--- a/src/modules/permissions/hash.h
+++ b/src/modules/permissions/hash.h
@@ -101,7 +101,7 @@ void free_hash_table(struct trusted_list **table);
  * Add <src_ip, proto, pattern, ruri_pattern, priority> into hash table, where proto is integer
  * representation of string argument proto.
  */
-int hash_table_insert(struct trusted_list **hash_table, char *src_ip,
+int hash_table_insert(struct trusted_hash_table *hash_table, char *src_ip,
 		char *proto, char *pattern, char *ruri_pattern, char *tag,
 		int priority);
 
@@ -110,14 +110,14 @@ int hash_table_insert(struct trusted_list **hash_table, char *src_ip,
  * Check if an entry exists in hash table that has given src_ip and protocol
  * value and pattern or ruri_pattern that matches to provided URI.
  */
-int match_hash_table(struct trusted_list **table, struct sip_msg *msg,
+int match_hash_table(struct trusted_hash_table *trusted_table, struct sip_msg *msg,
 		char *scr_ip, int proto, char *uri);
 
 
 /*
  * Print entries stored in hash table
  */
-int hash_table_rpc_print(struct trusted_list **hash_table, rpc_t *rpc, void *c);
+int hash_table_rpc_print(struct trusted_hash_table *trusted_table, rpc_t *rpc, void *c);
 
 /*
  * Empty hash table

--- a/src/modules/permissions/hash.h
+++ b/src/modules/permissions/hash.h
@@ -73,12 +73,6 @@ void free_hash_table(struct trusted_list **table);
 
 
 /*
- * Destroy a hash table
- */
-void destroy_hash_table(struct trusted_list **table);
-
-
-/*
  * Add <src_ip, proto, pattern, ruri_pattern, priority> into hash table, where proto is integer
  * representation of string argument proto.
  */
@@ -98,7 +92,6 @@ int match_hash_table(struct trusted_list **table, struct sip_msg *msg,
 /*
  * Print entries stored in hash table
  */
-void hash_table_print(struct trusted_list **hash_table, FILE *reply_file);
 int hash_table_rpc_print(struct trusted_list **hash_table, rpc_t *rpc, void *c);
 
 /*
@@ -133,12 +126,6 @@ void free_addr_hash_table(struct addr_list **table);
 
 
 /*
- * Destroy a hash table
- */
-void destroy_addr_hash_table(struct addr_list **table);
-
-
-/*
  * Add <group, ip_addr, port> into hash table
  */
 int addr_hash_table_insert(struct addr_list **hash_table, unsigned int grp,
@@ -165,7 +152,6 @@ int find_group_in_addr_hash_table(
 /*
  * Print addresses stored in hash table
  */
-void addr_hash_table_print(struct addr_list **hash_table, FILE *reply_file);
 int addr_hash_table_rpc_print(struct addr_list **table, rpc_t *rpc, void *c);
 
 
@@ -234,7 +220,6 @@ int subnet_table_insert(struct subnet *table, unsigned int grp,
 /*
  * Print subnets stored in subnet table
  */
-void subnet_table_print(struct subnet *table, FILE *reply_file);
 int subnet_table_rpc_print(struct subnet *table, rpc_t *rpc, void *c);
 
 
@@ -289,7 +274,6 @@ int find_group_in_domain_name_table(
 /*! \brief
  * RPC: Print addresses stored in hash table
  */
-void domain_name_table_print(struct subnet *table, FILE *reply_file);
 int domain_name_table_rpc_print(
 		struct domain_name_list **table, rpc_t *rpc, void *c);
 

--- a/src/modules/permissions/rpc.c
+++ b/src/modules/permissions/rpc.c
@@ -45,8 +45,7 @@ int rpc_check_reload(rpc_t *rpc, void *ctx)
 		rpc->fault(ctx, 500, "ongoing reload");
 		return -1;
 	}
-	// we are reloading, don't allow new reloads
-	*perm_rpc_reload_time = time(NULL) + 86400;
+	*perm_rpc_reload_time = time(NULL);
 	return 0;
 }
 
@@ -62,14 +61,10 @@ void rpc_trusted_reload(rpc_t *rpc, void *c)
 
 	if(reload_trusted_table_cmd() != 1) {
 		rpc->fault(c, 500, "Reload failed.");
-		goto done;
+		return;
 	}
 
 	rpc->rpl_printf(c, "Reload OK");
-done:
-	// reloading is done
-	*perm_rpc_reload_time = time(NULL);
-	return;
 }
 
 
@@ -105,13 +100,10 @@ void rpc_address_reload(rpc_t *rpc, void *c)
 
 	if(reload_address_table_cmd() != 1) {
 		rpc->fault(c, 500, "Reload failed.");
-		goto done;
+		return;
 	}
 
 	rpc->rpl_printf(c, "Reload OK");
-done:
-	// reloading is done
-	*perm_rpc_reload_time = time(NULL);
 	return;
 }
 

--- a/src/modules/permissions/rpc.c
+++ b/src/modules/permissions/rpc.c
@@ -74,12 +74,12 @@ void rpc_trusted_reload(rpc_t *rpc, void *c)
 void rpc_trusted_dump(rpc_t *rpc, void *c)
 {
 
-	if(perm_trust_table == NULL) {
+	if(current_trusted_table == NULL) {
 		rpc->fault(c, 500, "No trusted table");
 		return;
 	}
 
-	if(hash_table_rpc_print(*perm_trust_table, rpc, c) < 0) {
+	if(hash_table_rpc_print(*current_trusted_table, rpc, c) < 0) {
 		LM_DBG("failed to print a hash_table dump\n");
 		return;
 	}

--- a/src/modules/permissions/trusted.c
+++ b/src/modules/permissions/trusted.c
@@ -44,9 +44,10 @@
 static db1_con_t *perm_db_handle = 0;
 static db_func_t perm_dbf;
 
-struct trusted_hash_table **current_trusted_table = NULL; /* pointer to the current hash table (to its pointer) */
-struct trusted_hash_table * trusted_table_1 = NULL; /* hash table 1 */
-struct trusted_hash_table * trusted_table_2 = NULL; /* hash table 2 */
+struct trusted_hash_table **current_trusted_table =
+		NULL; /* pointer to the current hash table (to its pointer) */
+struct trusted_hash_table *trusted_table_1 = NULL; /* hash table 1 */
+struct trusted_hash_table *trusted_table_2 = NULL; /* hash table 2 */
 
 /*
  * Reload trusted table to new hash table and when done, make new hash table
@@ -59,7 +60,7 @@ int reload_trusted_table(void)
 	db_row_t *row;
 	db_val_t *val;
 
-	struct trusted_hash_table * new_trusted_table = NULL;
+	struct trusted_hash_table *new_trusted_table = NULL;
 	int i;
 	int priority;
 	int ret;
@@ -110,7 +111,7 @@ int reload_trusted_table(void)
 	/* clean newly selected table,
 	 * then re-initialize buckets
 	 * for further usage with the new data */
-	if (trusted_table_reinit(new_trusted_table, PERM_HASH_SIZE)) {
+	if(trusted_table_reinit(new_trusted_table, PERM_HASH_SIZE)) {
 		return -1;
 	}
 
@@ -261,9 +262,8 @@ int reload_trusted_table(void)
 			priority = (int)VAL_INT(val + 5);
 		}
 		if(hash_table_insert(new_trusted_table, (char *)VAL_STRING(val),
-					(char *)VAL_STRING(val + 1), pattern, ruri_pattern, tag,
-					priority))
-		{
+				   (char *)VAL_STRING(val + 1), pattern, ruri_pattern, tag,
+				   priority)) {
 			/* anything apart 0 means it has failed */
 
 			LM_WARN("could not insert a new entry\n");
@@ -330,7 +330,9 @@ int init_trusted(void)
 			return -1;
 		}
 
-		if(db_check_table_version(&perm_dbf, perm_db_handle, &perm_trusted_table, TABLE_VERSION) < 0) {
+		if(db_check_table_version(&perm_dbf, perm_db_handle,
+				   &perm_trusted_table, TABLE_VERSION)
+				< 0) {
 			DB_TABLE_VERSION_ERROR(perm_trusted_table);
 			perm_dbf.close(perm_db_handle);
 			perm_db_handle = 0;
@@ -339,30 +341,32 @@ int init_trusted(void)
 
 		/* allocate both tables */
 		trusted_table_1 = trusted_table_allocate(PERM_HASH_SIZE);
-		if (!trusted_table_1) {
+		if(!trusted_table_1) {
 			LM_ERR("failed to allocate trusted table 1\n");
 			return -1;
 		}
 		trusted_table_2 = trusted_table_allocate(PERM_HASH_SIZE);
-		if (!trusted_table_2) {
+		if(!trusted_table_2) {
 			LM_ERR("failed to allocate trusted table 2\n");
 			goto error;
 		}
 
 		/* now init both tables */
-		if (trusted_table_init(trusted_table_1, PERM_HASH_SIZE)) {
+		if(trusted_table_init(trusted_table_1, PERM_HASH_SIZE)) {
 			LM_ERR("failed to initialize trusted table 1\n");
 			goto error;
 		}
-		if (trusted_table_init(trusted_table_2, PERM_HASH_SIZE)) {
+		if(trusted_table_init(trusted_table_2, PERM_HASH_SIZE)) {
 			LM_ERR("failed to initialize trusted table 2\n");
 			goto error;
 		}
 
 		/* allocate space for the current table pointer */
-		current_trusted_table = (struct trusted_hash_table **)shm_malloc(sizeof(struct trusted_hash_table *));
-		if (!current_trusted_table) {
-			LM_ERR("failed to allocate shm for the current trusted table pointer.\n");
+		current_trusted_table = (struct trusted_hash_table **)shm_malloc(
+				sizeof(struct trusted_hash_table *));
+		if(!current_trusted_table) {
+			LM_ERR("failed to allocate shm for the current trusted table "
+				   "pointer.\n");
 			goto error;
 		}
 		/* select */
@@ -676,7 +680,8 @@ int allow_trusted(struct sip_msg *msg, char *src_ip, int proto, char *from_uri)
 		perm_dbf.free_result(perm_db_handle, res);
 		return result;
 	} else {
-		return match_hash_table(*current_trusted_table, msg, src_ip, proto, from_uri);
+		return match_hash_table(
+				*current_trusted_table, msg, src_ip, proto, from_uri);
 	}
 }
 

--- a/src/modules/permissions/trusted.h
+++ b/src/modules/permissions/trusted.h
@@ -28,12 +28,9 @@
 #include "../../core/parser/msg_parser.h"
 
 
-extern struct trusted_list **
-		*perm_trust_table; /* Pointer to current trusted hash table pointer */
-extern struct trusted_list *
-		*perm_trust_table_1; /* Pointer to trusted hash table 1 */
-extern struct trusted_list *
-		*perm_trust_table_2; /* Pointer to trusted hash table 2 */
+extern struct trusted_hash_table **current_trusted_table; /* pointer to the current hash table (to its pointer) */
+extern struct trusted_hash_table * trusted_table_1; /* hash table 1 */
+extern struct trusted_hash_table * trusted_table_2; /* hash table 2 */
 
 
 /*
@@ -68,7 +65,7 @@ int ki_allow_trusted(sip_msg_t *_msg);
 /*
  * Check if request comes from trusted ip address with matching from URI
  */
-int allow_trusted(struct sip_msg *_msg, char *_s1, char *_s2);
+int allow_trusted(struct sip_msg *msg, char *src_ip, int proto, char *from_uri);
 
 
 /*

--- a/src/modules/permissions/trusted.h
+++ b/src/modules/permissions/trusted.h
@@ -28,9 +28,10 @@
 #include "../../core/parser/msg_parser.h"
 
 
-extern struct trusted_hash_table **current_trusted_table; /* pointer to the current hash table (to its pointer) */
-extern struct trusted_hash_table * trusted_table_1; /* hash table 1 */
-extern struct trusted_hash_table * trusted_table_2; /* hash table 2 */
+extern struct trusted_hash_table **
+		current_trusted_table; /* pointer to the current hash table (to its pointer) */
+extern struct trusted_hash_table *trusted_table_1; /* hash table 1 */
+extern struct trusted_hash_table *trusted_table_2; /* hash table 2 */
 
 
 /*


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Move permissions module to work with hash tables instead of directly working with lists.

Use locks to cover these hash tables.
This allows to avoid using crutches alike 0039c50e83916,
and gives a race-free usage of tables regardless the amount of data inserted into tables and regardless how many competitive reloads are pending at a time (e.g. 2-3 RPC commands sent at a time to reload same tables).

Use hash indexes for a quicker lookup in buckets.

Improve the mechanism of duplicate entries detection,
use: the source ip, ruri pattern, from pattern and the protocol to detect existing similar entries.

Add more safety checks in functions manipulating hash tables,
like checking NULL pointers, empty patterns for matching purposes etc.

Align return values in trusted/hash implementations so that return values are everywhere considered in the similar way
(everything != 0 is considered as failure, 0 is considered as fine).

Split tables allocation and initialization.

Add destruction handlers for tables instead of manually handling
entries freeing.

Some other minor improvements.
