### PR TITLE
permissions: while reloading consider if cache is disabled

### DIFF
--- a/src/modules/permissions/rpc.c
+++ b/src/modules/permissions/rpc.c
@@ -60,12 +60,19 @@ void rpc_trusted_reload(rpc_t *rpc, void *c)
 		return;
 	}
 
-	if(reload_trusted_table_cmd() != 1) {
-		rpc->fault(c, 500, "Reload failed.");
-		goto done;
+	// only reload the hash buckets then, when the cache is activated (db_mode = 1)
+	if(perm_db_mode == ENABLE_CACHE) {
+		if(reload_trusted_table_cmd() != 1) {
+			rpc->fault(c, 500, "Reload failed.");
+			goto done;
+		}
+		rpc->rpl_printf(c, "Reload OK");
+	} else {
+		LM_DBG("Skip trusted sources reload in hash buckets, caching is "
+			   "disabled.\n");
+		rpc->fault(c, 500, "Reload skipped (disabled cache)");
 	}
 
-	rpc->rpl_printf(c, "Reload OK");
 done:
 	// reloading is done
 	*perm_rpc_reload_time = time(NULL);


### PR DESCRIPTION
Do not reload trusted table sources in hash buckets, when the db cache mode is disabled.

This prevents sudden attempt to actually initialize hash buckets, and fill them with the entries, when the db mode is 0.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

Do not reload trusted table sources in hash buckets, when the db cache mode is disabled.
This prevents sudden attempt to actually initialize hash buckets, when the mode is 0,
and nothing prevents the RPC command to trigger the `reload_trusted_table()` from trusted.c

When working in db mode 0 (no caching), permissions module does the match of sources fully based on SQL statements,
hence the RPC reload command has no sense to be executed, but if suddenly this happens (for any reason such RPC command comes to the module), then the hash buckets will be filled with the data.