### PR TITLE
uac: copy uac_flag to transaction's uas request in replace_callback

### DIFF
--- a/src/modules/uac/replace.c
+++ b/src/modules/uac/replace.c
@@ -884,6 +884,7 @@ static void replace_callback(
 	int dlgvar_index = 0;
 	int dlgvar_dpindex = 0;
 	str *dlgvar_names;
+	struct cell *Trans;
 
 	if(!dlg || !_params || _params->direction == DLG_DIR_NONE || !_params->req)
 		return;
@@ -1015,6 +1016,11 @@ static void replace_callback(
 		return;
 	}
 	msg->msg_flags |= uac_flag;
+
+	if((Trans = uac_tmb.t_gett()) != NULL && Trans != T_UNDEFINED
+			&& Trans->uas.request) {
+		Trans->uas.request->msg_flags |= uac_flag;
+	}
 
 	return;
 }


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
When using uac_replace_to/uac_replace_from with dialog matching, replace_callback(), after operating on the message being processed, doesn't set the flags (FL_USE_UAC_FROM | FL_USE_UAC_TO) on the trasaction's uas request. The effect is that replies to in-dialog messages don't get their headers restored.