### PR TITLE
ndb_redis: always use redisGetReply

### DIFF
--- a/src/modules/ndb_redis/redis_client.c
+++ b/src/modules/ndb_redis/redis_client.c
@@ -932,8 +932,7 @@ int redisc_exec_pipelined(redisc_server_t *rsrv)
 			freeReplyObject(rpl->rplRedis);
 			rpl->rplRedis = NULL;
 		}
-		if(redisGetReplyFromReader(rsrv->ctxRedis, (void **)&rpl->rplRedis)
-				!= REDIS_OK) {
+		if(redisGetReply(rsrv->ctxRedis, (void **)&rpl->rplRedis) != REDIS_OK) {
 			LM_ERR("Unable to read reply\n");
 			continue;
 		}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Pipelined redis response can be split across multiple network packets. After calling redisGetReply once it is not guaranteed, that all response packets have arrived and been read into the redis reader buffer. If the next pipelined reply is requested before it has been received from the network and processed into the redis reader buffer, fetching the reply will fail.
Therefore, always use redisGetReply to ensure, that all replies available in the network buffer are properly fed into the redis reply reader.
