### PR TITLE
uac: Fix 2 spaces when replacing empty display name

### DIFF
--- a/src/modules/uac/replace.c
+++ b/src/modules/uac/replace.c
@@ -249,7 +249,7 @@ int replace_uri(struct sip_msg *msg, str *display, str *uri,
 	str param;
 	str buf;
 	msg_flags_t uac_flag;
-	int i;
+	int i, del_offset, del_len;
 	int_str avp_value;
 	struct dlg_cell *dlg = 0;
 	str *dlgvar_names;
@@ -313,10 +313,23 @@ int replace_uri(struct sip_msg *msg, str *display, str *uri,
 		l = 0;
 		/* first remove the existing display */
 		if(body->display.len) {
+			del_offset = body->display.s - msg->buf;
+			del_len = body->display.len;
+
 			LM_DBG("removing display [%.*s]\n", body->display.len,
 					body->display.s);
+
+			/* if removing display, also remove trailing spaces after it */
+			if(!display->len) {
+				p = body->display.s + body->display.len;
+				while(p < msg->buf + msg->len && *p == ' ') {
+					del_len++;
+					p++;
+				}
+			}
+
 			/* build del lump */
-			l = del_lump(msg, body->display.s - msg->buf, body->display.len, 0);
+			l = del_lump(msg, del_offset, del_len, 0);
 			if(l == 0) {
 				LM_ERR("display del lump failed\n");
 				goto error;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4582

#### Description
<!-- Describe your changes in detail -->

PR aims to fix the 2 spaced related to the references issued. 

After reading the rfc of what is allow for the header fields, i tried to consider most of the cases and output the recommended form of `Header: header_value`, one space after colon. Also one space after the Display name.
