### PR TITLE
fix(rtpengine): avoid use-after-free when logging duplicate hash entry

### DIFF
--- a/src/modules/rtpengine/rtpengine_hash.c
+++ b/src/modules/rtpengine/rtpengine_hash.c
@@ -184,10 +184,12 @@ int rtpengine_hash_table_insert(
 				&& STR_EQ(entry->viabranch, new_entry->viabranch)) {
 			// unlock
 			lock_release(&rtpengine_hash_table->row_locks[hash_index]);
+
+			// entry may have been freed by a concurrent DELETE operation;
+			// use function parameters which are guaranteed to be valid
 			LM_NOTICE("callid=%.*s, viabranch=%.*s already in hashtable, "
 					  "ignore new value\n",
-					entry->callid.len, entry->callid.s, entry->viabranch.len,
-					entry->viabranch.s);
+					callid.len, callid.s, viabranch.len, viabranch.s);
 			return 0;
 		}
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

rtpengine: prevent crash in duplicate entry log (UAF)

Observed coredump in LM_NOTICE due to invalid entry->callid pointer.
The hash entry can be freed concurrently while still referenced in
rtpengine_hash_table_insert(). Replace logging with callid/viabranch
function arguments to avoid dereferencing freed memory.