### PR TITLE
outbound: parse Expires header to prevent crash

### DIFF
--- a/src/modules/outbound/outbound_mod.c
+++ b/src/modules/outbound/outbound_mod.c
@@ -342,11 +342,21 @@ static int use_outbound_register(struct sip_msg *msg)
 			return 0;
 		}
 
-		if(((contact_body_t *)msg->contact->parsed)->star
-				&& ((exp_body_t *)msg->expires->parsed)->val == 0) {
-			LM_DBG("found REGISTER with * in Contact: header body and Expires "
-				   ": 0 - outbound used\n");
-			return 1;
+		if(((contact_body_t *)msg->contact->parsed)->star) {
+			if(!msg->expires) {
+				LM_ERR("absent Expires header\n");
+				return 0;
+			}
+			if(!msg->expires->parsed && parse_expires(msg->expires) < 0) {
+				LM_ERR("parsing Expires: header body\n");
+				return 0;
+			}
+			if(((exp_body_t *)msg->expires->parsed)->val == 0) {
+				LM_DBG("found REGISTER with * in Contact: header body and "
+					   "Expires "
+					   ": 0 - outbound used\n");
+				return 1;
+			}
 		}
 
 		contact = ((contact_body_t *)msg->contact->parsed)->contacts;


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Fix crash on unregister all sip request.
- added parsing Expires header if it's present in sip request.

After receiving and processing the SIP REGISTER request, it's possible to call a `use_outbound_register` function as example in `add_path()` method of _path_ module. If the sip REGISTER request has a Contact header of the form `*` then the request must also contain the header Expires(rfc3261 10.2.2). The sip parser don't parse Expires header. And at this time kamailio crashes.

### Reproduction
Sent a request to deregister all SIP packets.
<details open>
<summary>Kamailio configuration</summary>

```
loadmodule "sl.so"
loadmodule "outbound.so"
loadmodule "path.so"

# Routing configuration
route {
    add_path();
    sl_send_reply("200","OK");
}
```
 </details>
 <details open>
 <summary>SIPp UAC scenario</summary>
 
```
<?xml version="1.0" encoding="ISO-8859-1" ?>
<!DOCTYPE scenario SYSTEM "unreg.sipp">

<scenario name="UAC - unregister all">

  <send retrans="500">
    <![CDATA[
      REGISTER sip:127.0.0.1 SIP/2.0
      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag[call_number]
      To: test <sip:127.0.0.1>
      Call-ID: [call_id]
      CSeq: 1 REGISTER
      Contact: *
      Expires: 0
      Max-Forwards: 70
    ]]>
  </send>

  <recv response="200"/>
</scenario>
```

 </details>