### PR TITLE
sipp: integrate SIPp for automated load testing via Kamailio RPC

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/devcontainers/base:trixie
 RUN apt-get update && \
   export DEBIAN_FRONTEND=noninteractive && \
   apt-get -y install --no-install-recommends \
-    apt-utils dialog clang-format clang pbuilder cmake
+    apt-utils dialog clang-format clang pbuilder cmake docbook-xsl lynx
 
 # trixie packaging
 RUN mkdir -p /usr/local/src/pkg

--- a/src/modules/sipp/Makefile
+++ b/src/modules/sipp/Makefile
@@ -1,0 +1,9 @@
+#
+# WARNING: do not run this directly, it should be run by the main Makefile
+
+include ../../Makefile.defs
+auto_gen=
+NAME=sipp.so
+LIBS=
+
+include ../../Makefile.modules

--- a/src/modules/sipp/doc/Makefile
+++ b/src/modules/sipp/doc/Makefile
@@ -1,0 +1,4 @@
+docs = sipp.xml
+
+docbook_dir = ../../../../doc/docbook
+include $(docbook_dir)/Makefile.module

--- a/src/modules/sipp/doc/sipp.xml
+++ b/src/modules/sipp/doc/sipp.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<book xmlns:xi="http://www.w3.org/2001/XInclude">
+    <bookinfo>
+	<title>SIPp Module</title>
+	<productname class="trade">&kamailioname;</productname>
+	<authorgroup>
+	    <author>
+		<firstname>Daniel</firstname>
+		<surname>Donoghue</surname>
+		<affiliation><orgname>Aurora Innovation AB</orgname></affiliation>
+	    </author>
+	</authorgroup>
+	<copyright>
+	    <year>2026</year>
+	    <holder>Aurora Innovation AB</holder>
+	</copyright>
+    </bookinfo>
+    <toc></toc>
+
+	<xi:include href="sipp_admin.xml"/>
+
+</book>

--- a/src/modules/sipp/doc/sipp_admin.xml
+++ b/src/modules/sipp/doc/sipp_admin.xml
@@ -1,0 +1,817 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<chapter>
+	<title>&adminguide;</title>
+
+	<section id="sipp.overview">
+		<title>Overview</title>
+		<para>
+		The SIPp module provides integration with SIPp (SIP Performance Testing Tool)
+		for automated SIP load testing and scenario execution from within Kamailio.
+		This module enables starting, stopping, and monitoring SIPp test sessions through
+		RPC commands, making it suitable for CI and operational workflows.
+		</para>
+		<para>
+		Key features include:
+		</para>
+		<itemizedlist>
+		<listitem>
+			<para>Start and stop SIPp test scenarios via RPC commands</para>
+		</listitem>
+		<listitem>
+			<para>Automatic transport protocol detection (UDP/TCP/TLS)</para>
+		</listitem>
+		<listitem>
+			<para>Configurable concurrent test limits</para>
+		</listitem>
+		<listitem>
+			<para>Domain whitelist for security</para>
+		</listitem>
+		<listitem>
+			<para>Real-time test status monitoring</para>
+		</listitem>
+		<listitem>
+			<para>Support for custom SIPp scenarios</para>
+		</listitem>
+		<listitem>
+			<para>Remote control of running tests (pause/resume/adjust rate)</para>
+		</listitem>
+		<listitem>
+			<para>Prometheus metrics export for monitoring and dashboards</para>
+		</listitem>
+		</itemizedlist>
+	</section>
+
+	<section id="sipp.dependencies">
+		<title>Dependencies</title>
+		<section>
+			<title>Kamailio Modules</title>
+			<para>
+			No additional Kamailio modules are required.
+			</para>
+			<para>
+			<emphasis>xhttp_prom (optional)</emphasis> - For Prometheus metrics export.
+			If you want to export SIPp metrics to Prometheus, load xhttp_prom before loading the sipp module.
+			</para>
+		</section>
+		<section>
+			<title>External Libraries or Applications</title>
+			<para>
+			The following libraries or applications must be installed before running
+			&kamailio; with this module loaded:
+			<itemizedlist>
+			<listitem>
+			<para>
+				<emphasis>SIPp</emphasis> - The SIPp binary must be available in the system PATH
+				or specified via the sipp_path parameter.
+			</para>
+			</listitem>
+			</itemizedlist>
+			</para>
+		</section>
+	</section>
+
+	<section id="sipp.parameters">
+		<title>Parameters</title>
+
+		<section id="sipp.p.sipp_path">
+			<title><varname>sipp_path</varname> (string)</title>
+			<para>
+			Path to the SIPp binary executable. If not set, the module will look for
+			'sipp' in the system PATH.
+			</para>
+			<para>
+			<emphasis>
+				Default value is NULL (uses system PATH).
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>sipp_path</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "sipp_path", "/usr/local/bin/sipp")
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.scenario_dir">
+			<title><varname>scenario_dir</varname> (string)</title>
+			<para>
+			Default directory where SIPp scenario files are stored. This directory
+			is used as the base path when relative scenario paths are provided.
+			</para>
+			<para>
+			<emphasis>
+				No default; this parameter must be set.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>scenario_dir</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "scenario_dir", "/etc/kamailio/sipp/scenarios")
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.work_dir">
+			<title><varname>work_dir</varname> (string)</title>
+			<para>
+			Working directory to use for SIPp child processes. When set, the module
+			will chdir to this directory before executing SIPp and will place log and
+			statistics files under this path. The directory must be writable by the
+			Kamailio user.
+			</para>
+			<para>
+			<emphasis>
+				Default value is NULL (uses /tmp for log/stat files).
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>work_dir</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "work_dir", "/run/kamailio")
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.media_ip">
+			<title><varname>media_ip</varname> (string)</title>
+			<para>
+			Local media IP address for SIPp. When set, the module passes the value
+			as SIPp's <literal>-mi</literal> option. If not set, SIPp uses its default
+			media IP selection.
+			</para>
+			<para>
+			<emphasis>
+				Default value is NULL (uses SIPp default).
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>media_ip</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "media_ip", "192.168.1.50")
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.send_socket_name">
+			<title><varname>send_socket_name</varname> (string)</title>
+			<para>
+			Name identifier for an existing Kamailio listen socket that SIPp should
+			use for sending traffic (for example: udp:192.168.1.10:5060).
+			This parameter is mutually exclusive with <varname>send_socket</varname>.
+			</para>
+			<para>
+			<emphasis>
+				Default value is NULL.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>send_socket_name</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "send_socket_name", "udp:192.168.1.10:5060")
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.send_socket">
+			<title><varname>send_socket</varname> (string)</title>
+			<para>
+			Socket specification in the format proto:ip:port that SIPp should use
+			for sending traffic.
+			This parameter is mutually exclusive with <varname>send_socket_name</varname>.
+			</para>
+			<para>
+			<emphasis>
+				Default value is NULL.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>send_socket</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "send_socket", "udp:192.168.1.10:5060")
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.target_domain">
+			<title><varname>target_domain</varname> (string)</title>
+			<para>
+			Default target domain for SIPp tests. This domain is optional and will
+			be used only if the scenario references <literal>[target_domain]</literal>
+			and no explicit target is provided in the RPC command.
+			</para>
+			<para>
+			If a scenario references <literal>[target_domain]</literal> and neither a
+			per-test value nor a module default is set, the module falls back to
+			<literal>&lt;local_ip&gt;:&lt;send_socket_port&gt;</literal>.
+			</para>
+			<para>
+			<emphasis>
+				Default value is NULL.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>target_domain</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "target_domain", "sip.example.com")
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.default_caller">
+			<title><varname>default_caller</varname> (string)</title>
+			<para>
+			Default caller user/number for SIPp tests. Used only if no explicit
+			caller is provided via RPC. Required when scenarios use
+			<literal>[caller]</literal> and no caller is passed.
+			</para>
+			<para>
+			<emphasis>
+				Default value is NULL.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>default_caller</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "default_caller", "1000")
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.default_service">
+			<title><varname>default_service</varname> (string)</title>
+			<para>
+			Default service user/number for SIPp tests. Used only if no explicit
+			service is provided via RPC. Required when no service is provided in RPC.
+			</para>
+			<para>
+			<emphasis>
+				Default value is NULL.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>default_service</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "default_service", "2000")
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.valid_domains">
+			<title><varname>valid_domains</varname> (string)</title>
+			<para>
+			Comma-separated list of domains that are allowed as SIPp test targets.
+			This provides a security whitelist to prevent unauthorized test execution
+			against arbitrary domains. If set, only domains in this list can be targeted.
+			</para>
+			<para>
+			<emphasis>
+				Default value is NULL (all domains allowed).
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>valid_domains</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "valid_domains", "test.example.com,staging.example.com,demo.example.com")
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.default_concurrent_calls">
+			<title><varname>default_concurrent_calls</varname> (integer)</title>
+			<para>
+			Default number of concurrent calls per test when the RPC command does not
+			provide a value.
+			</para>
+			<para>
+			<emphasis>
+				Default value is 50.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>default_concurrent_calls</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "default_concurrent_calls", 25)
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.max_concurrent_calls">
+			<title><varname>max_concurrent_calls</varname> (integer)</title>
+			<para>
+			Maximum number of concurrent calls per SIPp test session. This limits
+			the load generated by each individual test.
+			</para>
+			<para>
+			<emphasis>
+				Default value is 1000.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>max_concurrent_calls</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "max_concurrent_calls", 50)
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.max_concurrent_tests">
+			<title><varname>max_concurrent_tests</varname> (integer)</title>
+			<para>
+			Maximum number of SIPp test sessions that can run concurrently. This
+			prevents resource exhaustion from too many simultaneous tests.
+			<emphasis>Note:</emphasis> SIPp has a hard limit of 60 concurrent instances
+			(each uses a UDP control port starting from 8888). Values above 60 will
+			be automatically capped.
+			</para>
+			<para>
+			<emphasis>
+				Default value is 10. Maximum value is 60.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>max_concurrent_tests</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "max_concurrent_tests", 5)
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.default_duration">
+			<title><varname>default_duration</varname> (integer)</title>
+			<para>
+			Default call duration in seconds (SIPp -d) used when the RPC command does not
+			provide a duration.
+			</para>
+			<para>
+			<emphasis>
+				Default value is 60.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>default_duration</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "default_duration", 30)
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.default_call_rate">
+			<title><varname>default_call_rate</varname> (integer)</title>
+			<para>
+			Default call rate (calls per second) used when the RPC command does not
+			provide a rate. The rate can be adjusted at runtime using
+			<function>sipp.adjust_rate</function>.
+			</para>
+			<para>
+			<emphasis>
+				Default value is 10.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>default_call_rate</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "default_call_rate", 20)
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.default_total_calls">
+			<title><varname>default_total_calls</varname> (integer)</title>
+			<para>
+			Default maximum total calls per test. Set to 0 to allow tests to run
+			until explicitly stopped.
+			</para>
+			<para>
+			<emphasis>
+				Default value is 0 (unlimited).
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>default_total_calls</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "default_total_calls", 0)
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.default_max_test_duration">
+			<title><varname>default_max_test_duration</varname> (integer)</title>
+			<para>
+			Default maximum test duration in seconds. Set to 0 to allow tests to run
+			until explicitly stopped.
+			</para>
+			<para>
+			<emphasis>
+				Default value is 0 (unlimited).
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>default_max_test_duration</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "default_max_test_duration", 0)
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.p.enable_prometheus">
+			<title><varname>enable_prometheus</varname> (integer)</title>
+			<para>
+			Enable Prometheus metrics export when <emphasis>xhttp_prom</emphasis> is
+			loaded before the sipp module.
+			</para>
+			<para>
+			<emphasis>
+				Default value is 1.
+			</emphasis>
+			</para>
+			<example>
+			<title>Set <varname>enable_prometheus</varname> parameter</title>
+			<programlisting format="linespecific">
+...
+modparam("sipp", "enable_prometheus", 0)
+...
+</programlisting>
+			</example>
+		</section>
+
+	</section>
+
+	<section id="sipp.functions">
+		<title>Functions</title>
+		<para>
+		This module does not export any functions to be used in the routing script.
+		All functionality is exposed via RPC commands.
+		</para>
+	</section>
+
+	<section id="sipp.rpc">
+		<title>RPC Commands</title>
+
+		<section id="sipp.rpc.start">
+			<title><function>sipp.start_test</function></title>
+			<para>
+			Start a new SIPp test session with the specified parameters.
+			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+			<listitem><para>
+				<emphasis>scenario</emphasis> (string, required) - Name of SIPp scenario XML file
+			</para></listitem>
+			<listitem><para>
+				<emphasis>caller</emphasis> (string, optional) - Caller user/number/range/list
+			</para></listitem>
+			<listitem><para>
+				<emphasis>service</emphasis> (string, optional) - Service user/number/range/list
+			</para></listitem>
+			<listitem><para>
+				<emphasis>target_domain</emphasis> (string, optional) - Target domain for scenario variables
+			</para></listitem>
+			<listitem><para>
+				<emphasis>concurrent_calls</emphasis> (integer, optional) - Max concurrent calls
+			</para></listitem>
+			<listitem><para>
+				<emphasis>duration</emphasis> (integer, optional) - Call duration in seconds (SIPp -d)
+			</para></listitem>
+			<listitem><para>
+				<emphasis>total_calls</emphasis> (integer, optional) - Max total calls (0 = unlimited)
+			</para></listitem>
+			<listitem><para>
+				<emphasis>max_test_duration</emphasis> (integer, optional) - Max test duration in seconds (0 = unlimited)
+			</para></listitem>
+			</itemizedlist>
+			<example>
+			<title><function>sipp.start_test</function> RPC example</title>
+			<programlisting format="linespecific">
+...
+# Using kamcmd (positional)
+kamcmd sipp.start_test uac_invite.xml 1000 2000 sip.example.com 10 60 0 0
+
+# Using kamcmd (named)
+kamcmd sipp.start_test scenario=uac_invite.xml caller=1000 service=2000 \
+	target_domain=sip.example.com concurrent_calls=10 duration=60 \
+		total_calls=0 max_test_duration=0
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.rpc.stop">
+			<title><function>sipp.stop_test</function></title>
+			<para>
+			Stop a running SIPp test session.
+			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+			<listitem><para>
+				<emphasis>test_id</emphasis> (int) - Test ID to stop
+			</para></listitem>
+			</itemizedlist>
+			<example>
+			<title><function>sipp.stop_test</function> RPC example</title>
+			<programlisting format="linespecific">
+...
+# Using kamcmd
+kamcmd sipp.stop_test 1
+
+# Using kamctl
+kamctl rpc sipp.stop_test 1
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.rpc.get_stats">
+			<title><function>sipp.get_stats</function></title>
+			<para>
+			Retrieve statistics for a specific test session.
+			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+			<listitem><para>
+				<emphasis>test_id</emphasis> (int, required) - Test ID to query
+			</para></listitem>
+			</itemizedlist>
+			<example>
+			<title><function>sipp.get_stats</function> RPC example</title>
+			<programlisting format="linespecific">
+...
+# Get stats for specific test
+kamcmd sipp.get_stats 1
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.rpc.running">
+			<title><function>sipp.running</function></title>
+			<para>
+			List all currently running and recently completed test sessions with their status and statistics.
+			Completed, stopped, and failed tests are eligible for removal after 30 minutes (1800 seconds),
+			and cleanup runs on a periodic timer (every hour). As a result, tests can remain
+			visible for roughly 30 to 90 minutes depending on when the cleanup timer fires.
+			</para>
+			<para>Parameters: None</para>
+			<example>
+			<title><function>sipp.running</function> RPC example</title>
+			<programlisting format="linespecific">
+...
+kamcmd sipp.running
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.rpc.list">
+			<title><function>sipp.list</function></title>
+			<para>
+			List all available SIPp scenario files (.xml) from the configured scenario directory.
+			Returns the filename and size in bytes for each scenario found.
+			</para>
+			<para>Parameters: None</para>
+			<example>
+			<title><function>sipp.list</function> RPC example</title>
+			<programlisting format="linespecific">
+...
+kamcmd sipp.list
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.rpc.pause_test">
+			<title><function>sipp.pause_test</function></title>
+			<para>
+			Pause a running SIPp test via remote control socket.
+			This stops SIPp from creating new calls but keeps existing calls alive.
+			Uses the SIPp remote control socket created for the test.
+			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+			<listitem><para>test_id (int, required) - Test ID to pause</para></listitem>
+			</itemizedlist>
+			<example>
+			<title><function>sipp.pause_test</function> RPC example</title>
+			<programlisting format="linespecific">
+...
+kamcmd sipp.pause_test 1
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.rpc.resume_test">
+			<title><function>sipp.resume_test</function></title>
+			<para>
+			Resume a paused SIPp test via remote control socket.
+			This resumes call generation after a pause.
+			Uses the SIPp remote control socket created for the test.
+			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+			<listitem><para>test_id (int, required) - Test ID to resume</para></listitem>
+			</itemizedlist>
+			<example>
+			<title><function>sipp.resume_test</function> RPC example</title>
+			<programlisting format="linespecific">
+...
+kamcmd sipp.resume_test 1
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.rpc.adjust_rate">
+			<title><function>sipp.adjust_rate</function></title>
+			<para>
+			Dynamically adjust the call rate of a running SIPp test.
+			This allows increasing or decreasing the call generation rate without
+			stopping and restarting the test.
+			Uses the SIPp remote control socket created for the test.
+			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+			<listitem><para>test_id (int, required) - Test ID to adjust</para></listitem>
+			<listitem><para>change (string, required) - "increase" or "decrease"</para></listitem>
+			</itemizedlist>
+			<example>
+			<title><function>sipp.adjust_rate</function> RPC example</title>
+			<programlisting format="linespecific">
+...
+kamcmd sipp.adjust_rate 1 increase
+kamcmd sipp.adjust_rate 1 decrease
+...
+</programlisting>
+			</example>
+		</section>
+
+		<section id="sipp.rpc.get_live_stats">
+			<title><function>sipp.get_live_stats</function></title>
+			<para>
+			Get real-time statistics from a running SIPp test via the remote control socket.
+			This queries SIPp directly for current call counts, active calls, and failure counts.
+			Uses the SIPp remote control socket created for the test.
+			</para>
+			<para>Parameters:</para>
+			<itemizedlist>
+			<listitem><para>test_id (int, required) - Test ID to query</para></listitem>
+			</itemizedlist>
+			<para>Returns:</para>
+			<itemizedlist>
+			<listitem><para>test_id (int) - Test identifier</para></listitem>
+			<listitem><para>calls_active (int) - Currently active calls</para></listitem>
+			<listitem><para>calls_started (int) - Total calls started</para></listitem>
+			<listitem><para>calls_completed (int) - Calls completed successfully</para></listitem>
+			<listitem><para>calls_failed (int) - Failed calls</para></listitem>
+			</itemizedlist>
+			<example>
+			<title><function>sipp.get_live_stats</function> RPC example</title>
+			<programlisting format="linespecific">
+...
+kamcmd sipp.get_live_stats 1
+...
+</programlisting>
+			</example>
+		</section>
+
+	</section>
+
+	<section id="sipp.prometheus">
+		<title>Prometheus Metrics</title>
+		<para>
+		When the <emphasis>xhttp_prom</emphasis> module is loaded before the sipp module,
+		SIPp test metrics are automatically exported to Prometheus. Metrics are pushed
+		on a periodic timer (by default every 10 seconds).
+		</para>
+		<section id="sipp.prometheus.metrics">
+			<title>Exported Metrics</title>
+			<para>All metrics include the following labels:</para>
+			<itemizedlist>
+			<listitem><para><emphasis>test_id</emphasis> - Unique test identifier (e.g., "1")</para></listitem>
+			<listitem><para><emphasis>scenario</emphasis> - Scenario filename (e.g., "uac_invite.xml")</para></listitem>
+			<listitem><para><emphasis>from_to</emphasis> - Caller and callee combined (e.g., "1000-&gt;2000")</para></listitem>
+			</itemizedlist>
+			<para>Exported metric types:</para>
+			<itemizedlist>
+			<listitem><para><emphasis>sipp_calls_started_total</emphasis> (counter) - Total calls initiated</para></listitem>
+			<listitem><para><emphasis>sipp_calls_completed_total</emphasis> (counter) - Successfully completed calls</para></listitem>
+			<listitem><para><emphasis>sipp_calls_failed_total</emphasis> (counter) - Failed calls</para></listitem>
+			<listitem><para><emphasis>sipp_calls_active</emphasis> (gauge) - Currently active calls</para></listitem>
+			<listitem><para><emphasis>sipp_concurrent_calls_configured</emphasis> (gauge) - Configured concurrent call limit</para></listitem>
+			</itemizedlist>
+		</section>
+		<section id="sipp.prometheus.grafana">
+			<title>Grafana Queries</title>
+			<para>Example Prometheus queries for use in Grafana dashboards:</para>
+			<example>
+			<title>Call volume by scenario</title>
+			<programlisting format="linespecific">
+rate(sipp_calls_started_total[5m]) by (scenario)
+			</programlisting>
+			</example>
+			<example>
+			<title>Success rate by caller/callee</title>
+			<programlisting format="linespecific">
+(sipp_calls_completed_total / sipp_calls_started_total) by (from_to) * 100
+			</programlisting>
+			</example>
+			<example>
+			<title>Active calls by caller/callee</title>
+			<programlisting format="linespecific">
+sipp_calls_active by (from_to)
+			</programlisting>
+			</example>
+			<example>
+			<title>Failure rate</title>
+			<programlisting format="linespecific">
+rate(sipp_calls_failed_total[5m])
+			</programlisting>
+			</example>
+		</section>
+	</section>
+
+	<section id="sipp.troubleshooting">
+		<title>Troubleshooting</title>
+		<section id="sipp.troubleshooting.port">
+			<title>Control Port Conflicts</title>
+			<para>
+			Each SIPp test uses a dedicated UDP control port (8888 + test_id).
+			Before starting a test, the module verifies the port is available.
+			If another process is using the port, the test will fail with an error:
+			</para>
+			<programlisting format="linespecific">
+ERROR: control port 8889 is already in use - cannot start test
+ERROR: another SIPp instance or process may be using this port
+			</programlisting>
+			<para>
+			<emphasis>Solutions:</emphasis>
+			</para>
+			<itemizedlist>
+			<listitem><para>Stop the conflicting process using that port</para></listitem>
+			<listitem><para>Wait for subsequent tests (higher test_id = higher port number)</para></listitem>
+			<listitem><para>Restart Kamailio to reset the test_id counter</para></listitem>
+			</itemizedlist>
+		</section>
+		<section id="sipp.troubleshooting.logs">
+			<title>Finding Error Details</title>
+			<para>
+			When a test fails to start, detailed error messages are written to the
+			Kamailio log. Check the log for messages from the sipp module:
+			</para>
+			<programlisting format="linespecific">
+grep "sipp" /var/log/kamailio.log
+			</programlisting>
+			<para>
+			SIPp execution output is also captured in temporary log files:
+			</para>
+			<itemizedlist>
+			<listitem><para><literal>/tmp/sipp_test_&lt;id&gt;_&lt;timestamp&gt;.log</literal> - Main SIPp log</para></listitem>
+			<listitem><para><literal>/tmp/sipp_test_&lt;id&gt;_&lt;timestamp&gt;.log.exec.log</literal> - SIPp startup/error output</para></listitem>
+			<listitem><para><literal>/tmp/sipp_test_&lt;id&gt;_&lt;timestamp&gt;.log.stat.csv</literal> - Statistics CSV</para></listitem>
+			</itemizedlist>
+		</section>
+	</section>
+
+</chapter>

