### PR TITLE
core/qm: fix bookkeeping of used and real_used in case of fragment split

### DIFF
--- a/src/core/mem/q_malloc.c
+++ b/src/core/mem/q_malloc.c
@@ -693,10 +693,10 @@ void *qm_realloc(void *qmp, void *p, size_t size)
 #ifdef DBG_QM_MALLOC
 		MDBG("shrinking from %lu to %lu\n", f->size, (unsigned long)size);
 		if(split_frag(qm, f, size, file, "fragm. from qm_realloc", line, mname)
-				!= 0) {
+				== 0) {
 			MDBG("shrinked successful\n");
 #else
-		if(split_frag(qm, f, size) != 0) {
+		if(split_frag(qm, f, size) == 0) {
 #endif
 			/* update used sizes: freed the splited frag */
 			/* split frag already adds FRAG_OVERHEAD for the newly created


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4231

#### Description
<!-- Describe your changes in detail -->
When debugging memory leaks for Kamailio, it seems when splitting a fragment, the "used memory" counters are not updated correctly. This leads to Kamailio *indicating* less and less available memory, while in fact, it's just the bookkeeping.

Used the docker setup of #4231 for testing. Could reproduce that issue on my setup (Ubuntu Noble + Kamailio 5.8) and with this patch, problem is fixed.

Root cause: checking for `!=0` to indicate success; but `split_frag` returns 0 in case of success.