### PR TITLE
htable: Add new parameter reloadat

### DIFF
--- a/src/modules/htable/doc/htable_admin.xml
+++ b/src/modules/htable/doc/htable_admin.xml
@@ -363,6 +363,13 @@ $ kamctl rpc htable.dump htable
 		</listitem>
 		<listitem>
 		<para>
+			<emphasis>reloadat</emphasis> - time in seconds to reload a hash table.
+			For each new seconds interval, the hash table will be reloaded. You can catch
+			the reload on the event_route: htable:reloaded:<htable>.
+		</para>
+		</listitem>
+		<listitem>
+		<para>
 			<emphasis>dbtable</emphasis> - name of database to be loaded at
 			startup in hash table. If empty or missing, no data will be loaded.
 		</para>
@@ -2057,6 +2064,26 @@ event_route[htable:expired:mytable] {
 ...
 </programlisting>
 	</section>
+
+	</section>
+	<section>
+		<title>
+		<function moreinfo="none">htable:reloaded:&lt;table&gt;</function>
+		</title>
+		<para>
+			When defined, the module calls event_route[htable:reloaded:&lt;table&gt;]
+			when a hash table was reloaded.
+		</para>
+<programlisting  format="linespecific">
+...
+
+event_route[htable:reloaded:mytable] {
+    xlog("mytable was reloaded\n");
+}
+...
+</programlisting>
+	</section>
+
 	</section>
 
 </chapter>

--- a/src/modules/htable/ht_api.h
+++ b/src/modules/htable/ht_api.h
@@ -75,6 +75,11 @@ typedef struct _ht
 	int evex_index;
 	char evex_name_buf[HT_EVEX_NAME_SIZE];
 	str evex_name;
+	unsigned int reloadat;
+	time_t last_reload;
+	int evex_reload_index;
+	char evex_reload_name_buf[HT_EVEX_NAME_SIZE];
+	str evex_reload_name;
 	ht_entry_t *entries;
 	struct _ht *next;
 } ht_t;
@@ -88,7 +93,7 @@ typedef struct _ht_pv
 
 int ht_add_table(str *name, int autoexp, str *dbtable, str *dbcols, int size,
 		int dbmode, int itype, int_str *ival, int updateexpire,
-		int dmqreplicate, char coldelim, char colnull);
+		int dmqreplicate, char coldelim, char colnull, int reloadat);
 int ht_init_tables(void);
 int ht_destroy(void);
 int ht_set_cell(ht_t *ht, str *name, int type, int_str *val, int mode);
@@ -110,6 +115,8 @@ int ht_db_sync_tables(void);
 int ht_has_autoexpire(void);
 void ht_timer(unsigned int ticks, void *param);
 void ht_handle_expired_record(ht_t *ht, ht_cell_t *cell);
+int ht_reload_table(ht_t *ht);
+void ht_handle_reloaded_table(ht_t *ht);
 int ht_set_cell_expire(ht_t *ht, str *name, int type, int_str *val);
 int ht_get_cell_expire(ht_t *ht, str *name, unsigned int *val);
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Introduced a new parameter: `reloadat=<seconds_value>`, that could be applied individually per hash table.

At each `seconds_value` the hash table will be reloaded automatically.

Tests were done, and the timer logic and the reloads are working fine.
`rpc.reload` still works just fine.
