### PR TITLE
mtree: new connect mode to limit the amount of connections

### DIFF
--- a/src/modules/mtree/doc/mtree_admin.xml
+++ b/src/modules/mtree/doc/mtree_admin.xml
@@ -265,6 +265,39 @@ modparam("mtree", "fetch_rows", 4000)
 	    </example>
 	</section>
 
+	<section id="mtree.p.connect_mode">
+	    <title><varname>connect_mode</varname> (int)</title>
+	    <para>
+		Control how the module will connect to database.
+		Values:
+	    </para>
+	<itemizedlist>
+		<listitem>
+		<para>
+			<emphasis>0</emphasis> - connect at start up in each child process or fail
+		</para>
+		</listitem>
+		<listitem>
+		<para>
+			<emphasis>1</emphasis> - do not connect until tree reload is needed (this will limit the amount of idle connections)
+		</para>
+		</listitem>
+	</itemizedlist>
+	    <para>
+		<emphasis>
+		    Default value is 0.
+		</emphasis>
+	    </para>
+	    <example>
+		<title>Set <varname>connect_mode</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("mtree", "connect_mode", 1)
+...
+</programlisting>
+	    </example>
+	</section>
+
 	<section id="mtree.p.char_list">
 	    <title><varname>char_list</varname> (string)</title>
 	    <para>

--- a/src/modules/mtree/mtree_mod.c
+++ b/src/modules/mtree/mtree_mod.c
@@ -52,6 +52,7 @@ MODULE_VERSION
 #define NR_KEYS 3
 
 int mt_fetch_rows = 1000;
+static int mt_connect_mode = 0;
 
 /** database connection */
 static db1_con_t *db_con = NULL;
@@ -140,6 +141,7 @@ static param_export_t params[] = {
 	{"tvalue_column", PARAM_STR, &tvalue_column},
 	{"char_list", PARAM_STR, &mt_char_list},
 	{"fetch_rows", PARAM_INT, &mt_fetch_rows},
+	{"connect_mode", PARAM_INT, &mt_connect_mode},
 	{"pv_value", PARAM_STR, &value_param},
 	{"pv_values", PARAM_STR, &values_param},
 	{"pv_dstid", PARAM_STR, &dstid_param},
@@ -309,12 +311,20 @@ static int child_init(int rank)
 	if(rank == PROC_INIT || rank == PROC_MAIN || rank == PROC_TCP_MAIN)
 		return 0;
 
+	if(mt_connect_mode == 1) {
+		LM_DBG("mtree: database connection deferred until reload (connect_mode=1) "
+				"rank[%d] pid[%d]\n",
+				rank, getpid());
+		return 0;
+	}
+
 	db_con = mt_dbf.init(&db_url);
 	if(db_con == NULL) {
 		LM_ERR("failed to connect to database\n");
 		return -1;
 	}
-	LM_DBG("#%d: database connection opened successfully\n", rank);
+	LM_DBG("mtree: database connection opened at startup rank[%d] pid[%d]\n",
+			rank, getpid());
 
 	return 0;
 }
@@ -515,8 +525,19 @@ static int mt_load_db(m_tree_t *pt)
 	VAL_STRING(vals) = pt->tname.s;
 
 	if(db_con == NULL) {
-		LM_ERR("no db connection\n");
-		return -1;
+		if(mt_connect_mode != 1) {
+			LM_ERR("no db connection\n");
+			return -1;
+		}
+		LM_INFO("mtree: connecting to database on-demand for reload pid[%d]\n",
+				getpid());
+		db_con = mt_dbf.init(&db_url);
+		if(db_con == NULL) {
+			LM_ERR("failed to connect to database on-demand\n");
+			return -1;
+		}
+		LM_INFO("mtree: database connection established on-demand pid[%d]\n",
+				getpid());
 	}
 
 	old_tree = mt_get_tree(&(pt->tname));
@@ -666,8 +687,19 @@ static int mt_load_db_trees()
 	m_tree_t *old_head = NULL;
 
 	if(db_con == NULL) {
-		LM_ERR("no db connection\n");
-		return -1;
+		if(mt_connect_mode != 1) {
+			LM_ERR("no db connection\n");
+			return -1;
+		}
+		LM_INFO("mtree: connecting to database on-demand for trees reload pid[%d]\n",
+				getpid());
+		db_con = mt_dbf.init(&db_url);
+		if(db_con == NULL) {
+			LM_ERR("failed to connect to database on-demand\n");
+			return -1;
+		}
+		LM_INFO("mtree: database connection established on-demand pid[%d]\n",
+				getpid());
 	}
 
 	if(mt_dbf.use_table(db_con, &db_table) < 0) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] New feature (non-breaking change which adds new functionality)


#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] Tested changes locally


#### Description
<!-- Describe your changes in detail -->
Very often I only need one connection from a worker process, to cache fill provisioning data  to Kamailio.
This new mtree connect mode will reduce the amount of idle connection to the database server significantly.


