### PR TITLE
core: fix swapped comparison in atomic_stdatomic.h dec/inc_and_test

### DIFF
--- a/src/core/atomic/atomic_stdatomic.h
+++ b/src/core/atomic/atomic_stdatomic.h
@@ -84,14 +84,14 @@ inline static int atomic_inc_and_test_int(volatile int *var)
 {
 	return atomic_fetch_add_explicit(
 				   (_Atomic int *)var, 1, memory_order_relaxed)
-		   == 1;
+		   == -1;
 }
 
 inline static int atomic_dec_and_test_int(volatile int *var)
 {
 	return atomic_fetch_sub_explicit(
 				   (_Atomic int *)var, 1, memory_order_relaxed)
-		   == -1;
+		   == 1;
 }
 
 inline static int atomic_get_and_set_int(volatile int *var, int v)
@@ -143,14 +143,14 @@ inline static long atomic_inc_and_test_long(volatile long *var)
 {
 	return atomic_fetch_add_explicit(
 				   (_Atomic long *)var, 1, memory_order_relaxed)
-		   == 1;
+		   == -1;
 }
 
 inline static long atomic_dec_and_test_long(volatile long *var)
 {
 	return atomic_fetch_sub_explicit(
 				   (_Atomic long *)var, 1, memory_order_relaxed)
-		   == -1;
+		   == 1;
 }
 
 inline static long atomic_get_and_set_long(volatile long *var, long v)
@@ -216,14 +216,14 @@ inline static int mb_atomic_inc_and_test_int(volatile int *var)
 {
 	return atomic_fetch_add_explicit(
 				   (_Atomic int *)var, 1, memory_order_seq_cst)
-		   == 1;
+		   == -1;
 }
 
 inline static int mb_atomic_dec_and_test_int(volatile int *var)
 {
 	return atomic_fetch_sub_explicit(
 				   (_Atomic int *)var, 1, memory_order_seq_cst)
-		   == -1;
+		   == 1;
 }
 
 inline static int mb_atomic_get_and_set_int(volatile int *var, int v)
@@ -285,14 +285,14 @@ inline static long mb_atomic_inc_and_test_long(volatile long *var)
 {
 	return atomic_fetch_add_explicit(
 				   (_Atomic long *)var, 1, memory_order_seq_cst)
-		   == 1;
+		   == -1;
 }
 
 inline static long mb_atomic_dec_and_test_long(volatile long *var)
 {
 	return atomic_fetch_sub_explicit(
 				   (_Atomic long *)var, 1, memory_order_seq_cst)
-		   == -1;
+		   == 1;
 }
 
 inline static long mb_atomic_get_and_set_long(volatile long *var, long v)


### PR DESCRIPTION
## Summary

- Fix swapped comparison values in `atomic_stdatomic.h` `dec_and_test` and `inc_and_test` functions
- `atomic_fetch_sub_explicit()` returns the **pre-decrement** value, so testing "result == 0" requires comparing the old value against `1`, not `-1`
- The symmetric bug exists in `inc_and_test` (compares `== 1` instead of `== -1`)
- All 8 `_and_test` functions are fixed (int/long × relaxed/seq_cst)

### Impact

This header is only used on aarch64 (ARM64). The bug causes `atomic_dec_and_test` to always return false, so any refcount-guarded `free()` never fires. Affected subsystems include TM transactions, DNS cache, TCP connections, config framework, and WebSocket connections — all leak shared memory monotonically on aarch64.

### Reproduction

Reproduced on Apple Silicon (aarch64) using Docker with @whosgonna's [reproduction project](https://github.com/whosgonna/6.1.1_memleak). Unpatched 6.1.1 leaks ~175 KB/30s (linear, never returns to baseline). Patched 6.1.1 is stable with zero sustained growth.

Fixes: #4626

## Test plan

- [x] Reproduced leak on unpatched 6.1.1 aarch64 (20 samples, linear growth)
- [x] Verified patched 6.1.1 aarch64 has zero sustained memory growth (14 samples, returns to baseline)
- [x] Verified x86 semantics match: `decl` + `setz` tests post-decrement ZF (result == 0)
- [x] Verified `atomic_unknown.h` semantics match: `ret = --(*var); return (ret == 0)`
- [x] Confirmed all 8 _and_test functions have the same bug pattern