### PR TITLE
Support `shm.rprint` matching on function name and line numbers

### DIFF
--- a/src/core/mem/q_malloc.c
+++ b/src/core/mem/q_malloc.c
@@ -1014,7 +1014,8 @@ static void *qm_strnstr(const void *b1, int l1, const void *b2, int l2)
 	return NULL;
 }
 
-static int qm_frag_match(struct qm_frag *f, const str *fmatch)
+static int qm_frag_match(struct qm_frag *f, const str *fmatch, int fn_matches,
+		const char *func, unsigned long line)
 {
 	if(!fmatch)
 		return 1;
@@ -1023,6 +1024,8 @@ static int qm_frag_match(struct qm_frag *f, const str *fmatch)
 	if(strlen(f->file) >= fmatch->len
 			&& qm_strnstr(f->file, strlen(f->file), fmatch->s, fmatch->len)
 					   != NULL)
+		return 1;
+	if(fn_matches == 2 && f->line == line && !strcmp(f->func, func))
 		return 1;
 	return 0;
 }
@@ -1035,6 +1038,20 @@ void qm_status_filter(void *qmp, str *fmatch, FILE *fp)
 	int i, j;
 	int h;
 	int unused;
+#ifdef DBG_QM_MALLOC
+	char func_name[128];
+	unsigned long linenum;
+	int fn_matches = 0;
+
+	if(fmatch && fmatch->len) {
+		// try "func:123"
+		fn_matches =
+				sscanf(fmatch->s, "%127[a-zA-Z_]:%lu", func_name, &linenum);
+		if(fn_matches != 2) // try "func(123)"
+			fn_matches = sscanf(
+					fmatch->s, "%127[a-zA-Z_](%lu)", func_name, &linenum);
+	}
+#endif
 
 	qm = (struct qm_block *)qmp;
 
@@ -1052,7 +1069,7 @@ void qm_status_filter(void *qmp, str *fmatch, FILE *fp)
 			f = FRAG_NEXT(f), i++) {
 		if(!f->u.is_free) {
 #ifdef DBG_QM_MALLOC
-			if(qm_frag_match(f, fmatch)) {
+			if(qm_frag_match(f, fmatch, fn_matches, func_name, linenum)) {
 				fprintf(fp, "   %3d. %c  address=%p frag=%p size=%lu used=%d\n",
 						i, (f->u.is_free) ? 'A' : 'N',
 						(char *)f + sizeof(struct qm_frag), f, f->size,
@@ -1088,7 +1105,7 @@ void qm_status_filter(void *qmp, str *fmatch, FILE *fp)
 			if(!FRAG_WAS_USED(f)) {
 				unused++;
 #ifdef DBG_QM_MALLOC
-				if(qm_frag_match(f, fmatch)) {
+				if(qm_frag_match(f, fmatch, fn_matches, func_name, linenum)) {
 					fprintf(fp,
 							"unused fragm.: hash = %3d, fragment %p,"
 							" address %p size %lu, created from %s:%lu / "

--- a/src/modules/corex/corex_rpc_shm.c
+++ b/src/modules/corex/corex_rpc_shm.c
@@ -139,7 +139,7 @@ static void corex_rpc_shm_rprint(rpc_t *rpc, void *ctx)
 		rpc->fault(ctx, 500, "Cannot open file");
 		return;
 	}
-	LM_DBG("matching file name with: %.*s\n", fmatch.len, fmatch.s);
+	LM_DBG("matching file or function name with: %.*s\n", fmatch.len, fmatch.s);
 	shm_status_filter(&fmatch, fp);
 	fclose(fp);
 }

--- a/src/modules/corex/doc/corex_admin.xml
+++ b/src/modules/corex/doc/corex_admin.xml
@@ -1317,14 +1317,17 @@ msg_vbflag_reset("1");
 		</para>
 		<para>
 			It takes two parameters: the path to file where to write the report;
-			the string to match the allocation file (the match is done as value
-			included in the path fo the allocation file).
+			the string to match the allocation location. The location can be
+			given as either a file name (the match is done as value included in
+			the path of the allocation file), or as a function name and line
+			number as reported by <emphasis>mod.mem_stats</emphasis>.
 		</para>
 		<para>
-		Example:
+		Examples:
 		</para>
         <programlisting  format="linespecific">
 			&kamcli; rpc shm.rprint /tmp/kamailioshm.txt dns_cache.c
+			&kamcli; rpc shm.rprint /tmp/kamailioshm.txt init_dns_cache:359
 		</programlisting>
     </section>
     </section>


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [X] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
(Two commits: the first one is just a refactor. To make reviewing easier - I can squash them into one if preferred)

The `shm.rprint` RPC call currently supports filtering based on file/path name, but other RPC calls such as `mod.mem_stats` report a breakdown of the allocation based on function name and line number. To consolidate the two, make `shm.rprint` support filtering based on function name and line number.