### PR TITLE
dialog: fix race condition in link_dlg_profile

### DIFF
--- a/src/modules/dialog/dlg_profile.c
+++ b/src/modules/dialog/dlg_profile.c
@@ -518,15 +518,16 @@ static void link_dlg_profile(
 		linker->next = dlg->profile_links;
 		dlg->profile_links = linker;
 		linker->hash_linker.dlg = dlg;
+		link_profile(linker, &dlg->callid);
 		dlg_unlock(d_table, d_entry);
 	} else {
 		linker->next = dlg->profile_links;
 		dlg->profile_links = linker;
 		linker->hash_linker.dlg = dlg;
+		link_profile(linker, &dlg->callid);
 	}
 
 	atomic_or_int((volatile int *)&dlg->dflags, DLG_FLAG_CHANGED_PROF);
-	link_profile(linker, &dlg->callid);
 }
 
 


### PR DESCRIPTION
## Summary

Fix race condition in `link_dlg_profile()` that causes SIGSEGV or infinite loop in `get_profile_size()` under concurrent load with dialog expirations.

- Move `link_profile()` inside the dialog entry lock so the linker is atomically visible to both the dialog's profile list and the profile hash table
- Prevents `destroy_linkers()` from freeing a linker before `link_profile()` inserts it into the hash table
- Lock ordering (dialog lock → profile lock) is preserved

## Root Cause

In `link_dlg_profile()`, the dialog entry lock is released at line 521 before `link_profile()` is called at line 529. Between these two points, the linker is on the dialog's profile list (visible to `destroy_linkers()`) but not yet in the profile hash table (`hash_linker.next` is still NULL).

When `destroy_linkers()` runs concurrently (e.g., dialog timeout expiration), it checks `l->hash_linker.next` to decide whether to unlink from the profile hash table. Since `link_profile()` hasn't run yet, `next` is NULL, so `destroy_linkers()` skips the unlink and calls `shm_free()`. The original worker then calls `link_profile()` on freed memory, corrupting the hash table.

## Reproduction

Tested on unmodified master at commit 6ca2cf8, built with `gcc 14.2.0`, `CFLAGS="-g -O0"`, on x86_64 Linux.

**Without fix:** SIGSEGV in `get_profile_size()` within seconds at 1000 calls/sec.
**With fix:** Survived 30,000 calls at 1000 cps and 46,000+ calls at 2000 cps with zero crashes.

Two servers: Kamailio on 10.0.0.40:5060, SIPp UAS on 10.0.0.41:5080. SIPp UAC sends INVITE → ACK → 4 rapid INFO requests near the 1-second dialog timeout boundary.

<details>
<summary>Kamailio configuration</summary>

