### PR TITLE
tm: fix transaction leak on drop; in branch_route

### DIFF
--- a/src/modules/tm/t_lookup.c
+++ b/src/modules/tm/t_lookup.c
@@ -2057,7 +2057,7 @@ int t_unref(struct sip_msg *p_msg)
 		return -1;
 	if(p_msg->first_line.type == SIP_REQUEST) {
 		kr = get_kr();
-		if(unlikely(kr == REQ_ERR_DELAYED)) {
+		if(unlikely(kr & REQ_ERR_DELAYED)) {
 			LM_DBG("delayed error reply generation(%d)\n", tm_error);
 			if(unlikely(is_route_type(FAILURE_ROUTE))) {
 				LM_BUG("called w/ kr=REQ_ERR_DELAYED in failure"
@@ -2074,13 +2074,11 @@ int t_unref(struct sip_msg *p_msg)
 								   && !(kr & REQ_RLSD)))) {
 			LM_WARN("script writer didn't release transaction\n");
 			t_release_transaction(T);
-		} else if(unlikely((kr & REQ_ERR_DELAYED)
-						   && (kr
-								   & ~(REQ_RLSD | REQ_RPLD | REQ_ERR_DELAYED
-										   | REQ_FWDED)))) {
-			LM_BUG("REQ_ERR DELAYED should have been caught much"
-				   " earlier for %p: %d (hex %x)\n",
-					T, kr, kr);
+		} else if(unlikely(T->nr_of_outgoings == 0
+						   && !(T->flags & T_IN_AGONY))) {
+			LM_WARN("dropping orphaned transaction without branches"
+					" T=%p kr=%d\n",
+					T, kr);
 			t_release_transaction(T);
 		}
 	}


### PR DESCRIPTION
Fixes #4503.

### Problem

Transactions leak when `drop;` executes in a `branch_route` and modules
like `pua_dialoginfo` are loaded.  The leaked transactions persist
indefinitely in shared memory with `ref_count: 1`, `outgoings: 0`, no
timers running.  The only recovery is `kamcmd tm.clean`.

### Cause

There are two code paths that lead to the leak.  Both require a module
that calls `tmb.t_request()` inline during INVITE processing (such as
`pua_dialoginfo`) to contaminate the process-local `_tm_kr` variable
with `REQ_FWDED` via `t_uac_prepare()`.

**Path A — `REQ_ERR_DELAYED` set but masked by contamination:**

When `t_relay()` is used without `T_DISABLE_INTERNAL_REPLY`, the error
path in `t_relay_to()` calls `set_kr(REQ_ERR_DELAYED)`.  Because
`set_kr()` uses `|=`, the result is `REQ_FWDED | REQ_ERR_DELAYED` (17).
The first check in `t_unref()` uses exact equality (`kr == 16`), which
fails for 17.  The other two checks also fail for this value.

**Path B — `REQ_ERR_DELAYED` never set:**

When `T_DISABLE_INTERNAL_REPLY` is active — set explicitly via
`t_set_disable_internal_reply(1)`, or implicitly via `t_relay_to()` with
flag 2 — the error path skips both `set_kr(REQ_ERR_DELAYED)` and
`kill_transaction()`.  The `_tm_kr` value remains just `REQ_FWDED` (1).
All three checks in `t_unref()` fail for this value.

In both paths, `UNREF(T)` decrements `ref_count` from 2 to 1 (releasing
the process reference from `new_t()`), but the hash table reference is
never released because neither `kill_transaction()` nor
`t_release_transaction()` ran.

### Fix

Two changes to `t_unref()`:

**Change 1:** The first check uses exact equality to bitwise test.
This handles path A — `kill_transaction()` now fires when
`REQ_ERR_DELAYED` is present regardless of other accumulated flags.

**Change 2:** A fallback after the existing three checks catches
orphaned transactions with no forwarded branches.  This handles path B
and any future scenario where `_tm_kr` contamination causes all
existing checks to fail.  It uses `t_release_transaction()` rather
than `kill_transaction()` — it does not generate a SIP error reply,
consistent with configs that set `T_DISABLE_INTERNAL_REPLY` to
suppress automatic replies.

```diff
--- a/src/modules/tm/t_lookup.c
+++ b/src/modules/tm/t_lookup.c
@@ -N,7 +N,7 @@ int t_unref(struct sip_msg *p_msg)
 	if(p_msg->first_line.type == SIP_REQUEST) {
 		kr = get_kr();
-		if(unlikely(kr == REQ_ERR_DELAYED)) {
+		if(unlikely(kr & REQ_ERR_DELAYED)) {
 			LM_DBG("delayed error reply generation(%d)\n", tm_error);
@@ after the REQ_ERR_DELAYED BUG check block:
 			t_release_transaction(T);
+		} else if(unlikely(T->nr_of_outgoings == 0
+						   && !(T->flags & T_IN_AGONY))) {
+			LM_WARN("dropping orphaned transaction without branches"
+				   " T=%p kr=%d\n", T, kr);
+			t_release_transaction(T);
 		}
 	}
 	tm_error = 0; /* clear it */
```

### Test results

Kamailio 6.0.3, upstream tag, 8 x86_64 cores, 8 workers, 10,000
INVITEs per test at 500/sec.  All configs load `pua_dialoginfo` and
`rtpengine` with an unreachable daemon so every call hits
`rtpengine_offer()` failure followed by `drop;` in `branch_route`.

Values are `tm.stats current` after all timers expire (0 = no leak):

**Without `T_DISABLE_INTERNAL_REPLY`:**

| Config | No patch | `==` to `&` only | This PR |
|--------|:--------:|:----------------:|:-------:|
| `t_relay()` | 3548 | 0 | 0 |
| `t_relay_to()` | 3546 | 0 | 0 |
| `t_relay_to_udp("host","port")` | 3548 | 0 | 0 |
| `t_relay_to("proxy","0")` | 3547 | 0 | 0 |
| `t_relay_to("proxy","1")` no auto 100 | 3707 | 0 | 0 |
| `t_relay_to("proxy","4")` no dns fo | 3549 | 0 | 0 |
| `t_relay_to("proxy","5")` 1+4 | 3703 | 0 | 0 |

**With `T_DISABLE_INTERNAL_REPLY`:**

| Config | No patch | `==` to `&` only | This PR |
|--------|:--------:|:----------------:|:-------:|
| `t_relay_to("proxy","2")` no int reply | 3549 | **3547** | 0 |
| `t_relay_to("proxy","3")` 1+2 | 3703 | **3703** | 0 |
| `t_relay_to("proxy","6")` 2+4 | 3547 | **3544** | 0 |
| `t_relay_to("proxy","7")` 1+2+4 | 3702 | **3708** | 0 |
| `t_set_disable_internal_reply(1)` + `t_relay()` | 3545 | **3547** | 0 |
| `t_set_disable_internal_reply(1)` + `t_relay_to()` | 3542 | **3544** | 0 |
| `t_set_disable_internal_reply(1)` + `t_relay_to_udp()` | 3548 | **3548** | 0 |

The `==` to `&` change alone fixes configs without
`T_DISABLE_INTERNAL_REPLY`.  The orphan fallback is required for configs
that use it — including any config using `t_relay_to()` with flag 2, or
calling `t_set_disable_internal_reply(1)` for serial forking.

Documented flags: 1 (no auto 100), 2 (no internal reply), 4 (no DNS
failover).  Flags 3, 5, 6, 7 are undocumented combinations tested for
completeness.