### PR TITLE
tls: check SSL_set_app_data return value and handle the error case

### DIFF
--- a/src/modules/tls/tls_server.c
+++ b/src/modules/tls/tls_server.c
@@ -376,11 +376,18 @@ static int tls_complete_init(struct tcp_connection *c)
 	}
 #endif
 #endif
-	SSL_set_bio(data->ssl, data->rwbio, data->rwbio);
-	c->extra_data = data;
-
-	/* link the extra data struct inside ssl connection*/
-	SSL_set_app_data(data->ssl, data);
+        /* link the extra data struct inside ssl connection*/
+        if (SSL_set_app_data(data->ssl, data) == 0) {
+                LM_ERR("Failed to set app_data - possible memory issue\n");
+                if (data->ssl)
+                        SSL_free(data->ssl);
+                if (data->rwbio)
+                        BIO_free(data->rwbio);
+                goto error;
+        }
+        /* SSL_set_bio does not allocate memory and has no return value */
+        SSL_set_bio(data->ssl, data->rwbio, data->rwbio);
+        c->extra_data = data;
 	return 0;
 
 error:


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Issue: https://github.com/kamailio/kamailio/issues/4610

in tls_complete_init function, the return value of SSL_set_app_data should be checked and handled. When shared memory is very low, SSL_set_app_data will return 0(failed), at this time, ssl session should be released and error should be returned.  And besides, SSL_set_bio has no return value, this function can be called after SSL_set_app_data.