```
##
## Kamailio configuration to reproduce dialog profile race condition
## https://github.com/kamailio/kamailio/issues/2923
##

#!define LISTEN_IP "10.0.0.40"
#!define LISTEN_PORT 5060
#!define UAS_IP "10.0.0.41"
#!define UAS_PORT 5080

debug=0
log_stderror=no
log_facility=LOG_LOCAL0
fork=yes
children=16
auto_aliases=no

listen=udp:LISTEN_IP:LISTEN_PORT

mpath="/usr/local/kamailio-master/lib64/kamailio/modules/"

loadmodule "tm.so"
loadmodule "sl.so"
loadmodule "rr.so"
loadmodule "maxfwd.so"
loadmodule "textops.so"
loadmodule "siputils.so"
loadmodule "pv.so"
loadmodule "dialog.so"
loadmodule "xlog.so"
loadmodule "jsonrpcs.so"
loadmodule "kex.so"
loadmodule "rtimer.so"
loadmodule "htable.so"

modparam("jsonrpcs", "fifo_name", "/var/run/kamailio/kamailio_rpc.fifo")
modparam("jsonrpcs", "dgram_socket", "/var/run/kamailio/kamailio_rpc.sock")

modparam("dialog", "timeout_avp", "$avp(dlg_timeout)")
modparam("dialog", "default_timeout", 1)
modparam("dialog", "profiles_with_value", "carrier ; region ; service ; tier")
modparam("dialog", "profiles_no_value", "calls ; active ; premium ; standard")

modparam("tm", "fr_timer", 5000)
modparam("tm", "fr_inv_timer", 10000)

modparam("rr", "enable_full_lr", 1)
modparam("rr", "append_fromtag", 1)

modparam("rtimer", "timer", "name=prof_check;interval=50000;mode=1")
modparam("rtimer", "exec", "timer=prof_check;route=PROFILE_CHECK")

modparam("htable", "htable", "stats=>size=4;autoexpire=300")

request_route {
    if (!mf_process_maxfwd_header("10")) {
        sl_send_reply("483", "Too Many Hops");
        exit;
    }

    if (is_method("INVITE|UPDATE")) {
        record_route();
    }

    if (has_totag()) {
        if (is_method("UPDATE|BYE|PRACK|INFO")) {
            $var(idx) = $Ts mod 20;

            set_dlg_profile("carrier", "carrier-$var(idx)");
            set_dlg_profile("region", "region-$var(idx)");
            set_dlg_profile("service", "svc-$var(idx)");
            set_dlg_profile("tier", "tier-$var(idx)");
            set_dlg_profile("calls");
            set_dlg_profile("active");
            set_dlg_profile("premium");
            set_dlg_profile("standard");

            get_profile_size("carrier", "carrier-$var(idx)", "$var(cnt1)");
            get_profile_size("region", "region-$var(idx)", "$var(cnt2)");
            get_profile_size("service", "svc-$var(idx)", "$var(cnt3)");
            get_profile_size("calls", "$var(cnt4)");
            get_profile_size("active", "$var(cnt5)");
        }

        if (loose_route()) {
            route(RELAY);
            exit;
        }
        if (is_method("ACK")) {
            if (t_check_trans()) {
                route(RELAY);
                exit;
            }
            exit;
        }
        if (is_method("INFO|UPDATE")) {
            sl_send_reply("200", "OK");
            exit;
        }
        sl_send_reply("404", "Not Here");
        exit;
    }

    if (is_method("CANCEL")) {
        if (t_check_trans()) {
            t_relay();
        }
        exit;
    }

    if (is_method("INVITE")) {
        dlg_manage();

        $var(idx) = $Ts mod 20;
        set_dlg_profile("carrier", "carrier-$var(idx)");
        set_dlg_profile("region", "region-$var(idx)");
        set_dlg_profile("service", "svc-$var(idx)");
        set_dlg_profile("tier", "tier-$var(idx)");
        set_dlg_profile("calls");
        set_dlg_profile("active");
        set_dlg_profile("premium");
        set_dlg_profile("standard");

        get_profile_size("carrier", "carrier-$var(idx)", "$var(cnt)");
        get_profile_size("calls", "$var(total)");

        $avp(dlg_timeout) = 1;

        $ru = "sip:test@" + UAS_IP + ":" + UAS_PORT;
        route(RELAY);
        exit;
    }

    if (is_method("OPTIONS")) {
        sl_send_reply("200", "OK");
        exit;
    }

    sl_send_reply("405", "Method Not Allowed");
    exit;
}

route[RELAY] {
    if (!t_relay()) {
        sl_reply_error();
    }
}

onreply_route {
    if (is_method("INVITE") && status =~ "2[0-9][0-9]") {
        $var(idx) = $Ts mod 20;
        set_dlg_profile("carrier", "carrier-$var(idx)");
        set_dlg_profile("region", "region-$var(idx)");
        get_profile_size("carrier", "carrier-$var(idx)", "$var(cnt)");
        get_profile_size("calls", "$var(total)");
    }
}

route[PROFILE_CHECK] {
    $var(i) = 0;
    while ($var(i) < 20) {
        get_profile_size("carrier", "carrier-$var(i)", "$var(cnt)");
        get_profile_size("region", "region-$var(i)", "$var(cnt)");
        $var(i) = $var(i) + 1;
    }
    get_profile_size("calls", "$var(total)");
    get_profile_size("active", "$var(total2)");
}
```

