### PR TITLE
tls: fix segfault on musl libc due to uninitialized pthread TSD

### DIFF
--- a/src/modules/tls/tls_mod.c
+++ b/src/modules/tls/tls_mod.c
@@ -410,6 +410,15 @@ static int mod_init(void)
 	}
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
+	/* musl libc does not initialize pthread TSD for the main thread until
+	 * pthread_key_create() is called at least once; calling
+	 * pthread_getspecific() before that dereferences a NULL tsd pointer.
+	 * Create and immediately delete a key to force TSD initialization. */
+	{
+		pthread_key_t _ksr_tsd_init;
+		pthread_key_create(&_ksr_tsd_init, NULL);
+		pthread_key_delete(_ksr_tsd_init);
+	}
 	for(k = 0; k < 32; k++) {
 		if(pthread_getspecific(k) != 0) {
 			LM_WARN("detected initialized thread-locals created before tls.so; "


### PR DESCRIPTION
## Summary

The diagnostic loop in `mod_init()` at [tls_mod.c:413](https://github.com/kamailio/kamailio/blob/6.1.1/src/modules/tls/tls_mod.c#L413) calls `pthread_getspecific()` with raw integer keys 0–31. On musl libc (Alpine Linux), the main thread's pthread TSD array (`self->tsd`) is `NULL` until `pthread_key_create()` is called at least once, so `pthread_getspecific()` dereferences a NULL pointer → segfault.

This loop runs unconditionally before any `tls_threads_mode` or `tls_disable` check, so no configuration setting can prevent the crash.

### Fix

Create and immediately delete a pthread key before the diagnostic loop to force musl's TSD initialization. This is a no-op on glibc (where TSD is always pre-initialized) and resolves the crash on musl.

### Reproduction

```
docker run --rm --entrypoint sh ghcr.io/kamailio/kamailio-ci:6.1.1-alpine -c '
cat > /tmp/tls_test.cfg << "CFGEOF"
enable_tls = 1
tcp_main_threads = 1

loadmodule "sl.so"
loadmodule "tm.so"
loadmodule "tls.so"

listen=tls:0.0.0.0:5061

request_route {
  sl_send_reply("200", "OK");
}
CFGEOF
kamailio -f /tmp/tls_test.cfg -DD -E; echo "EXIT CODE: $?"'
```

Output: `EXIT CODE: 139` (SIGSEGV)

### References

- kamailio/kamailio-ci#20
- #4534
- [musl mailing list analysis](https://www.openwall.com/lists/musl/2025/12/21/2) — Rich Felker (musl author) confirms iterating raw integers through `pthread_getspecific` is undefined behavior

Made with [Cursor](https://cursor.com)