--- a/src/modules/sipp/examples/kamailio.cfg
+++ b/src/modules/sipp/examples/kamailio.cfg
@@ -1,0 +1,1202 @@
+#!KAMAILIO
+#
+# Kamailio SIP Server v6.0 - default configuration script
+#     - web: https://www.kamailio.org
+#     - git: https://github.com/kamailio/kamailio
+#
+# Direct your questions about this file to: <sr-users@lists.kamailio.org>
+#
+# Refer to the Core CookBook at https://www.kamailio.org/wikidocs/
+# for an explanation of possible statements, functions and parameters.
+#
+# Note: the comments can be:
+#     - lines starting with #, but not the pre-processor directives,
+#       which start with #!, like #!define, #!ifdef, #!endif, #!else, #!trydef,
+#       #!subst, #!substdef, ...
+#     - lines starting with //
+#     - blocks enclosed in between /* */
+# Note: the config performs symmetric SIP signaling
+#     - it sends the reply to the source address of the request
+#     - remove the use of force_rport() for asymmetric SIP signaling
+#
+# Several features can be enabled using '#!define WITH_FEATURE' directives:
+#
+# *** To run in debug mode:
+#     - define WITH_DEBUG
+#     - debug level increased to 3, logs still sent to syslog
+#     - debugger module loaded with cfgtrace enabled
+#
+# *** To enable mysql:
+#     - define WITH_MYSQL
+#
+# *** To enable authentication execute:
+#     - enable mysql
+#     - define WITH_AUTH
+#     - add users using 'kamctl' or 'kamcli'
+#
+# *** To enable IP authentication execute:
+#     - enable mysql
+#     - enable authentication
+#     - define WITH_IPAUTH
+#     - add IP addresses with group id '1' to 'address' table
+#
+# *** To enable persistent user location execute:
+#     - enable mysql
+#     - define WITH_USRLOCDB
+#
+# *** To enable presence server execute:
+#     - enable mysql
+#     - define WITH_PRESENCE
+#     - if modified headers or body in config must be used by presence handling:
+#     - define WITH_MSGREBUILD
+#
+# *** To enable nat traversal execute:
+#     - define WITH_NAT
+#     - option for NAT SIP OPTIONS keepalives: WITH_NATSIPPING
+#     - option to relay RTP always (with RTPProxy or RTPEngine): WITH_RTPRELAY
+#     - install RTPProxy: http://www.rtpproxy.org
+#     - start RTPProxy:
+#        rtpproxy -l _your_public_ip_ -s udp:localhost:7722
+#
+# *** To use RTPEngine (instead of RTPProxy) for nat traversal execute:
+#     - define WITH_RTPENGINE
+#     - install RTPEngine: https://github.com/sipwise/rtpengine
+#     - start RTPEngine:
+#        rtpengine --listen-ng=127.0.0.1:2223 ...
+#
+# *** To enable PSTN gateway routing execute:
+#     - define WITH_PSTN
+#     - set the value of pstn.gw_ip
+#     - check route[PSTN] for regexp routing condition
+#
+# *** To enable database aliases lookup execute:
+#     - enable mysql
+#     - define WITH_ALIASDB
+#
+# *** To enable speed dial lookup execute:
+#     - enable mysql
+#     - define WITH_SPEEDDIAL
+#
+# *** To enable multi-domain support execute:
+#     - enable mysql
+#     - define WITH_MULTIDOMAIN
+#
+# *** To enable TLS support execute:
+#     - adjust CFGDIR/tls.cfg as needed
+#     - define WITH_TLS
+#
+# *** To enable JSONRPC over HTTP(S) support execute:
+#     - define WITH_JSONRPC
+#     - adjust event_route[xhttp:request] for access policy
+#
+# *** To enable anti-flood detection execute:
+#     - adjust pike and htable=>ipban settings as needed (default is
+#       block if more than 16 requests in 2 seconds and ban for 300 seconds)
+#     - define WITH_ANTIFLOOD
+#
+# *** To load htable module execute:
+#     - define WITH_HTABLE
+#
+# *** To block 3XX redirect replies execute:
+#     - define WITH_BLOCK3XX
+#
+# *** To block 401 and 407 authentication replies execute:
+#     - define WITH_BLOCK401407
+#
+# *** To enable VoiceMail routing execute:
+#     - define WITH_VOICEMAIL
+#     - set the value of voicemail.srv_ip
+#     - adjust the value of voicemail.srv_port
+#
+# *** To enhance accounting execute:
+#     - enable mysql
+#     - define WITH_ACCDB
+#     - add following columns to database
+#!ifdef ACCDB_COMMENT
+  ALTER TABLE acc ADD COLUMN src_user VARCHAR(64) NOT NULL DEFAULT '';
+  ALTER TABLE acc ADD COLUMN src_domain VARCHAR(128) NOT NULL DEFAULT '';
+  ALTER TABLE acc ADD COLUMN src_ip varchar(64) NOT NULL default '';
+  ALTER TABLE acc ADD COLUMN dst_ouser VARCHAR(64) NOT NULL DEFAULT '';
+  ALTER TABLE acc ADD COLUMN dst_user VARCHAR(64) NOT NULL DEFAULT '';
+  ALTER TABLE acc ADD COLUMN dst_domain VARCHAR(128) NOT NULL DEFAULT '';
+  ALTER TABLE missed_calls ADD COLUMN src_user VARCHAR(64) NOT NULL DEFAULT '';
+  ALTER TABLE missed_calls ADD COLUMN src_domain VARCHAR(128) NOT NULL DEFAULT '';
+  ALTER TABLE missed_calls ADD COLUMN src_ip varchar(64) NOT NULL default '';
+  ALTER TABLE missed_calls ADD COLUMN dst_ouser VARCHAR(64) NOT NULL DEFAULT '';
+  ALTER TABLE missed_calls ADD COLUMN dst_user VARCHAR(64) NOT NULL DEFAULT '';
+  ALTER TABLE missed_calls ADD COLUMN dst_domain VARCHAR(128) NOT NULL DEFAULT '';
+#!endif
+
+####### Include Local Config If Exists #########
+import_file "kamailio-local.cfg"
+
+####### Defined Values #########
+
+# *** Value defines - IDs used later in config
+#!ifdef WITH_DEBUG
+#!define DBGLEVEL 3
+#!else
+#!define DBGLEVEL 2
+#!endif
+
+#!ifdef WITH_MYSQL
+# - database URL - used to connect to database server by modules such
+#       as: auth_db, acc, usrloc, a.s.o.
+#!trydef DBURL "mysql://kamailio:kamailiorw@localhost/kamailio"
+#!endif
+
+#!ifdef WITH_MULTIDOMAIN
+# - the value for 'use_domain' parameters
+#!define MULTIDOMAIN 1
+#!else
+#!define MULTIDOMAIN 0
+#!endif
+
+#!ifdef WITH_ANTIFLOOD
+# - hash table 'ipban' used to store blocked IP addresses
+#!trydef WITH_HTABLE
+#!endif
+
+# - flags
+# FLT_ - per transaction (message) flags
+#!define FLT_ACC 1
+#!define FLT_ACCMISSED 2
+#!define FLT_ACCFAILED 3
+#!define FLT_NATS 5
+
+# FLB_ - per branch flags
+#!define FLB_NATB 6
+#!define FLB_NATSIPPING 7
+
+#!ifdef WITH_SIPP
+# Upstream UAS for SIPp proxying (SIPp UAS listener)
+#!define UAS_URI "sip:127.0.0.1:5070"
+# Domains used by SIPp tests (align with sipp.valid_domains)
+#!define SIPP_TEST_DOMAINS "^(localhost|127\\.0\\.0\\.1|test\\.example\\.com)$"
+#!endif
+
+####### Global Parameters #########
+
+/* LOG Levels: 3=DBG, 2=INFO, 1=NOTICE, 0=WARN, -1=ERR, ... */
+debug=DBGLEVEL
+
+/* set to 'yes' to print log messages to terminal or use '-E' cli option */
+log_stderror=no
+
+memdbg=5
+memlog=5
+
+log_facility=LOG_LOCAL0
+log_prefix="{$mt $hdr(CSeq) $ci} "
+
+/* number of SIP routing processes for each UDP socket
+ * - value inherited by tcp_children and sctp_children when not set explicitely */
+children=8
+
+/* uncomment the next line to disable TCP (default on) */
+# disable_tcp=yes
+
+/* number of SIP routing processes for all TCP/TLS sockets */
+# tcp_children=8
+
+/* UDP receiving mode:
+ * - 0: multi-process (default)
+ * - 1: multi-threaded with async worker group 'udp'
+ * - 2: per socket configuration (see core cookbook) */
+# async_workers_group="name=udp;workers=8"
+# udp_receiver_mode = 1
+
+/* uncomment the next line to disable the auto discovery of local aliases
+ * based on reverse DNS on IPs (default on) */
+# auto_aliases=no
+
+/* add local domain aliases - it can be set many times */
+# alias="sip.mydomain.com"
+
+/* listen sockets - if none set, Kamailio binds to all local IP addresses
+ * - basic prototype (full prototype can be found in Wiki - Core Cookbook):
+ *      listen=[proto]:[localip]:[lport] advertise [publicip]:[pport]
+ * - it can be set many times to add more sockets to listen to */
+# listen=udp:10.0.0.10:5060
+
+/* life time of TCP connection when there is no traffic
+ * - a bit higher than registration expires to cope with UA behind NAT */
+tcp_connection_lifetime=3605
+
+/* upper limit for TCP connections (it includes the TLS connections) */
+tcp_max_connections=2048
+
+/* upper limit for TCP connections for one ip address - default 1024 */
+#tcp_accept_iplimit=1024
+
+#!ifdef WITH_JSONRPC
+tcp_accept_no_cl=yes
+#!endif
+
+#!ifdef WITH_TLS
+enable_tls=yes
+
+/* upper limit for TLS connections */
+tls_max_connections=2048
+
+/* For OpenSSL 3 integration
+ * functions calling libssl3 can be invoked in a transient thread
+ * 0: disable threaded calls
+ * 1: use thread executors for process #0 only
+ * 2: no thread executors, but use atfork handler to reset thread-locals to NULL */
+tls_threads_mode=2
+
+#!endif
+
+/* set it to yes to enable sctp and load sctp.so module */
+enable_sctp=no
+
+####### Custom Parameters #########
+
+/* These parameters can be modified at runtime via RPC interface
+ * - see the documentation of 'cfg_rpc' module.
+ *
+ * Format: group.id = value 'desc' description
+ * Access: $sel(cfg_get.group.id) or @cfg_get.group.id */
+
+#!ifdef WITH_PSTN
+/* PSTN GW Routing
+ *
+ * - pstn.gw_ip: valid IP or hostname as string value, example:
+ * pstn.gw_ip = "10.0.0.101" desc "My PSTN GW Address"
+ *
+ * - by default is empty to avoid misrouting */
+pstn.gw_ip = "" desc "PSTN GW Address"
+pstn.gw_port = "" desc "PSTN GW Port"
+#!endif
+
+#!ifdef WITH_VOICEMAIL
+/* VoiceMail Routing on offline, busy or no answer
+ *
+ * - by default Voicemail server IP is empty to avoid misrouting */
+voicemail.srv_ip = "" desc "VoiceMail IP Address"
+voicemail.srv_port = "5060" desc "VoiceMail Port"
+#!endif
+
+####### Modules Section ########
+
+/* set paths to location of modules */
+# mpath="/usr/local/lib/kamailio/modules/"
+
+# when using TLS with OpenSSL it is recommended to load this module
+# first so that OpenSSL is initialized correctly
+#!ifdef WITH_TLS
+loadmodule "tls.so"
+#!endif
+
+#!ifdef WITH_MYSQL
+loadmodule "db_mysql.so"
+#!endif
+
+#!ifdef WITH_JSONRPC
+loadmodule "xhttp.so"
+#!endif
+loadmodule "jsonrpcs.so"
+loadmodule "kex.so"
+loadmodule "corex.so"
+loadmodule "tm.so"
+loadmodule "tmx.so"
+loadmodule "sl.so"
+loadmodule "rr.so"
+loadmodule "pv.so"
+loadmodule "maxfwd.so"
+loadmodule "usrloc.so"
+loadmodule "registrar.so"
+loadmodule "textops.so"
+loadmodule "textopsx.so"
+loadmodule "siputils.so"
+loadmodule "xlog.so"
+loadmodule "sanity.so"
+loadmodule "ctl.so"
+loadmodule "cfg_rpc.so"
+loadmodule "acc.so"
+loadmodule "counters.so"
+loadmodule "dlgs.so"
+
+#!ifdef WITH_AUTH
+loadmodule "auth.so"
+loadmodule "auth_db.so"
+#!ifdef WITH_IPAUTH
+loadmodule "permissions.so"
+#!endif
+#!endif
+
+#!ifdef WITH_ALIASDB
+loadmodule "alias_db.so"
+#!endif
+
+#!ifdef WITH_SPEEDDIAL
+loadmodule "speeddial.so"
+#!endif
+
+#!ifdef WITH_MULTIDOMAIN
+loadmodule "domain.so"
+#!endif
+
+#!ifdef WITH_PRESENCE
+loadmodule "presence.so"
+loadmodule "presence_xml.so"
+#!endif
+
+#!ifdef WITH_NAT
+loadmodule "nathelper.so"
+#!ifdef WITH_RTPENGINE
+loadmodule "rtpengine.so"
+#!else
+loadmodule "rtpproxy.so"
+#!endif
+#!endif
+
+#!ifdef WITH_HTABLE
+loadmodule "htable.so"
+#!endif
+
+#!ifdef WITH_ANTIFLOOD
+loadmodule "pike.so"
+#!endif
+
+#!ifdef WITH_SIPP
+loadmodule "sipp.so"
+#!endif
+
+#!ifdef WITH_DEBUG
+loadmodule "debugger.so"
+#!endif
+
+# ----------------- setting module-specific parameters ---------------
+
+
+# ----- jsonrpcs params -----
+modparam("jsonrpcs", "pretty_format", 1)
+/* set the path to RPC fifo control file */
+# modparam("jsonrpcs", "fifo_name", "/run/kamailio/kamailio_rpc.fifo")
+/* set the path to RPC unix socket control file */
+# modparam("jsonrpcs", "dgram_socket", "/run/kamailio/kamailio_rpc.sock")
+#!ifdef WITH_JSONRPC
+modparam("jsonrpcs", "transport", 7)
+#!endif
+
+# ----- ctl params -----
+/* set the path to RPC unix socket control file */
+# modparam("ctl", "binrpc", "unix:/run/kamailio/kamailio_ctl")
+
+# ----- sanity params -----
+modparam("sanity", "autodrop", 0)
+
+# ----- tm params -----
+# auto-discard branches from previous serial forking leg
+modparam("tm", "failure_reply_mode", 3)
+# default retransmission timeout: 30sec
+modparam("tm", "fr_timer", 30000)
+# default invite retransmission timeout after 1xx: 120sec
+modparam("tm", "fr_inv_timer", 120000)
+
+# ----- rr params -----
+# set next param to 1 to add value to ;lr param (helps with some UAs)
+modparam("rr", "enable_full_lr", 0)
+# do not append from tag to the RR (no need for this script)
+modparam("rr", "append_fromtag", 0)
+
+# ----- dlgs params -----
+modparam("dlgs", "timer_interval", 10)
+modparam("dlgs", "init_lifetime", 180)
+modparam("dlgs", "active_lifetime", 7200)
+modparam("dlgs", "finish_lifetime", 10)
+
+# ----- registrar params -----
+modparam("registrar", "method_filtering", 1)
+/* uncomment the next line to disable parallel forking via location */
+# modparam("registrar", "append_branches", 0)
+/* uncomment the next line not to allow more than 10 contacts per AOR */
+# modparam("registrar", "max_contacts", 10)
+/* max value for expires of registrations */
+modparam("registrar", "max_expires", 3600)
+/* set it to 1 to enable GRUU */
+modparam("registrar", "gruu_enabled", 0)
+/* set it to 0 to disable Path handling */
+modparam("registrar", "use_path", 1)
+/* save Path even if not listed in Supported header */
+modparam("registrar", "path_mode", 0)
+
+# ----- acc params -----
+/* what special events should be accounted ? */
+modparam("acc", "early_media", 0)
+modparam("acc", "report_ack", 0)
+modparam("acc", "report_cancels", 0)
+/* by default we do not adjust the direct of the sequential requests.
+ * if you enable this parameter, be sure the enable "append_fromtag"
+ * in "rr" module */
+modparam("acc", "detect_direction", 0)
+/* account triggers (flags) */
+modparam("acc", "log_flag", FLT_ACC)
+modparam("acc", "log_missed_flag", FLT_ACCMISSED)
+modparam("acc", "log_extra",
+	"src_user=$fU;src_domain=$fd;src_ip=$si;"
+	"dst_ouser=$tU;dst_user=$rU;dst_domain=$rd")
+modparam("acc", "failed_transaction_flag", FLT_ACCFAILED)
+/* enhanced DB accounting */
+#!ifdef WITH_ACCDB
+modparam("acc", "db_flag", FLT_ACC)
+modparam("acc", "db_missed_flag", FLT_ACCMISSED)
+modparam("acc", "db_url", DBURL)
+modparam("acc", "db_extra",
+	"src_user=$fU;src_domain=$fd;src_ip=$si;"
+	"dst_ouser=$tU;dst_user=$rU;dst_domain=$rd")
+#!endif
+
+# ----- usrloc params -----
+modparam("usrloc", "timer_interval", 60)
+modparam("usrloc", "timer_procs", 1)
+modparam("usrloc", "use_domain", MULTIDOMAIN)
+/* enable DB persistency for location entries */
+#!ifdef WITH_USRLOCDB
+modparam("usrloc", "db_url", DBURL)
+modparam("usrloc", "db_mode", 2)
+#!endif
+
+# ----- auth_db params -----
+#!ifdef WITH_AUTH
+modparam("auth_db", "db_url", DBURL)
+modparam("auth_db", "calculate_ha1", yes)
+modparam("auth_db", "password_column", "password")
+modparam("auth_db", "load_credentials", "")
+modparam("auth_db", "use_domain", MULTIDOMAIN)
+
+# ----- permissions params -----
+#!ifdef WITH_IPAUTH
+modparam("permissions", "db_url", DBURL)
+modparam("permissions", "load_backends", 1)
+#!endif
+
+#!endif
+
+# ----- alias_db params -----
+#!ifdef WITH_ALIASDB
+modparam("alias_db", "db_url", DBURL)
+modparam("alias_db", "use_domain", MULTIDOMAIN)
+#!endif
+
+# ----- speeddial params -----
+#!ifdef WITH_SPEEDDIAL
+modparam("speeddial", "db_url", DBURL)
+modparam("speeddial", "use_domain", MULTIDOMAIN)
+#!endif
+
+# ----- domain params -----
+#!ifdef WITH_MULTIDOMAIN
+modparam("domain", "db_url", DBURL)
+/* register callback to match myself condition with domains list */
+modparam("domain", "register_myself", 1)
+#!endif
+
+#!ifdef WITH_PRESENCE
+# ----- presence params -----
+modparam("presence", "db_url", DBURL)
+
+# ----- presence_xml params -----
+modparam("presence_xml", "db_url", DBURL)
+modparam("presence_xml", "force_active", 1)
+#!endif
+
+#!ifdef WITH_NAT
+#!ifdef WITH_RTPENGINE
+# ----- rtpengine params -----
+modparam("rtpengine", "rtpengine_sock", "udp:127.0.0.1:2223")
+#!else
+# ----- rtpproxy params -----
+modparam("rtpproxy", "rtpproxy_sock", "udp:127.0.0.1:7722")
+#!endif
+# ----- nathelper params -----
+modparam("nathelper", "natping_interval", 30)
+modparam("nathelper", "ping_nated_only", 1)
+modparam("nathelper", "sipping_bflag", FLB_NATSIPPING)
+modparam("nathelper", "sipping_from", "sip:pinger@kamailio.org")
+
+# params needed for NAT traversal in other modules
+modparam("nathelper|registrar", "received_avp", "$avp(RECEIVED)")
+modparam("usrloc", "nat_bflag", FLB_NATB)
+#!endif
+
+#!ifdef WITH_TLS
+# ----- tls params -----
+modparam("tls", "config", "/usr/local/etc/kamailio/tls.cfg")
+#!endif
+
+#!ifdef WITH_ANTIFLOOD
+# ----- pike params -----
+modparam("pike", "sampling_time_unit", 2)
+modparam("pike", "reqs_density_per_unit", 16)
+modparam("pike", "remove_latency", 4)
+#!endif
+
+#!ifdef WITH_HTABLE
+# ----- htable params -----
+#!ifdef WITH_ANTIFLOOD
+/* ip ban htable with autoexpire after 5 minutes */
+modparam("htable", "htable", "ipban=>size=8;autoexpire=300;")
+#!endif
+#!endif
+
+#!ifdef WITH_SIPP
+# ----- sipp params -----
+
+# Path to SIPp executable (optional - defaults to 'sipp' in PATH)
+modparam("sipp", "sipp_path", "/usr/local/bin/sipp")
+
+# Working directory for SIPp (optional - defaults to /tmp)
+modparam("sipp", "work_dir", "/tmp/sipp")
+
+# Directory containing SIPp scenario files
+# Uses /tmp/scenarios for consistent access across containers and environments
+modparam("sipp", "scenario_dir", "/tmp/scenarios")
+
+# Default target domain for tests
+modparam("sipp", "target_domain", "localhost")
+
+# Default caller and service (optional, used if not provided via RPC)
+modparam("sipp", "default_caller", "1000")
+modparam("sipp", "default_service", "2000")
+
+# Send socket configuration - SIPp will use this socket for sending
+modparam("sipp", "send_socket", "udp:127.0.0.1:5060")
+
+# Whitelist of valid test target domains (for security)
+modparam("sipp", "valid_domains", "localhost,127.0.0.1,test.example.com")
+
+# Maximum concurrent calls per test
+modparam("sipp", "max_concurrent_calls", 50)
+
+# Default test duration in seconds
+modparam("sipp", "default_duration", 60)
+
+# Default maximum test duration in seconds (0 = unlimited)
+modparam("sipp", "default_max_test_duration", 120)
+
+# Default concurrent calls
+modparam("sipp", "default_concurrent_calls", 10)
+
+# Maximum concurrent tests (SIPp hard limit is 60)
+# Each test uses a control port: 8888 + test_id
+modparam("sipp", "max_concurrent_tests", 10)
+
+# Enable Prometheus metrics export (optional)
+# Requires xhttp_prom module to be loaded for metrics export
+modparam("sipp", "enable_prometheus", 1)
+#!endif
+
+#!ifdef WITH_DEBUG
+# ----- debugger params -----
+modparam("debugger", "cfgtrace", 1)
+modparam("debugger", "log_level_name", "exec")
+#!endif
+
+####### Routing Logic ########
+
+
+/* Main SIP request routing logic
+ * - processing of any incoming SIP request starts with this route
+ * - note: this is the same as route { ... } */
+request_route {
+
+	# per request initial checks
+	route(REQINIT);
+
+	# NAT detection
+	route(NATDETECT);
+
+	# CANCEL processing
+	if (is_method("CANCEL")) {
+		dlgs_update();
+		if (t_check_trans()) {
+			route(RELAY);
+		}
+		exit;
+	}
+
+	# handle retransmissions
+	if (!is_method("ACK")) {
+		if(t_precheck_trans()) {
+			t_check_trans();
+			exit;
+		}
+		t_check_trans();
+	}
+
+	# handle requests within SIP dialogs
+	route(WITHINDLG);
+
+#!ifdef WITH_SIPP
+	route(SIPP_TEST);
+#!endif
+
+	### only initial requests (no To tag)
+
+	# authentication
+	route(AUTH);
+
+	# record routing for dialog forming requests (in case they are routed)
+	# - remove preloaded route headers
+	remove_hf("Route");
+	if (is_method("INVITE|SUBSCRIBE|REFER")) {
+		record_route();
+	}
+
+	# account only INVITEs
+	if (is_method("INVITE")) {
+		setflag(FLT_ACC); # do accounting
+	}
+
+	# dispatch requests to foreign domains
+	route(SIPOUT);
+
+	### requests for my local domains
+
+	# handle presence related requests
+	route(PRESENCE);
+
+	# handle registrations
+	route(REGISTRAR);
+
+	if ($rU==$null) {
+		# request with no Username in RURI
+		sl_send_reply("484", "Address Incomplete");
+		exit;
+	}
+
+	if(is_method("INVITE")) {
+		dlgs_init("$fu", "$tu", "srcip=$si");
+	}
+
+	# dispatch destinations to PSTN
+	route(PSTN);
+
+	# user location service
+	route(LOCATION);
+
+	return;
+}
+
+#!ifdef WITH_SIPP
+route[SIPP_TEST] {
+	if (!is_method("INVITE")) return;
+	if (has_totag()) return;
+	if ($si != "127.0.0.1") return;
+	if (!($rd =~ SIPP_TEST_DOMAINS)) return;
+
+	if (!t_check_trans()) {
+		t_newtran();
+	}
+
+	t_reply("100", "Trying");
+	add_rr_param(";sipp=yes");
+	record_route();
+
+	$du = UAS_URI;
+	route(RELAY);
+	exit;
+}
+#!endif
+
+# Wrapper for relaying requests
+route[RELAY] {
+
+	# enable additional event routes for forwarded requests
+	# - serial forking, RTP relaying handling, a.s.o.
+	if (is_method("INVITE|BYE|SUBSCRIBE|UPDATE")) {
+		if(!t_is_set("branch_route")) t_on_branch("MANAGE_BRANCH");
+	}
+	if (is_method("INVITE|SUBSCRIBE|UPDATE")) {
+		if(!t_is_set("onreply_route")) t_on_reply("MANAGE_REPLY");
+	}
+	if (is_method("INVITE")) {
+		if(!t_is_set("failure_route")) t_on_failure("MANAGE_FAILURE");
+	}
+
+	if (!t_relay()) {
+		send_reply_error();
+	}
+	exit;
+}
+
+# Per SIP request initial checks
+route[REQINIT] {
+	# no connect for sending replies
+	set_reply_no_connect();
+	# enforce symmetric signaling
+	# - send back replies to the source address of request
+	force_rport();
+
+#!ifdef WITH_ANTIFLOOD
+	# flood detection from same IP and traffic ban for a while
+	# be sure you exclude checking trusted peers, such as pstn gateways
+	# - local host excluded (e.g., loop to self)
+	if(src_ip!=myself) {
+		if($sht(ipban=>$si)!=$null) {
+			# ip is already blocked
+			xdbg("request from blocked IP - $rm from $fu (IP:$si:$sp)\n");
+			exit;
+		}
+		if (!pike_check_req()) {
+			xalert("ALERT: pike blocking $rm from $fu (IP:$si:$sp)\n");
+			$sht(ipban=>$si) = 1;
+			exit;
+		}
+	}
+#!endif
+	if($ua =~ "friendly|scanner|sipcli|sipvicious|VaxSIPUserAgent|pplsip") {
+		# silent drop for scanners - uncomment next line if want to reply
+		# sl_send_reply("200", "OK");
+		exit;
+	}
+
+	if (!mf_process_maxfwd_header("10")) {
+		sl_send_reply("483", "Too Many Hops");
+		exit;
+	}
+
+	if(is_method("OPTIONS") && uri==myself && $rU==$null) {
+		sl_send_reply("200", "Keepalive");
+		exit;
+	}
+
+	if(!sanity_check("17895", "7")) {
+		xlog("Malformed SIP request from $si:$sp\n");
+		exit;
+	}
+}
+
+# Handle requests within SIP dialogs
+route[WITHINDLG] {
+	if (!has_totag()) return;
+
+	# sequential request within a dialog should
+	# take the path determined by record-routing
+	if (loose_route()) {
+		route(DLGURI);
+
+#!ifdef WITH_SIPP
+		if (check_route_param("sipp=yes")) {
+			$du = UAS_URI;
+		}
+#!endif
+
+		dlgs_update();
+		if (is_method("BYE")) {
+			setflag(FLT_ACC); # do accounting ...
+			setflag(FLT_ACCFAILED); # ... even if the transaction fails
+		} else if ( is_method("ACK") ) {
+			# ACK is forwarded statelessly
+			route(NATMANAGE);
+		} else if ( is_method("NOTIFY|REFER") ) {
+			# Add Record-Route for in-dialog NOTIFY and REFER (RFC6665, RFC3515)
+			record_route();
+		}
+		route(RELAY);
+		exit;
+	}
+
+	if (is_method("SUBSCRIBE") && uri == myself) {
+		# in-dialog subscribe requests
+		route(PRESENCE);
+		exit;
+	}
+	if ( is_method("ACK") ) {
+		if ( t_check_trans() ) {
+			# no loose-route, but stateful ACK;
+			# must be an ACK after a 487
+			# or e.g. 404 from upstream server
+			route(RELAY);
+			exit;
+		} else {
+			# ACK without matching transaction ... ignore and discard
+			exit;
+		}
+	}
+	sl_send_reply("404", "Not here");
+	exit;
+}
+
+# Handle SIP registrations
+route[REGISTRAR] {
+	if (!is_method("REGISTER")) return;
+
+	if(isflagset(FLT_NATS)) {
+		setbflag(FLB_NATB);
+#!ifdef WITH_NATSIPPING
+		# do SIP NAT pinging
+		setbflag(FLB_NATSIPPING);
+#!endif
+	}
+	if (!save("location")) {
+		send_reply_error();
+	}
+	exit;
+}
+
+# User location service
+route[LOCATION] {
+
+#!ifdef WITH_SPEEDDIAL
+	# search for short dialing - 2-digit extension
+	if($rU=~"^[0-9][0-9]$") {
+		if(sd_lookup("speed_dial")) {
+			route(SIPOUT);
+		}
+	}
+#!endif
+
+#!ifdef WITH_ALIASDB
+	# search in DB-based aliases
+	if(alias_db_lookup("dbaliases")) {
+		route(SIPOUT);
+	}
+#!endif
+
+	$avp(oexten) = $rU;
+	if (!lookup("location")) {
+		$var(rc) = $rc;
+		route(TOVOICEMAIL);
+		t_newtran();
+		switch ($var(rc)) {
+			case -1:
+			case -3:
+				send_reply("404", "Not Found");
+				exit;
+			case -2:
+				send_reply("405", "Method Not Allowed");
+				exit;
+		}
+	}
+
+	# when routing via usrloc, log the missed calls also
+	if (is_method("INVITE")) {
+		setflag(FLT_ACCMISSED);
+	}
+
+	route(RELAY);
+	exit;
+}
+
+# Presence server processing
+route[PRESENCE] {
+	if(!is_method("PUBLISH|SUBSCRIBE")) return;
+
+	if(is_method("SUBSCRIBE") && $hdr(Event)=="message-summary") {
+		route(TOVOICEMAIL);
+		# returns here if no voicemail server is configured
+		sl_send_reply("404", "No voicemail service");
+		exit;
+	}
+
+#!ifdef WITH_PRESENCE
+#!ifdef WITH_MSGREBUILD
+	# apply changes in case the request headers or body were modified
+	msg_apply_changes();
+#!endif
+	if (!t_newtran()) {
+		send_reply_error();
+		exit;
+	}
+
+	if(is_method("PUBLISH")) {
+		handle_publish();
+		t_release();
+	} else if(is_method("SUBSCRIBE")) {
+		handle_subscribe();
+		t_release();
+	}
+	exit;
+#!endif
+
+	# if presence enabled, this part will not be executed
+	if (is_method("PUBLISH") || $rU==$null) {
+		sl_send_reply("404", "Not here");
+		exit;
+	}
+	return;
+}
+
+# IP authorization and user authentication
+route[AUTH] {
+#!ifdef WITH_AUTH
+
+#!ifdef WITH_IPAUTH
+	if((!is_method("REGISTER")) && allow_source_address()) {
+		# source IP allowed
+		return;
+	}
+#!endif
+
+	if (is_method("REGISTER") || from_uri==myself) {
+		# authenticate requests
+		if (!auth_check("$fd", "subscriber", "1")) {
+			auth_challenge("$fd", "0");
+			exit;
+		}
+		# user authenticated - remove auth header
+		if(!is_method("REGISTER|PUBLISH"))
+			consume_credentials();
+	}
+	# if caller is not local subscriber, then check if it calls
+	# a local destination, otherwise deny, not an open relay here
+	if (from_uri!=myself && uri!=myself) {
+		sl_send_reply("403", "Not relaying");
+		exit;
+	}
+
+#!else
+
+	# authentication not enabled - do not relay at all to foreign networks
+	if(uri!=myself) {
+		sl_send_reply("403", "Not relaying");
+		exit;
+	}
+
+#!endif
+	return;
+}
+
+# Caller NAT detection
+route[NATDETECT] {
+#!ifdef WITH_NAT
+	if (nat_uac_test("19")) {
+		if (is_method("REGISTER")) {
+			fix_nated_register();
+		} else {
+			if(is_first_hop()) {
+				set_contact_alias();
+			}
+		}
+		setflag(FLT_NATS);
+	}
+#!endif
+	return;
+}
+
+# RTP relaying management and signaling updates for NAT traversal
+route[NATMANAGE] {
+#!ifdef WITH_NAT
+	if (is_request()) {
+		if(has_totag()) {
+			if(check_route_param("nat=yes")) {
+				setbflag(FLB_NATB);
+			}
+		}
+	}
+
+#!ifndef WITH_RTPRELAY
+	if (!(isflagset(FLT_NATS) || isbflagset(FLB_NATB))) return;
+#!endif
+
+#!ifdef WITH_RTPENGINE
+	if(nat_uac_test("8")) {
+		rtpengine_manage("SIP-source-address replace-origin replace-session-connection");
+	} else {
+		rtpengine_manage("replace-origin replace-session-connection");
+	}
+#!else
+	if(nat_uac_test("8")) {
+		rtpproxy_manage("co");
+	} else {
+		rtpproxy_manage("cor");
+	}
+#!endif
+
+	if (is_request()) {
+		if (!has_totag()) {
+			if(t_is_branch_route()) {
+				add_rr_param(";nat=yes");
+			}
+		}
+	}
+	if (is_reply()) {
+		if(isbflagset(FLB_NATB)) {
+			if(is_first_hop())
+				set_contact_alias();
+		}
+	}
+
+	if(isbflagset(FLB_NATB)) {
+		# no connect message in a dialog involving NAT traversal
+		if (is_request()) {
+			if(has_totag()) {
+				set_forward_no_connect();
+			}
+		}
+	}
+#!endif
+	return;
+}
+
+# URI update for dialog requests
+route[DLGURI] {
+#!ifdef WITH_NAT
+	if(!isdsturiset()) {
+		handle_ruri_alias();
+	}
+#!endif
+	return;
+}
+
+# Routing to foreign domains
+route[SIPOUT] {
+	if (uri==myself) return;
+
+	append_hf("P-Hint: outbound\r\n");
+	route(RELAY);
+	exit;
+}
+
+# PSTN GW routing
+route[PSTN] {
+#!ifdef WITH_PSTN
+	# check if PSTN GW IP is defined
+	if (strempty($sel(cfg_get.pstn.gw_ip))) {
+		xlog("SCRIPT: PSTN routing enabled but pstn.gw_ip not defined\n");
+		return;
+	}
+
+	# route to PSTN dialed numbers starting with '+' or '00'
+	#     (international format)
+	# - update the condition to match your dialing rules for PSTN routing
+	if(!($rU=~"^(\+|00)[1-9][0-9]{3,20}$")) return;
+
+	# only local users allowed to call
+	if(from_uri!=myself) {
+		sl_send_reply("403", "Not Allowed");
+		exit;
+	}
+
+	# normalize target number for pstn gateway
+	# - convert leading 00 to +
+	if (starts_with("$rU", "00")) {
+		strip(2);
+		prefix("+");
+	}
+
+	if (strempty($sel(cfg_get.pstn.gw_port))) {
+		$ru = "sip:" + $rU + "@" + $sel(cfg_get.pstn.gw_ip);
+	} else {
+		$ru = "sip:" + $rU + "@" + $sel(cfg_get.pstn.gw_ip) + ":"
+					+ $sel(cfg_get.pstn.gw_port);
+	}
+
+	route(RELAY);
+	exit;
+#!endif
+
+	return;
+}
+
+# JSONRPC over HTTP(S) routing
+#!ifdef WITH_JSONRPC
+event_route[xhttp:request] {
+	set_reply_close();
+	set_reply_no_connect();
+	if(src_ip!=127.0.0.1) {
+		xhttp_reply("403", "Forbidden", "text/html",
+				"<html><body>Not allowed from $si</body></html>");
+		exit;
+	}
+	if ($hu =~ "^/RPC") {
+		jsonrpc_dispatch();
+		exit;
+	}
+
+	xhttp_reply("200", "OK", "text/html",
+				"<html><body>Wrong URL $hu</body></html>");
+	exit;
+}
+#!endif
+
+# Routing to voicemail server
+route[TOVOICEMAIL] {
+#!ifdef WITH_VOICEMAIL
+	if(!is_method("INVITE|SUBSCRIBE")) return;
+
+	# check if VoiceMail server IP is defined
+	if (strempty($sel(cfg_get.voicemail.srv_ip))) {
+		xlog("SCRIPT: VoiceMail routing enabled but IP not defined\n");
+		return;
+	}
+	if(is_method("INVITE")) {
+		if($avp(oexten)==$null) return;
+
+		$ru = "sip:" + $avp(oexten) + "@" + $sel(cfg_get.voicemail.srv_ip)
+				+ ":" + $sel(cfg_get.voicemail.srv_port);
+	} else {
+		if($rU==$null) return;
+
+		$ru = "sip:" + $rU + "@" + $sel(cfg_get.voicemail.srv_ip)
+				+ ":" + $sel(cfg_get.voicemail.srv_port);
+	}
+	route(RELAY);
+	exit;
+#!endif
+
+	return;
+}
+
+# Manage outgoing branches
+branch_route[MANAGE_BRANCH] {
+	xdbg("new branch [$T_branch_idx] to $ru\n");
+	route(NATMANAGE);
+	return;
+}
+
+# Manage incoming replies
+reply_route {
+	if(!sanity_check("17604", "6")) {
+		xlog("Malformed SIP response from $si:$sp\n");
+		drop;
+	}
+	return;
+}
+
+# Manage incoming replies in transaction context
+onreply_route[MANAGE_REPLY] {
+	xdbg("incoming reply\n");
+	if(status=~"[12][0-9][0-9]") {
+		route(NATMANAGE);
+	}
+	return;
+}
+
+# Manage failure routing cases
+failure_route[MANAGE_FAILURE] {
+	route(NATMANAGE);
+
+	if (t_is_canceled()) exit;
+
+#!ifdef WITH_BLOCK3XX
+	# block call redirect based on 3xx replies.
+	if (t_check_status("3[0-9][0-9]")) {
+		t_reply("404", "Not found");
+		exit;
+	}
+#!endif
+
+#!ifdef WITH_BLOCK401407
+	# block downstream auth based on 401, 407 replies.
+	if (t_check_status("401|407")) {
+		t_reply("404", "Not found");
+		exit;
+	}
+#!endif
+
+#!ifdef WITH_VOICEMAIL
+	# serial forking
+	# - route to voicemail on busy or no answer (timeout)
+	if (t_check_status("486|408")) {
+		$du = $null;
+		route(TOVOICEMAIL);
+		exit;
+	}
+#!endif
+	return;
+}