</details>

<details>
<summary>SIPp UAC scenario</summary>

```xml
<?xml version="1.0" encoding="ISO-8859-1" ?>
<!DOCTYPE scenario SYSTEM "sipp.dtd">

<scenario name="UAC - aggressive race trigger">

  <send retrans="500">
    <![CDATA[
      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag[call_number]
      To: test <sip:[service]@[remote_ip]:[remote_port]>
      Call-ID: [call_id]
      CSeq: 1 INVITE
      Contact: sip:sipp@[local_ip]:[local_port]
      Max-Forwards: 70
      Content-Type: application/sdp
      Content-Length: [len]

      v=0
      o=user1 53655765 2353687637 IN IP[local_ip_type] [local_ip]
      s=-
      c=IN IP[media_ip_type] [media_ip]
      t=0 0
      m=audio [media_port] RTP/AVP 0
      a=rtpmap:0 PCMU/8000
    ]]>
  </send>

  <recv response="100" optional="true" />
  <recv response="180" optional="true" />
  <recv response="183" optional="true" />
  <recv response="200" rtd="true" />

  <send>
    <![CDATA[
      ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag[call_number]
      To: test <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
      Call-ID: [call_id]
      CSeq: 1 ACK
      Contact: sip:sipp@[local_ip]:[local_port]
      Max-Forwards: 70
      [routes]
      Content-Length: 0
    ]]>
  </send>

  <pause milliseconds="700" />

  <send retrans="500">
    <![CDATA[
      INFO sip:[service]@[remote_ip]:[remote_port] SIP/2.0
      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag[call_number]
      To: test <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
      Call-ID: [call_id]
      CSeq: 2 INFO
      Contact: sip:sipp@[local_ip]:[local_port]
      Max-Forwards: 70
      [routes]
      Content-Length: 0
    ]]>
  </send>

  <recv response="200" timeout="2000" />
  <pause milliseconds="50" />

  <send retrans="500">
    <![CDATA[
      INFO sip:[service]@[remote_ip]:[remote_port] SIP/2.0
      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag[call_number]
      To: test <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
      Call-ID: [call_id]
      CSeq: 3 INFO
      Contact: sip:sipp@[local_ip]:[local_port]
      Max-Forwards: 70
      [routes]
      Content-Length: 0
    ]]>
  </send>

  <recv response="200" timeout="2000" />
  <pause milliseconds="50" />

  <send retrans="500">
    <![CDATA[
      INFO sip:[service]@[remote_ip]:[remote_port] SIP/2.0
      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag[call_number]
      To: test <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
      Call-ID: [call_id]
      CSeq: 4 INFO
      Contact: sip:sipp@[local_ip]:[local_port]
      Max-Forwards: 70
      [routes]
      Content-Length: 0
    ]]>
  </send>

  <recv response="200" timeout="2000" />
  <pause milliseconds="200" />

  <send retrans="500">
    <![CDATA[
      INFO sip:[service]@[remote_ip]:[remote_port] SIP/2.0
      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag[call_number]
      To: test <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
      Call-ID: [call_id]
      CSeq: 5 INFO
      Contact: sip:sipp@[local_ip]:[local_port]
      Max-Forwards: 70
      [routes]
      Content-Length: 0
    ]]>
  </send>

  <recv response="200" timeout="2000" />

</scenario>
```

</details>

<details>
<summary>SIPp UAS scenario</summary>

