### PR TITLE
siptrace: fixed port for outbound TCP/TLS connections

### DIFF
--- a/src/core/ip_addr.h
+++ b/src/core/ip_addr.h
@@ -236,6 +236,15 @@ typedef struct receive_info
 } receive_info_t;
 
 
+/* optional actual local address used for TCP/TLS send (ephemeral port) */
+typedef struct dest_sent_local
+{
+	struct ip_addr ip;
+	unsigned short port;
+	char proto;
+	unsigned char set; /* 1 if filled by tcp_send for TCP/TLS */
+} dest_sent_local_t;
+
 typedef struct dest_info
 {
 	struct socket_info *send_sock;
@@ -250,6 +259,7 @@ typedef struct dest_info
 	char proto_pad0;  /* padding field */
 	short proto_pad1; /* padding field */
 #endif
+	dest_sent_local_t sent_local; /* actual local addr for outbound TCP/TLS */
 } dest_info_t;
 
 typedef struct sr_net_info

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -2136,6 +2136,7 @@ int tcp_send(struct dest_info *dst, union sockaddr_union *from, const char *buf,
 		LM_ERR("no destination address provided\n");
 		return -1;
 	}
+	dst->sent_local.set = 0;
 
 	port = su_getport(&dst->to);
 	try_local_port = (dst->send_sock) ? dst->send_sock->port_no : 0;
@@ -2512,14 +2513,32 @@ int tcp_send(struct dest_info *dst, union sockaddr_union *from, const char *buf,
 			tcp_safe_close(fd);
 		/* here we can have only commands that _do_ _not_ dec refcnt.
 	 * (CONN_EOF, CON_ERROR, CON_QUEUED_WRITE are all treated above) */
+		if(n >= 0) {
+			dst->sent_local.ip = c->rcv.dst_ip;
+			dst->sent_local.port = c->rcv.dst_port;
+			dst->sent_local.proto = c->rcv.proto;
+			dst->sent_local.set = 1;
+		}
 		goto release_c;
 	} /* if (c==0 or unusable) new connection */
 	/* existing connection, send on it */
 	n = tcpconn_send_put(c, buf, len, dst->send_flags);
 	/* no deref needed (automatically done inside tcpconn_send_put() */
+	if(n >= 0) {
+		dst->sent_local.ip = c->rcv.dst_ip;
+		dst->sent_local.port = c->rcv.dst_port;
+		dst->sent_local.proto = c->rcv.proto;
+		dst->sent_local.set = 1;
+	}
 	return n;
 #ifdef TCP_CONNECT_WAIT
 conn_wait_success:
+	if(n >= 0) {
+		dst->sent_local.ip = c->rcv.dst_ip;
+		dst->sent_local.port = c->rcv.dst_port;
+		dst->sent_local.proto = c->rcv.proto;
+		dst->sent_local.set = 1;
+	}
 #ifdef TCP_FD_CACHE
 	if(cfg_get(tcp, tcp_cfg, fd_cache)) {
 		tcp_fd_cache_add(c, fd);
@@ -2564,6 +2583,12 @@ conn_wait_close:
 	return n;
 #endif /* TCP_CONNECT_WAIT */
 release_c:
+	if(n >= 0) {
+		dst->sent_local.ip = c->rcv.dst_ip;
+		dst->sent_local.port = c->rcv.dst_port;
+		dst->sent_local.proto = c->rcv.proto;
+		dst->sent_local.set = 1;
+	}
 	tcpconn_chld_put(c); /* release c (dec refcnt & free on 0) */
 end_no_deref:
 end_no_conn:

--- a/src/modules/siptrace/siptrace.c
+++ b/src/modules/siptrace/siptrace.c
@@ -2456,8 +2456,25 @@ int siptrace_net_data_sent(sr_event_param_t *evp)
 	if(unlikely(new_dst.send_sock == 0)) {
 		LM_WARN("no sending socket found\n");
 		strcpy(sto.fromip_buff, SIPTRACE_ANYADDR);
+		sto.fromip.s = sto.fromip_buff;
 		sto.fromip.len = SIPTRACE_ANYADDR_LEN;
 		proto = PROTO_UDP;
+	} else if(new_dst.sent_local.set
+			  && (new_dst.sent_local.proto == PROTO_TCP
+					  || new_dst.sent_local.proto == PROTO_TLS)) {
+		/* use actual local address (ephemeral port) for outbound TCP/TLS */
+		sto.fromip.len = snprintf(sto.fromip_buff, SIPTRACE_ADDR_MAX,
+				"%s:%s:%d", siptrace_proto_name(new_dst.sent_local.proto),
+				ip_addr2strz(&new_dst.sent_local.ip),
+				(int)new_dst.sent_local.port);
+		if(sto.fromip.len < 0 || sto.fromip.len >= SIPTRACE_ADDR_MAX) {
+			LM_ERR("failed to format fromip buffer (%d)\n", sto.fromip.len);
+			sto.fromip.s = SIPTRACE_ANYADDR;
+			sto.fromip.len = SIPTRACE_ANYADDR_LEN;
+		} else {
+			sto.fromip.s = sto.fromip_buff;
+		}
+		proto = new_dst.sent_local.proto;
 	} else {
 		if((_siptrace_data_mode & SIPTRACE_DATA_MODE_ADVADDR)
 				&& new_dst.send_sock->useinfo.sock_str.len > 0) {
@@ -2472,9 +2489,9 @@ int siptrace_net_data_sent(sr_event_param_t *evp)
 		memcpy(sto.fromip_buff, vsock.s, vsock.len);
 		sto.fromip.len = vsock.len;
 		sto.fromip_buff[sto.fromip.len] = '\0';
+		sto.fromip.s = sto.fromip_buff;
 		proto = new_dst.send_sock->proto;
 	}
-	sto.fromip.s = sto.fromip_buff;
 
 	sto.toip.len = snprintf(sto.toip_buff, SIPTRACE_ADDR_MAX, "%s:%s:%d",
 			siptrace_proto_name(proto), suip2a(&new_dst.to, sizeof(new_dst.to)),


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2092 

#### Description
Fixes source port reporting.
Useful for call signaling analyse using Homer servers.