--- a/src/modules/sipp/examples/sipp-scenarios/uac_invite.xml
+++ b/src/modules/sipp/examples/sipp-scenarios/uac_invite.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- 
+  Basic UAC scenario for INVITE with call hold/unhold
+  This scenario simulates a user agent client making a call,
+  putting it on hold, and then resuming
+-->
+
+<scenario name="UAC Basic INVITE">
+  <!-- Send INVITE -->
+  <send retrans="500">
+    <![CDATA[
+
+      INVITE sip:[service]@[target_domain] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: [caller] <sip:[caller]@[local_ip]:[local_port]>;tag=[pid]SIPpTag09[call_number]
+      To: [service] <sip:[service]@[target_domain]>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: sip:[caller]@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Performance Test
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=user1 53655765 2353687637 IN IP[media_ip_type] [media_ip]
+      s=-
+      c=IN IP[media_ip_type] [media_ip]
+      t=0 0
+      m=audio [auto_media_port] RTP/AVP 0
+      a=rtpmap:0 PCMA/8000
+
+    ]]>
+  </send>
+
+  <!-- Receive 100 Trying (optional) -->
+  <recv response="100" optional="true">
+  </recv>
+
+  <!-- Receive 180 Ringing (optional) -->
+  <recv response="180" optional="true">
+  </recv>
+
+  <!-- Receive 200 OK for INVITE -->
+  <recv response="200" rtd="true" timeout="5000">
+  </recv>
+
+  <!-- Send ACK -->
+  <send>
+    <![CDATA[
+
+      ACK [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: [caller] <sip:[caller]@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
+      To: [service] <sip:[service]@[target_domain]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 1 ACK
+      Contact: sip:[caller]@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- Call duration -->
+  <pause milliseconds="5000"/>
+
+  <!-- Send BYE -->
+  <send retrans="500">
+    <![CDATA[
+
+      BYE [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: [caller] <sip:[caller]@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
+      To: [service] <sip:[service]@[target_domain]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 4 BYE
+      Contact: sip:[caller]@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- Receive 200 OK for BYE -->
+  <recv response="200" crlf="true" timeout="5000">
+  </recv>
+
+  <!-- Definition of response time statistics -->
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>

--- a/src/modules/sipp/examples/sipp-scenarios/uac_register.xml
+++ b/src/modules/sipp/examples/sipp-scenarios/uac_register.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- 
+  Simple UAC REGISTER scenario
+  This scenario simulates a user agent registering with a SIP server
+-->
+
+<scenario name="UAC REGISTER Basic">
+  <!-- Send REGISTER -->
+  <send retrans="500">
+    <![CDATA[
+
+      REGISTER sip:[target_domain] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: [caller] <sip:[caller]@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
+      To: [service] <sip:[service]@[target_domain]>
+      Call-ID: [call_id]
+      CSeq: 1 REGISTER
+      Contact: <sip:[caller]@[local_ip]:[local_port];transport=[transport]>
+      Max-Forwards: 70
+      Expires: 3600
+      User-Agent: SIPp
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- Receive 401 Unauthorized (optional - if auth required) -->
+  <recv response="401" auth="true" optional="true">
+  </recv>
+
+  <!-- Send authenticated REGISTER (if challenged) -->
+  <send retrans="500">
+    <![CDATA[
+
+      REGISTER sip:[target_domain] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: [caller] <sip:[caller]@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
+      To: [service] <sip:[service]@[target_domain]>
+      Call-ID: [call_id]
+      CSeq: 2 REGISTER
+      Contact: <sip:[caller]@[local_ip]:[local_port];transport=[transport]>
+      [authentication username=[caller] password=secret]
+      Max-Forwards: 70
+      Expires: 3600
+      User-Agent: SIPp
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- Receive 200 OK -->
+  <recv response="200">
+  </recv>
+
+  <!-- Keep registered for a while -->
+  <pause milliseconds="5000"/>
+
+  <!-- Send REGISTER with Expires: 0 to unregister -->
+  <send retrans="500">
+    <![CDATA[
+
+      REGISTER sip:[target_domain] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: [caller] <sip:[caller]@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
+      To: [service] <sip:[service]@[target_domain]>
+      Call-ID: [call_id]
+      CSeq: 1 REGISTER
+      Contact: <sip:[caller]@[local_ip]:[local_port];transport=[transport]>
+      Max-Forwards: 70
+      Expires: 0
+      User-Agent: SIPp
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- Receive 200 OK for unregister -->
+  <recv response="200">
+  </recv>
+
+  <!-- Definition of response time statistics -->
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+</scenario>

--- a/src/modules/sipp/examples/sipp-scenarios/uas_answer.xml
+++ b/src/modules/sipp/examples/sipp-scenarios/uas_answer.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- 
+  Basic UAS scenario responding to INVITE
+  This scenario simulates a user agent server receiving and answering calls
+-->
+
+<scenario name="UAS Basic Answer">
+  <!-- Receive INVITE -->
+  <recv request="INVITE" crlf="true">
+  </recv>
+
+  <!-- Send 100 Trying -->
+  <send>
+    <![CDATA[
+
+      SIP/2.0 100 Trying
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- Optional delay before ringing -->
+  <pause milliseconds="500"/>
+
+  <!-- Send 180 Ringing -->
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 180 Ringing
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- Delay before answering -->
+  <pause milliseconds="1000"/>
+
+  <!-- Send 200 OK with SDP -->
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=user1 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[media_ip_type] [media_ip]
+      t=0 0
+      m=audio [media_port] RTP/AVP 0
+      a=rtpmap:0 PCMA/8000
+
+    ]]>
+  </send>
+
+  <!-- Receive ACK -->
+  <recv request="ACK" rtd="true" crlf="true">
+  </recv>
+
+
+
+  <!-- Wait for BYE -->
+  <recv request="BYE">
+  </recv>
+
+  <!-- Send 200 OK for BYE -->
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- Definition of response time statistics -->
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>

--- a/src/modules/sipp/sipp_mod.c
+++ b/src/modules/sipp/sipp_mod.c
@@ -1,0 +1,472 @@
+/**
+ * Copyright (C) 2026 Aurora Innovation AB
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/*!
+ * \file
+ * \brief SIPp Integration Module
+ * \ingroup sipp
+ * - Module: \ref sipp
+ *
+ * This module provides integration with SIPp for automated SIP load testing.
+ * It allows starting, stopping, and monitoring SIPp tests via RPC commands.
+ *
+ * Features:
+ * - Start SIPp tests with configurable scenarios
+ * - Support for multiple concurrent calls
+ * - Dynamic target domain and number configuration
+ * - Test statistics and monitoring via RPC
+ * - Automatic transport detection (UDP/TCP)
+ * - Ephemeral port binding to Kamailio send sockets
+ *
+ * Example configuration:
+ * \code
+ * loadmodule "sipp.so"
+ * modparam("sipp", "scenario_dir", "/etc/kamailio/sipp")
+ * modparam("sipp", "target_domain", "sip.example.com")
+ * modparam("sipp", "send_socket_name", "udp:eth0:5060")
+ * modparam("sipp", "default_concurrent_calls", 50)
+ * modparam("sipp", "max_concurrent_calls", 1000)
+ * modparam("sipp", "valid_domains", "sip.example.com,test.example.com")
+ * \endcode
+ *
+ * RPC Commands:
+ * - sipp.start_test - Start a new SIPp test
+ * - sipp.stop_test - Stop a running SIPp test
+ * - sipp.get_stats - Get statistics for a running or completed test
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <errno.h>
+#include <ctype.h>
+
+#include "../../core/sr_module.h"
+#include "../../core/dprint.h"
+#include "../../core/ut.h"
+#include "../../core/mod_fix.h"
+#include "../../core/socket_info.h"
+#include "../../core/rpc.h"
+#include "../../core/rpc_lookup.h"
+#include "../../core/timer.h"
+
+#include "sipp_test.h"
+#include "sipp_rpc.h"
+#include "sipp_prom.h"
+
+MODULE_VERSION
+
+
+/* Module parameters */
+static str sipp_path = STR_NULL;
+static str sipp_send_socket_name = STR_NULL;
+static str sipp_send_socket = STR_NULL;
+static str sipp_target_domain = STR_NULL;
+static str sipp_scenario_dir = STR_NULL;
+static str sipp_work_dir = STR_NULL;
+static str sipp_media_ip = STR_NULL;
+static str sipp_valid_domains = STR_NULL;
+static str sipp_default_from_number = STR_NULL;
+static str sipp_default_to_number = STR_NULL;
+
+static int sipp_default_concurrent_calls = 50;
+static int sipp_max_concurrent_calls = 1000;
+static int sipp_max_concurrent_tests = 10; /* SIPp hard limit is 60 */
+static int sipp_default_duration = 60;
+static int sipp_default_call_rate = 10;
+static int sipp_default_total_calls = 0;
+static int sipp_default_max_test_duration = 0;
+static int sipp_enable_prometheus = 1;
+
+/* Module functions */
+static int mod_init(void);
+static int child_init(int rank);
+static void mod_destroy(void);
+
+/* clang-format off */
+static param_export_t params[] = {
+	{"sipp_path", PARAM_STR, &sipp_path},
+	{"send_socket_name", PARAM_STR, &sipp_send_socket_name},
+	{"send_socket", PARAM_STR, &sipp_send_socket},
+	{"target_domain", PARAM_STR, &sipp_target_domain},
+	{"default_caller", PARAM_STR, &sipp_default_from_number},
+	{"default_service", PARAM_STR, &sipp_default_to_number},
+	{"scenario_dir", PARAM_STR, &sipp_scenario_dir},
+	{"work_dir", PARAM_STR, &sipp_work_dir},
+	{"media_ip", PARAM_STR, &sipp_media_ip},
+	{"valid_domains", PARAM_STR, &sipp_valid_domains},
+	{"default_concurrent_calls", PARAM_INT, &sipp_default_concurrent_calls},
+	{"max_concurrent_calls", PARAM_INT, &sipp_max_concurrent_calls},
+	{"max_concurrent_tests", PARAM_INT, &sipp_max_concurrent_tests},
+	{"default_duration", PARAM_INT, &sipp_default_duration},
+	{"default_call_rate", PARAM_INT, &sipp_default_call_rate},
+	{"default_total_calls", PARAM_INT, &sipp_default_total_calls},
+	{"default_max_test_duration", PARAM_INT, &sipp_default_max_test_duration},
+	{"enable_prometheus", PARAM_INT, &sipp_enable_prometheus},
+	{0, 0, 0}
+};
+
+static cmd_export_t cmds[] = {
+	{0, 0, 0, 0, 0, 0}
+};
+
+struct module_exports exports = {
+	"sipp",			   /* module name */
+	DEFAULT_DLFLAGS,   /* dlopen flags */
+	cmds,			   /* exported functions */
+	params,			   /* exported parameters */
+	0,				   /* exported RPC methods */
+	0,				   /* exported pseudo-variables */
+	0,				   /* response function */
+	mod_init,		   /* module initialization function */
+	child_init,		   /* per-child init function */
+	mod_destroy		   /* destroy function */
+};
+/* clang-format on */
+
+
+/**
+ * Timer callback for periodic metrics update
+ * Called every 5-10 seconds
+ */
+static void sipp_metrics_timer(unsigned int ticks, void *param)
+{
+	LM_DBG("updating SIPp metrics\n");
+	sipp_metrics_update();
+}
+
+
+/**
+ * Timer callback for periodic cleanup
+ * Called every hour
+ */
+static void sipp_cleanup_timer(unsigned int ticks, void *param)
+{
+	LM_DBG("running SIPp cleanup\n");
+	sipp_test_cleanup();
+}
+
+
+static int sipp_validate_media_ip(const str *media_ip)
+{
+	int i;
+
+	if(media_ip == NULL || media_ip->s == NULL || media_ip->len <= 0) {
+		return -1;
+	}
+
+	for(i = 0; i < media_ip->len; i++) {
+		unsigned char c = (unsigned char)media_ip->s[i];
+		if(!isalnum(c) && c != '.' && c != ':' && c != '-' && c != '_') {
+			LM_ERR("media_ip contains unsafe character '%c' (0x%02x) at "
+				   "position %d\n",
+					c, c, i);
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+
+/**
+ * Module initialization function
+ * - Validates module parameters
+ * - Initializes test management structures
+ * - Registers RPC commands
+ */
+static int mod_init(void)
+{
+	socket_info_t *si = NULL;
+	str sproto;
+
+	LM_INFO("initializing SIPp integration module\n");
+
+	/* Check for required parameters */
+	if(sipp_scenario_dir.s == NULL || sipp_scenario_dir.len <= 0) {
+		LM_ERR("scenario_dir parameter is required\n");
+		return -1;
+	}
+
+	if(sipp_target_domain.s == NULL || sipp_target_domain.len <= 0) {
+		LM_INFO("target_domain not set (optional)\n");
+	}
+
+	/* Log the scenario directory path for troubleshooting */
+	LM_INFO("scenario_dir configured as: %.*s\n", sipp_scenario_dir.len,
+			sipp_scenario_dir.s);
+
+	if(sipp_work_dir.s != NULL && sipp_work_dir.len > 0) {
+		if(access(sipp_work_dir.s, W_OK | X_OK) < 0) {
+			LM_ERR("work_dir not writable: %.*s (%s)\n", sipp_work_dir.len,
+					sipp_work_dir.s, strerror(errno));
+			return -1;
+		}
+	}
+
+	if(sipp_media_ip.s != NULL && sipp_media_ip.len > 0) {
+		if(sipp_validate_media_ip(&sipp_media_ip) < 0) {
+			LM_ERR("media_ip contains unsafe characters\n");
+			return -1;
+		}
+	}
+
+	/* Validate that only one send socket parameter is provided */
+	if(sipp_send_socket_name.s != NULL && sipp_send_socket.s != NULL) {
+		LM_ERR("send_socket_name and send_socket are mutually exclusive\n");
+		return -1;
+	}
+
+	/* Validate send_socket_name if provided */
+	if(sipp_send_socket_name.s != NULL && sipp_send_socket_name.len > 0) {
+		si = lookup_local_socket(&sipp_send_socket_name);
+		if(si == NULL) {
+			LM_ERR("send_socket_name not found: %.*s\n",
+					sipp_send_socket_name.len, sipp_send_socket_name.s);
+			return -1;
+		}
+		LM_INFO("using send socket: %.*s (proto=%d, addr=%s:%d)\n",
+				sipp_send_socket_name.len, sipp_send_socket_name.s, si->proto,
+				ip_addr2a(&si->address), si->port_no);
+	}
+
+	/* Validate send_socket if provided */
+	if(sipp_send_socket.s != NULL && sipp_send_socket.len > 0) {
+		/* Parse the raw socket format: <proto>:<ip>:<port> */
+		char *p = sipp_send_socket.s;
+		char *end = p + sipp_send_socket.len;
+		char *colon1 = memchr(p, ':', end - p);
+		if(colon1 == NULL) {
+			LM_ERR("invalid send_socket format (missing protocol): %.*s\n",
+					sipp_send_socket.len, sipp_send_socket.s);
+			return -1;
+		}
+		sproto.s = p;
+		sproto.len = colon1 - p;
+
+		/* Validate protocol */
+		if(sproto.len == 3 && strncasecmp(sproto.s, "udp", 3) == 0) {
+			/* UDP is valid */
+		} else if(sproto.len == 3 && strncasecmp(sproto.s, "tcp", 3) == 0) {
+			/* TCP is valid */
+		} else if(sproto.len == 3 && strncasecmp(sproto.s, "tls", 3) == 0) {
+			LM_WARN("TLS transport specified but not yet fully supported\n");
+		} else {
+			LM_ERR("invalid transport protocol in send_socket: %.*s\n",
+					sproto.len, sproto.s);
+			return -1;
+		}
+
+		LM_INFO("using raw send socket: %.*s\n", sipp_send_socket.len,
+				sipp_send_socket.s);
+	}
+
+	/* Validate concurrent call limits */
+	if(sipp_default_concurrent_calls < 1) {
+		LM_ERR("default_concurrent_calls must be at least 1\n");
+		return -1;
+	}
+
+	if(sipp_max_concurrent_calls < sipp_default_concurrent_calls) {
+		LM_ERR("max_concurrent_calls must be >= default_concurrent_calls\n");
+		return -1;
+	}
+
+	if(sipp_default_duration < 1) {
+		LM_ERR("default_duration must be at least 1 second\n");
+		return -1;
+	}
+
+	if(sipp_default_total_calls < 0) {
+		LM_ERR("default_total_calls must be >= 0\n");
+		return -1;
+	}
+
+	if(sipp_default_max_test_duration < 0) {
+		LM_ERR("default_max_test_duration must be >= 0\n");
+		return -1;
+	}
+
+
+	/* Validate and cap max_concurrent_tests at SIPp's hard limit of 60 */
+	if(sipp_max_concurrent_tests < 1) {
+		LM_ERR("max_concurrent_tests must be at least 1\n");
+		return -1;
+	}
+	if(sipp_max_concurrent_tests > 60) {
+		LM_WARN("max_concurrent_tests capped at 60 (SIPp hard limit)\n");
+		sipp_max_concurrent_tests = 60;
+	}
+
+	/* Initialize test management */
+	if(sipp_test_init() < 0) {
+		LM_ERR("failed to initialize test management\n");
+		return -1;
+	}
+
+	/* Register RPC commands */
+	if(sipp_rpc_init() < 0) {
+		LM_ERR("failed to register RPC commands\n");
+		return -1;
+	}
+
+	/* Initialize Prometheus integration (optional) */
+	if(sipp_prom_init() < 0) {
+		LM_ERR("failed to initialize Prometheus integration\n");
+		return -1;
+	}
+
+	/* Register periodic timers */
+	/* Metrics update: every 10 seconds */
+	if(register_timer(sipp_metrics_timer, NULL, 10) < 0) {
+		LM_ERR("failed to register metrics timer\n");
+		return -1;
+	}
+
+	/* Cleanup: every 1 hour (3600 seconds) */
+	if(register_timer(sipp_cleanup_timer, NULL, 3600) < 0) {
+		LM_ERR("failed to register cleanup timer\n");
+		return -1;
+	}
+
+	LM_INFO("SIPp module initialized successfully\n");
+	return 0;
+}
+
+
+/**
+ * Per-child initialization function
+ */
+static int child_init(int rank)
+{
+	LM_DBG("child [%d] initialized\n", rank);
+	return 0;
+}
+
+
+/**
+ * Module cleanup function
+ * - Stops all running tests
+ * - Frees allocated memory
+ */
+static void mod_destroy(void)
+{
+	LM_INFO("cleaning up SIPp module\n");
+	sipp_test_destroy();
+}
+
+
+/**
+ * Accessor functions for module parameters
+ */
+
+str *sipp_get_send_socket_name(void)
+{
+	return &sipp_send_socket_name;
+}
+
+str *sipp_get_send_socket(void)
+{
+	return &sipp_send_socket;
+}
+
+str *sipp_get_target_domain(void)
+{
+	return &sipp_target_domain;
+}
+
+str *sipp_get_scenario_dir(void)
+{
+	return &sipp_scenario_dir;
+}
+
+str *sipp_get_work_dir(void)
+{
+	return &sipp_work_dir;
+}
+
+str *sipp_get_media_ip(void)
+{
+	return &sipp_media_ip;
+}
+
+str *sipp_get_valid_domains(void)
+{
+	return &sipp_valid_domains;
+}
+
+int sipp_get_default_concurrent_calls(void)
+{
+	return sipp_default_concurrent_calls;
+}
+
+int sipp_get_max_concurrent_calls(void)
+{
+	return sipp_max_concurrent_calls;
+}
+
+int sipp_get_max_concurrent_tests(void)
+{
+	return sipp_max_concurrent_tests;
+}
+
+int sipp_get_default_duration(void)
+{
+	return sipp_default_duration;
+}
+
+int sipp_get_default_call_rate(void)
+{
+	return sipp_default_call_rate;
+}
+
+int sipp_get_default_total_calls(void)
+{
+	return sipp_default_total_calls;
+}
+
+int sipp_get_default_max_test_duration(void)
+{
+	return sipp_default_max_test_duration;
+}
+
+str *sipp_get_sipp_path(void)
+{
+	return &sipp_path;
+}
+
+str *sipp_get_default_from_number(void)
+{
+	return &sipp_default_from_number;
+}
+
+str *sipp_get_default_to_number(void)
+{
+	return &sipp_default_to_number;
+}
+
+int sipp_get_enable_prometheus(void)
+{
+	return sipp_enable_prometheus;
+}

--- a/src/modules/sipp/sipp_prom.c
+++ b/src/modules/sipp/sipp_prom.c
@@ -1,0 +1,175 @@
+/**
+ * Copyright (C) 2026 Aurora Innovation AB
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "../../core/dprint.h"
+#include "../../core/sr_module.h"
+
+#include "../xhttp_prom/bind_prom.h"
+#include "sipp_prom.h"
+#include "sipp_test.h"
+
+/* Prometheus module API */
+static prom_api_t _sipp_prom_api;
+static int _sipp_prom_metrics_ready = 0;
+
+static int _sipp_prom_enabled = 0;
+
+static int sipp_prom_create_metrics(void)
+{
+	if(_sipp_prom_metrics_ready) {
+		return 0;
+	}
+
+	if(_sipp_prom_api.counter_create == NULL
+			|| _sipp_prom_api.gauge_create == NULL) {
+		LM_ERR("Prometheus API missing create functions\n");
+		return -1;
+	}
+
+	if(_sipp_prom_api.counter_create(
+			   "name=sipp_calls_started_total;help=Total calls initiated;"
+			   "label=test_id:scenario:from_to")
+			|| _sipp_prom_api.counter_create(
+					"name=sipp_calls_completed_total;help=Successfully "
+					"completed "
+					"calls;label=test_id:scenario:from_to")
+			|| _sipp_prom_api.counter_create(
+					"name=sipp_calls_failed_total;help=Failed calls;"
+					"label=test_id:scenario:from_to")
+			|| _sipp_prom_api.gauge_create(
+					"name=sipp_calls_active;help=Currently active calls;"
+					"label=test_id:scenario:from_to")
+			|| _sipp_prom_api.gauge_create(
+					"name=sipp_concurrent_calls_configured;help=Configured "
+					"concurrent call limit;label=test_id:scenario:from_to")) {
+		LM_ERR("Failed to create Prometheus metrics\n");
+		return -1;
+	}
+
+	_sipp_prom_metrics_ready = 1;
+	return 0;
+}
+
+
+/**
+ * Initialize Prometheus integration
+ * Checks if xhttp_prom module is loaded and binds to its API
+ */
+int sipp_prom_init(void)
+{
+	if(!sipp_get_enable_prometheus()) {
+		LM_INFO("Prometheus integration disabled by config\n");
+		return 0;
+	}
+	if(prom_load_api(&_sipp_prom_api) != 0) {
+		LM_INFO("xhttp_prom module not loaded - Prometheus metrics disabled\n");
+		LM_INFO("To enable metrics, load xhttp_prom module before sipp "
+				"module\n");
+		_sipp_prom_enabled = 0;
+		return 0;
+	}
+
+	if(sipp_prom_create_metrics() != 0) {
+		_sipp_prom_enabled = 0;
+		return -1;
+	}
+
+	_sipp_prom_enabled = 1;
+	LM_INFO("Prometheus integration enabled - xhttp_prom API bound\n");
+	return 0;
+}
+
+
+/**
+ * Push SIPp test metrics to Prometheus
+ */
+void sipp_prom_push_metrics(sipp_test_t *test)
+{
+	char test_id_str[32];
+	char scenario_name[256];
+	char from_number[SIPP_MAX_NUMBER_LEN];
+	char to_number[SIPP_MAX_NUMBER_LEN];
+	char from_to_number[(SIPP_MAX_NUMBER_LEN * 2) + 8];
+	str s_name;
+	str l1;
+	str l2;
+	str l3;
+
+	if(!_sipp_prom_enabled || test == NULL) {
+		return;
+	}
+
+	/* Prepare labels */
+	snprintf(test_id_str, sizeof(test_id_str), "%d", test->test_id);
+	snprintf(scenario_name, sizeof(scenario_name), "%s", test->scenario);
+	snprintf(from_number, sizeof(from_number), "%s", test->from_number);
+	snprintf(to_number, sizeof(to_number), "%s", test->to_number);
+	snprintf(from_to_number, sizeof(from_to_number), "%s->%s", from_number,
+			to_number);
+
+	l1.s = test_id_str;
+	l1.len = (int)strlen(test_id_str);
+	l2.s = scenario_name;
+	l2.len = (int)strlen(scenario_name);
+	l3.s = from_to_number;
+	l3.len = (int)strlen(from_to_number);
+
+	/* Counter: Total calls started */
+	s_name.s = "sipp_calls_started_total";
+	s_name.len = (int)strlen(s_name.s);
+	_sipp_prom_api.counter_inc(&s_name, test->calls_started, &l1, &l2, &l3);
+
+	/* Counter: Total calls completed */
+	s_name.s = "sipp_calls_completed_total";
+	s_name.len = (int)strlen(s_name.s);
+	_sipp_prom_api.counter_inc(&s_name, test->calls_completed, &l1, &l2, &l3);
+
+	/* Counter: Total calls failed */
+	s_name.s = "sipp_calls_failed_total";
+	s_name.len = (int)strlen(s_name.s);
+	_sipp_prom_api.counter_inc(&s_name, test->calls_failed, &l1, &l2, &l3);
+
+	/* Gauge: Active calls */
+	s_name.s = "sipp_calls_active";
+	s_name.len = (int)strlen(s_name.s);
+	_sipp_prom_api.gauge_set(
+			&s_name, (double)test->calls_active, &l1, &l2, &l3);
+
+	/* Gauge: Concurrent calls configured */
+	s_name.s = "sipp_concurrent_calls_configured";
+	s_name.len = (int)strlen(s_name.s);
+	_sipp_prom_api.gauge_set(
+			&s_name, (double)test->concurrent_calls, &l1, &l2, &l3);
+
+	LM_DBG("pushed metrics for test %d to Prometheus (from=%s, to=%s)\n",
+			test->test_id, test->from_number, test->to_number);
+}
+
+
+/**
+ * Check if Prometheus integration is enabled
+ */
+int sipp_prom_is_enabled(void)
+{
+	return _sipp_prom_enabled;
+}

--- a/src/modules/sipp/sipp_prom.h
+++ b/src/modules/sipp/sipp_prom.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2026 Aurora Innovation AB
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _SIPP_PROM_H_
+#define _SIPP_PROM_H_
+
+#include "sipp_test.h"
+
+/**
+ * Initialize Prometheus integration
+ * Checks if xhttp_prom module is loaded
+ * @return 0 on success, -1 on error
+ */
+int sipp_prom_init(void);
+
+/**
+ * Push SIPp test metrics to Prometheus
+ * @param test Test structure containing metrics
+ */
+void sipp_prom_push_metrics(sipp_test_t *test);
+
+/**
+ * Check if Prometheus integration is enabled
+ * @return 1 if enabled, 0 if disabled
+ */
+int sipp_prom_is_enabled(void);
+
+#endif /* _SIPP_PROM_H_ */

--- a/src/modules/sipp/sipp_rpc.c
+++ b/src/modules/sipp/sipp_rpc.c
@@ -1,0 +1,1043 @@
+/**
+ * Copyright (C) 2026 Aurora Innovation AB
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+#include "../../core/dprint.h"
+#include "../../core/rpc.h"
+#include "../../core/rpc_lookup.h"
+#include "../../core/ut.h"
+
+#include "sipp_test.h"
+#include "sipp_rpc.h"
+
+
+/**
+ * RPC: sipp.start_test
+ *
+ * Start a new SIPp test
+ *
+ * Parameters:
+ * - scenario (string, required): Name of the SIPp XML scenario
+ * - caller (string, optional): Caller user/number/range/list
+ * - service (string, optional): Service user/number/range/list
+ * - target_domain (string, optional): Target domain (overrides module param)
+ * - concurrent_calls (int, optional): Number of concurrent calls
+ * - duration (int, optional): Call duration in seconds
+ * - total_calls (int, optional): Max total calls (0 = unlimited)
+ * - max_test_duration (int, optional): Max test duration in seconds (0 = unlimited)
+ *
+ * Returns:
+ * - test_id (int): Unique test identifier
+ * - status (string): "started"
+ *
+ * Example:
+ *   kamcmd sipp.start_test scenario=uac.xml caller=1000 service=2000 \
+ *           target_domain=sip.example.com concurrent_calls=50 duration=60
+ */
+static void sipp_rpc_start_test(rpc_t *rpc, void *ctx)
+{
+	str scenario = STR_NULL;
+	str first_param = STR_NULL;
+	str param = STR_NULL;
+	str param_list[8];
+	str target_domain = STR_NULL;
+	str caller = STR_NULL;
+	str service = STR_NULL;
+	int concurrent_calls = -1;
+	int duration = -1;
+	int total_calls = -1;
+	int max_test_duration = -1;
+	sipp_test_params_t params;
+	int param_count = 0;
+	int positional_idx = 0;
+	int i = 0;
+	int ival = 0;
+	int test_id = 0;
+	void *th = NULL;
+
+	LM_DBG("RPC start_test called\n");
+
+	/* Read first parameter (may be scenario or key=value) */
+	if(rpc->scan(ctx, "S", &first_param) < 1 || first_param.s == NULL
+			|| first_param.len <= 0) {
+		LM_ERR("Failed to scan scenario parameter\n");
+		rpc->fault(ctx, 400, "Missing required parameter: scenario");
+		return;
+	}
+
+	/* Collect remaining parameters (positional or key=value), max 8 */
+	while(rpc->scan(ctx, "*.S", &param) > 0) {
+		if(param_count < 8) {
+			param_list[param_count++] = param;
+		} else {
+			LM_WARN("Ignoring extra parameter beyond expected 7\n");
+		}
+	}
+
+	/* If first parameter is key=value, push it to the list; otherwise treat as scenario */
+	{
+		char *eq = memchr(first_param.s, '=', first_param.len);
+		if(eq != NULL) {
+			if(param_count < 8) {
+				param_list[param_count++] = first_param;
+			} else {
+				LM_WARN("Ignoring extra parameter beyond expected 8\n");
+			}
+		} else {
+			scenario = first_param;
+		}
+	}
+
+	for(i = 0; i < param_count; i++) {
+		char *eq = memchr(param_list[i].s, '=', param_list[i].len);
+		if(eq != NULL) {
+			str key;
+			str val;
+			key.s = param_list[i].s;
+			key.len = (int)(eq - param_list[i].s);
+			val.s = eq + 1;
+			val.len = param_list[i].len - key.len - 1;
+
+			if(key.len == 8 && strncmp(key.s, "scenario", 8) == 0) {
+				if(val.len > 0)
+					scenario = val;
+			} else if(key.len == 6 && strncmp(key.s, "caller", 6) == 0) {
+				caller = val;
+			} else if(key.len == 7 && strncmp(key.s, "service", 7) == 0) {
+				service = val;
+			} else if(key.len == 13
+					  && strncmp(key.s, "target_domain", 13) == 0) {
+				target_domain = val;
+			} else if(key.len == 16
+					  && strncmp(key.s, "concurrent_calls", 16) == 0) {
+				if(val.len > 0 && str2sint(&val, &ival) == 0) {
+					concurrent_calls = ival;
+				} else if(val.len > 0) {
+					rpc->fault(ctx, 400, "Invalid concurrent_calls parameter");
+					return;
+				}
+			} else if(key.len == 8 && strncmp(key.s, "duration", 8) == 0) {
+				if(val.len > 0 && str2sint(&val, &ival) == 0) {
+					duration = ival;
+				} else if(val.len > 0) {
+					rpc->fault(ctx, 400, "Invalid duration parameter");
+					return;
+				}
+			} else if(key.len == 11 && strncmp(key.s, "total_calls", 11) == 0) {
+				if(val.len > 0 && str2sint(&val, &ival) == 0) {
+					total_calls = ival;
+				} else if(val.len > 0) {
+					rpc->fault(ctx, 400, "Invalid total_calls parameter");
+					return;
+				}
+			} else if(key.len == 17
+					  && strncmp(key.s, "max_test_duration", 17) == 0) {
+				if(val.len > 0 && str2sint(&val, &ival) == 0) {
+					max_test_duration = ival;
+				} else if(val.len > 0) {
+					rpc->fault(ctx, 400, "Invalid max_test_duration parameter");
+					return;
+				}
+			} else {
+				LM_WARN("Unknown parameter '%.*s' ignored\n", key.len, key.s);
+			}
+		} else {
+			switch(positional_idx) {
+				case 0:
+					caller = param_list[i];
+					break;
+				case 1:
+					service = param_list[i];
+					break;
+				case 2:
+					target_domain = param_list[i];
+					break;
+				case 3:
+					if(str2sint(&param_list[i], &ival) == 0) {
+						concurrent_calls = ival;
+					} else {
+						rpc->fault(
+								ctx, 400, "Invalid concurrent_calls parameter");
+						return;
+					}
+					break;
+				case 4:
+					if(str2sint(&param_list[i], &ival) == 0) {
+						duration = ival;
+					} else {
+						rpc->fault(ctx, 400, "Invalid duration parameter");
+						return;
+					}
+					break;
+				case 5:
+					if(str2sint(&param_list[i], &ival) == 0) {
+						total_calls = ival;
+					} else {
+						rpc->fault(ctx, 400, "Invalid total_calls parameter");
+						return;
+					}
+					break;
+				case 6:
+					if(str2sint(&param_list[i], &ival) == 0) {
+						max_test_duration = ival;
+					} else {
+						rpc->fault(ctx, 400,
+								"Invalid max_test_duration parameter");
+						return;
+					}
+					break;
+				default:
+					break;
+			}
+			positional_idx++;
+		}
+	}
+
+	/* Scenario is required after parsing */
+	if(scenario.s == NULL || scenario.len <= 0) {
+		LM_ERR("Missing scenario parameter after parsing\n");
+		rpc->fault(ctx, 400, "Missing required parameter: scenario");
+		return;
+	}
+
+	/* Validate scenario */
+	if(scenario.s == NULL || scenario.len <= 0) {
+		rpc->fault(ctx, 400, "Invalid scenario parameter");
+		return;
+	}
+
+	/* Initialize params structure */
+	memset(&params, 0, sizeof(params));
+	params.scenario = scenario;
+
+	/* Set caller (optional, defaults will be used if not provided) */
+	if(caller.s != NULL && caller.len > 0) {
+		params.from_number = caller;
+	}
+
+	/* Set service (optional, defaults will be used if not provided) */
+	if(service.s != NULL && service.len > 0) {
+		params.to_number = service;
+	}
+
+	/* Set target_domain (optional, module default will be used if not provided) */
+	if(target_domain.s != NULL && target_domain.len > 0) {
+		params.target_domain = target_domain;
+	}
+
+	/* Set concurrent_calls (use module default if not provided) */
+	if(concurrent_calls > 0) {
+		params.concurrent_calls = concurrent_calls;
+	} else {
+		params.concurrent_calls = sipp_get_default_concurrent_calls();
+	}
+
+	/* Set duration (use module default if not provided) */
+	if(duration > 0) {
+		params.duration = duration;
+	} else {
+		params.duration = sipp_get_default_duration();
+	}
+
+	/* Set total_calls (0 = unlimited, use module default if not provided) */
+	if(total_calls >= 0) {
+		params.total_calls_limit = total_calls;
+	} else {
+		params.total_calls_limit = sipp_get_default_total_calls();
+	}
+
+	/* Set max_test_duration (0 = unlimited, use module default if not provided) */
+	if(max_test_duration >= 0) {
+		params.max_test_duration = max_test_duration;
+	} else {
+		params.max_test_duration = sipp_get_default_max_test_duration();
+	}
+
+	LM_DBG("starting test: scenario=%.*s, caller=%.*s, service=%.*s, "
+		   "domain=%.*s, "
+		   "calls=%d, duration=%d, total_calls=%d, max_test_duration=%d\n",
+			params.scenario.len, params.scenario.s, params.from_number.len,
+			params.from_number.s, params.to_number.len, params.to_number.s,
+			params.target_domain.len, params.target_domain.s,
+			params.concurrent_calls, params.duration, params.total_calls_limit,
+			params.max_test_duration);
+
+
+	/* Start the test */
+	if(sipp_test_start(&params, &test_id) < 0) {
+		rpc->fault(ctx, 500, "Failed to start SIPp test");
+		return;
+	}
+
+	/* Return test_id and status */
+	if(rpc->add(ctx, "{", &th) < 0) {
+		rpc->fault(ctx, 500, "Failed to create response");
+		return;
+	}
+
+	{
+		sipp_test_t test_copy;
+		int pid = 0;
+		if(sipp_test_get_copy(test_id, &test_copy) == 0) {
+			pid = test_copy.pid;
+		}
+		if(rpc->struct_add(th, "dsd", "test_id", test_id, "status", "started",
+				   "pid", pid)
+				< 0) {
+			rpc->fault(ctx, 500, "Failed to add response fields");
+			return;
+		}
+	}
+
+	LM_INFO("test %d started successfully\n", test_id);
+}
+
+
+static const char *sipp_rpc_start_test_doc[] = {"Start a new SIPp test",
+		"Parameters:",
+		"  scenario (string, required) - Name of the SIPp XML scenario",
+		"  caller (string, optional) - Caller user/number/range/list",
+		"  service (string, optional) - Service user/number/range/list",
+		"  target_domain (string, optional) - Target domain",
+		"  concurrent_calls (int, optional) - Number of concurrent calls",
+		"  duration (int, optional) - Call duration in seconds",
+		"  total_calls (int, optional) - Max total calls (0 = unlimited)",
+		"  max_test_duration (int, optional) - Max test duration in seconds (0 "
+		"= unlimited)",
+		"Example:", "  kamcmd sipp.start_test uac.xml",
+		"  kamcmd sipp.start_test uac.xml 1000 2000 sip.example.com 50 60", 0};
+
+
+/**
+ * RPC: sipp.stop_test
+ *
+ * Stop a running SIPp test
+ *
+ * Parameters:
+ * - test_id (int, required): Test ID to stop
+ *
+ * Returns:
+ * - test_id (int): Test identifier
+ * - status (string): "stopped"
+ *
+ * Example:
+ *   kamcmd sipp.stop_test 1
+ */
+static void sipp_rpc_stop_test(rpc_t *rpc, void *ctx)
+{
+	int test_id = 0;
+	void *th = NULL;
+
+	/* Parse test_id parameter */
+	if(rpc->scan(ctx, "d", &test_id) < 1) {
+		rpc->fault(ctx, 400, "Missing required parameter: test_id");
+		return;
+	}
+
+	if(test_id <= 0) {
+		rpc->fault(ctx, 400, "Invalid test_id");
+		return;
+	}
+
+	LM_DBG("stopping test %d\n", test_id);
+
+	/* Stop the test */
+	if(sipp_test_stop(test_id) < 0) {
+		rpc->fault(ctx, 404, "Test not found or not running");
+		return;
+	}
+
+	/* Return test_id and status */
+	if(rpc->add(ctx, "{", &th) < 0) {
+		rpc->fault(ctx, 500, "Failed to create response");
+		return;
+	}
+
+	if(rpc->struct_add(th, "ds", "test_id", test_id, "status", "stopped") < 0) {
+		rpc->fault(ctx, 500, "Failed to add response fields");
+		return;
+	}
+
+	LM_DBG("test %d stopped successfully\n", test_id);
+}
+
+
+static const char *sipp_rpc_stop_test_doc[] = {"Stop a running SIPp test",
+		"Parameters:", "  test_id (int, required) - Test ID to stop",
+		"Example:", "  kamcmd sipp.stop_test 1", 0};
+
+
+/**
+ * RPC: sipp.get_stats
+ *
+ * Get statistics for a SIPp test
+ *
+ * Parameters:
+ * - test_id (int, required): Test ID to query
+ *
+ * Returns:
+ * - test_id (int): Test identifier
+ * - state (string): Test state (running, stopped, completed, failed)
+ * - scenario (string): Scenario name
+ * - caller (string): Caller
+ * - service (string): Service
+ * - target_domain (string): Target domain
+ * - concurrent_calls (int): Number of concurrent calls
+ * - duration (int): Test duration
+ * - start_time (int): Start timestamp
+ * - end_time (int): End timestamp (0 if running)
+ * - calls_started (int): Calls started
+ * - calls_completed (int): Calls completed
+ * - calls_failed (int): Calls failed
+ *
+ * Example:
+ *   kamcmd sipp.get_stats 1
+ */
+static void sipp_rpc_get_stats(rpc_t *rpc, void *ctx)
+{
+	int test_id = 0;
+	sipp_test_t test_copy;
+	void *th = NULL;
+	const char *state_str = "unknown";
+
+	/* Parse test_id parameter */
+	if(rpc->scan(ctx, "d", &test_id) < 1) {
+		rpc->fault(ctx, 400, "Missing required parameter: test_id");
+		return;
+	}
+
+	if(test_id <= 0) {
+		rpc->fault(ctx, 400, "Invalid test_id");
+		return;
+	}
+
+	LM_DBG("getting stats for test %d\n", test_id);
+
+	/* First update live stats from stat file */
+	sipp_test_get_live_stats(test_id);
+
+	/* Get thread-safe copy of test data */
+	if(sipp_test_get_copy(test_id, &test_copy) < 0) {
+		rpc->fault(ctx, 404, "Test not found");
+		return;
+	}
+
+	/* Convert state to string */
+	switch(test_copy.state) {
+		case SIPP_TEST_STATE_RUNNING:
+			state_str = "running";
+			break;
+		case SIPP_TEST_STATE_STOPPED:
+			state_str = "stopped";
+			break;
+		case SIPP_TEST_STATE_COMPLETED:
+			state_str = "completed";
+			break;
+		case SIPP_TEST_STATE_FAILED:
+			state_str = "failed";
+			break;
+		default:
+			state_str = "unknown";
+			break;
+	}
+
+	/* Build response */
+	if(rpc->add(ctx, "{", &th) < 0) {
+		rpc->fault(ctx, 500, "Failed to create response");
+		return;
+	}
+
+	if(rpc->struct_add(th, "dsssssddddddddd", "test_id", test_copy.test_id,
+			   "state", state_str, "scenario", test_copy.scenario, "caller",
+			   test_copy.from_number, "service", test_copy.to_number,
+			   "target_domain", test_copy.target_domain, "concurrent_calls",
+			   // Removed logging of resolved RPC parameters
+
+			   "total_calls", test_copy.total_calls_limit, "max_test_duration",
+			   test_copy.max_test_duration, "start_time",
+			   (int)test_copy.start_time, "end_time", (int)test_copy.end_time,
+			   "calls_started", test_copy.calls_started, "calls_completed",
+			   test_copy.calls_completed, "calls_failed",
+			   test_copy.calls_failed)
+			< 0) {
+		rpc->fault(ctx, 500, "Failed to add response fields");
+		return;
+	}
+
+	LM_DBG("returned stats for test %d\n", test_id);
+}
+
+
+static const char *sipp_rpc_get_stats_doc[] = {"Get statistics for a SIPp test",
+		"Parameters:", "  test_id (int, required) - Test ID to query",
+		"Returns:",
+		"  test_id, state, scenario, caller, service, target_domain,",
+		"  concurrent_calls, duration, total_calls, max_test_duration,",
+		"  start_time, end_time,",
+		"  calls_started, calls_completed, calls_failed",
+		"Example:", "  kamcmd sipp.get_stats 1", 0};
+
+
+/**
+ * RPC: sipp.running
+ *
+ * List all running and recent SIPp tests
+ *
+ * Returns:
+ * - Array of test information structures
+ *
+ * Example:
+ *   kamcmd sipp.running
+ */
+static void sipp_rpc_running(rpc_t *rpc, void *ctx)
+{
+	sipp_test_t *test = NULL;
+	void *th = NULL;
+	const char *state_str = "unknown";
+	int count = 0;
+
+	LM_DBG("listing all tests\n");
+
+	/* Lock for entire traversal to prevent race conditions */
+	sipp_test_lock();
+
+	/* Get all tests */
+	test = sipp_test_get_all();
+
+	while(test != NULL) {
+		int cur_id = test->test_id;
+		sipp_test_t *found = NULL;
+		sipp_test_t *next = test->next;
+
+		// Removed logging of effective test parameters
+		sipp_test_update_stats(test);
+
+		/* Refresh live stats from CSV without holding the lock */
+		sipp_test_unlock();
+		sipp_test_get_live_stats(cur_id);
+		sipp_test_lock();
+		/* Find test again (may have moved/been removed) */
+		found = sipp_test_get_all();
+		while(found != NULL && found->test_id != cur_id) {
+			found = found->next;
+		}
+		if(found == NULL) {
+			/* Continue from next if possible */
+			test = next;
+			continue;
+		}
+		test = found;
+
+		/* Convert state to string */
+		switch(test->state) {
+			case SIPP_TEST_STATE_RUNNING:
+				state_str = "running";
+				break;
+			case SIPP_TEST_STATE_STOPPED:
+				state_str = "stopped";
+				break;
+			case SIPP_TEST_STATE_COMPLETED:
+				state_str = "completed";
+				break;
+			case SIPP_TEST_STATE_FAILED:
+				state_str = "failed";
+				break;
+			default:
+				state_str = "unknown";
+				break;
+		}
+
+		/* Add test info */
+		if(rpc->add(ctx, "{", &th) < 0) {
+			sipp_test_unlock();
+			rpc->fault(ctx, 500, "Failed to create response");
+			return;
+		}
+
+		if(rpc->struct_add(th, "dsssssddddddddd", "test_id", test->test_id,
+				   "state", state_str, "scenario", test->scenario, "caller",
+				   test->from_number, "service", test->to_number,
+				   "target_domain", test->target_domain, "concurrent_calls",
+				   test->concurrent_calls, "duration", test->duration,
+				   "total_calls", test->total_calls_limit, "max_test_duration",
+				   test->max_test_duration, "start_time", (int)test->start_time,
+				   "end_time", (int)test->end_time, "calls_started",
+				   test->calls_started, "calls_completed",
+				   test->calls_completed, "calls_failed", test->calls_failed)
+				< 0) {
+			sipp_test_unlock();
+			rpc->fault(ctx, 500, "Failed to add response fields");
+			return;
+		}
+
+		count++;
+		test = test->next;
+	}
+
+	sipp_test_unlock();
+	LM_DBG("listed %d tests\n", count);
+}
+
+
+static const char *sipp_rpc_running_doc[] = {
+		"List all running and recent SIPp tests",
+		"Returns:", "  Array of test information structures",
+		"Example:", "  kamcmd sipp.running", 0};
+
+/**
+ * RPC: sipp.list
+ *
+ * List available SIPp scenario files from the configured scenario_dir
+ *
+ * Returns:
+ * - Array of scenario information structures
+ *
+ * Example:
+ *   kamcmd sipp.list
+ */
+static void sipp_rpc_list(rpc_t *rpc, void *ctx)
+{
+	void *th = NULL;
+	str *scenario_dir_str = NULL;
+	char *scenario_dir = NULL;
+	DIR *dir = NULL;
+	struct dirent *entry = NULL;
+	int count = 0;
+
+	/* Get scenario directory */
+	scenario_dir_str = sipp_get_scenario_dir();
+	if(scenario_dir_str == NULL || scenario_dir_str->s == NULL
+			|| scenario_dir_str->len == 0) {
+		rpc->fault(ctx, 500, "Scenario directory not configured");
+		return;
+	}
+
+	scenario_dir = scenario_dir_str->s;
+	LM_DBG("listing scenarios from directory: %s\n", scenario_dir);
+
+	/* Open directory */
+	dir = opendir(scenario_dir);
+	if(dir == NULL) {
+		LM_ERR("failed to open scenario directory '%s': %s\n", scenario_dir,
+				strerror(errno));
+		rpc->fault(ctx, 500, "Failed to open scenario directory");
+		return;
+	}
+
+	/* Read directory entries */
+	while((entry = readdir(dir)) != NULL) {
+		char filepath[512];
+		struct stat st;
+		int len = strlen(entry->d_name);
+		FILE *f = NULL;
+		char line[512];
+		char scenario_name[256] = "";
+
+		/* Skip . and .. */
+		if(strcmp(entry->d_name, ".") == 0
+				|| strcmp(entry->d_name, "..") == 0) {
+			continue;
+		}
+
+		/* Only show .xml files */
+		if(len < 4 || strcmp(entry->d_name + len - 4, ".xml") != 0) {
+			continue;
+		}
+
+		/* Build full path */
+		snprintf(filepath, sizeof(filepath), "%s/%s", scenario_dir,
+				entry->d_name);
+
+		/* Check if it's a regular file */
+		if(stat(filepath, &st) != 0 || !S_ISREG(st.st_mode)) {
+			continue;
+		}
+
+		/* Try to extract scenario name from XML */
+		f = fopen(filepath, "r");
+		if(f != NULL) {
+			while(fgets(line, sizeof(line), f) != NULL) {
+				char *p = strstr(line, "<scenario");
+				if(p != NULL) {
+					char *name_start = strstr(p, "name=\"");
+					if(name_start != NULL) {
+						name_start += 6; /* Skip 'name="' */
+						char *name_end = strchr(name_start, '"');
+						if(name_end != NULL) {
+							int name_len = name_end - name_start;
+							if(name_len > 0
+									&& name_len < sizeof(scenario_name)) {
+								strncpy(scenario_name, name_start, name_len);
+								scenario_name[name_len] = '\0';
+							}
+						}
+					}
+					break;
+				}
+			}
+			fclose(f);
+		}
+
+		/* Add scenario info */
+		if(rpc->add(ctx, "{", &th) < 0) {
+			rpc->fault(ctx, 500, "Failed to create response");
+			closedir(dir);
+			return;
+		}
+
+		if(scenario_name[0] != '\0') {
+			if(rpc->struct_add(th, "ssd", "scenario", entry->d_name, "name",
+					   scenario_name, "size", (int)st.st_size)
+					< 0) {
+				rpc->fault(ctx, 500, "Failed to add response fields");
+				closedir(dir);
+				return;
+			}
+		} else {
+			if(rpc->struct_add(th, "sd", "scenario", entry->d_name, "size",
+					   (int)st.st_size)
+					< 0) {
+				rpc->fault(ctx, 500, "Failed to add response fields");
+				closedir(dir);
+				return;
+			}
+		}
+
+		count++;
+	}
+
+	closedir(dir);
+	LM_DBG("listed %d scenarios\n", count);
+}
+
+
+static const char *sipp_rpc_list_doc[] = {"List available SIPp scenario files",
+		"Returns:", "  Array of scenario files with size",
+		"Example:", "  kamcmd sipp.list", 0};
+
+
+/**
+ * RPC: sipp.pause_test
+ *
+ * Pause a running SIPp test (requires remote control enabled)
+ *
+ * Parameters:
+ * - test_id (int, required): Test ID to pause
+ *
+ * Returns:
+ * - test_id (int): Test identifier
+ * - status (string): "paused"
+ *
+ * Example:
+ *   kamcmd sipp.pause_test 1
+ */
+static void sipp_rpc_pause_test(rpc_t *rpc, void *ctx)
+{
+	int test_id = 0;
+	void *th = NULL;
+
+	/* Parse test_id parameter */
+	if(rpc->scan(ctx, "d", &test_id) < 1) {
+		rpc->fault(ctx, 400, "Missing required parameter: test_id");
+		return;
+	}
+
+	if(test_id <= 0) {
+		rpc->fault(ctx, 400, "Invalid test_id");
+		return;
+	}
+
+	LM_DBG("pausing test %d\n", test_id);
+
+	/* Send pause command */
+	if(sipp_test_control_command(test_id, 'p') < 0) {
+		rpc->fault(ctx, 500,
+				"Failed to pause test (remote control may not be enabled)");
+		return;
+	}
+
+	/* Return test_id and status */
+	if(rpc->add(ctx, "{", &th) < 0) {
+		rpc->fault(ctx, 500, "Failed to create response");
+		return;
+	}
+
+	if(rpc->struct_add(th, "ds", "test_id", test_id, "status", "paused") < 0) {
+		rpc->fault(ctx, 500, "Failed to add response fields");
+		return;
+	}
+
+	LM_DBG("test %d paused successfully\n", test_id);
+}
+
+
+static const char *sipp_rpc_pause_test_doc[] = {
+		"Pause a running SIPp test (requires remote control)",
+		"Parameters:", "  test_id (int, required) - Test ID to pause",
+		"Example:", "  kamcmd sipp.pause_test 1", 0};
+
+
+/**
+ * RPC: sipp.resume_test
+ *
+ * Resume a paused SIPp test (requires remote control enabled)
+ *
+ * Parameters:
+ * - test_id (int, required): Test ID to resume
+ *
+ * Returns:
+ * - test_id (int): Test identifier
+ * - status (string): "resumed"
+ *
+ * Example:
+ *   kamcmd sipp.resume_test 1
+ */
+static void sipp_rpc_resume_test(rpc_t *rpc, void *ctx)
+{
+	int test_id = 0;
+	void *th = NULL;
+
+	/* Parse test_id parameter */
+	if(rpc->scan(ctx, "d", &test_id) < 1) {
+		rpc->fault(ctx, 400, "Missing required parameter: test_id");
+		return;
+	}
+
+	if(test_id <= 0) {
+		rpc->fault(ctx, 400, "Invalid test_id");
+		return;
+	}
+
+	LM_DBG("resuming test %d\n", test_id);
+
+	/* Send resume command */
+	if(sipp_test_control_command(test_id, 'r') < 0) {
+		rpc->fault(ctx, 500,
+				"Failed to resume test (remote control may not be enabled)");
+		return;
+	}
+
+	/* Return test_id and status */
+	if(rpc->add(ctx, "{", &th) < 0) {
+		rpc->fault(ctx, 500, "Failed to create response");
+		return;
+	}
+
+	if(rpc->struct_add(th, "ds", "test_id", test_id, "status", "resumed") < 0) {
+		rpc->fault(ctx, 500, "Failed to add response fields");
+		return;
+	}
+
+	LM_DBG("test %d resumed successfully\n", test_id);
+}
+
+
+static const char *sipp_rpc_resume_test_doc[] = {
+		"Resume a paused SIPp test (requires remote control)",
+		"Parameters:", "  test_id (int, required) - Test ID to resume",
+		"Example:", "  kamcmd sipp.resume_test 1", 0};
+
+
+/**
+ * RPC: sipp.adjust_rate
+ *
+ * Adjust call rate of a running SIPp test (requires remote control enabled)
+ *
+ * Parameters:
+ * - test_id (int, required): Test ID
+ * - change (string, required): "increase" or "decrease"
+ *
+ * Returns:
+ * - test_id (int): Test identifier
+ * - status (string): "rate_adjusted"
+ *
+ * Example:
+ *   kamcmd sipp.adjust_rate 1 increase
+ */
+static void sipp_rpc_adjust_rate(rpc_t *rpc, void *ctx)
+{
+	int test_id = 0;
+	char *change_str = NULL;
+	char rate_cmd;
+	void *th = NULL;
+
+	/* Parse parameters */
+	if(rpc->scan(ctx, "ds", &test_id, &change_str) < 2) {
+		rpc->fault(ctx, 400, "Missing required parameters: test_id, change");
+		return;
+	}
+
+	if(test_id <= 0) {
+		rpc->fault(ctx, 400, "Invalid test_id");
+		return;
+	}
+
+	if(strcmp(change_str, "increase") == 0) {
+		rate_cmd = '+';
+	} else if(strcmp(change_str, "decrease") == 0) {
+		rate_cmd = '-';
+	} else {
+		rpc->fault(ctx, 400,
+				"Invalid change value (use 'increase' or 'decrease')");
+		return;
+	}
+
+	LM_DBG("adjusting rate for test %d (%c)\n", test_id, rate_cmd);
+
+	/* Send rate adjustment command */
+	if(sipp_test_adjust_rate(test_id, rate_cmd) < 0) {
+		rpc->fault(ctx, 500,
+				"Failed to adjust rate (remote control may not be enabled)");
+		return;
+	}
+
+	/* Return test_id and status */
+	if(rpc->add(ctx, "{", &th) < 0) {
+		rpc->fault(ctx, 500, "Failed to create response");
+		return;
+	}
+
+	if(rpc->struct_add(th, "ds", "test_id", test_id, "status", "rate_adjusted")
+			< 0) {
+		rpc->fault(ctx, 500, "Failed to add response fields");
+		return;
+	}
+
+	LM_DBG("test %d rate adjusted (%s)\n", test_id, change_str);
+}
+
+
+static const char *sipp_rpc_adjust_rate_doc[] = {
+		"Adjust call rate of a running SIPp test (requires remote control)",
+		"Parameters:", "  test_id (int, required) - Test ID",
+		"  change (string, required) - 'increase' or 'decrease'",
+		"Example:", "  kamcmd sipp.adjust_rate 1 increase", 0};
+
+
+/**
+ * RPC: sipp.get_live_stats
+ *
+ * Get real-time statistics from SIPp control socket
+ *
+ * Parameters:
+ * - test_id (int, required): Test ID to query
+ *
+ * Returns:
+ * - test_id (int): Test identifier
+ * - calls_active (int): Currently active calls
+ * - calls_started (int): Total calls started
+ * - calls_completed (int): Calls completed successfully
+ * - calls_failed (int): Failed calls
+ *
+ * Example:
+ *   kamcmd sipp.get_live_stats 1
+ */
+static void sipp_rpc_get_live_stats(rpc_t *rpc, void *ctx)
+{
+	int test_id = 0;
+	sipp_test_t test_copy;
+	void *th = NULL;
+
+	/* Parse test_id parameter */
+	if(rpc->scan(ctx, "d", &test_id) < 1) {
+		rpc->fault(ctx, 400, "Missing required parameter: test_id");
+		return;
+	}
+
+	if(test_id <= 0) {
+		rpc->fault(ctx, 400, "Invalid test_id");
+		return;
+	}
+
+	LM_DBG("getting live stats for test %d\n", test_id);
+
+	/* Get live stats from stat file */
+	if(sipp_test_get_live_stats(test_id) < 0) {
+		rpc->fault(ctx, 500, "Failed to get live stats");
+		return;
+	}
+
+	/* Get thread-safe copy of test data */
+	if(sipp_test_get_copy(test_id, &test_copy) < 0) {
+		rpc->fault(ctx, 404, "Test not found");
+		return;
+	}
+
+	/* Return stats */
+	if(rpc->add(ctx, "{", &th) < 0) {
+		rpc->fault(ctx, 500, "Failed to create response");
+		return;
+	}
+
+	if(rpc->struct_add(th, "ddddd", "test_id", test_copy.test_id,
+			   "calls_active", test_copy.calls_active, "calls_started",
+			   test_copy.calls_started, "calls_completed",
+			   test_copy.calls_completed, "calls_failed",
+			   test_copy.calls_failed)
+			< 0) {
+		rpc->fault(ctx, 500, "Failed to add response fields");
+		return;
+	}
+
+	LM_DBG("live stats retrieved for test %d\n", test_id);
+}
+
+
+static const char *sipp_rpc_get_live_stats_doc[] = {
+		"Get real-time statistics from SIPp stat file",
+		"Parameters:", "  test_id (int, required) - Test ID to query",
+		"Example:", "  kamcmd sipp.get_live_stats 1", 0};
+
+/* RPC command exports */
+/* clang-format off */
+rpc_export_t sipp_rpc_cmds[] = {
+	{"sipp.start_test", sipp_rpc_start_test, sipp_rpc_start_test_doc, 0},
+	{"sipp.stop_test", sipp_rpc_stop_test, sipp_rpc_stop_test_doc, 0},
+	{"sipp.get_stats", sipp_rpc_get_stats, sipp_rpc_get_stats_doc, 0},
+	{"sipp.running", sipp_rpc_running, sipp_rpc_running_doc, RET_ARRAY},
+	{"sipp.list", sipp_rpc_list, sipp_rpc_list_doc, RET_ARRAY},
+	{"sipp.pause_test", sipp_rpc_pause_test, sipp_rpc_pause_test_doc, 0},
+	{"sipp.resume_test", sipp_rpc_resume_test, sipp_rpc_resume_test_doc, 0},
+	{"sipp.adjust_rate", sipp_rpc_adjust_rate, sipp_rpc_adjust_rate_doc, 0},
+	{"sipp.get_live_stats", sipp_rpc_get_live_stats, sipp_rpc_get_live_stats_doc, 0},
+	{0, 0, 0, 0}
+};
+/* clang-format on */
+
+
+/**
+ * Initialize RPC interface
+ */
+int sipp_rpc_init(void)
+{
+	if(rpc_register_array(sipp_rpc_cmds) != 0) {
+		LM_ERR("failed to register RPC commands\n");
+		return -1;
+	}
+
+	LM_DBG("RPC commands registered successfully\n");
+	return 0;
+}

--- a/src/modules/sipp/sipp_rpc.h
+++ b/src/modules/sipp/sipp_rpc.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2026 Aurora Innovation AB
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _SIPP_RPC_H_
+#define _SIPP_RPC_H_
+
+#include "../../core/rpc.h"
+
+/**
+ * Initialize RPC interface
+ * Registers all RPC commands
+ * @return 0 on success, -1 on error
+ */
+int sipp_rpc_init(void);
+
+#endif /* _SIPP_RPC_H_ */

--- a/src/modules/sipp/sipp_test.c
+++ b/src/modules/sipp/sipp_test.c
@@ -1,0 +1,2122 @@
+/**
+ * Copyright (C) 2026 Aurora Innovation AB
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* Enable GNU extensions for strsep, memmem */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <signal.h>
+#include <errno.h>
+#include <time.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <ctype.h>
+
+#include "../../core/dprint.h"
+#include "../../core/mem/mem.h"
+#include "../../core/mem/shm_mem.h"
+#include "../../core/socket_info.h"
+#include "../../core/ut.h"
+#include "../../core/locking.h"
+
+#include "sipp_test.h"
+#include "sipp_prom.h"
+
+/* Global test list (shared memory) */
+static sipp_test_t **_sipp_test_list = NULL;
+static gen_lock_t *_sipp_test_lock = NULL;
+static int *_sipp_test_counter = NULL;
+
+
+/**
+ * Acquire test list lock for external iteration
+ */
+void sipp_test_lock(void)
+{
+	if(_sipp_test_lock != NULL) {
+		lock_get(_sipp_test_lock);
+	}
+}
+
+
+/**
+ * Release test list lock
+ */
+void sipp_test_unlock(void)
+{
+	if(_sipp_test_lock != NULL) {
+		lock_release(_sipp_test_lock);
+	}
+}
+
+
+/**
+ * Validate string contains only safe characters for shell command
+ * Allows: alphanumeric, underscore, hyphen, dot, @, plus
+ * Returns: 0 if safe, -1 if contains unsafe characters
+ */
+int sipp_validate_safe_string(const char *str, int len)
+{
+	int i;
+
+	if(str == NULL || len <= 0) {
+		return -1;
+	}
+
+	for(i = 0; i < len; i++) {
+		unsigned char c = (unsigned char)str[i];
+		if(!isalnum(c) && c != '_' && c != '-' && c != '.' && c != '@'
+				&& c != '+') {
+			LM_ERR("unsafe character '%c' (0x%02x) at position %d\n", c, c, i);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+
+/**
+ * Validate target_domain string
+ * Allows: alphanumeric, underscore, hyphen, dot, @, plus, colon
+ */
+static int sipp_validate_target_domain(const char *str, int len)
+{
+	int i;
+
+	if(str == NULL || len <= 0) {
+		return -1;
+	}
+
+	for(i = 0; i < len; i++) {
+		unsigned char c = (unsigned char)str[i];
+		if(!isalnum(c) && c != '_' && c != '-' && c != '.' && c != '@'
+				&& c != '+' && c != ':') {
+			LM_ERR("unsafe character '%c' (0x%02x) at position %d\n", c, c, i);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+
+/**
+ * Validate scenario name (safe chars, no path traversal)
+ */
+int sipp_validate_scenario_name(const char *scenario, int len)
+{
+	if(scenario == NULL || len <= 0) {
+		LM_ERR("empty scenario name\n");
+		return -1;
+	}
+
+	/* Check for path traversal */
+	if(len >= 2
+			&& (strncmp(scenario, "..", 2) == 0
+					|| memmem(scenario, len, "/..", 3) != NULL
+					|| memmem(scenario, len, "../", 3) != NULL)) {
+		LM_ERR("scenario name contains path traversal\n");
+		return -1;
+	}
+
+	/* Cannot be absolute path */
+	if(scenario[0] == '/') {
+		LM_ERR("scenario name cannot be absolute path\n");
+		return -1;
+	}
+
+	/* Check for safe characters - allow / for subdirectories */
+	int i;
+	for(i = 0; i < len; i++) {
+		unsigned char c = (unsigned char)scenario[i];
+		if(!isalnum(c) && c != '_' && c != '-' && c != '.' && c != '/') {
+			LM_ERR("unsafe character '%c' in scenario name at position %d\n", c,
+					i);
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+
+/**
+ * Check if a UDP port is available for binding
+ * Used to verify control port is not already in use before starting SIPp
+ * @param ip IP address to bind to
+ * @param port Port number to check
+ * @return 0 if available, -1 if in use or error
+ */
+static int sipp_check_port_available(const char *ip, int port)
+{
+	int sock;
+	struct sockaddr_in addr;
+	int ret;
+	int reuse = 1;
+
+	if(ip == NULL || port <= 0 || port > 65535) {
+		return -1;
+	}
+
+	sock = socket(AF_INET, SOCK_DGRAM, 0);
+	if(sock < 0) {
+		LM_WARN("failed to create socket for port check: %s\n",
+				strerror(errno));
+		return -1;
+	}
+
+	/* Allow reuse to avoid TIME_WAIT issues */
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(port);
+	if(inet_pton(AF_INET, ip, &addr.sin_addr) <= 0) {
+		/* If IP parsing fails, try binding to INADDR_ANY */
+		addr.sin_addr.s_addr = INADDR_ANY;
+	}
+
+	ret = bind(sock, (struct sockaddr *)&addr, sizeof(addr));
+	close(sock);
+
+	if(ret < 0) {
+		LM_DBG("port %d is not available: %s\n", port, strerror(errno));
+		return -1;
+	}
+
+	LM_DBG("port %d is available\n", port);
+	return 0;
+}
+
+
+static int sipp_buf_has_token(
+		const char *buf, size_t len, const char *token, size_t tlen)
+{
+	size_t i;
+
+	if(buf == NULL || token == NULL || tlen == 0 || len < tlen) {
+		return 0;
+	}
+
+	for(i = 0; i + tlen <= len; i++) {
+		if(memcmp(buf + i, token, tlen) == 0) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+
+static int sipp_scenario_has_token(const char *path, const char *token)
+{
+	int fd;
+	char buf[4096 + 64];
+	ssize_t rlen;
+	size_t tlen;
+	size_t carry = 0;
+
+	if(path == NULL || token == NULL) {
+		return 0;
+	}
+
+	tlen = strlen(token);
+	if(tlen == 0 || tlen >= sizeof(buf)) {
+		return 0;
+	}
+
+	fd = open(path, O_RDONLY);
+	if(fd < 0) {
+		LM_WARN("failed to open scenario file for token scan: %s (%s)\n", path,
+				strerror(errno));
+		return 0;
+	}
+
+	while((rlen = read(fd, buf + carry, sizeof(buf) - carry)) > 0) {
+		size_t total = carry + (size_t)rlen;
+		if(sipp_buf_has_token(buf, total, token, tlen) == 1) {
+			close(fd);
+			return 1;
+		}
+		if(total >= tlen - 1) {
+			carry = tlen - 1;
+			memmove(buf, buf + total - carry, carry);
+		} else {
+			carry = total;
+		}
+	}
+
+	close(fd);
+	return 0;
+}
+
+
+/**
+ * Initialize test management system
+ */
+int sipp_test_init(void)
+{
+	_sipp_test_lock = lock_alloc();
+	if(_sipp_test_lock == NULL) {
+		LM_ERR("failed to allocate lock\n");
+		return -1;
+	}
+
+	if(lock_init(_sipp_test_lock) == 0) {
+		LM_ERR("failed to initialize lock\n");
+		lock_dealloc(_sipp_test_lock);
+		_sipp_test_lock = NULL;
+		return -1;
+	}
+
+	_sipp_test_list = (sipp_test_t **)shm_malloc(sizeof(sipp_test_t *));
+	if(_sipp_test_list == NULL) {
+		LM_ERR("failed to allocate test list head\n");
+		lock_dealloc(_sipp_test_lock);
+		_sipp_test_lock = NULL;
+		return -1;
+	}
+	*_sipp_test_list = NULL;
+
+	_sipp_test_counter = (int *)shm_malloc(sizeof(int));
+	if(_sipp_test_counter == NULL) {
+		LM_ERR("failed to allocate test counter\n");
+		shm_free(_sipp_test_list);
+		_sipp_test_list = NULL;
+		lock_dealloc(_sipp_test_lock);
+		_sipp_test_lock = NULL;
+		return -1;
+	}
+	*_sipp_test_counter = 0;
+
+	LM_DBG("test management system initialized\n");
+	return 0;
+}
+
+
+/**
+ * Cleanup and destroy all tests
+ */
+void sipp_test_destroy(void)
+{
+	sipp_test_t *test, *next;
+
+	if(_sipp_test_lock == NULL) {
+		return;
+	}
+
+	lock_get(_sipp_test_lock);
+
+	test = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+	while(test != NULL) {
+		next = test->next;
+
+		/* Stop running tests */
+		if(test->state == SIPP_TEST_STATE_RUNNING && test->pid > 0) {
+			int status;
+			LM_DBG("stopping test %d (pid %d)\n", test->test_id, test->pid);
+			kill(test->pid, SIGTERM);
+			/* Give it 500ms to terminate gracefully */
+			usleep(500000);
+			/* Check if process exited */
+			if(waitpid(test->pid, &status, WNOHANG) == 0) {
+				/* Still running, force kill */
+				LM_WARN("test %d did not respond to SIGTERM, sending SIGKILL\n",
+						test->test_id);
+				kill(test->pid, SIGKILL);
+				waitpid(test->pid, NULL, 0);
+			}
+		}
+
+		/* Close control socket if open */
+		if(test->control_socket > 0) {
+			close(test->control_socket);
+			test->control_socket = -1;
+		}
+
+		/* Remove log file */
+		if(test->log_file[0] != '\0') {
+			char extra_file[SIPP_MAX_LOG_PATH_LEN + 16];
+
+			if(unlink(test->log_file) < 0) {
+				LM_DBG("failed to remove log file %s: %s\n", test->log_file,
+						strerror(errno));
+			} else {
+				LM_DBG("removed log file %s\n", test->log_file);
+			}
+
+			snprintf(extra_file, sizeof(extra_file), "%s.exec.log",
+					test->log_file);
+			if(unlink(extra_file) < 0 && errno != ENOENT) {
+				LM_DBG("failed to remove exec log %s: %s\n", extra_file,
+						strerror(errno));
+			}
+
+			snprintf(extra_file, sizeof(extra_file), "%s.stat.csv",
+					test->log_file);
+			if(unlink(extra_file) < 0 && errno != ENOENT) {
+				LM_DBG("failed to remove stats file %s: %s\n", extra_file,
+						strerror(errno));
+			}
+
+			snprintf(extra_file, sizeof(extra_file), "%s.errors.log",
+					test->log_file);
+			if(unlink(extra_file) < 0 && errno != ENOENT) {
+				LM_DBG("failed to remove errors log %s: %s\n", extra_file,
+						strerror(errno));
+			}
+		}
+
+		shm_free(test);
+		test = next;
+	}
+
+	if(_sipp_test_list != NULL) {
+		*_sipp_test_list = NULL;
+	}
+	lock_release(_sipp_test_lock);
+
+	lock_destroy(_sipp_test_lock);
+	lock_dealloc(_sipp_test_lock);
+	_sipp_test_lock = NULL;
+
+	if(_sipp_test_list != NULL) {
+		shm_free(_sipp_test_list);
+		_sipp_test_list = NULL;
+	}
+	if(_sipp_test_counter != NULL) {
+		shm_free(_sipp_test_counter);
+		_sipp_test_counter = NULL;
+	}
+
+	LM_DBG("test management system destroyed\n");
+}
+
+
+/**
+ * Get transport type from module configuration
+ */
+int sipp_get_transport(void)
+{
+	str *send_socket_name = sipp_get_send_socket_name();
+	str *send_socket = sipp_get_send_socket();
+	socket_info_t *si = NULL;
+
+	/* Try send_socket_name first */
+	if(send_socket_name != NULL && send_socket_name->s != NULL
+			&& send_socket_name->len > 0) {
+		si = lookup_local_socket(send_socket_name);
+		if(si != NULL) {
+			switch(si->proto) {
+				case PROTO_UDP:
+					return SIPP_TRANSPORT_UDP;
+				case PROTO_TCP:
+					return SIPP_TRANSPORT_TCP;
+				case PROTO_TLS:
+					return SIPP_TRANSPORT_TLS;
+				default:
+					LM_WARN("unknown protocol %d, defaulting to UDP\n",
+							si->proto);
+					return SIPP_TRANSPORT_UDP;
+			}
+		}
+	}
+
+	/* Try send_socket (raw format) */
+	if(send_socket != NULL && send_socket->s != NULL && send_socket->len > 0) {
+		/* Parse protocol from <proto>:<ip>:<port> */
+		if(send_socket->len >= 3) {
+			if(strncasecmp(send_socket->s, "udp", 3) == 0) {
+				return SIPP_TRANSPORT_UDP;
+			} else if(strncasecmp(send_socket->s, "tcp", 3) == 0) {
+				return SIPP_TRANSPORT_TCP;
+			} else if(strncasecmp(send_socket->s, "tls", 3) == 0) {
+				return SIPP_TRANSPORT_TLS;
+			}
+		}
+	}
+
+	/* Default to UDP */
+	LM_DBG("no transport specified, defaulting to UDP\n");
+	return SIPP_TRANSPORT_UDP;
+}
+
+
+/**
+ * Get local IP address to bind SIPp
+ */
+int sipp_get_local_ip(char *ip_buf, int buf_len)
+{
+	str *send_socket_name = sipp_get_send_socket_name();
+	str *send_socket = sipp_get_send_socket();
+	socket_info_t *si = NULL;
+
+	if(ip_buf == NULL || buf_len <= 0) {
+		LM_ERR("invalid buffer\n");
+		return -1;
+	}
+
+	/* Try send_socket_name first */
+	if(send_socket_name != NULL && send_socket_name->s != NULL
+			&& send_socket_name->len > 0) {
+		si = lookup_local_socket(send_socket_name);
+		if(si != NULL) {
+			char *ip_str = ip_addr2a(&si->address);
+			if(ip_str != NULL) {
+				snprintf(ip_buf, buf_len, "%s", ip_str);
+				LM_DBG("resolved local IP from send_socket_name: %s\n", ip_buf);
+				return 0;
+			}
+		}
+	}
+
+	/* Try send_socket (raw format: <proto>:<ip>:<port>) */
+	if(send_socket != NULL && send_socket->s != NULL && send_socket->len > 0) {
+		char *p = send_socket->s;
+		char *end = p + send_socket->len;
+		char *colon1 = memchr(p, ':', end - p);
+
+		if(colon1 != NULL) {
+			char *colon2 = memchr(colon1 + 1, ':', end - (colon1 + 1));
+			if(colon2 != NULL) {
+				int ip_len = colon2 - (colon1 + 1);
+				if(ip_len > 0 && ip_len < buf_len) {
+					memcpy(ip_buf, colon1 + 1, ip_len);
+					ip_buf[ip_len] = '\0';
+					LM_DBG("parsed local IP from send_socket: %s\n", ip_buf);
+					return 0;
+				}
+			}
+		}
+	}
+
+	LM_ERR("failed to determine local IP address\n");
+	return -1;
+}
+
+
+/**
+ * Get local port from send_socket configuration
+ * Returns the port number, or 5060 as default
+ */
+int sipp_get_local_port(void)
+{
+	str *send_socket_name = sipp_get_send_socket_name();
+	str *send_socket = sipp_get_send_socket();
+	socket_info_t *si = NULL;
+
+	/* Try send_socket_name first */
+	if(send_socket_name != NULL && send_socket_name->s != NULL
+			&& send_socket_name->len > 0) {
+		si = lookup_local_socket(send_socket_name);
+		if(si != NULL && si->port_no > 0) {
+			LM_DBG("resolved local port from send_socket_name: %d\n",
+					si->port_no);
+			return si->port_no;
+		}
+	}
+
+	/* Try send_socket (raw format: <proto>:<ip>:<port>) */
+	if(send_socket != NULL && send_socket->s != NULL && send_socket->len > 0) {
+		char *p = send_socket->s;
+		char *end = p + send_socket->len;
+		char *colon1 = memchr(p, ':', end - p);
+
+		if(colon1 != NULL) {
+			char *colon2 = memchr(colon1 + 1, ':', end - (colon1 + 1));
+			if(colon2 != NULL && colon2 + 1 < end) {
+				int port = atoi(colon2 + 1);
+				if(port > 0 && port <= 65535) {
+					LM_DBG("parsed local port from send_socket: %d\n", port);
+					return port;
+				}
+			}
+		}
+	}
+
+	/* Default to 5060 */
+	LM_DBG("no port specified, defaulting to 5060\n");
+	return 5060;
+}
+
+
+/**
+ * Parse number specification
+ * Supports: single number (1000), range (1000-1020), comma-separated (1000,1001,1002)
+ */
+int sipp_parse_number_spec(str *spec, char *output, int output_len)
+{
+	if(spec == NULL || spec->s == NULL || spec->len <= 0) {
+		LM_ERR("invalid number specification\n");
+		return -1;
+	}
+
+	if(output == NULL || output_len <= 0) {
+		LM_ERR("invalid output buffer\n");
+		return -1;
+	}
+
+	/* For simplicity, we'll use the first number/username from the spec */
+	/* In a production implementation, this would need to handle ranges and lists */
+
+	/* Check for range (e.g., 1000-1020) */
+	char *dash = memchr(spec->s, '-', spec->len);
+	if(dash != NULL) {
+		/* Extract first number */
+		int len = dash - spec->s;
+		if(len > 0 && len < output_len) {
+			memcpy(output, spec->s, len);
+			output[len] = '\0';
+			LM_DBG("parsed range start: %s\n", output);
+			return 0;
+		}
+	}
+
+	/* Check for comma-separated list (e.g., 1000,1001,1002) */
+	char *comma = memchr(spec->s, ',', spec->len);
+	if(comma != NULL) {
+		/* Extract first number */
+		int len = comma - spec->s;
+		if(len > 0 && len < output_len) {
+			memcpy(output, spec->s, len);
+			output[len] = '\0';
+			LM_DBG("parsed list first: %s\n", output);
+			return 0;
+		}
+	}
+
+	/* Single number or username */
+	if(spec->len < output_len) {
+		memcpy(output, spec->s, spec->len);
+		output[spec->len] = '\0';
+		LM_DBG("parsed single value: %s\n", output);
+		return 0;
+	}
+
+	LM_ERR("number specification too long\n");
+	return -1;
+}
+
+
+/**
+ * Validate domain against valid_domains list
+ */
+int sipp_validate_domain(str *domain)
+{
+	str *valid_domains = sipp_get_valid_domains();
+
+	if(domain == NULL || domain->s == NULL || domain->len <= 0) {
+		LM_DBG("empty domain, skipping validation\n");
+		return 0;
+	}
+
+	/* If no valid_domains list, allow any domain */
+	if(valid_domains == NULL || valid_domains->s == NULL
+			|| valid_domains->len <= 0) {
+		LM_DBG("no valid_domains restriction, allowing domain: %.*s\n",
+				domain->len, domain->s);
+		return 0;
+	}
+
+	/* Check if domain is in the comma-separated list */
+	char *p = valid_domains->s;
+	char *end = p + valid_domains->len;
+
+	while(p < end) {
+		/* Skip whitespace */
+		while(p < end && (*p == ' ' || *p == '\t')) {
+			p++;
+		}
+
+		/* Find next comma or end */
+		char *comma = memchr(p, ',', end - p);
+		char *domain_end = (comma != NULL) ? comma : end;
+
+		/* Trim trailing whitespace */
+		while(domain_end > p
+				&& (*(domain_end - 1) == ' ' || *(domain_end - 1) == '\t')) {
+			domain_end--;
+		}
+
+		/* Compare domain */
+		int len = domain_end - p;
+		if(len == domain->len && strncasecmp(p, domain->s, len) == 0) {
+			LM_DBG("domain validated: %.*s\n", domain->len, domain->s);
+			return 0;
+		}
+
+		/* Move to next domain */
+		p = (comma != NULL) ? comma + 1 : end;
+	}
+
+	LM_ERR("domain not in valid_domains list: %.*s\n", domain->len, domain->s);
+	return -1;
+}
+
+
+/**
+ * Build SIPp command line
+ */
+static int sipp_build_command(sipp_test_t *test, char *cmd_buf, int buf_len)
+{
+	str *scenario_dir = sipp_get_scenario_dir();
+	str *sipp_path = sipp_get_sipp_path();
+	str *media_ip = sipp_get_media_ip();
+	const char *sipp_cmd = "sipp"; /* Default if not configured */
+	int transport = test->transport;
+	const char *transport_arg = "";
+	char scenario_path[1024];
+	char set_from[256];
+	char set_domain[256];
+	char set_media_ip[256];
+	char max_calls_arg[64];
+	int has_from = 0;
+	int has_domain = 0;
+	size_t domain_len = 0;
+
+	/* Use configured sipp_path if available */
+	if(sipp_path != NULL && sipp_path->s != NULL && sipp_path->len > 0) {
+		sipp_cmd = sipp_path->s;
+	}
+
+	/* Determine transport argument for SIPp */
+	switch(transport) {
+		case SIPP_TRANSPORT_TCP:
+			transport_arg = "-t tn";
+			break;
+		case SIPP_TRANSPORT_TLS:
+			transport_arg = "-t ln";
+			break;
+		case SIPP_TRANSPORT_UDP:
+		default:
+			transport_arg = "-t un";
+			break;
+	}
+
+	/* Build SIPp command:
+	 * sipp -sf <scenario_file> -s <service>
+	 *      -i <local_ip> -p <local_port>
+	 *      -r <call_rate> -l <concurrent_calls>
+	 *      -d <duration> [-m <max_calls>]
+	 *      -key caller <caller>
+	 *      -key target_domain <target_domain>
+	 *      -trace_err
+	 *      -bg -log_file <log_file>
+	 *      [-ci <local_ip> -cp <control_port>]  (if remote control enabled)
+	 *      <local_ip>:5060
+	 *
+	 * Note: The positional target (<local_ip>:5060) tells SIPp where to send traffic.
+	 * This should be Kamailio's listening address (from send_socket config).
+	 * The target_domain variable is used within scenarios for the domain part of SIP URIs.
+	 * The control socket (-ci/-cp) enables real-time control and monitoring.
+	 */
+
+	snprintf(scenario_path, sizeof(scenario_path), "%.*s/%s", scenario_dir->len,
+			scenario_dir->s, test->scenario);
+
+	has_from = sipp_scenario_has_token(scenario_path, "[caller]")
+			   || sipp_scenario_has_token(scenario_path, "[$caller]");
+	has_domain = sipp_scenario_has_token(scenario_path, "[target_domain]")
+				 || sipp_scenario_has_token(scenario_path, "[$target_domain]");
+
+	if(has_from) {
+		snprintf(set_from, sizeof(set_from), "-key caller %s ",
+				test->from_number);
+	} else {
+		set_from[0] = '\0';
+	}
+
+	if(has_domain) {
+		domain_len = strnlen(test->target_domain, sizeof(test->target_domain));
+		snprintf(set_domain, sizeof(set_domain), "-key target_domain %.*s ",
+				(int)domain_len, test->target_domain);
+	} else {
+		set_domain[0] = '\0';
+	}
+
+	if(media_ip != NULL && media_ip->s != NULL && media_ip->len > 0) {
+		snprintf(set_media_ip, sizeof(set_media_ip), "-mi %.*s ", media_ip->len,
+				media_ip->s);
+	} else {
+		set_media_ip[0] = '\0';
+	}
+
+	if(test->total_calls_limit > 0) {
+		snprintf(max_calls_arg, sizeof(max_calls_arg), "-m %d ",
+				test->total_calls_limit);
+	} else {
+		max_calls_arg[0] = '\0';
+	}
+
+	char set_service[256];
+	snprintf(set_service, sizeof(set_service), "-s %s ", test->to_number);
+
+	char control_args[256] = "";
+	if(test->control_port > 0) {
+		snprintf(control_args, sizeof(control_args), "-ci %s -cp %d ",
+				test->local_ip, test->control_port);
+	}
+
+	/* Get the target port from send_socket config (defaults to 5060) */
+	int target_port = sipp_get_local_port();
+	char error_file[SIPP_MAX_LOG_PATH_LEN + 16];
+	int err_ret = snprintf(
+			error_file, sizeof(error_file), "%s.errors.log", test->log_file);
+	if(err_ret < 0 || err_ret >= (int)sizeof(error_file)) {
+		LM_ERR("error log path too long\n");
+		return -1;
+	}
+
+	int n = snprintf(cmd_buf, buf_len,
+			"%s -sf %.*s/%s "
+			"%s"
+			"-i %s -p %d "
+			"%s"
+			"%s "
+			"-r %d -l %d "
+			"-d %d "
+			"%s"
+			"%s"
+			"%s"
+			"%s"
+			"-stf %s.stat.csv -fd 1 "
+			"-error_file %s "
+			"-trace_err -trace_stat "
+			"-bg "
+			"-log_file %s "
+			"%s:%d",
+			sipp_cmd, scenario_dir->len, scenario_dir->s, test->scenario,
+			set_service, test->local_ip, test->local_port, set_media_ip,
+			transport_arg, test->call_rate, test->concurrent_calls,
+			test->duration * 1000, /* Convert to ms */
+			max_calls_arg, set_from, set_domain, control_args, test->log_file,
+			error_file, test->log_file, test->local_ip,
+			target_port); /* Send to Kamailio's listening address */
+
+	if(n < 0 || n >= buf_len) {
+		LM_ERR("command buffer too small\n");
+		return -1;
+	}
+
+	LM_DBG("SIPp command: %s\n", cmd_buf);
+	return 0;
+}
+
+
+/**
+ * Start a new SIPp test
+ */
+int sipp_test_start(sipp_test_params_t *params, int *test_id)
+{
+	sipp_test_t *test = NULL;
+	sipp_test_t *t = NULL;
+	char cmd_buf[2048];
+	str *sipp_path = NULL;
+	int transport;
+	char local_ip[SIPP_MAX_IP_LEN];
+	str *target_domain = NULL;
+	char fallback_domain[SIPP_MAX_DOMAIN_LEN];
+	str fallback_domain_str = STR_NULL;
+	str *default_from = NULL;
+	str *default_to = NULL;
+	str *from_to_use = NULL;
+	str *to_to_use = NULL;
+	int max_calls;
+	int running_tests = 0;
+	int max_tests;
+	int target_port = 0;
+	str *scenario_dir = NULL;
+	char scenario_path[1024];
+
+	if(params == NULL || test_id == NULL) {
+		LM_ERR("invalid parameters\n");
+		return -1;
+	}
+
+	/* ============================================================
+	 * PHASE 1: Validation BEFORE acquiring lock or allocating memory
+	 * This ensures we don't leak resources on validation failures
+	 * ============================================================ */
+
+	/* Validate scenario name length */
+	if(params->scenario.s == NULL || params->scenario.len <= 0
+			|| params->scenario.len >= SIPP_MAX_SCENARIO_LEN) {
+		LM_ERR("invalid scenario name\n");
+		return -1;
+	}
+
+	/* Validate scenario name for command injection and path traversal */
+	if(sipp_validate_scenario_name(params->scenario.s, params->scenario.len)
+			< 0) {
+		LM_ERR("scenario name contains unsafe characters or path traversal\n");
+		return -1;
+	}
+
+	/* Validate caller availability and safety */
+	if(params->from_number.s != NULL && params->from_number.len > 0) {
+		if(sipp_validate_safe_string(
+				   params->from_number.s, params->from_number.len)
+				< 0) {
+			LM_ERR("caller contains unsafe characters\n");
+			return -1;
+		}
+		from_to_use = &params->from_number;
+	} else {
+		default_from = sipp_get_default_from_number();
+		if(default_from == NULL || default_from->s == NULL
+				|| default_from->len <= 0) {
+			LM_ERR("caller not provided and default_caller not set\n");
+			return -1;
+		}
+		from_to_use = default_from;
+	}
+
+	/* Validate service availability and safety */
+	if(params->to_number.s != NULL && params->to_number.len > 0) {
+		if(sipp_validate_safe_string(params->to_number.s, params->to_number.len)
+				< 0) {
+			LM_ERR("service contains unsafe characters\n");
+			return -1;
+		}
+		to_to_use = &params->to_number;
+	} else {
+		default_to = sipp_get_default_to_number();
+		if(default_to == NULL || default_to->s == NULL
+				|| default_to->len <= 0) {
+			LM_ERR("service not provided and default_service not set\n");
+			return -1;
+		}
+		to_to_use = default_to;
+	}
+
+	/* Validate target_domain if provided */
+	if(params->target_domain.s != NULL && params->target_domain.len > 0) {
+		if(sipp_validate_target_domain(
+				   params->target_domain.s, params->target_domain.len)
+				< 0) {
+			LM_ERR("target_domain contains unsafe characters\n");
+			return -1;
+		}
+	}
+
+	/* Check max concurrent tests limit */
+	max_tests = sipp_get_max_concurrent_tests();
+	lock_get(_sipp_test_lock);
+	for(t = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL; t != NULL;
+			t = t->next) {
+		if(t->state == SIPP_TEST_STATE_RUNNING) {
+			running_tests++;
+		}
+	}
+	lock_release(_sipp_test_lock);
+
+	if(running_tests >= max_tests) {
+		LM_ERR("max concurrent tests limit reached (%d/%d)\n", running_tests,
+				max_tests);
+		return -1;
+	}
+
+	/* Validate concurrent calls */
+	max_calls = sipp_get_max_concurrent_calls();
+	if(params->concurrent_calls > max_calls) {
+		LM_ERR("concurrent_calls (%d) exceeds max_concurrent_calls (%d)\n",
+				params->concurrent_calls, max_calls);
+		return -1;
+	}
+
+	/* Validate total_calls_limit and max_test_duration (allow -1 = use default) */
+	if(params->total_calls_limit < -1) {
+		LM_ERR("total_calls_limit must be >= 0 (or -1 for default)\n");
+		return -1;
+	}
+	if(params->max_test_duration < -1) {
+		LM_ERR("max_test_duration must be >= 0 (or -1 for default)\n");
+		return -1;
+	}
+
+	/* Determine target domain */
+	if(params->target_domain.s != NULL && params->target_domain.len > 0) {
+		/* Validate domain */
+		if(sipp_validate_domain(&params->target_domain) < 0) {
+			LM_ERR("invalid target domain\n");
+			return -1;
+		}
+		target_domain = &params->target_domain;
+	} else {
+		target_domain = sipp_get_target_domain();
+	}
+
+	/* If scenario uses [target_domain], ensure it is set */
+
+	scenario_dir = sipp_get_scenario_dir();
+	if(scenario_dir != NULL && scenario_dir->s != NULL
+			&& scenario_dir->len > 0) {
+		int ret = snprintf(scenario_path, sizeof(scenario_path), "%.*s/%.*s",
+				scenario_dir->len, scenario_dir->s, params->scenario.len,
+				params->scenario.s);
+		if(ret < 0 || ret >= (int)sizeof(scenario_path)) {
+			LM_ERR("scenario path too long (max %zu bytes)\n",
+					sizeof(scenario_path) - 1);
+			return -1;
+		}
+
+		/* Get local IP and target port for target_domain fallback */
+		if(sipp_get_local_ip(local_ip, sizeof(local_ip)) < 0) {
+			LM_ERR("failed to get local IP\n");
+			return -1;
+		}
+		target_port = sipp_get_local_port();
+
+		if(sipp_scenario_has_token(scenario_path, "[target_domain]")
+				|| sipp_scenario_has_token(scenario_path, "[$target_domain]")) {
+			if(target_domain == NULL || target_domain->s == NULL
+					|| target_domain->len <= 0) {
+				int fd_ret = snprintf(fallback_domain, sizeof(fallback_domain),
+						"%s:%d", local_ip, target_port);
+				if(fd_ret < 0 || fd_ret >= (int)sizeof(fallback_domain)) {
+					LM_ERR("fallback target_domain too long\n");
+					return -1;
+				}
+				fallback_domain_str.s = fallback_domain;
+				fallback_domain_str.len = fd_ret;
+				target_domain = &fallback_domain_str;
+				LM_DBG("target_domain not set; using fallback %s\n",
+						fallback_domain);
+			}
+		}
+	}
+
+	/* Get transport type */
+	transport = sipp_get_transport();
+
+	/* Allocate test structure */
+	test = (sipp_test_t *)shm_malloc(sizeof(sipp_test_t));
+	if(test == NULL) {
+		LM_ERR("failed to allocate test structure\n");
+		return -1;
+	}
+	memset(test, 0, sizeof(sipp_test_t));
+
+	/* Acquire lock and assign test ID */
+	lock_get(_sipp_test_lock);
+	if(_sipp_test_counter == NULL) {
+		LM_ERR("test counter not initialized\n");
+		lock_release(_sipp_test_lock);
+		shm_free(test);
+		return -1;
+	}
+	(*_sipp_test_counter)++;
+
+	/* Check for test_id overflow */
+	if(*_sipp_test_counter <= 0) {
+		LM_ERR("test_id counter overflow\n");
+		lock_release(_sipp_test_lock);
+		shm_free(test);
+		return -1;
+	}
+
+	test->test_id = *_sipp_test_counter;
+	*test_id = test->test_id;
+
+	/* Initialize test structure */
+	test->state = SIPP_TEST_STATE_RUNNING;
+	test->transport = transport;
+	test->start_time = time(NULL);
+	test->end_time = 0;
+	test->control_socket = -1; /* Explicitly initialize to invalid */
+
+	/* Copy scenario name */
+	snprintf(test->scenario, sizeof(test->scenario), "%.*s",
+			params->scenario.len, params->scenario.s);
+
+	/* Parse and copy caller (already validated in Phase 1) */
+	if(sipp_parse_number_spec(
+			   from_to_use, test->from_number, sizeof(test->from_number))
+			< 0) {
+		LM_ERR("failed to parse caller\n");
+		lock_release(_sipp_test_lock);
+		shm_free(test);
+		return -1;
+	}
+
+	/* Parse and copy service (already validated in Phase 1) */
+	if(sipp_parse_number_spec(
+			   to_to_use, test->to_number, sizeof(test->to_number))
+			< 0) {
+		LM_ERR("failed to parse service\n");
+		lock_release(_sipp_test_lock);
+		shm_free(test);
+		return -1;
+	}
+
+	/* Copy target domain (may be empty) */
+	if(target_domain != NULL && target_domain->s != NULL
+			&& target_domain->len > 0) {
+		snprintf(test->target_domain, sizeof(test->target_domain), "%.*s",
+				target_domain->len, target_domain->s);
+	} else {
+		test->target_domain[0] = '\0';
+	}
+
+	/* Copy local IP */
+	snprintf(test->local_ip, sizeof(test->local_ip), "%s", local_ip);
+
+	/* Use ephemeral port (0 = let OS assign) */
+	test->local_port = 0;
+
+	/* Setup remote control socket
+	 * SIPp's default control port base is 8888, and it supports up to 60 instances.
+	 * We use -cp to explicitly set the port based on test_id.
+	 * Port range: 8888 + test_id (so 8889, 8890, ..., up to 8888+test_id)
+	 */
+#define SIPP_CONTROL_PORT_BASE 8888
+	test->control_port = SIPP_CONTROL_PORT_BASE + test->test_id;
+
+	/* Validate port range - shouldn't happen with max 60 tests, but check anyway */
+	if(test->control_port > 65535) {
+		LM_ERR("control port %d exceeds max port 65535 (test_id=%d too "
+			   "large)\n",
+				test->control_port, test->test_id);
+		lock_release(_sipp_test_lock);
+		shm_free(test);
+		return -1;
+	}
+
+	/* Check if control port is available before starting SIPp
+	 * This prevents confusing failures when another process is using the port
+	 */
+	if(sipp_check_port_available(local_ip, test->control_port) < 0) {
+		LM_ERR("control port %d is already in use - cannot start test\n",
+				test->control_port);
+		LM_ERR("another SIPp instance or process may be using this port\n");
+		LM_DBG("hint: stop conflicting process or wait for test_id to "
+			   "increment "
+			   "past the conflict\n");
+		lock_release(_sipp_test_lock);
+		shm_free(test);
+		return -1;
+	}
+
+	/* Validate scenario file exists */
+	if(scenario_dir != NULL && scenario_dir->s != NULL
+			&& scenario_dir->len > 0) {
+		if(access(scenario_path, F_OK) < 0) {
+			LM_ERR("scenario file not found: %s\n", scenario_path);
+			lock_release(_sipp_test_lock);
+			shm_free(test);
+			return -1;
+		}
+	}
+
+
+	/* Copy test parameters */
+	test->concurrent_calls = params->concurrent_calls;
+	test->call_rate = params->call_rate > 0 ? params->call_rate
+											: sipp_get_default_call_rate();
+	test->duration = params->duration;
+	if(params->total_calls_limit >= 0) {
+		test->total_calls_limit = params->total_calls_limit;
+	} else {
+		test->total_calls_limit = sipp_get_default_total_calls();
+	}
+	if(params->max_test_duration >= 0) {
+		test->max_test_duration = params->max_test_duration;
+	} else {
+		test->max_test_duration = sipp_get_default_max_test_duration();
+	}
+
+	/* Generate log file path with bounds checking */
+	{
+		str *work_dir = sipp_get_work_dir();
+		if(work_dir != NULL && work_dir->s != NULL && work_dir->len > 0) {
+			int log_ret = snprintf(test->log_file, sizeof(test->log_file),
+					"%.*s/sipp_test_%d_%ld.log", work_dir->len, work_dir->s,
+					test->test_id, (long)test->start_time);
+			if(log_ret < 0 || log_ret >= (int)sizeof(test->log_file)) {
+				LM_ERR("log file path too long\n");
+				lock_release(_sipp_test_lock);
+				shm_free(test);
+				return -1;
+			}
+		} else {
+			int log_ret = snprintf(test->log_file, sizeof(test->log_file),
+					"/tmp/sipp_test_%d_%ld.log", test->test_id,
+					(long)test->start_time);
+			if(log_ret < 0 || log_ret >= (int)sizeof(test->log_file)) {
+				LM_ERR("log file path too long\n");
+				lock_release(_sipp_test_lock);
+				shm_free(test);
+				return -1;
+			}
+		}
+	}
+
+	/* Add to test list */
+	if(_sipp_test_list != NULL) {
+		test->next = *_sipp_test_list;
+		*_sipp_test_list = test;
+	} else {
+		test->next = NULL;
+	}
+
+	lock_release(_sipp_test_lock);
+
+	/* Build SIPp command */
+	if(sipp_build_command(test, cmd_buf, sizeof(cmd_buf)) < 0) {
+		LM_ERR("failed to build SIPp command\n");
+		test->state = SIPP_TEST_STATE_FAILED;
+		test->end_time = time(NULL); /* Mark end time for cleanup */
+		return -1;
+	}
+
+	/* Validate configured sipp_path (if set) */
+	sipp_path = sipp_get_sipp_path();
+	if(sipp_path != NULL && sipp_path->s != NULL && sipp_path->len > 0) {
+		if(access(sipp_path->s, X_OK) < 0) {
+			LM_ERR("sipp_path not executable: %.*s (%s)\n", sipp_path->len,
+					sipp_path->s, strerror(errno));
+			test->state = SIPP_TEST_STATE_FAILED;
+			test->end_time = time(NULL); /* Mark end time for cleanup */
+			return -1;
+		}
+	}
+
+	/* Fork and execute SIPp */
+	pid_t pid = fork();
+	if(pid < 0) {
+		LM_ERR("fork failed: %s\n", strerror(errno));
+		test->state = SIPP_TEST_STATE_FAILED;
+		test->end_time = time(NULL); /* Mark end time for cleanup */
+		return -1;
+	}
+
+	if(pid == 0) {
+		/* Child process */
+		int null_fd = -1;
+		int log_fd = -1;
+		char exec_log[512];
+		str *work_dir = sipp_get_work_dir();
+
+		/* Reset signal handlers to default - don't inherit Kamailio's handlers */
+		signal(SIGTERM, SIG_DFL);
+		signal(SIGINT, SIG_DFL);
+		signal(SIGHUP, SIG_DFL);
+		signal(SIGCHLD, SIG_DFL);
+		signal(SIGPIPE, SIG_DFL);
+
+		if(work_dir != NULL && work_dir->s != NULL && work_dir->len > 0) {
+			if(chdir(work_dir->s) < 0) {
+				LM_WARN("failed to chdir to work_dir %.*s: %s\n", work_dir->len,
+						work_dir->s, strerror(errno));
+			}
+		}
+
+		null_fd = open("/dev/null", O_RDONLY);
+		if(null_fd >= 0) {
+			dup2(null_fd, 0);
+			if(null_fd > 2)
+				close(null_fd);
+		}
+
+		{
+			int max_len = (int)sizeof(exec_log) - 1 - (int)strlen(".exec.log");
+			if(max_len < 0) {
+				max_len = 0;
+			}
+			snprintf(exec_log, sizeof(exec_log), "%.*s.exec.log", max_len,
+					test->log_file);
+		}
+		log_fd = open(exec_log, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+		if(log_fd >= 0) {
+			dup2(log_fd, 1);
+			dup2(log_fd, 2);
+			if(log_fd > 2)
+				close(log_fd);
+		} else {
+			LM_WARN("failed to open exec log %s: %s\n", exec_log,
+					strerror(errno));
+		}
+
+		/* Execute SIPp */
+		execl("/bin/sh", "sh", "-c", cmd_buf, (char *)NULL);
+
+		/* If we get here, exec failed */
+		dprintf(2, "execl failed: %s\n", strerror(errno));
+		exit(1);
+	}
+
+	/* Parent process */
+	test->pid = pid;
+
+	/* Check if SIPp exited immediately (capture exec log in Kamailio logs) */
+	{
+		int status = 0;
+		pid_t wpid;
+		char exec_log[512];
+		char buf[2048];
+		int fd;
+		ssize_t rlen;
+
+		usleep(100000); /* 100ms */
+		wpid = waitpid(test->pid, &status, WNOHANG);
+		if(wpid == test->pid) {
+			int bg_pid = -1;
+			{
+				int max_len =
+						(int)sizeof(exec_log) - 1 - (int)strlen(".exec.log");
+				if(max_len < 0) {
+					max_len = 0;
+				}
+				snprintf(exec_log, sizeof(exec_log), "%.*s.exec.log", max_len,
+						test->log_file);
+			}
+			fd = open(exec_log, O_RDONLY);
+			if(fd >= 0) {
+				rlen = read(fd, buf, sizeof(buf) - 1);
+				if(rlen > 0) {
+					buf[rlen] = '\0';
+					{
+						char *pid_start = strstr(buf, "PID=[");
+						if(pid_start != NULL) {
+							pid_start += 5;
+							bg_pid = atoi(pid_start);
+						}
+					}
+					if(bg_pid > 0) {
+						LM_DBG("SIPp background mode detected for test %d: "
+							   "parent pid=%d, bg pid=%d\n",
+								test->test_id, (int)test->pid, bg_pid);
+					} else {
+						LM_WARN("SIPp exited immediately (pid %d). "
+								"Output:\n%s\n",
+								(int)test->pid, buf);
+					}
+				} else {
+					LM_ERR("SIPp exited immediately (pid %d). No output "
+						   "captured.\n",
+							(int)test->pid);
+				}
+				close(fd);
+				if(unlink(exec_log) < 0 && errno != ENOENT) {
+					LM_DBG("failed to remove exec log %s: %s\n", exec_log,
+							strerror(errno));
+				}
+			} else {
+				LM_ERR("SIPp exited immediately (pid %d). Exec log missing "
+					   "(%s).\n",
+						(int)test->pid, strerror(errno));
+			}
+
+			if(bg_pid > 0) {
+				test->pid = bg_pid;
+				return 0;
+			}
+			if(test->log_file[0] != '\0') {
+				char extra_file[SIPP_MAX_LOG_PATH_LEN + 16];
+
+				if(unlink(test->log_file) < 0 && errno != ENOENT) {
+					LM_DBG("failed to remove log file %s: %s\n", test->log_file,
+							strerror(errno));
+				}
+
+				snprintf(extra_file, sizeof(extra_file), "%s.exec.log",
+						test->log_file);
+				if(unlink(extra_file) < 0 && errno != ENOENT) {
+					LM_DBG("failed to remove exec log %s: %s\n", extra_file,
+							strerror(errno));
+				}
+
+				snprintf(extra_file, sizeof(extra_file), "%s.stat.csv",
+						test->log_file);
+				if(unlink(extra_file) < 0 && errno != ENOENT) {
+					LM_DBG("failed to remove stats file %s: %s\n", extra_file,
+							strerror(errno));
+				}
+			}
+			test->state = SIPP_TEST_STATE_FAILED;
+			test->end_time = time(NULL); /* Mark end time for cleanup */
+			return -1;
+		}
+	}
+
+	LM_INFO("started SIPp test %d (pid %d): scenario=%s, caller=%s, "
+			"service=%s, "
+			"domain=%s, calls=%d, duration=%d, total_calls_limit=%d, "
+			"max_test_duration=%d\n",
+			test->test_id, test->pid, test->scenario, test->from_number,
+			test->to_number, test->target_domain, test->concurrent_calls,
+			test->duration, test->total_calls_limit, test->max_test_duration);
+
+	return 0;
+}
+
+
+/**
+ * Stop a running test
+ */
+int sipp_test_stop(int test_id)
+{
+	sipp_test_t *test = NULL;
+	int found = 0;
+	int pid = 0;
+	int status = 0;
+	int sent_quit = 0;
+	int i = 0;
+
+	lock_get(_sipp_test_lock);
+
+	/* Find test */
+	test = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+	while(test != NULL) {
+		if(test->test_id == test_id) {
+			found = 1;
+			break;
+		}
+		test = test->next;
+	}
+
+	if(!found) {
+		lock_release(_sipp_test_lock);
+		LM_ERR("test %d not found\n", test_id);
+		return -1;
+	}
+
+	/* Check if test is running */
+	if(test->state != SIPP_TEST_STATE_RUNNING) {
+		lock_release(_sipp_test_lock);
+		LM_WARN("test %d is not running (state=%d)\n", test_id, test->state);
+		return -1;
+	}
+
+	pid = test->pid;
+	lock_release(_sipp_test_lock);
+
+	if(pid > 0) {
+		if(sipp_test_control_command(test_id, 'Q') == 0) {
+			sent_quit = 1;
+		}
+	}
+
+	if(sent_quit && pid > 0) {
+		for(i = 0; i < 10; i++) {
+			if(waitpid(pid, &status, WNOHANG) > 0) {
+				lock_get(_sipp_test_lock);
+				test = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+				while(test != NULL) {
+					if(test->test_id == test_id) {
+						test->state = SIPP_TEST_STATE_STOPPED;
+						test->end_time = time(NULL);
+						break;
+					}
+					test = test->next;
+				}
+				lock_release(_sipp_test_lock);
+				return 0;
+			}
+			usleep(200000);
+		}
+	}
+
+	lock_get(_sipp_test_lock);
+	found = 0;
+	test = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+	while(test != NULL) {
+		if(test->test_id == test_id) {
+			found = 1;
+			break;
+		}
+		test = test->next;
+	}
+
+	if(!found) {
+		lock_release(_sipp_test_lock);
+		LM_ERR("test %d not found\n", test_id);
+		return -1;
+	}
+
+	if(test->state != SIPP_TEST_STATE_RUNNING) {
+		lock_release(_sipp_test_lock);
+		return 0;
+	}
+
+	/* Send SIGTERM to SIPp process and wait briefly */
+	if(test->pid > 0) {
+		LM_INFO("stopping test %d (pid %d)\n", test_id, test->pid);
+		if(kill(test->pid, SIGTERM) < 0) {
+			if(errno == ESRCH) {
+				LM_DBG("SIGTERM skipped; pid %d no longer exists\n", test->pid);
+			} else {
+				LM_WARN("failed to send SIGTERM to pid %d: %s\n", test->pid,
+						strerror(errno));
+			}
+		}
+		/* Give process 500ms to terminate gracefully */
+		usleep(500000);
+		/* Send SIGKILL if still running */
+		if(waitpid(test->pid, &status, WNOHANG) == 0) {
+			LM_WARN("test %d did not terminate, sending SIGKILL\n", test_id);
+			kill(test->pid, SIGKILL);
+			waitpid(test->pid, NULL, 0);
+		}
+	}
+
+	test->state = SIPP_TEST_STATE_STOPPED;
+	test->end_time = time(NULL);
+
+	lock_release(_sipp_test_lock);
+
+	return 0;
+}
+
+
+/**
+ * Get test information
+ * WARNING: Returns pointer without lock - use sipp_test_get_copy() for thread-safety
+ */
+sipp_test_t *sipp_test_get(int test_id)
+{
+	sipp_test_t *test = NULL;
+
+	lock_get(_sipp_test_lock);
+
+	test = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+	while(test != NULL) {
+		if(test->test_id == test_id) {
+			lock_release(_sipp_test_lock);
+			return test;
+		}
+		test = test->next;
+	}
+
+	lock_release(_sipp_test_lock);
+	return NULL;
+}
+
+
+/**
+ * Thread-safe copy of test data
+ * @param test_id Test ID to query
+ * @param out Output buffer for test copy (caller-allocated)
+ * @return 0 on success, -1 if not found
+ */
+int sipp_test_get_copy(int test_id, sipp_test_t *out)
+{
+	sipp_test_t *test = NULL;
+	int found = 0;
+
+	if(out == NULL) {
+		return -1;
+	}
+
+	lock_get(_sipp_test_lock);
+
+	test = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+	while(test != NULL) {
+		if(test->test_id == test_id) {
+			memcpy(out, test, sizeof(sipp_test_t));
+			out->next = NULL; /* Don't expose internal pointer */
+			found = 1;
+			break;
+		}
+		test = test->next;
+	}
+
+	lock_release(_sipp_test_lock);
+	return found ? 0 : -1;
+}
+
+
+/**
+ * Get all tests
+ * NOTE: Caller MUST hold _sipp_test_lock for entire traversal
+ */
+sipp_test_t *sipp_test_get_all(void)
+{
+	return (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+}
+
+
+/**
+ * Update test statistics from SIPp log file
+ */
+int sipp_test_update_stats(sipp_test_t *test)
+{
+	/* This is a placeholder for parsing SIPp CSV output */
+	/* In a production implementation, this would read the log file */
+	/* and extract statistics like calls_started, calls_completed, calls_failed */
+
+	if(test == NULL) {
+		return -1;
+	}
+
+	/* For now, we'll just check if the process is still running */
+	if(test->pid > 0 && test->state == SIPP_TEST_STATE_RUNNING) {
+		int status;
+		pid_t result = waitpid(test->pid, &status, WNOHANG);
+
+		if(result > 0) {
+			/* Process has exited */
+			if(WIFEXITED(status)) {
+				int exit_code = WEXITSTATUS(status);
+				if(exit_code == 0) {
+					test->state = SIPP_TEST_STATE_COMPLETED;
+					LM_INFO("test %d completed successfully\n", test->test_id);
+				} else {
+					test->state = SIPP_TEST_STATE_FAILED;
+					LM_WARN("test %d failed with exit code %d\n", test->test_id,
+							exit_code);
+				}
+			} else if(WIFSIGNALED(status)) {
+				test->state = SIPP_TEST_STATE_FAILED;
+				LM_WARN("test %d terminated by signal %d\n", test->test_id,
+						WTERMSIG(status));
+			}
+			test->end_time = time(NULL);
+		}
+	}
+
+	return 0;
+}
+
+
+/**
+ * Update and push metrics for all running tests to Prometheus
+ * Called frequently (every 5-10 seconds) by timer
+ */
+void sipp_metrics_update(void)
+{
+	sipp_test_t *test, *next;
+	int cur_id = 0;
+	int next_id = 0;
+
+	lock_get(_sipp_test_lock);
+
+	test = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+	while(test != NULL) {
+		/* Save next pointer and ids before potentially releasing lock */
+		next = test->next;
+		cur_id = test->test_id;
+		next_id = (next != NULL) ? next->test_id : 0;
+
+		/* Enforce optional max test duration */
+		if(test->state == SIPP_TEST_STATE_RUNNING
+				&& test->max_test_duration > 0) {
+			time_t now = time(NULL);
+			if(now - test->start_time >= test->max_test_duration) {
+				LM_INFO("test %d reached max_test_duration=%d (elapsed=%ld) - "
+						"stopping\n",
+						cur_id, test->max_test_duration,
+						(long)(now - test->start_time));
+				lock_release(_sipp_test_lock);
+				sipp_test_stop(cur_id);
+				lock_get(_sipp_test_lock);
+				/* Continue from next_id if possible */
+				if(next_id > 0) {
+					test = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+					while(test != NULL && test->test_id != next_id) {
+						test = test->next;
+					}
+					continue;
+				}
+				test = NULL;
+				continue;
+			}
+		}
+
+		/* Update stats for running tests */
+		if(test->state == SIPP_TEST_STATE_RUNNING) {
+			sipp_test_update_stats(test);
+
+			/* Get live stats via control socket if enabled */
+			if(test->control_port > 0) {
+				lock_release(_sipp_test_lock);
+				sipp_test_get_live_stats(cur_id);
+				lock_get(_sipp_test_lock);
+				/* Find test again as it may have been modified/removed */
+				sipp_test_t *found =
+						(_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+				while(found != NULL && found->test_id != cur_id) {
+					found = found->next;
+				}
+				if(found == NULL) {
+					/* Test was removed during lock release, continue from next_id */
+					if(next_id > 0) {
+						test = (_sipp_test_list != NULL) ? *_sipp_test_list
+														 : NULL;
+						while(test != NULL && test->test_id != next_id) {
+							test = test->next;
+						}
+						continue;
+					}
+					test = NULL;
+					continue;
+				}
+				test = found;
+				next = test->next;
+			}
+
+			/* Push metrics to Prometheus */
+			sipp_push_prometheus_metrics(test);
+		}
+
+		test = next;
+	}
+
+	lock_release(_sipp_test_lock);
+}
+
+
+/**
+ * Clean up old completed tests and remove log files
+ * Called infrequently (every 1 hour) by timer
+ */
+void sipp_test_cleanup(void)
+{
+	sipp_test_t *test, *prev;
+	time_t now = time(NULL);
+	int cleanup_age = 1800; /* 30 minutes */
+
+	lock_get(_sipp_test_lock);
+
+	prev = NULL;
+	test = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+
+	while(test != NULL) {
+		/* Remove old completed/stopped/failed tests */
+		if((test->state == SIPP_TEST_STATE_COMPLETED
+				   || test->state == SIPP_TEST_STATE_STOPPED
+				   || test->state == SIPP_TEST_STATE_FAILED)
+				&& (now - test->end_time > cleanup_age)) {
+
+			LM_DBG("cleaning up old test %d\n", test->test_id);
+
+			/* Close control socket if open */
+			if(test->control_socket >= 0) {
+				close(test->control_socket);
+				test->control_socket = -1;
+			}
+
+			/* Remove log files */
+			if(test->log_file[0] != '\0') {
+				char extra_file[SIPP_MAX_LOG_PATH_LEN + 16];
+
+				/* Remove main log file */
+				if(unlink(test->log_file) < 0 && errno != ENOENT) {
+					LM_DBG("failed to remove log file %s: %s\n", test->log_file,
+							strerror(errno));
+				}
+
+				/* Remove exec log file */
+				snprintf(extra_file, sizeof(extra_file), "%s.exec.log",
+						test->log_file);
+				if(unlink(extra_file) < 0 && errno != ENOENT) {
+					LM_DBG("failed to remove exec log %s: %s\n", extra_file,
+							strerror(errno));
+				}
+
+				/* Remove stats CSV file */
+				snprintf(extra_file, sizeof(extra_file), "%s.stat.csv",
+						test->log_file);
+				if(unlink(extra_file) < 0 && errno != ENOENT) {
+					LM_DBG("failed to remove stats file %s: %s\n", extra_file,
+							strerror(errno));
+				}
+
+				/* Remove errors log file */
+				snprintf(extra_file, sizeof(extra_file), "%s.errors.log",
+						test->log_file);
+				if(unlink(extra_file) < 0 && errno != ENOENT) {
+					LM_DBG("failed to remove errors log %s: %s\n", extra_file,
+							strerror(errno));
+				}
+			}
+
+			/* Remove from list */
+			if(prev == NULL) {
+				if(_sipp_test_list != NULL) {
+					*_sipp_test_list = test->next;
+				}
+			} else {
+				prev->next = test->next;
+			}
+
+			sipp_test_t *to_free = test;
+			test = test->next;
+			shm_free(to_free);
+			continue;
+		}
+
+		prev = test;
+		test = test->next;
+	}
+
+	lock_release(_sipp_test_lock);
+}
+
+
+/**
+ * Create UDP socket for SIPp remote control
+ * NOTE: SIPp uses UDP for remote control, not TCP!
+ * NOTE: Caller must already hold _sipp_test_lock
+ * Returns: socket fd on success, -1 on failure
+ * On success, caches socket in test->control_socket
+ */
+static int sipp_control_connect(sipp_test_t *test)
+{
+	struct sockaddr_in addr;
+	int sock;
+	struct timeval tv;
+
+	if(test->control_port <= 0) {
+		return -1; /* Remote control not enabled */
+	}
+
+	if(test->control_socket >= 0) {
+		return test->control_socket; /* Already have a socket */
+	}
+
+	/* Create UDP socket - SIPp uses UDP for remote control */
+	sock = socket(AF_INET, SOCK_DGRAM, 0);
+	if(sock < 0) {
+		LM_ERR("failed to create UDP control socket: %s\n", strerror(errno));
+		return -1;
+	}
+
+	/* Set timeout to avoid blocking (shorter for UDP) */
+	tv.tv_sec = 0;
+	tv.tv_usec = 500000; /* 500ms */
+	setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof tv);
+	setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const char *)&tv, sizeof tv);
+
+	/* Use connect() on UDP to set default destination */
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(test->control_port);
+	if(inet_pton(AF_INET, test->local_ip, &addr.sin_addr) <= 0) {
+		LM_ERR("invalid local IP address: %s\n", test->local_ip);
+		close(sock);
+		return -1;
+	}
+
+	if(connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		LM_WARN("failed to connect UDP socket to control port %d: %s\n",
+				test->control_port, strerror(errno));
+		close(sock);
+		test->control_socket = -1;
+		return -1;
+	}
+
+	test->control_socket = sock;
+	LM_DBG("created UDP control socket for test %d (port %d)\n", test->test_id,
+			test->control_port);
+
+	return sock;
+}
+
+
+/**
+ * Send remote control command to SIPp
+ */
+int sipp_test_control_command(int test_id, char cmd)
+{
+	sipp_test_t *test;
+	int sock;
+	ssize_t sent;
+
+	lock_get(_sipp_test_lock);
+	test = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+	while(test != NULL) {
+		if(test->test_id == test_id) {
+			break;
+		}
+		test = test->next;
+	}
+
+	if(test == NULL) {
+		lock_release(_sipp_test_lock);
+		LM_ERR("test %d not found\n", test_id);
+		return -1;
+	}
+
+	if(test->state != SIPP_TEST_STATE_RUNNING) {
+		lock_release(_sipp_test_lock);
+		LM_ERR("test %d is not running\n", test_id);
+		return -1;
+	}
+
+	/* Connect to control socket if needed */
+	sock = sipp_control_connect(test);
+	if(sock < 0) {
+		lock_release(_sipp_test_lock);
+		LM_ERR("failed to connect to control socket for test %d\n", test_id);
+		return -1;
+	}
+
+	/* Send command */
+	sent = send(sock, &cmd, 1, 0);
+	if(sent != 1) {
+		LM_ERR("failed to send control command to test %d: %s\n", test_id,
+				strerror(errno));
+		/* Close and invalidate control socket only (sock is the cached socket) */
+		if(test->control_socket >= 0) {
+			close(test->control_socket);
+			test->control_socket = -1;
+		}
+		lock_release(_sipp_test_lock);
+		return -1;
+	}
+
+	/* Socket is cached in test->control_socket, don't close it here */
+	LM_DBG("sent control command '%c' to test %d\n", cmd, test_id);
+	lock_release(_sipp_test_lock);
+	return 0;
+}
+
+
+/**
+ * Get real-time statistics from SIPp stat file
+ * SIPp writes periodic CSV stats to <log_file>.stat.csv when -trace_stat is used.
+ * NOTE: Control socket is for commands only, not for querying stats.
+ */
+int sipp_test_get_live_stats(int test_id)
+{
+	sipp_test_t *test;
+	char stat_file[SIPP_MAX_LOG_PATH_LEN + 16];
+	FILE *f;
+	char line[SIPP_MAX_STAT_LINE_LEN];
+	char last_line[SIPP_MAX_STAT_LINE_LEN] = "";
+	char header_line[SIPP_MAX_STAT_LINE_LEN] = "";
+	int found_data = 0;
+
+	lock_get(_sipp_test_lock);
+	test = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+	while(test != NULL) {
+		if(test->test_id == test_id) {
+			break;
+		}
+		test = test->next;
+	}
+
+	if(test == NULL) {
+		lock_release(_sipp_test_lock);
+		LM_ERR("test %d not found\n", test_id);
+		return -1;
+	}
+
+	/* Allow stats refresh even after test completion */
+
+	/* Build stat file path */
+	snprintf(stat_file, sizeof(stat_file), "%s.stat.csv", test->log_file);
+
+	/* Read stat file - we need to release lock during file I/O */
+	int cur_test_id = test->test_id;
+	lock_release(_sipp_test_lock);
+
+	f = fopen(stat_file, "r");
+	if(f == NULL) {
+		/* File may not exist yet if test just started */
+		LM_DBG("stat file not found for test %d: %s\n", test_id, stat_file);
+		return 0;
+	}
+
+	/* Read header and last data line (most recent stats) */
+	while(fgets(line, sizeof(line), f) != NULL) {
+		/* Capture header line */
+		if(strstr(line, "ElapsedTime") != NULL
+				|| strstr(line, "CurrentTime") != NULL) {
+			strncpy(header_line, line, sizeof(header_line) - 1);
+			header_line[sizeof(header_line) - 1] = '\0';
+			continue;
+		}
+		/* Skip empty lines */
+		if(line[0] == '\n' || line[0] == '\r') {
+			continue;
+		}
+		/* Save this line as potential last data line */
+		strncpy(last_line, line, sizeof(last_line) - 1);
+		last_line[sizeof(last_line) - 1] = '\0';
+		found_data = 1;
+	}
+	fclose(f);
+
+	if(!found_data) {
+		LM_DBG("no data in stat file for test %d\n", test_id);
+		return 0;
+	}
+
+	/* Parse the last line
+	 * SIPp CSV format (semicolon separated), common headers:
+	 * StartTime;LastResetTime;CurrentTime;ElapsedTime(P);ElapsedTime(C);...
+	 * TotalCallCreated;CurrentCall;SuccessfulCall(P);SuccessfulCall(C);
+	 * FailedCall(P);FailedCall(C);FailedCallRejected(P);FailedCallRejected(C);...
+	 */
+	int total_created = 0, current_calls = 0, successful = 0, failed = 0;
+	int idx_total = 6, idx_current = 7, idx_success = 8, idx_failed = 9;
+	int failed_comp_idx[64];
+	int failed_comp_count = 0;
+	int found_success_c = 0;
+	int found_failed_c = 0;
+
+	/* If header is available, map indices by name */
+	if(header_line[0] != '\0') {
+		char *hp = header_line;
+		char *hfield;
+		int hidx = 0;
+		while((hfield = strsep(&hp, ";")) != NULL) {
+			size_t hlen;
+			/* Trim leading/trailing whitespace and newline */
+			while(*hfield == ' ' || *hfield == '\t')
+				hfield++;
+			hlen = strlen(hfield);
+			if(hlen > 0) {
+				for(char *e = hfield + hlen - 1; e >= hfield; e--) {
+					if(*e == '\n' || *e == '\r' || *e == ' ' || *e == '\t') {
+						*e = '\0';
+					} else {
+						break;
+					}
+				}
+			}
+			if(strcmp(hfield, "TotalCallCreated") == 0) {
+				idx_total = hidx;
+			} else if(strcmp(hfield, "CurrentCall") == 0) {
+				idx_current = hidx;
+			} else if(strcmp(hfield, "SuccessfulCall(C)") == 0) {
+				idx_success = hidx;
+				found_success_c = 1;
+			} else if(strcmp(hfield, "SuccessfulCall") == 0
+					  || (!found_success_c
+							  && strcmp(hfield, "SuccessfulCall(P)") == 0)) {
+				idx_success = hidx;
+			} else if(strcmp(hfield, "FailedCall(C)") == 0) {
+				idx_failed = hidx;
+				found_failed_c = 1;
+			} else if(strcmp(hfield, "FailedCall") == 0
+					  || (!found_failed_c
+							  && strcmp(hfield, "FailedCall(P)") == 0)) {
+				idx_failed = hidx;
+			}
+
+			if(strncmp(hfield, "Failed", 6) == 0 && hlen >= 3
+					&& strcmp(hfield, "FailedCall(C)") != 0) {
+				const char *suffix = hfield + hlen - 3;
+				if(strcmp(suffix, "(C)") == 0
+						&& failed_comp_count
+								   < (int)(sizeof(failed_comp_idx)
+										   / sizeof(failed_comp_idx[0]))) {
+					failed_comp_idx[failed_comp_count++] = hidx;
+				}
+			}
+			hidx++;
+		}
+	}
+
+	/* Parse last data line using mapped indices */
+	{
+		char *p = last_line;
+		char *field;
+		int field_idx = 0;
+		int failed_components_sum = 0;
+		while((field = strsep(&p, ";")) != NULL) {
+			if(field_idx == idx_total) {
+				total_created = atoi(field);
+			} else if(field_idx == idx_current) {
+				current_calls = atoi(field);
+			} else if(field_idx == idx_success) {
+				successful = atoi(field);
+			} else if(field_idx == idx_failed) {
+				failed = atoi(field);
+			}
+			if(failed_comp_count > 0) {
+				for(int i = 0; i < failed_comp_count; i++) {
+					if(field_idx == failed_comp_idx[i]) {
+						failed_components_sum += atoi(field);
+						break;
+					}
+				}
+			}
+			field_idx++;
+		}
+
+		if(failed == 0 && failed_components_sum > 0) {
+			failed = failed_components_sum;
+		}
+	}
+
+	/* Re-acquire lock and update test */
+	lock_get(_sipp_test_lock);
+
+	/* Find test again (may have been removed) */
+	test = (_sipp_test_list != NULL) ? *_sipp_test_list : NULL;
+	while(test != NULL) {
+		if(test->test_id == cur_test_id) {
+			break;
+		}
+		test = test->next;
+	}
+
+	if(test != NULL) {
+		test->calls_started = total_created;
+		test->calls_active = current_calls;
+		test->calls_completed = successful;
+		test->calls_failed = failed;
+
+		LM_DBG("test %d stats from file: started=%d active=%d completed=%d "
+			   "failed=%d\n",
+				test_id, test->calls_started, test->calls_active,
+				test->calls_completed, test->calls_failed);
+	}
+
+	lock_release(_sipp_test_lock);
+	return 0;
+}
+
+
+/**
+ * Adjust call rate dynamically
+ */
+int sipp_test_adjust_rate(int test_id, char rate_change)
+{
+	if(rate_change != '+' && rate_change != '-') {
+		LM_ERR("invalid rate change command: %c (use + or -)\n", rate_change);
+		return -1;
+	}
+
+	return sipp_test_control_command(test_id, rate_change);
+}
+
+
+/**
+ * Push metrics to Prometheus (if xhttp_prom is loaded)
+ */
+void sipp_push_prometheus_metrics(sipp_test_t *test)
+{
+	/* Delegate to Prometheus integration module */
+	sipp_prom_push_metrics(test);
+}

--- a/src/modules/sipp/sipp_test.h
+++ b/src/modules/sipp/sipp_test.h
@@ -1,0 +1,280 @@
+/**
+ * Copyright (C) 2026 Aurora Innovation AB
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _SIPP_TEST_H_
+#define _SIPP_TEST_H_
+
+#include "../../core/str.h"
+#include "../../core/locking.h"
+
+/* Test states */
+#define SIPP_TEST_STATE_RUNNING 1
+#define SIPP_TEST_STATE_STOPPED 2
+#define SIPP_TEST_STATE_COMPLETED 3
+#define SIPP_TEST_STATE_FAILED 4
+
+/* Transport types */
+#define SIPP_TRANSPORT_UDP 1
+#define SIPP_TRANSPORT_TCP 2
+#define SIPP_TRANSPORT_TLS 3
+
+/* Maximum string lengths */
+#define SIPP_MAX_SCENARIO_LEN 256
+#define SIPP_MAX_DOMAIN_LEN 256
+#define SIPP_MAX_NUMBER_LEN 64
+#define SIPP_MAX_IP_LEN 64
+#define SIPP_MAX_LOG_PATH_LEN 512
+#define SIPP_MAX_STAT_LINE_LEN 1024
+
+
+/**
+ * Structure representing a single SIPp test instance
+ */
+typedef struct sipp_test
+{
+	int test_id;	   /* Unique test identifier */
+	int pid;		   /* SIPp process ID */
+	int state;		   /* Test state (running, stopped, completed, failed) */
+	int transport;	   /* Transport type (UDP, TCP, TLS) */
+	time_t start_time; /* Test start timestamp */
+	time_t end_time;   /* Test end timestamp */
+
+	/* Test configuration */
+	char scenario[SIPP_MAX_SCENARIO_LEN];	 /* Scenario name */
+	char from_number[SIPP_MAX_NUMBER_LEN];	 /* Caller user/number */
+	char to_number[SIPP_MAX_NUMBER_LEN];	 /* Service user/number */
+	char target_domain[SIPP_MAX_DOMAIN_LEN]; /* Target domain */
+	char local_ip[SIPP_MAX_IP_LEN];			 /* Local IP to bind */
+	int local_port;							 /* Local port (ephemeral) */
+	int concurrent_calls;					 /* Number of concurrent calls */
+	int call_rate;							 /* Calls per second */
+	int duration;							 /* Call duration in seconds */
+	int total_calls_limit; /* Max total calls (0 = unlimited) */
+	int max_test_duration; /* Max test duration in seconds (0 = unlimited) */
+
+	/* Statistics */
+	int calls_started;	 /* Number of calls started */
+	int calls_completed; /* Number of calls completed successfully */
+	int calls_failed;	 /* Number of failed calls */
+	int calls_active;	 /* Number of currently active calls */
+
+	/* Remote control */
+	int control_socket; /* Socket FD for remote control, -1 if not enabled */
+	int control_port;	/* Port for remote control */
+
+	/* Log file path */
+	char log_file[SIPP_MAX_LOG_PATH_LEN];
+
+	/* Linked list */
+	struct sipp_test *next;
+} sipp_test_t;
+
+
+/**
+ * Parameters for starting a new test
+ */
+typedef struct sipp_test_params
+{
+	str scenario;		  /* Scenario name (required) */
+	str from_number;	  /* Caller user/number/range/list */
+	str to_number;		  /* Service user/number/range/list */
+	str target_domain;	  /* Target domain (optional, uses module default) */
+	int concurrent_calls; /* Number of concurrent calls */
+	int call_rate;		  /* Calls per second (0 = use default) */
+	int duration;		  /* Call duration in seconds */
+	int total_calls_limit; /* Max total calls (0 = unlimited, -1 = use default) */
+	int max_test_duration; /* Max test duration in seconds (0 = unlimited, -1 = use default) */
+} sipp_test_params_t;
+
+
+/**
+ * Initialize the test management system
+ * @return 0 on success, -1 on error
+ */
+int sipp_test_init(void);
+
+/**
+ * Cleanup and destroy all tests
+ */
+void sipp_test_destroy(void);
+
+/**
+ * Start a new SIPp test
+ * @param params Test parameters
+ * @param test_id Output parameter for the new test ID
+ * @return 0 on success, -1 on error
+ */
+int sipp_test_start(sipp_test_params_t *params, int *test_id);
+
+/**
+ * Stop a running test
+ * @param test_id Test ID to stop
+ * @return 0 on success, -1 on error (test not found or already stopped)
+ */
+int sipp_test_stop(int test_id);
+
+/**
+ * Get test information and statistics
+ * @param test_id Test ID to query
+ * @return Test structure pointer on success, NULL if not found
+ */
+sipp_test_t *sipp_test_get(int test_id);
+
+/**
+ * Get all tests (for listing)
+ * NOTE: Caller must hold test lock via sipp_test_lock() for entire traversal
+ * @return Pointer to first test in linked list, NULL if no tests
+ */
+sipp_test_t *sipp_test_get_all(void);
+
+/**
+ * Thread-safe copy of test data
+ * @param test_id Test ID to query
+ * @param out Output buffer for test copy (caller-allocated)
+ * @return 0 on success, -1 if not found
+ */
+int sipp_test_get_copy(int test_id, sipp_test_t *out);
+
+/**
+ * Acquire test list lock for external iteration
+ * Must be paired with sipp_test_unlock()
+ */
+void sipp_test_lock(void);
+
+/**
+ * Release test list lock
+ */
+void sipp_test_unlock(void);
+
+/**
+ * Validate string contains only safe characters (alphanumeric, _, -, ., @)
+ * @param str String to validate
+ * @param len Length of string
+ * @return 0 if safe, -1 if contains unsafe characters
+ */
+int sipp_validate_safe_string(const char *str, int len);
+
+/**
+ * Validate scenario name (safe chars, no path traversal)
+ * @param scenario Scenario name
+ * @param len Length of scenario name
+ * @return 0 if valid, -1 if invalid
+ */
+int sipp_validate_scenario_name(const char *scenario, int len);
+
+/**
+ * Parse number specification (single, range, or comma-separated list)
+ * @param spec Number specification string
+ * @param output Output buffer for parsed first number
+ * @param output_len Maximum length of output buffer
+ * @return 0 on success, -1 on error
+ */
+int sipp_parse_number_spec(str *spec, char *output, int output_len);
+
+/**
+ * Validate domain against valid_domains list
+ * @param domain Domain to validate
+ * @return 0 if valid, -1 if invalid
+ */
+int sipp_validate_domain(str *domain);
+
+/**
+ * Determine transport from socket info
+ * @return Transport type (SIPP_TRANSPORT_UDP, SIPP_TRANSPORT_TCP, etc.)
+ */
+int sipp_get_transport(void);
+
+/**
+ * Get local IP address to bind SIPp
+ * @param ip_buf Buffer to store IP address
+ * @param buf_len Maximum length of buffer
+ * @return 0 on success, -1 on error
+ */
+int sipp_get_local_ip(char *ip_buf, int buf_len);
+
+/**
+ * Update test statistics from SIPp output
+ * @param test Test structure to update
+ * @return 0 on success, -1 on error
+ */
+int sipp_test_update_stats(sipp_test_t *test);
+
+/**
+ * Update and push metrics for all running tests to Prometheus
+ * Called frequently (every 5-10 seconds) by timer
+ */
+void sipp_metrics_update(void);
+
+/**
+ * Clean up old completed tests and remove log files
+ * Called infrequently (every 1 hour) by timer
+ */
+void sipp_test_cleanup(void);
+
+/**
+ * Send remote control command to SIPp
+ * @param test_id Test ID
+ * @param cmd Command character (q=quit, p=pause, r=resume, etc.)
+ * @return 0 on success, -1 on error
+ */
+int sipp_test_control_command(int test_id, char cmd);
+
+/**
+ * Get real-time statistics from SIPp via control socket
+ * @param test_id Test ID
+ * @return 0 on success, -1 on error
+ */
+int sipp_test_get_live_stats(int test_id);
+
+/**
+ * Adjust call rate dynamically
+ * @param test_id Test ID
+ * @param rate_change '+' to increase, '-' to decrease
+ * @return 0 on success, -1 on error
+ */
+int sipp_test_adjust_rate(int test_id, char rate_change);
+
+/**
+ * Push metrics to Prometheus (if xhttp_prom is loaded)
+ * @param test Test structure
+ */
+void sipp_push_prometheus_metrics(sipp_test_t *test);
+
+/* Accessor functions for module parameters */
+str *sipp_get_sipp_path(void);
+str *sipp_get_send_socket_name(void);
+str *sipp_get_send_socket(void);
+str *sipp_get_target_domain(void);
+str *sipp_get_default_from_number(void);
+str *sipp_get_default_to_number(void);
+str *sipp_get_scenario_dir(void);
+str *sipp_get_work_dir(void);
+str *sipp_get_media_ip(void);
+str *sipp_get_valid_domains(void);
+int sipp_get_default_concurrent_calls(void);
+int sipp_get_max_concurrent_calls(void);
+int sipp_get_max_concurrent_tests(void);
+int sipp_get_default_duration(void);
+int sipp_get_default_call_rate(void);
+int sipp_get_default_total_calls(void);
+int sipp_get_default_max_test_duration(void);
+int sipp_get_enable_prometheus(void);
+
+#endif /* _SIPP_TEST_H_ */


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Adds a SIPp integration module to run automated load tests via Kamailio RPC.  
Includes test start/stop/monitoring, domain whitelist and concurrency limits,  
remote control commands for pause/resume/rate adjustment, and Prometheus export  
via xhttp_prom when enabled.