```xml
<?xml version="1.0" encoding="ISO-8859-1" ?>
<!DOCTYPE scenario SYSTEM "sipp.dtd">

<!-- UAS scenario: auto-answer INVITEs immediately -->
<scenario name="UAS - Auto answer">

  <recv request="INVITE" crlf="true" />

  <send>
    <![CDATA[
      SIP/2.0 200 OK
      [last_Via:]
      [last_From:]
      [last_To:];tag=[pid]SIPpTag[call_number]
      [last_Call-ID:]
      [last_CSeq:]
      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
      Content-Type: application/sdp
      Content-Length: [len]

      v=0
      o=user1 53655765 2353687637 IN IP[local_ip_type] [local_ip]
      s=-
      c=IN IP[media_ip_type] [media_ip]
      t=0 0
      m=audio [media_port] RTP/AVP 0
      a=rtpmap:0 PCMU/8000
    ]]>
  </send>

  <recv request="ACK" optional="true" timeout="5000" crlf="true" />

  <recv request="BYE" />

  <send>
    <![CDATA[
      SIP/2.0 200 OK
      [last_Via:]
      [last_From:]
      [last_To:]
      [last_Call-ID:]
      [last_CSeq:]
      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
      Content-Length: 0
    ]]>
  </send>

  <timewait milliseconds="100" />

</scenario>
```

</details>

<details>
<summary>GDB backtrace analysis (crash on unmodified master)</summary>

