### PR TITLE
xhttp_prom: add timestamp_format parameter

### DIFF
--- a/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
+++ b/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
@@ -365,6 +365,76 @@ modparam("xhttp_prom", "xhttp_prom_tags", "tag_bar=foo,host_job=wurst");
 		</programlisting>
 	  </example>
 	</section>
+	<section id="xhttp_prom.p.timestamp_format">
+	  <title><varname>timestamp_format</varname> (str)</title>
+	  <para>
+		Controls the format of timestamps exported in Prometheus metrics.
+	  </para>
+	  <para>
+		<emphasis>Rationale:</emphasis> The default behavior (integer milliseconds) violates
+		the OpenMetrics specification which requires timestamps to be in seconds with optional
+		fractional precision. Some monitoring systems like Grafana Alloy and Mimir reject
+		metrics with millisecond timestamps, causing ingestion failures. This parameter
+		provides flexibility to ensure compatibility while maintaining backward compatibility.
+	  </para>
+	  <para>
+		Allowed values:
+		<itemizedlist>
+		  <listitem>
+			<para>
+			  <emphasis>"ms"</emphasis> - Integer milliseconds (default, for backward compatibility).
+			  Example: 1737283200000. Note: Violates OpenMetrics spec and may cause ingestion
+			  issues with strict parsers.
+			</para>
+		  </listitem>
+		  <listitem>
+			<para>
+			  <emphasis>"s"</emphasis> - Integer seconds (OpenMetrics compliant).
+			  Example: 1737283200. Recommended for compatibility with strict OpenMetrics parsers.
+			</para>
+		  </listitem>
+		  <listitem>
+			<para>
+			  <emphasis>"sf"</emphasis> - Seconds with fractional milliseconds (OpenMetrics compliant).
+			  Example: 1737283200.123. Provides millisecond precision while compliant with the
+			  OpenMetrics specification.
+			</para>
+		  </listitem>
+		</itemizedlist>
+	  </para>
+	  <para>
+		<emphasis>
+		  Default value is "ms" (backward compatible).
+		</emphasis>
+	  </para>
+	  <example>
+		<title>Set <varname>timestamp_format</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+# Use milliseconds (default, backward compatible but violates OpenMetrics)
+modparam("xhttp_prom", "timestamp_format", "ms")
+
+# Use integer seconds (OpenMetrics compliant)
+modparam("xhttp_prom", "timestamp_format", "s")
+
+# Use seconds with fractional milliseconds (OpenMetrics compliant, preserves precision)
+modparam("xhttp_prom", "timestamp_format", "sf")
+...
+		</programlisting>
+	  </example>
+	  <para>
+		<emphasis>Example output for each mode:</emphasis>
+	  </para>
+	  <para>
+		Mode "ms": kamailio_my_counter{label="value"} 42 1737283200000
+	  </para>
+	  <para>
+		Mode "s": kamailio_my_counter{label="value"} 42 1737283200
+	  </para>
+	  <para>
+		Mode "sf": kamailio_my_counter{label="value"} 42 1737283200.123
+	  </para>
+	</section>
 	<section id="xhttp_prom.p.prom_counter">
 	  <title><varname>prom_counter</varname> (str)</title>
 	  <para>

