### PR TITLE
core: tls - preserve outbound SNI across tcp main

### DIFF
--- a/src/core/tcp_conn.h
+++ b/src/core/tcp_conn.h
@@ -30,6 +30,7 @@
 #include "tcp_options.h"
 
 #include "ip_addr.h"
+#include "str.h"
 #include "locking.h"
 #include "atomic_ops.h"
 #include "timer_ticks.h"
@@ -283,6 +284,8 @@ typedef struct tcp_connection
 	enum tcp_conn_states state; /* connection state */
 	enum tcp_conn_states initstate; /* initial connection state */
 	void *extra_data; /* extra data associated to the connection, 0 for tcp*/
+	str tls_sni; /* outbound SNI (TLS) */
+	str tls_srvid; /* outbound TLS server_id */
 	struct timer_ln timer;
 	time_t timestamp; /* connection creation timestamp */
 	ticks_t timeout;  /* connection timeout, after this it will be removed*/


### PR DESCRIPTION
<!--
Explain what you did, what you expected to happen, and what actually happened.
-->

We started using tcp_main_threads=1 (with tls_threads_mode=2) to avoid stuck UDP workers (the initial issue described [here](https://github.com/kamailio/kamailio/issues/4325)) under high load with a lot of TLS connections. However, now we realized (not really realized, but receive a complaint that calls are completely broken with an operator that requires SNI) that SNI is not added anymore.

#### Reproduction

We've been using the following configuration for years:

```
modparam("tls", "xavp_cfg", "tls")
...
$xavp(tls=>server_name) = "domain.com";
```

When tcp_main_threads=1 doesn't present, SNI is added to outgoing TLS connection as it should. When it's added, Kamailio stops adding SNI at all.

#### Log Messages

```
Feb 04 16:58:33 myhost kamailio[654955]: DEBUG: tls [tls_server.c:202]: tls_get_connect_server_name(): xavp with outbound server name not found
```

### Additional Information

  * **Kamailio Version** - I repeated tests using the latest Kamailio from master and it works the same

```
# kamailio -v
version: kamailio 6.2.0-dev0 (aarch64/linux) e5e0e9-dirty
flags: , EXTRA_DEBUGUSE_TCP, USE_TLS, USE_SCTP, TLS_HOOKS, USE_RAW_SOCKS, DISABLE_NAGLE, USE_MCAST, DNS_IP_HACK, SHM_MMAP, PKG_MALLOC, MEM_JOIN_FREE, Q_MALLOC, F_MALLOC, TLSF_MALLOC, DBG_SR_MEMORY, DBG_QM_MALLOC, DBG_F_MALLOC, DBG_TLSF_MALLOC, USE_FUTEX, FAST_LOCK-ADAPTIVE_WAIT, USE_DNS_CACHE, USE_DNS_FAILOVER, USE_NAPTR, USE_DST_BLOCKLIST, HAVE_RESOLV_RES
ADAPTIVE_WAIT_LOOPS 1024, MAX_RECV_BUFFER_SIZE 262144, MAX_SEND_BUFFER_SIZE 262144, MAX_URI_SIZE 1024, BUF_SIZE 65535, DEFAULT PKG_SIZE 8MB
poll method support: poll, epoll_lt, epoll_et, sigio_rt, select.
id: e5e0e9 -dirty
compiled on 13:14:23 Feb  4 2026 with gcc 12.2.0
```
* **Operating System**:
```
# lsb_release -a
No LSB modules are available.
Distributor ID: Debian
Description:    Debian GNU/Linux 12 (bookworm)
Release:        12
Codename:       bookworm

# uname -a
Linux myhost 6.1.0-42-cloud-arm64 #1 SMP Debian 6.1.159-1 (2025-12-30) aarch64 GNU/Linux
```

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
In multi‑process mode (tcp_main_threads=1), XAVP list head is process‑local, so values set in worker routes are not visible in tcp main when TLS handshake occurs. This caused missing SNI even when $xavp(tls=>server_name) was set correctly. Storing the values in the shared tcp_connection resolves this while keeping behavior unchanged in single‑process mode.

Changes:
- store outbound TLS server_name/server_id from XAVP in tcp_connection (shm)
- use stored values during TLS init in tcp main
- free stored strings on connection cleanup