Core from kamailio 6.2.0-dev0 (commit 6ca2cf8), built with `gcc 14.2.0`, `CFLAGS="-g -O0"`, x86_64 Linux.

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007fd1c88a1e73 in get_profile_size (profile=0x7fd1c4997b70, value=0x7fff8f522910) at dlg_profile.c:868
868                     if(value->len == ph->value.len
```

**Faulting address from dmesg:** `segfault at 8` — this is `NULL + offsetof(dlg_profile_hash, value.len)`, confirming `ph = 0x0`.

**Kernel error code:** `error 4` — user-mode read of an unmapped page (not-present, read access, user mode).

```
dmesg:
  kamailio[2479212]: segfault at 8 ip 00007fd1c88a1e73 sp 00007fff8f522790
  error 4 in dialog.so[a5e73,7fd1c8805000+cc000]
```

**Local variables (bt full):**

| Frame | Function | Variable | Value | Significance |
|-------|----------|----------|-------|--------------|
| #0 | `get_profile_size` | `ph` | `0x0` | NULL in a circular list — the list is corrupted |
| #0 | | `n` | `280` | 280 nodes traversed before hitting the corrupt entry |
| #0 | | `i` | `7` | Hash bucket index for this profile value |
| #2 | `w_get_profile_size3` | `val_s` | `{s = "svc-14", len = 6}` | Profile value being looked up |
| #10 | `receive_msg` | `buf` | `"INFO sip:test@10.0.0.40:5060 SIP/2.0..."` | Triggering SIP message |
| #12 | `main_loop` | `si_desc` | `"udp receiver child=1 sock=10.0.0.40:5060"` | Crashing worker process |
| #12 | | `nrprocs` | `16` | Concurrent worker count |

`get_profile_size()` traverses `profile->entries[i]` as a circular doubly-linked list via `ph = ph->next` until it wraps back to `first`. A NULL `next` pointer cannot occur in a correctly maintained circular list. The only code path that sets `next = NULL` is `destroy_linkers()` (`lh->next = lh->prev = NULL` after unlinking, followed by `shm_free`). The 280 successful iterations before the NULL indicate localized corruption of the hash chain rather than an uninitialized or empty list.

</details>

<details>
<summary>Full GDB session output</summary>

```
Core file: /tmp/core.kamailio.2479212
Binary:    /usr/local/kamailio-master/sbin/kamailio
Command:   /usr/local/kamailio-master/sbin/kamailio -f /etc/kamailio/kamailio-repro.cfg -DD -E
Version:   kamailio 6.2.0-dev0 (x86_64/linux) 6ca2cf
Compiled:  Feb 13 2026 with gcc 14.2.0
Commit:    6ca2cf8 (master branch, unmodified)
Build:     make cfg group_include="kstandard" CFLAGS="-g -O0" PREFIX=/usr/local/kamailio-master

dmesg entry:
  kamailio[2479212]: segfault at 8 ip 00007fd1c88a1e73 sp 00007fff8f522790 error 4 in dialog.so[a5e73,7fd1c8805000+cc000] likely on CPU 0 (core 0, socket 0)

BACKTRACE (bt)

Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007fd1c88a1e73 in get_profile_size (profile=0x7fd1c4997b70, value=0x7fff8f522910) at dlg_profile.c:868
868                     if(value->len == ph->value.len
#0  0x00007fd1c88a1e73 in get_profile_size (profile=0x7fd1c4997b70, value=0x7fff8f522910) at dlg_profile.c:868
#1  0x00007fd1c8813bb9 in w_get_profile_size_helper (msg=0x7fd1c8ec45b0, profile=0x7fd1c4997b70, value=0x7fff8f522910, spd=0x7fd1c8e7eec0) at dialog.c:1021
#2  0x00007fd1c88143ef in w_get_profile_size3 (msg=0x7fd1c8ec45b0, profile=0x7fd1c4997b70, value=0x7fd1c8e86f20, result=0x7fd1c8e7eec0) at dialog.c:1060
#3  0x0000555750caaaa6 in do_action (h=0x7fff8f524440, a=0x7fd1c8e869f0, msg=0x7fd1c8ec45b0) at core/action.c:1137
#4  0x0000555750cb9036 in run_actions (h=0x7fff8f524440, a=0x7fd1c8e836f0, msg=0x7fd1c8ec45b0) at core/action.c:1620
#5  0x0000555750caa878 in do_action (h=0x7fff8f524440, a=0x7fd1c8e87c20, msg=0x7fd1c8ec45b0) at core/action.c:1115
#6  0x0000555750cb9036 in run_actions (h=0x7fff8f524440, a=0x7fd1c8e87c20, msg=0x7fd1c8ec45b0) at core/action.c:1620
#7  0x0000555750caa878 in do_action (h=0x7fff8f524440, a=0x7fd1c8e8dfc0, msg=0x7fd1c8ec45b0) at core/action.c:1115
#8  0x0000555750cb9036 in run_actions (h=0x7fff8f524440, a=0x7fd1c8e7f540, msg=0x7fd1c8ec45b0) at core/action.c:1620
#9  0x0000555750cb97e1 in run_top_route (a=0x7fd1c8e7f540, msg=0x7fd1c8ec45b0, c=0x0) at core/action.c:1703
#10 0x0000555750e3c5bf in receive_msg (buf=0x55575132ab40 <buf> "INFO sip:test@10.0.0.40:5060 SIP/2.0\r\nVia: SIP/2.0/UDP 10.0.0.40:5061;branch=z9hG4bK-2479262-677-13\r\nFrom: sipp <sip:sipp@10.0.0.40:5061>;tag=2479262SIPpTag677\r\nTo: test <sip:test@10.0.0.40:5060>;tag="..., len=339, rcv_info=0x7fff8f524af0) at core/receive.c:520
#11 0x0000555750fae242 in udp_rcv_loop () at core/udp_server.c:788
#12 0x0000555750c93846 in main_loop () at main.c:1907
#13 0x0000555750ca0ef3 in main (argc=5, argv=0x7fff8f525208) at main.c:3434

REGISTERS (info registers)

rax            0x0                 0
rbx            0x100000000         4294967296
rcx            0x34312d632d637673  3760837067817580147
rdx            0x6                 6
rsi            0x2d637673          761493107
rdi            0x2d637673          761493107
rbp            0x7fff8f5227b0      0x7fff8f5227b0
rsp            0x7fff8f522790      0x7fff8f522790
r8             0x7fff8f522918      140735597914392
r9             0x24b               587
r10            0x555750ff19e8      93833509411304
r11            0x0                 0
r12            0x0                 0
r13            0x7fff8f525238      140735597924920
r14            0x7fd1c980b000      140539005546496
r15            0x555751260d48      93833511963976
rip            0x7fd1c88a1e73      0x7fd1c88a1e73 <get_profile_size+220>
eflags         0x10287             [ CF PF SF IF RF ]

FULL BACKTRACE (bt full)

#0  get_profile_size (profile=0x7fd1c4997b70, value=0x7fff8f522910) at dlg_profile.c:868
        n = 280
        i = 7
        ph = 0x0

#1  w_get_profile_size_helper at dialog.c:1021
        size = 32721
        val = {rs = {s = 0x7fff8f522860, len = 1356993086}, ...}

#2  w_get_profile_size3 at dialog.c:1060
        val_s = {s = 0x7fd1c8e59590 "svc-14", len = 6}

#3-#9  do_action / run_actions call chain (Kamailio script execution)

#10 receive_msg at core/receive.c:520
        buf = "INFO sip:test@10.0.0.40:5060 SIP/2.0\r\nVia: SIP/2.0/UDP 10.0.0.40:5061;branch=z9hG4bK-2479262-677-13\r\n..."
        len = 339

#11 udp_rcv_loop at core/udp_server.c:788
        len = 339
        rcvi.src_ip = 10.0.0.40
        rcvi.src_port = 5061
        rcvi.dst_port = 5060

#12 main_loop at main.c:1907
        si_desc = "udp receiver child=1 sock=10.0.0.40:5060"
        nrprocs = 16

#13 main at main.c:3434

THREADS (info threads)

  Id   Target Id                           Frame
* 1    Thread 0x7fd1c94df740 (LWP 2479212) 0x00007fd1c88a1e73 in get_profile_size (profile=0x7fd1c4997b70, value=0x7fff8f522910) at dlg_profile.c:868

THREAD BACKTRACE (thread apply all bt)

Thread 1 (Thread 0x7fd1c94df740 (LWP 2479212)):
#0  0x00007fd1c88a1e73 in get_profile_size (profile=0x7fd1c4997b70, value=0x7fff8f522910) at dlg_profile.c:868
#1  0x00007fd1c8813bb9 in w_get_profile_size_helper (msg=0x7fd1c8ec45b0, profile=0x7fd1c4997b70, value=0x7fff8f522910, spd=0x7fd1c8e7eec0) at dialog.c:1021
#2  0x00007fd1c88143ef in w_get_profile_size3 (msg=0x7fd1c8ec45b0, ...) at dialog.c:1060
#3  0x0000555750caaaa6 in do_action (...) at core/action.c:1137
#4  0x0000555750cb9036 in run_actions (...) at core/action.c:1620
#5  0x0000555750caa878 in do_action (...) at core/action.c:1115
#6  0x0000555750cb9036 in run_actions (...) at core/action.c:1620
#7  0x0000555750caa878 in do_action (...) at core/action.c:1115
#8  0x0000555750cb9036 in run_actions (...) at core/action.c:1620
#9  0x0000555750cb97e1 in run_top_route (...) at core/action.c:1703
#10 0x0000555750e3c5bf in receive_msg (...) at core/receive.c:520
#11 0x0000555750fae242 in udp_rcv_loop () at core/udp_server.c:788
#12 0x0000555750c93846 in main_loop () at main.c:1907
#13 0x0000555750ca0ef3 in main (argc=5, argv=0x7fff8f525208) at main.c:3434
```

</details>

<details>
<summary>Test results comparison</summary>

| | Before fix | After fix |
|---|---|---|
| Test rate | 1000 cps | 1000 cps AND 2000 cps |
| Crashed? | YES, in <10 seconds | NO |
| Core dumps | SIGSEGV in dialog.so | None |
| Total calls survived | ~few thousand | 30,000 at 1000 cps, 46,000+ at 2000 cps |
| dmesg segfaults | Yes | None |

</details>

GH #2923