--- a/src/modules/xhttp_prom/prom.h
+++ b/src/modules/xhttp_prom/prom.h
@@ -44,6 +44,15 @@
 int get_timestamp(uint64_t *ts);
 
 /**
+ * @brief Format and print timestamp according to timestamp_format parameter.
+ *
+ * @param ctx prom_ctx_t context for output buffer
+ * @param ts timestamp in milliseconds
+ * @return number of bytes written, or -1 on error
+ */
+int prom_body_timestamp_printf(prom_ctx_t *ctx, uint64_t ts);
+
+/**
  * @brief Write some data in prom_body buffer.
  *
  * @return number of bytes written.

--- a/src/modules/xhttp_prom/prom_metric.c
+++ b/src/modules/xhttp_prom/prom_metric.c
@@ -1898,7 +1898,12 @@ static int prom_metric_lvalue_print(
 			goto error;
 		}
 
-		if(prom_body_printf(ctx, " %" PRIu64 "\n", ts) == -1) {
+		if(prom_body_timestamp_printf(ctx, ts) == -1) {
+			LM_ERR("Fail to print\n");
+			goto error;
+		}
+
+		if(prom_body_printf(ctx, "\n") == -1) {
 			LM_ERR("Fail to print\n");
 			goto error;
 		}
@@ -1930,7 +1935,12 @@ static int prom_metric_lvalue_print(
 			goto error;
 		}
 
-		if(prom_body_printf(ctx, " %" PRIu64 "\n", ts) == -1) {
+		if(prom_body_timestamp_printf(ctx, ts) == -1) {
+			LM_ERR("Fail to print\n");
+			goto error;
+		}
+
+		if(prom_body_printf(ctx, "\n") == -1) {
 			LM_ERR("Fail to print\n");
 			goto error;
 		}
@@ -1973,7 +1983,12 @@ static int prom_metric_lvalue_print(
 				goto error;
 			}
 
-			if(prom_body_printf(ctx, " %" PRIu64 "\n", ts) == -1) {
+			if(prom_body_timestamp_printf(ctx, ts) == -1) {
+				LM_ERR("Fail to print\n");
+				goto error;
+			}
+
+			if(prom_body_printf(ctx, "\n") == -1) {
 				LM_ERR("Fail to print\n");
 				goto error;
 			}
@@ -1999,7 +2014,12 @@ static int prom_metric_lvalue_print(
 			goto error;
 		}
 
-		if(prom_body_printf(ctx, " %" PRIu64 "\n", ts) == -1) {
+		if(prom_body_timestamp_printf(ctx, ts) == -1) {
+			LM_ERR("Fail to print\n");
+			goto error;
+		}
+
+		if(prom_body_printf(ctx, "\n") == -1) {
 			LM_ERR("Fail to print\n");
 			goto error;
 		}
@@ -2023,7 +2043,12 @@ static int prom_metric_lvalue_print(
 			goto error;
 		}
 
-		if(prom_body_printf(ctx, " %" PRIu64 "\n", ts) == -1) {
+		if(prom_body_timestamp_printf(ctx, ts) == -1) {
+			LM_ERR("Fail to print\n");
+			goto error;
+		}
+
+		if(prom_body_printf(ctx, "\n") == -1) {
 			LM_ERR("Fail to print\n");
 			goto error;
 		}
@@ -2047,7 +2072,12 @@ static int prom_metric_lvalue_print(
 			goto error;
 		}
 
-		if(prom_body_printf(ctx, " %" PRIu64 "\n", ts) == -1) {
+		if(prom_body_timestamp_printf(ctx, ts) == -1) {
+			LM_ERR("Fail to print\n");
+			goto error;
+		}
+
+		if(prom_body_printf(ctx, "\n") == -1) {
 			LM_ERR("Fail to print\n");
 			goto error;
 		}

--- a/src/modules/xhttp_prom/xhttp_prom.h
+++ b/src/modules/xhttp_prom/xhttp_prom.h
@@ -126,6 +126,11 @@ extern int pkg_proc_stats_no;
  */
 extern int metadata_flags;
 
+/**
+ * @brief timestamp format: "ms" (milliseconds), "s" (seconds), or "sf" (seconds with fraction)
+ */
+extern str timestamp_format;
+
 enum
 {
 	METADATA_FLAGS_TYPE = (1 << 0),


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

##### Problem
The default timestamp format (integer milliseconds) in xhttp_prom metrics violates the OpenMetrics specification, which requires timestamps in seconds. Monitoring systems like Grafana Alloy and Mimir may reject millisecond timestamps, causing metrics ingestion failures.

##### Solution
Added new module parameter `timestamp_format` with three configuration options:
- **"ms"** (default): Integer milliseconds - maintains backward compatibility
- **"s"**: Integer seconds - OpenMetrics compliant
- **"sf"**: Seconds with fractional milliseconds - OpenMetrics compliant with sub-second precision

##### Testing
- Default behavior tested (parameter omitted defaults to "ms")
- All three timestamp formats validated with regex pattern matching
- Backward compatibility confirmed
- Module compiles cleanly with no warnings

##### Related Files
- Module documentation updated in `doc/xhttp_prom_admin.xml`