### PR TITLE
rtpengine: update documentation for rtp_inst_pvar variable

### DIFF
--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -528,8 +528,8 @@ route {
 	<section id="rtpengine.p.rtp_inst_pvar">
 		<title><varname>rtp_inst_pvar</varname> (string)</title>
 		<para>
-			A pseudo variable to store the chosen RTP Engine IP address.
-			If this parameter is set, the IP address and port of the instance chosen will be stored in the given variable.
+			A pseudo variable to store the chosen RTP Engine URI.
+			If this parameter is set, the URI of the instance chosen will be stored in the given variable.
 		</para>
 		<para>
 			By default, this parameter is not set.


### PR DESCRIPTION
#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Variable rtp_inst_pvar stores URI which can be IP address and port or DNS name or port. Description is getting false sense that this variable holds IP address received by RTPengine NG protocol.
