### PR TITLE
tls: OpenSSL - add dual-cert support via certificate2/private_key2

### DIFF
--- a/src/modules/tls/README
+++ b/src/modules/tls/README
@@ -12,9 +12,9 @@ Olle E. Johansson
 
    Edvina AB
 
-   Copyright Â© 2007 iptelorg GmbH
+   Copyright © 2007 iptelorg GmbH
 
-   Copyright Â© 2014 ng-voice GmbH
+   Copyright © 2014 ng-voice GmbH
      __________________________________________________________________
 
    Table of Contents
@@ -36,46 +36,49 @@ Olle E. Johansson
               10.2. certificate (string)
               10.3. private_key (string)
               10.4. private_key_password (string)
-              10.5. key_password_mode (int)
-              10.6. ca_list (string)
-              10.7. ca_path (str)
-              10.8. crl (string)
-              10.9. verify_certificate (boolean)
-              10.10. verify_depth (integer)
-              10.11. require_certificate (boolean)
-              10.12. cipher_list (string)
-              10.13. server_name (string)
-              10.14. connection_timeout (int)
-              10.15. tls_disable_compression (boolean)
-              10.16. ssl_release_buffers (integer)
-              10.17. ssl_freelist_max_len (integer)
-              10.18. ssl_max_send_fragment (integer)
-              10.19. ssl_read_ahead (boolean)
-              10.20. send_close_notify (boolean)
-              10.21. con_ct_wq_max (integer)
-              10.22. ct_wq_max (integer)
-              10.23. ct_wq_blk_size (integer)
-              10.24. tls_log (int)
-              10.25. tls_debug (int)
-              10.26. low_mem_threshold1 (integer)
-              10.27. low_mem_threshold2 (integer)
-              10.28. tls_force_run (boolean)
-              10.29. session_cache (boolean)
-              10.30. session_id (str)
-              10.31. renegotiation (boolean)
-              10.32. init_mode (int)
-              10.33. config (string)
-              10.34. xavp_cfg (string)
-              10.35. event_callback (str)
-              10.36. rand_engine (str)
-              10.37. engine (string)
-              10.38. engine_config (string)
-              10.39. engine_algorithms (string)
-              10.40. verify_client (string)
-              10.41. provider_quirks (integer)
-              10.42. keylog_mode (int)
-              10.43. keylog_file (str)
-              10.44. keylog_peer (str)
+              10.5. certificate2 (string)
+              10.6. private_key2 (string)
+              10.7. private_key_password2 (string)
+              10.8. key_password_mode (int)
+              10.9. ca_list (string)
+              10.10. ca_path (str)
+              10.11. crl (string)
+              10.12. verify_certificate (boolean)
+              10.13. verify_depth (integer)
+              10.14. require_certificate (boolean)
+              10.15. cipher_list (string)
+              10.16. server_name (string)
+              10.17. connection_timeout (int)
+              10.18. tls_disable_compression (boolean)
+              10.19. ssl_release_buffers (integer)
+              10.20. ssl_freelist_max_len (integer)
+              10.21. ssl_max_send_fragment (integer)
+              10.22. ssl_read_ahead (boolean)
+              10.23. send_close_notify (boolean)
+              10.24. con_ct_wq_max (integer)
+              10.25. ct_wq_max (integer)
+              10.26. ct_wq_blk_size (integer)
+              10.27. tls_log (int)
+              10.28. tls_debug (int)
+              10.29. low_mem_threshold1 (integer)
+              10.30. low_mem_threshold2 (integer)
+              10.31. tls_force_run (boolean)
+              10.32. session_cache (boolean)
+              10.33. session_id (str)
+              10.34. renegotiation (boolean)
+              10.35. init_mode (int)
+              10.36. config (string)
+              10.37. xavp_cfg (string)
+              10.38. event_callback (str)
+              10.39. rand_engine (str)
+              10.40. engine (string)
+              10.41. engine_config (string)
+              10.42. engine_algorithms (string)
+              10.43. verify_client (string)
+              10.44. provider_quirks (integer)
+              10.45. keylog_mode (int)
+              10.46. keylog_file (str)
+              10.47. keylog_peer (str)
 
         11. Functions
 
@@ -109,57 +112,60 @@ Olle E. Johansson
    1.4. Set certificate parameter
    1.5. Set private_key parameter
    1.6. Set private_key_password parameter
-   1.7. Set key_password_mode parameter
-   1.8. Set ca_list parameter
-   1.9. Set ca_path parameter
-   1.10. Set crl parameter
-   1.11. Set verify_certificate parameter
-   1.12. Set verify_depth parameter
-   1.13. Set require_certificate parameter
-   1.14. Set cipher_list parameter
-   1.15. Set server_name parameter
-   1.16. Set connection_timeout parameter
-   1.17. Set tls.connection_timeout at runtime
-   1.18. Set tls_disable_compression parameter
-   1.19. Set ssl_release_buffers parameter
-   1.20. Set ssl_freelist_max_len parameter
-   1.21. Set ssl_max_send_fragment parameter
-   1.22. Set ssl_read_ahead parameter
-   1.23. Set send_close_notify parameter
-   1.24. Set tls.send_close_notify at runtime
-   1.25. Set con_ct_wq_max parameter
-   1.26. Set tls.con_ct_wq_max at runtime
-   1.27. Set ct_wq_max parameter
-   1.28. Set tls.ct_wq_max at runtime
-   1.29. Set ct_wq_blk_size parameter
-   1.30. Set tls.ct_wq_max at runtime
-   1.31. Set tls_log parameter
-   1.32. Set tls.log at runtime
-   1.33. Set tls_debug parameter
-   1.34. Set tls.debug at runtime
-   1.35. Set low_mem_threshold1 parameter
-   1.36. Set tls.low_mem_threshold1 at runtime
-   1.37. Set tls.low_mem_threshold2 parameter
-   1.38. Set tls.low_mem_threshold2 at runtime
-   1.39. Set tls_force_run parameter
-   1.40. Set session_cache parameter
-   1.41. Set session_id parameter
-   1.42. Set renegotiation parameter
-   1.43. Set init_mode parameter
-   1.44. Sample TLS Config File
-   1.45. Set config parameter
-   1.46. Change and reload the TLS configuration at runtime
-   1.47. Set xavp_cfg parameter
-   1.48. Set event_callback parameter
-   1.49. Set rand_engine parameter
-   1.50. Set verify_client modparam parameter
-   1.51. Set verify_client tls.cfg parameter
-   1.52. Set keylog_mode parameter
-   1.53. Set keylog_file parameter
-   1.54. Set keylog_peer parameter
-   1.55. is_peer_verified usage
-   1.56. tls_set_connect_server_id usage
-   1.57. Use of event_route[tls:connection-out]
+   1.7. Set certificate2 parameter
+   1.8. Set private_key2 parameter
+   1.9. Set private_key_password2 parameter
+   1.10. Set key_password_mode parameter
+   1.11. Set ca_list parameter
+   1.12. Set ca_path parameter
+   1.13. Set crl parameter
+   1.14. Set verify_certificate parameter
+   1.15. Set verify_depth parameter
+   1.16. Set require_certificate parameter
+   1.17. Set cipher_list parameter
+   1.18. Set server_name parameter
+   1.19. Set connection_timeout parameter
+   1.20. Set tls.connection_timeout at runtime
+   1.21. Set tls_disable_compression parameter
+   1.22. Set ssl_release_buffers parameter
+   1.23. Set ssl_freelist_max_len parameter
+   1.24. Set ssl_max_send_fragment parameter
+   1.25. Set ssl_read_ahead parameter
+   1.26. Set send_close_notify parameter
+   1.27. Set tls.send_close_notify at runtime
+   1.28. Set con_ct_wq_max parameter
+   1.29. Set tls.con_ct_wq_max at runtime
+   1.30. Set ct_wq_max parameter
+   1.31. Set tls.ct_wq_max at runtime
+   1.32. Set ct_wq_blk_size parameter
+   1.33. Set tls.ct_wq_max at runtime
+   1.34. Set tls_log parameter
+   1.35. Set tls.log at runtime
+   1.36. Set tls_debug parameter
+   1.37. Set tls.debug at runtime
+   1.38. Set low_mem_threshold1 parameter
+   1.39. Set tls.low_mem_threshold1 at runtime
+   1.40. Set tls.low_mem_threshold2 parameter
+   1.41. Set tls.low_mem_threshold2 at runtime
+   1.42. Set tls_force_run parameter
+   1.43. Set session_cache parameter
+   1.44. Set session_id parameter
+   1.45. Set renegotiation parameter
+   1.46. Set init_mode parameter
+   1.47. Sample TLS Config File
+   1.48. Set config parameter
+   1.49. Change and reload the TLS configuration at runtime
+   1.50. Set xavp_cfg parameter
+   1.51. Set event_callback parameter
+   1.52. Set rand_engine parameter
+   1.53. Set verify_client modparam parameter
+   1.54. Set verify_client tls.cfg parameter
+   1.55. Set keylog_mode parameter
+   1.56. Set keylog_file parameter
+   1.57. Set keylog_peer parameter
+   1.58. is_peer_verified usage
+   1.59. tls_set_connect_server_id usage
+   1.60. Use of event_route[tls:connection-out]
 
 Chapter 1. Admin Guide
 
@@ -180,46 +186,49 @@ Chapter 1. Admin Guide
         10.2. certificate (string)
         10.3. private_key (string)
         10.4. private_key_password (string)
-        10.5. key_password_mode (int)
-        10.6. ca_list (string)
-        10.7. ca_path (str)
-        10.8. crl (string)
-        10.9. verify_certificate (boolean)
-        10.10. verify_depth (integer)
-        10.11. require_certificate (boolean)
-        10.12. cipher_list (string)
-        10.13. server_name (string)
-        10.14. connection_timeout (int)
-        10.15. tls_disable_compression (boolean)
-        10.16. ssl_release_buffers (integer)
-        10.17. ssl_freelist_max_len (integer)
-        10.18. ssl_max_send_fragment (integer)
-        10.19. ssl_read_ahead (boolean)
-        10.20. send_close_notify (boolean)
-        10.21. con_ct_wq_max (integer)
-        10.22. ct_wq_max (integer)
-        10.23. ct_wq_blk_size (integer)
-        10.24. tls_log (int)
-        10.25. tls_debug (int)
-        10.26. low_mem_threshold1 (integer)
-        10.27. low_mem_threshold2 (integer)
-        10.28. tls_force_run (boolean)
-        10.29. session_cache (boolean)
-        10.30. session_id (str)
-        10.31. renegotiation (boolean)
-        10.32. init_mode (int)
-        10.33. config (string)
-        10.34. xavp_cfg (string)
-        10.35. event_callback (str)
-        10.36. rand_engine (str)
-        10.37. engine (string)
-        10.38. engine_config (string)
-        10.39. engine_algorithms (string)
-        10.40. verify_client (string)
-        10.41. provider_quirks (integer)
-        10.42. keylog_mode (int)
-        10.43. keylog_file (str)
-        10.44. keylog_peer (str)
+        10.5. certificate2 (string)
+        10.6. private_key2 (string)
+        10.7. private_key_password2 (string)
+        10.8. key_password_mode (int)
+        10.9. ca_list (string)
+        10.10. ca_path (str)
+        10.11. crl (string)
+        10.12. verify_certificate (boolean)
+        10.13. verify_depth (integer)
+        10.14. require_certificate (boolean)
+        10.15. cipher_list (string)
+        10.16. server_name (string)
+        10.17. connection_timeout (int)
+        10.18. tls_disable_compression (boolean)
+        10.19. ssl_release_buffers (integer)
+        10.20. ssl_freelist_max_len (integer)
+        10.21. ssl_max_send_fragment (integer)
+        10.22. ssl_read_ahead (boolean)
+        10.23. send_close_notify (boolean)
+        10.24. con_ct_wq_max (integer)
+        10.25. ct_wq_max (integer)
+        10.26. ct_wq_blk_size (integer)
+        10.27. tls_log (int)
+        10.28. tls_debug (int)
+        10.29. low_mem_threshold1 (integer)
+        10.30. low_mem_threshold2 (integer)
+        10.31. tls_force_run (boolean)
+        10.32. session_cache (boolean)
+        10.33. session_id (str)
+        10.34. renegotiation (boolean)
+        10.35. init_mode (int)
+        10.36. config (string)
+        10.37. xavp_cfg (string)
+        10.38. event_callback (str)
+        10.39. rand_engine (str)
+        10.40. engine (string)
+        10.41. engine_config (string)
+        10.42. engine_algorithms (string)
+        10.43. verify_client (string)
+        10.44. provider_quirks (integer)
+        10.45. keylog_mode (int)
+        10.46. keylog_file (str)
+        10.47. keylog_peer (str)
 
    11. Functions
 
@@ -266,6 +275,12 @@ Chapter 1. Admin Guide
    the same file in PEM format. The parameters for them are certificate
    and private_key. They can be given as modparam or provided in the
    profiles of tls.cfg file.
+
+   For dual-cert support (e.g., serving both RSA and ECDSA certificates),
+   set certificate2 and private_key2 in addition to the primary
+   certificate. OpenSSL automatically selects the appropriate certificate
+   during the TLS handshake based on the client's advertised signature
+   algorithms.
 
    When installing tls module of kamailio, a sample 'tls.cfg' file is
    deployed in the same folder with 'kamailio.cfg'. For freshly generated
@@ -623,46 +638,49 @@ Place holder
    10.2. certificate (string)
    10.3. private_key (string)
    10.4. private_key_password (string)
-   10.5. key_password_mode (int)
-   10.6. ca_list (string)
-   10.7. ca_path (str)
-   10.8. crl (string)
-   10.9. verify_certificate (boolean)
-   10.10. verify_depth (integer)
-   10.11. require_certificate (boolean)
-   10.12. cipher_list (string)
-   10.13. server_name (string)
-   10.14. connection_timeout (int)
-   10.15. tls_disable_compression (boolean)
-   10.16. ssl_release_buffers (integer)
-   10.17. ssl_freelist_max_len (integer)
-   10.18. ssl_max_send_fragment (integer)
-   10.19. ssl_read_ahead (boolean)
-   10.20. send_close_notify (boolean)
-   10.21. con_ct_wq_max (integer)
-   10.22. ct_wq_max (integer)
-   10.23. ct_wq_blk_size (integer)
-   10.24. tls_log (int)
-   10.25. tls_debug (int)
-   10.26. low_mem_threshold1 (integer)
-   10.27. low_mem_threshold2 (integer)
-   10.28. tls_force_run (boolean)
-   10.29. session_cache (boolean)
-   10.30. session_id (str)
-   10.31. renegotiation (boolean)
-   10.32. init_mode (int)
-   10.33. config (string)
-   10.34. xavp_cfg (string)
-   10.35. event_callback (str)
-   10.36. rand_engine (str)
-   10.37. engine (string)
-   10.38. engine_config (string)
-   10.39. engine_algorithms (string)
-   10.40. verify_client (string)
-   10.41. provider_quirks (integer)
-   10.42. keylog_mode (int)
-   10.43. keylog_file (str)
-   10.44. keylog_peer (str)
+   10.5. certificate2 (string)
+   10.6. private_key2 (string)
+   10.7. private_key_password2 (string)
+   10.8. key_password_mode (int)
+   10.9. ca_list (string)
+   10.10. ca_path (str)
+   10.11. crl (string)
+   10.12. verify_certificate (boolean)
+   10.13. verify_depth (integer)
+   10.14. require_certificate (boolean)
+   10.15. cipher_list (string)
+   10.16. server_name (string)
+   10.17. connection_timeout (int)
+   10.18. tls_disable_compression (boolean)
+   10.19. ssl_release_buffers (integer)
+   10.20. ssl_freelist_max_len (integer)
+   10.21. ssl_max_send_fragment (integer)
+   10.22. ssl_read_ahead (boolean)
+   10.23. send_close_notify (boolean)
+   10.24. con_ct_wq_max (integer)
+   10.25. ct_wq_max (integer)
+   10.26. ct_wq_blk_size (integer)
+   10.27. tls_log (int)
+   10.28. tls_debug (int)
+   10.29. low_mem_threshold1 (integer)
+   10.30. low_mem_threshold2 (integer)
+   10.31. tls_force_run (boolean)
+   10.32. session_cache (boolean)
+   10.33. session_id (str)
+   10.34. renegotiation (boolean)
+   10.35. init_mode (int)
+   10.36. config (string)
+   10.37. xavp_cfg (string)
+   10.38. event_callback (str)
+   10.39. rand_engine (str)
+   10.40. engine (string)
+   10.41. engine_config (string)
+   10.42. engine_algorithms (string)
+   10.43. verify_client (string)
+   10.44. provider_quirks (integer)
+   10.45. keylog_mode (int)
+   10.46. keylog_file (str)
+   10.47. keylog_peer (str)
 
 10.1. tls_method (string)
 
@@ -768,19 +786,65 @@ modparam("tls", "private_key", "/usr/local/etc/kamailio/my_pkey.pem")
 modparam("tls", "private_key_password", "secret")
 ...
 
-10.5. key_password_mode (int)
+10.5. certificate2 (string)
+
+   Sets the file name for a second certificate, enabling dual-cert
+   support. This is typically used to configure both an RSA and an ECDSA
+   certificate for the same TLS domain. OpenSSL will automatically select
+   the appropriate certificate during the TLS handshake based on the
+   client's advertised signature algorithms.
+
+   The path resolution rules are the same as for certificate.
+
+   The parameter is optional. When not set, the TLS domain serves only the
+   certificate configured via certificate. It does not inherit from the
+   parent domain.
+
+   The default value is empty (not set).
+
+   Example 1.7. Set certificate2 parameter
+...
+modparam("tls", "certificate2", "/usr/local/etc/kamailio/my_ecdsa_cert.pem")
+...
+
+10.6. private_key2 (string)
+
+   Sets the file name for the private key corresponding to the second
+   certificate (certificate2).
+
+   The path resolution rules are the same as for private_key.
+
+   The default value is empty (not set).
+
+   Example 1.8. Set private_key2 parameter
+...
+modparam("tls", "private_key2", "/usr/local/etc/kamailio/my_ecdsa_pkey.pem")
+...
+
+10.7. private_key_password2 (string)
+
+   The password for the second private key (private_key2).
+
+   The default value is empty.
+
+   Example 1.9. Set private_key_password2 parameter
+...
+modparam("tls", "private_key_password2", "secret")
+...
+
+10.8. key_password_mode (int)
 
    The mode to get the password for the private key. If 0, take it from
    the config "private_key_password". If 1, promt for it at start up.
 
    The default value is 0.
 
-   Example 1.7. Set key_password_mode parameter
+   Example 1.10. Set key_password_mode parameter
 ...
 modparam("tls", "key_password_mode", 0)
 ...
 
-10.6. ca_list (string)
+10.9. ca_list (string)
 
    Sets the CA list file name. This file contains a list of all the
    trusted CAs certificates used when connecting to other SIP
@@ -801,12 +865,12 @@ for f in trusted_cas/*.pem ; do cat "$f" >> ca_list.pem ; done
 
    See also verify_certificate, verify_depth, require_certificate and crl.
 
-   Example 1.8. Set ca_list parameter
+   Example 1.11. Set ca_list parameter
 ...
 modparam("tls", "ca_list", "/usr/local/etc/kamailio/ca_list.pem")
 ...
 
-10.7. ca_path (str)
+10.10. ca_path (str)
 
    Sets the path with the trusted CA files, to be given as parameter
    SSL_CTX_load_verify_locations(). The certificates in ca_path are only
@@ -820,12 +884,12 @@ modparam("tls", "ca_list", "/usr/local/etc/kamailio/ca_list.pem")
 
    By default it is not set.
 
-   Example 1.9. Set ca_path parameter
+   Example 1.12. Set ca_path parameter
 ...
 modparam("tls", "ca_path", "/usr/local/etc/kamailio/ca")
 ...
 
-10.8. crl (string)
+10.11. crl (string)
 
    Sets the certificate revocation list (CRL) file name. This file
    contains a list of revoked certificates. Any attempt to verify a
@@ -867,12 +931,12 @@ Note
    See also ca_list, verify_certificate, verify_depth and
    require_certificate.
 
-   Example 1.10. Set crl parameter
+   Example 1.13. Set crl parameter
 ...
 modparam("tls", "crl", "/usr/local/etc/kamailio/crl.pem")
 ...
 
-10.9. verify_certificate (boolean)
+10.12. verify_certificate (boolean)
 
    If enabled it will force certificate verification when connecting to
    other SIP servers.. For more information see the verify(1) OpenSSL man
@@ -885,12 +949,12 @@ modparam("tls", "crl", "/usr/local/etc/kamailio/crl.pem")
 
    By default the certificate verification is off.
 
-   Example 1.11. Set verify_certificate parameter
+   Example 1.14. Set verify_certificate parameter
 ...
 modparam("tls", "verify_certificate", 1)
 ...
 
-10.10. verify_depth (integer)
+10.13. verify_depth (integer)
 
    Sets how far up the certificate chain will the certificate verification
    go in the search for a trusted CA.
@@ -899,12 +963,12 @@ modparam("tls", "verify_certificate", 1)
 
    The default value is 9.
 
-   Example 1.12. Set verify_depth parameter
+   Example 1.15. Set verify_depth parameter
 ...
 modparam("tls", "verify_depth", 9)
 ...
 
-10.11. require_certificate (boolean)
+10.14. require_certificate (boolean)
 
    When enabled Kamailio will require a certificate from a client
    connecting to the TLS port. If the client does not offer a certificate
@@ -912,12 +976,12 @@ modparam("tls", "verify_depth", 9)
 
    The default value is off.
 
-   Example 1.13. Set require_certificate parameter
+   Example 1.16. Set require_certificate parameter
 ...
 modparam("tls", "require_certificate", 1)
 ...
 
-10.12. cipher_list (string)
+10.15. cipher_list (string)
 
    Sets the list of accepted ciphers. The list consists of cipher strings
    separated by colons. For more information on the cipher list format see
@@ -926,12 +990,12 @@ modparam("tls", "require_certificate", 1)
    The default value is not set (all the OpenSSL supported ciphers are
    enabled).
 
-   Example 1.14. Set cipher_list parameter
+   Example 1.17. Set cipher_list parameter
 ...
 modparam("tls", "cipher_list", "HIGH")
 ...
 
-10.13. server_name (string)
+10.16. server_name (string)
 
    Sets the Server Name Indication (SNI) value.
 
@@ -940,12 +1004,12 @@ modparam("tls", "cipher_list", "HIGH")
 
    The default value is empty (not set).
 
-   Example 1.15. Set server_name parameter
+   Example 1.18. Set server_name parameter
 ...
 modparam("tls", "server_name", "kamailio.org")
 ...
 
-10.14. connection_timeout (int)
+10.17. connection_timeout (int)
 
    Sets the amount of time after which an idle TLS connection will be
    closed, if no I/O ever occurred after the initial open. If an I/O event
@@ -959,15 +1023,15 @@ modparam("tls", "server_name", "kamailio.org")
    This setting can be changed also at runtime, via the RPC interface and
    config framework. The config variable name is tls.connection_timeout.
 
-   Example 1.16. Set connection_timeout parameter
+   Example 1.19. Set connection_timeout parameter
 ...
 modparam("tls", "connection_timeout", 60)
 ...
 
-   Example 1.17. Set tls.connection_timeout at runtime
+   Example 1.20. Set tls.connection_timeout at runtime
  $ kamcmd cfg.set_now_int tls connection_timeout 180
 
-10.15. tls_disable_compression (boolean)
+10.18. tls_disable_compression (boolean)
 
    If set compression over TLS will be disabled. Note that compression
    uses a lot of memory (about 10x more than with the compression
@@ -977,12 +1041,12 @@ modparam("tls", "connection_timeout", 60)
 
    By default TLS compression is disabled.
 
-   Example 1.18. Set tls_disable_compression parameter
+   Example 1.21. Set tls_disable_compression parameter
 ...
 modparam("tls", "tls_disable_compression", 0) # enable
 ...
 
-10.16. ssl_release_buffers (integer)
+10.19. ssl_release_buffers (integer)
 
    Release internal OpenSSL read or write buffers as soon as they are no
    longer needed. Combined with ssl_freelist_max_len has the potential of
@@ -1001,10 +1065,10 @@ Note
    This option is supported only for OpenSSL versions >= 1.0.0. On all the
    other versions attempting to change the default will trigger an error.
 
-   Example 1.19. Set ssl_release_buffers parameter
+   Example 1.22. Set ssl_release_buffers parameter
 modparam("tls", "ssl_release_buffers", 1)
 
-10.17. ssl_freelist_max_len (integer)
+10.20. ssl_freelist_max_len (integer)
 
    Sets the maximum number of free memory chunks, that OpenSSL will keep
    per connection. Setting it to 0 would cause any unused memory chunk to
@@ -1024,10 +1088,10 @@ Note
    This option is supported only for OpenSSL versions >= 1.0.0. On all the
    other versions attempting to change the default will trigger an error.
 
-   Example 1.20. Set ssl_freelist_max_len parameter
+   Example 1.23. Set ssl_freelist_max_len parameter
 modparam("tls", "ssl_freelist_max_len", 0)
 
-10.18. ssl_max_send_fragment (integer)
+10.21. ssl_max_send_fragment (integer)
 
    Sets the maximum number of bytes (from the clear text) sent into one
    TLS record. Valid values are between 512 and 16384. Note however that
@@ -1059,10 +1123,10 @@ Note
    This option is supported only for OpenSSL versions >= 0.9.9. On all the
    other versions attempting to change the default will trigger an error.
 
-   Example 1.21. Set ssl_max_send_fragment parameter
+   Example 1.24. Set ssl_max_send_fragment parameter
 modparam("tls", "ssl_max_send_fragment", 4096)
 
-10.19. ssl_read_ahead (boolean)
+10.22. ssl_read_ahead (boolean)
 
    Enables read ahead, reducing the number of internal OpenSSL BIO read()
    calls. This option has only debugging value, in normal circumstances it
@@ -1081,10 +1145,10 @@ modparam("tls", "ssl_max_send_fragment", 4096)
 
    By default the value is 0 (disabled).
 
-   Example 1.22. Set ssl_read_ahead parameter
+   Example 1.25. Set ssl_read_ahead parameter
 modparam("tls", "ssl_read_ahead", 1)
 
-10.20. send_close_notify (boolean)
+10.23. send_close_notify (boolean)
 
    Enables/disables sending close notify alerts prior to closing the
    corresponding TCP connection. Sending the close notify prior to TCP
@@ -1097,15 +1161,15 @@ modparam("tls", "ssl_read_ahead", 1)
    It can be changed also at runtime, via the RPC interface and config
    framework. The config variable name is tls.send_close_notify.
 
-   Example 1.23. Set send_close_notify parameter
+   Example 1.26. Set send_close_notify parameter
 ...
 modparam("tls", "send_close_notify", 1)
 ...
 
-   Example 1.24. Set tls.send_close_notify at runtime
+   Example 1.27. Set tls.send_close_notify at runtime
  $ kamcmd cfg.set_now_int tls send_close_notify 1
 
-10.21. con_ct_wq_max (integer)
+10.24. con_ct_wq_max (integer)
 
    Sets the maximum allowed per connection clear-text send queue size in
    bytes. This queue is used when data cannot be encrypted and sent
@@ -1116,15 +1180,15 @@ modparam("tls", "send_close_notify", 1)
    It can be changed also at runtime, via the RPC interface and config
    framework. The config variable name is tls.con_ct_wq_max.
 
-   Example 1.25. Set con_ct_wq_max parameter
+   Example 1.28. Set con_ct_wq_max parameter
 ...
 modparam("tls", "con_ct_wq_max", 1048576)
 ...
 
-   Example 1.26. Set tls.con_ct_wq_max at runtime
+   Example 1.29. Set tls.con_ct_wq_max at runtime
  $ kamcmd cfg.set_now_int tls con_ct_wq_max 1048576
 
-10.22. ct_wq_max (integer)
+10.25. ct_wq_max (integer)
 
    Sets the maximum total number of bytes queued in all the clear-text
    send queues. These queues are used when data cannot be encrypted and
@@ -1135,15 +1199,15 @@ modparam("tls", "con_ct_wq_max", 1048576)
    It can be changed also at runtime, via the RPC interface and config
    framework. The config variable name is tls.ct_wq_max.
 
-   Example 1.27. Set ct_wq_max parameter
+   Example 1.30. Set ct_wq_max parameter
 ...
 modparam("tls", "ct_wq_max", 4194304)
 ...
 
-   Example 1.28. Set tls.ct_wq_max at runtime
+   Example 1.31. Set tls.ct_wq_max at runtime
  $ kamcmd cfg.set_now_int tls ct_wq_max 4194304
 
-10.23. ct_wq_blk_size (integer)
+10.26. ct_wq_blk_size (integer)
 
    Minimum block size for the internal clear-text send queues (debugging /
    advanced tuning). Good values are multiple of typical datagram sizes.
@@ -1153,15 +1217,15 @@ modparam("tls", "ct_wq_max", 4194304)
    It can be changed also at runtime, via the RPC interface and config
    framework. The config variable name is tls.ct_wq_blk_size.
 
-   Example 1.29. Set ct_wq_blk_size parameter
+   Example 1.32. Set ct_wq_blk_size parameter
 ...
 modparam("tls", "ct_wq_blk_size", 2048)
 ...
 
-   Example 1.30. Set tls.ct_wq_max at runtime
+   Example 1.33. Set tls.ct_wq_max at runtime
  $ kamcmd cfg.set_now_int tls ct_wq_blk_size 2048
 
-10.24. tls_log (int)
+10.27. tls_log (int)
 
    Sets the log level at which TLS related messages will be logged.
 
@@ -1170,16 +1234,16 @@ modparam("tls", "ct_wq_blk_size", 2048)
    It can be changed also at runtime, via the RPC interface and config
    framework. The config variable name is tls.log.
 
-   Example 1.31. Set tls_log parameter
+   Example 1.34. Set tls_log parameter
 ...
 # ignore TLS messages if Kamailio is started with debug less than 10
 modparam("tls", "tls_log", 10)
 ...
 
-   Example 1.32. Set tls.log at runtime
+   Example 1.35. Set tls.log at runtime
  $ kamcmd cfg.set_now_int tls log 10
 
-10.25. tls_debug (int)
+10.28. tls_debug (int)
 
    Sets the log level at which TLS debug messages will be logged. Note
    that TLS debug messages are enabled only if the TLS module is compiled
@@ -1191,16 +1255,16 @@ modparam("tls", "tls_log", 10)
    It can be changed also at runtime, via the RPC interface and config
    framework. The config variable name is tls.debug.
 
-   Example 1.33. Set tls_debug parameter
+   Example 1.36. Set tls_debug parameter
 ...
 # ignore TLS debug messages if Kamailio is started with debug less than 10
 modparam("tls", "tls_debug", 10)
 ...
 
-   Example 1.34. Set tls.debug at runtime
+   Example 1.37. Set tls.debug at runtime
  $ kamcmd cfg.set_now_int tls debug 10
 
-10.26. low_mem_threshold1 (integer)
+10.29. low_mem_threshold1 (integer)
 
    Sets the minimal free memory from which attempts to open or accept new
    TLS connections will start to fail. The value is expressed in KB.
@@ -1223,15 +1287,15 @@ modparam("tls", "tls_debug", 10)
 
    See also tls.low_mem_threshold2.
 
-   Example 1.35. Set low_mem_threshold1 parameter
+   Example 1.38. Set low_mem_threshold1 parameter
 ...
 modparam("tls", "low_mem_threshold1", -1)
 ...
 
-   Example 1.36. Set tls.low_mem_threshold1 at runtime
+   Example 1.39. Set tls.low_mem_threshold1 at runtime
  $ kamcmd cfg.set_now_int tls low_mem_threshold1 2048
 
-10.27. low_mem_threshold2 (integer)
+10.30. low_mem_threshold2 (integer)
 
    Sets the minimal free memory from which TLS operations on already
    established TLS connections will start to fail preemptively. The value
@@ -1255,15 +1319,15 @@ modparam("tls", "low_mem_threshold1", -1)
 
    See also tls.low_mem_threshold1.
 
-   Example 1.37. Set tls.low_mem_threshold2 parameter
+   Example 1.40. Set tls.low_mem_threshold2 parameter
 ...
 modparam("tls", "low_mem_threshold2", -1)
 ...
 
-   Example 1.38. Set tls.low_mem_threshold2 at runtime
+   Example 1.41. Set tls.low_mem_threshold2 at runtime
  $ kamcmd cfg.set_now_int tls low_mem_threshold2 1024
 
-10.28. tls_force_run (boolean)
+10.31. tls_force_run (boolean)
 
    If enabled Kamailio will start even if some of the OpenSSL sanity
    checks fail (turn it on at your own risk).
@@ -1278,36 +1342,36 @@ modparam("tls", "low_mem_threshold2", -1)
 
    By default tls_force_run is disabled.
 
-   Example 1.39. Set tls_force_run parameter
+   Example 1.42. Set tls_force_run parameter
 ...
 modparam("tls", "tls_force_run", 11)
 ...
 
-10.29. session_cache (boolean)
+10.32. session_cache (boolean)
 
    If enabled Kamailio will do caching of the TLS sessions data,
    generation a session_id and sending it back to client.
 
    By default TLS session caching is disabled (0).
 
-   Example 1.40. Set session_cache parameter
+   Example 1.43. Set session_cache parameter
 ...
 modparam("tls", "session_cache", 1)
 ...
 
-10.30. session_id (str)
+10.33. session_id (str)
 
    The value for session ID context, making sense when session caching is
    enabled.
 
    By default TLS session_id is "kamailio-tls-5.x.y".
 
-   Example 1.41. Set session_id parameter
+   Example 1.44. Set session_id parameter
 ...
 modparam("tls", "session_id", "my-session-id-context")
 ...
 
-10.31. renegotiation (boolean)
+10.34. renegotiation (boolean)
 
    If enabled Kamailio will allow renegotiations of TLS connection
    initiated by the client. This may expose to a security risk if the
@@ -1316,12 +1380,12 @@ modparam("tls", "session_id", "my-session-id-context")
 
    By default TLS renegotiation is disabled (0).
 
-   Example 1.42. Set renegotiation parameter
+   Example 1.45. Set renegotiation parameter
 ...
 modparam("tls", "renegotiation", 1)
 ...
 
-10.32. init_mode (int)
+10.35. init_mode (int)
 
    Allow setting flags that control how the module is initialized and
    works at runtime. Many flags (bits) can be set at the same time (set
@@ -1340,12 +1404,12 @@ modparam("tls", "renegotiation", 1)
 
    Default value is 0.
 
-   Example 1.43. Set init_mode parameter
+   Example 1.46. Set init_mode parameter
 ...
 modparam("tls", "init_mode", 1)
 ...
 
-10.33. config (string)
+10.36. config (string)
 
    Sets the name of the TLS specific configuration file or configuration
    directory.
@@ -1422,7 +1486,7 @@ modparam("tls", "init_mode", 1)
    SNI is provided, then the profile definition is searched again to match
    on 'server_name'.
 
-   Example 1.44. Sample TLS Config File
+   Example 1.47. Sample TLS Config File
 ...
 [server:default]
 method = TLSv1
@@ -1475,7 +1539,7 @@ server_name_mode = 1
    For a more complete example check the tls.cfg distributed with the
    Kamailio source (kamailio/modules/tls/tls.cfg).
 
-   Example 1.45. Set config parameter
+   Example 1.48. Set config parameter
 ...
 modparam("tls", "config", "/usr/local/etc/kamailio/tls.cfg")
 ...
@@ -1483,11 +1547,11 @@ modparam("tls", "config", "/usr/local/etc/kamailio/tls.cfg")
    The file can be changed at runtime. The new config will not be loaded
    immediately, but after the first tls.reload RPC call.
 
-   Example 1.46. Change and reload the TLS configuration at runtime
+   Example 1.49. Change and reload the TLS configuration at runtime
  $ kamcmd cfg.set_now_string tls config "/usr/local/etc/kamailio/new_tls.cfg"
  $ kamcmd tls.reload
 
-10.34. xavp_cfg (string)
+10.37. xavp_cfg (string)
 
    Sets the name of XAVP that stores attributes for TLS connections.
 
@@ -1502,7 +1566,7 @@ modparam("tls", "config", "/usr/local/etc/kamailio/tls.cfg")
 
    The default value is empty (not set).
 
-   Example 1.47. Set xavp_cfg parameter
+   Example 1.50. Set xavp_cfg parameter
 ...
   modparam("tls", "xavp_cfg", "tls")
  ...
@@ -1512,7 +1576,7 @@ modparam("tls", "config", "/usr/local/etc/kamailio/tls.cfg")
   route(RELAY);
 ...
 
-10.35. event_callback (str)
+10.38. event_callback (str)
 
    The name of the function in the kemi configuration file (embedded
    scripting language such as Lua, Python, ...) to be executed instead of
@@ -1523,7 +1587,7 @@ modparam("tls", "config", "/usr/local/etc/kamailio/tls.cfg")
 
    Default value is 'empty' (no function is executed for events).
 
-   Example 1.48. Set event_callback parameter
+   Example 1.51. Set event_callback parameter
 ...
 modparam("tls", "event_callback", "ksr_tls_event")
 ...
@@ -1534,7 +1598,7 @@ function ksr_tls_event(evname)
 end
 ...
 
-10.36. rand_engine (str)
+10.39. rand_engine (str)
 
    Set the random number generator engine for libssl.
 
@@ -1557,12 +1621,12 @@ end
    The default value is empty (not set) for libssl v1.0.x or older, and
    "cryptorand" for libssl v1.1.x or newer.
 
-   Example 1.49. Set rand_engine parameter
+   Example 1.52. Set rand_engine parameter
 ...
 modparam("tls", "rand_engine", "fastrand")
 ...
 
-10.37. engine (string)
+10.40. engine (string)
 
    If OpenSSL is compiled with engine support this will allow algorithms
    to be offloaded and private keys from HSM to be used. Currently only a
@@ -1588,13 +1652,13 @@ modparam("tls", "engine_algorithms", "ALL")
    By default OpenSSL engine support is disabled (NONE). This global param
    is not supported in the tls config file.
 
-10.38. engine_config (string)
+10.41. engine_config (string)
 
    An OpenSSL configuration file to initialize the engine. Typically used
    to send PIN to HSMs to unlock private keys. See the HSM howto for an
    example. This global param is not supported in the tls config file.
 
-10.39. engine_algorithms (string)
+10.42. engine_algorithms (string)
 
    A list of cryptographic methods to be set as default in the engine.
    This is a comma-separated list of values from ALL RSA DSA DH EC RAND
@@ -1604,7 +1668,7 @@ modparam("tls", "engine_algorithms", "ALL")
    The default is not to set any methods as default. This global param is
    not supported in the tls config file.
 
-10.40. verify_client (string)
+10.43. verify_client (string)
 
    Provides an alternative to verify_certificate and require_certificate
    modparam and tls.cfg parameters, and creates an additional
@@ -1636,12 +1700,12 @@ modparam("tls", "engine_algorithms", "ALL")
        verify_client="optional"
      * verify_certificate=1, require_certificate=1 => verify_client="on"
 
-   Example 1.50. Set verify_client modparam parameter
+   Example 1.53. Set verify_client modparam parameter
 ...
 modparam("tls", "verify_client", "on")
 ...
 
-   Example 1.51. Set verify_client tls.cfg parameter
+   Example 1.54. Set verify_client tls.cfg parameter
 ...
 [server:1.2.3.4:5061]
 method = TLSv1
@@ -1653,14 +1717,14 @@ method = TLSv1.2
 verify_client = optional_no_ca
 ...
 
-10.41. provider_quirks (integer)
+10.44. provider_quirks (integer)
 
    Sets a flag to configure OpenSSL 3 behaviour. Currently only 1
      * 0 - no flags set (default)
      * 1 - create a new `OSSL_LIB_CTX` context in the child process. Known
        to be required when using OpenSSL 3 pkcs11-provider.
 
-10.42. keylog_mode (int)
+10.45. keylog_mode (int)
 
    Control the TLS key logging functionality, available for libssl version
    greater than 1.1.0. Its value is composed from bitwise values (can be
@@ -1682,12 +1746,12 @@ verify_client = optional_no_ca
 
    The default value: 0.
 
-   Example 1.52. Set keylog_mode parameter
+   Example 1.55. Set keylog_mode parameter
 ...
 modparam("tls", "keylog_mode", 15)
 ...
 
-10.43. keylog_file (str)
+10.46. keylog_file (str)
 
    Path to the file where to write the TLS keys. The values are appended
    to the content of the file. The value 8 (bit 4) has to be set to
@@ -1695,12 +1759,12 @@ modparam("tls", "keylog_mode", 15)
 
    The default value: NULL.
 
-   Example 1.53. Set keylog_file parameter
+   Example 1.56. Set keylog_file parameter
 ...
 modparam("tls", "keylog_file", "/tmp/kamailio-tls-keylog.txt")
 ...
 
-10.44. keylog_peer (str)
+10.47. keylog_peer (str)
 
    Address of the peer where to send the keys log. It has to be in the
    format "proto:ip:port". Only "udp" protocol (proto) is supported. The
@@ -1708,7 +1772,7 @@ modparam("tls", "keylog_file", "/tmp/kamailio-tls-keylog.txt")
 
    The default value: NULL.
 
-   Example 1.54. Set keylog_peer parameter
+   Example 1.57. Set keylog_peer parameter
 ...
 modparam("tls", "keylog_peer", "udp:127.0.0.1:8020")
 ...
@@ -1726,7 +1790,7 @@ modparam("tls", "keylog_peer", "udp:127.0.0.1:8020")
 
    It can be used only in a request route.
 
-   Example 1.55. is_peer_verified usage
+   Example 1.58. is_peer_verified usage
 ...
         if (proto==TLS && !is_peer_verified()) {
                 sl_send_reply("400", "No certificate or verification failed");
@@ -1745,7 +1809,7 @@ modparam("tls", "keylog_peer", "udp:127.0.0.1:8020")
 
    It can be used only in ANY_ROUTE.
 
-   Example 1.56. tls_set_connect_server_id usage
+   Example 1.59. tls_set_connect_server_id usage
 ...
     tls_set_connect_server_id("clientone");
 ...
@@ -1837,7 +1901,7 @@ modparam("tls", "keylog_peer", "udp:127.0.0.1:8020")
    If drop() is executed in the event route, then the data is no longer
    sent over the connection.
 
-   Example 1.57. Use of event_route[tls:connection-out]
+   Example 1.60. Use of event_route[tls:connection-out]
 ...
 event_route[tls:connection-out] {
   if($sndto(ip)=="1.2.3.4") {

--- a/src/modules/tls/doc/params.xml
+++ b/src/modules/tls/doc/params.xml
@@ -197,6 +197,79 @@ modparam("tls", "private_key_password", "secret")
 	</example>
 	</section>
 
+	<section id="tls.p.certificate2">
+	<title><varname>certificate2</varname> (string)</title>
+	<para>
+		Sets the file name for a second certificate, enabling dual-cert
+		support. This is typically used to configure both an RSA and an
+		ECDSA certificate for the same TLS domain. OpenSSL will
+		automatically select the appropriate certificate during the TLS
+		handshake based on the client's advertised signature algorithms.
+	</para>
+	<para>
+		The path resolution rules are the same as for
+		<varname>certificate</varname>.
+	</para>
+	<para>
+		The parameter is optional. When not set, the TLS domain serves
+		only the certificate configured via <varname>certificate</varname>.
+		It does not inherit from the parent domain.
+	</para>
+	<para>
+		The default value is empty (not set).
+	</para>
+	<example>
+	    <title>Set <varname>certificate2</varname> parameter</title>
+	    <programlisting>
+...
+modparam("tls", "certificate2", "/usr/local/etc/kamailio/my_ecdsa_cert.pem")
+...
+	    </programlisting>
+	</example>
+	</section>
+
+	<section id="tls.p.private_key2">
+	<title><varname>private_key2</varname> (string)</title>
+	<para>
+		Sets the file name for the private key corresponding to the
+		second certificate (<varname>certificate2</varname>).
+	</para>
+	<para>
+		The path resolution rules are the same as for
+		<varname>private_key</varname>.
+	</para>
+	<para>
+		The default value is empty (not set).
+	</para>
+	<example>
+	    <title>Set <varname>private_key2</varname> parameter</title>
+	    <programlisting>
+...
+modparam("tls", "private_key2", "/usr/local/etc/kamailio/my_ecdsa_pkey.pem")
+...
+	    </programlisting>
+	</example>
+	</section>
+
+	<section id="tls.p.private_key_password2">
+	<title><varname>private_key_password2</varname> (string)</title>
+	<para>
+		The password for the second private key
+		(<varname>private_key2</varname>).
+	</para>
+	<para>
+		The default value is empty.
+	</para>
+	<example>
+	    <title>Set <varname>private_key_password2</varname> parameter</title>
+	    <programlisting>
+...
+modparam("tls", "private_key_password2", "secret")
+...
+	    </programlisting>
+	</example>
+	</section>
+
 	<section id="tls.p.key_password_mode">
 	<title><varname>key_password_mode</varname> (int)</title>
 	<para>

--- a/src/modules/tls/doc/tls.xml
+++ b/src/modules/tls/doc/tls.xml
@@ -77,6 +77,13 @@
 		They can be given as modparam or provided in the profiles of tls.cfg file.
 		</para>
 		<para>
+		For dual-cert support (e.g., serving both RSA and ECDSA certificates),
+		set <varname>certificate2</varname> and <varname>private_key2</varname>
+		in addition to the primary certificate. OpenSSL automatically selects
+		the appropriate certificate during the TLS handshake based on the
+		client's advertised signature algorithms.
+		</para>
+		<para>
 		When installing tls module of kamailio, a sample 'tls.cfg' file is deployed in the same
 		folder with 'kamailio.cfg'. For freshly generated self signed certificates make must be called from tls folder
 		<programlisting>

--- a/src/modules/tls/tls_config.c
+++ b/src/modules/tls/tls_config.c
@@ -178,7 +178,15 @@ static cfg_option_t options[] = {
 		{"server_id", .f = cfg_parse_str_opt, .flags = CFG_STR_SHMMEM},
 		{"verify_client", .param = verify_client_params,
 				.f = cfg_parse_enum_opt},
-		{"ca_path", .f = cfg_parse_str_opt, .flags = CFG_STR_SHMMEM}, {0}};
+		{"ca_path", .f = cfg_parse_str_opt, .flags = CFG_STR_SHMMEM},
+		{"certificate2", .f = cfg_parse_str_opt, .flags = CFG_STR_SHMMEM},
+		{"cert_file2", .f = cfg_parse_str_opt, .flags = CFG_STR_SHMMEM},
+		{"private_key2", .f = cfg_parse_str_opt, .flags = CFG_STR_SHMMEM},
+		{"pkey_file2", .f = cfg_parse_str_opt, .flags = CFG_STR_SHMMEM},
+		{"private_key_password2", .f = cfg_parse_str_opt,
+				.flags = CFG_STR_SHMMEM},
+		{"pkey_password2", .f = cfg_parse_str_opt, .flags = CFG_STR_SHMMEM},
+		{0}};
 
 
 static void update_opt_variables(void)
@@ -232,6 +240,18 @@ static void update_opt_variables(void)
 	}
 	n++;
 	options[n].param = &_ksr_tls_domain->ca_path;
+	n++;
+	options[n].param = &_ksr_tls_domain->cert_file2;
+	n++;
+	options[n].param = &_ksr_tls_domain->cert_file2;
+	n++;
+	options[n].param = &_ksr_tls_domain->pkey_file2;
+	n++;
+	options[n].param = &_ksr_tls_domain->pkey_file2;
+	n++;
+	options[n].param = &_ksr_tls_domain->pkey_password2;
+	n++;
+	options[n].param = &_ksr_tls_domain->pkey_password2;
 }
 
 

--- a/src/modules/tls/tls_domain.c
+++ b/src/modules/tls/tls_domain.c
@@ -407,6 +407,15 @@ static int ksr_tls_fill_missing(tls_domain_t *d, tls_domain_t *parent)
 	LOG(L_INFO, "%s: private_key_password='%s'\n", tls_domain_str(d),
 			d->pkey_password.s ? "..." : NULL);
 
+	if(d->cert_file2.s) {
+		LOG(L_INFO, "%s: certificate2='%s'\n", tls_domain_str(d),
+				d->cert_file2.s);
+	}
+	if(d->pkey_file2.s) {
+		LOG(L_INFO, "%s: private_key2='%s'\n", tls_domain_str(d),
+				d->pkey_file2.s);
+	}
+
 	if(d->verify_cert == -1)
 		d->verify_cert = parent->verify_cert;
 	LOG(L_INFO, "%s: verify_certificate=%d\n", tls_domain_str(d),
@@ -604,6 +613,21 @@ static int load_cert(tls_domain_t *d)
 			return -1;
 		}
 	}
+
+	if(d->cert_file2.s && d->cert_file2.len) {
+		if(fix_shm_pathname(&d->cert_file2) < 0)
+			return -1;
+		for(i = 0; i < procs_no; i++) {
+			if(!SSL_CTX_use_certificate_chain_file(
+					   d->ctx[i], d->cert_file2.s)) {
+				ERR("%s: Unable to load certificate2 file '%s'\n",
+						tls_domain_str(d), d->cert_file2.s);
+				TLS_ERR("load_cert:");
+				return -1;
+			}
+		}
+	}
+
 	return 0;
 }
 
@@ -1272,6 +1296,30 @@ static int ksr_passwd_cfg_cb(char *buf, int size, int rwflag, void *tlsd)
 }
 
 /**
+ * @brief Password callback for second private key, using pkey_password2
+ */
+static int ksr_passwd_cfg_cb2(char *buf, int size, int rwflag, void *tlsd)
+{
+	tls_domain_t *d;
+
+	d = (tls_domain_t *)tlsd;
+	if(d->pkey_password2.s == NULL || d->pkey_password2.len <= 0) {
+		return 0;
+	}
+	if(d->pkey_password2.len >= size - 1) {
+		LM_WARN("key2 password is too long (%d / %d) - truncating\n",
+				d->pkey_password2.len, size);
+		memcpy(buf, d->pkey_password2.s, size - 1);
+		buf[size - 1] = '\0';
+	} else {
+		memcpy(buf, d->pkey_password2.s, d->pkey_password2.len);
+		buf[d->pkey_password2.len] = '\0';
+	}
+	LM_DBG("returning password for private key2\n");
+	return strlen(buf);
+}
+
+/**
  * @brief Password callback, ask for private key password on CLI
  * @param buf buffer
  * @param size buffer size
@@ -1451,6 +1499,38 @@ static int load_private_key(tls_domain_t *d)
 
 	DBG("%s: Key '%s' successfully loaded\n", tls_domain_str(d),
 			d->pkey_file.s);
+
+	/* Load second private key if configured (for dual-cert support) */
+	if(d->pkey_file2.s && d->pkey_file2.len) {
+		if(fix_shm_pathname(&d->pkey_file2) < 0)
+			return -1;
+
+		for(i = 0; i < procs_no; i++) {
+			if(d->pkey_password2.s && d->pkey_password2.len > 0) {
+				SSL_CTX_set_default_passwd_cb(d->ctx[i], ksr_passwd_cfg_cb2);
+				SSL_CTX_set_default_passwd_cb_userdata(d->ctx[i], d);
+			} else if(ksr_tls_key_password_mode == 1) {
+				SSL_CTX_set_default_passwd_cb(d->ctx[i], ksr_passwd_ui_cb);
+				SSL_CTX_set_default_passwd_cb_userdata(
+						d->ctx[i], d->pkey_file2.s);
+			} else {
+				SSL_CTX_set_default_passwd_cb(d->ctx[i], ksr_passwd_cfg_cb2);
+				SSL_CTX_set_default_passwd_cb_userdata(d->ctx[i], d);
+			}
+
+			ret_pwd = SSL_CTX_use_PrivateKey_file(
+					d->ctx[i], d->pkey_file2.s, SSL_FILETYPE_PEM);
+			if(!ret_pwd) {
+				ERR("%s: Unable to load private key2 file '%s'\n",
+						tls_domain_str(d), d->pkey_file2.s);
+				TLS_ERR("load_private_key:");
+				return -1;
+			}
+		}
+		DBG("%s: Key2 '%s' successfully loaded\n", tls_domain_str(d),
+				d->pkey_file2.s);
+	}
+
 	return 0;
 }
 

--- a/src/modules/tls/tls_domain.h
+++ b/src/modules/tls/tls_domain.h
@@ -127,6 +127,9 @@ typedef struct tls_domain
 	str cert_file;
 	str pkey_file;
 	str pkey_password;
+	str cert_file2;
+	str pkey_file2;
+	str pkey_password2;
 	int verify_cert;
 	int verify_depth;
 	str ca_file;

--- a/src/modules/tls/tls_mod.c
+++ b/src/modules/tls/tls_mod.c
@@ -126,6 +126,9 @@ static tls_domain_t mod_params = {
 	STR_STATIC_INIT(TLS_CERT_FILE),	 /* Certificate file */
 	STR_STATIC_INIT(TLS_PKEY_FILE),	 /* Private key file */
 	{0, 0},							 /* Private key password */
+	{0, 0},							 /* Second certificate file */
+	{0, 0},							 /* Second private key file */
+	{0, 0},							 /* Second private key password */
 	0,								 /* Verify certificate */
 	9,								 /* Verify depth */
 	STR_STATIC_INIT(TLS_CA_FILE),	 /* CA file */
@@ -153,6 +156,9 @@ tls_domain_t srv_defaults = {
 	STR_STATIC_INIT(TLS_CERT_FILE),	 /* Certificate file */
 	STR_STATIC_INIT(TLS_PKEY_FILE),	 /* Private key file */
 	{0, 0},							 /* Private key password */
+	{0, 0},							 /* Second certificate file */
+	{0, 0},							 /* Second private key file */
+	{0, 0},							 /* Second private key password */
 	0,								 /* Verify certificate */
 	9,								 /* Verify depth */
 	STR_STATIC_INIT(TLS_CA_FILE),	 /* CA file */
@@ -206,6 +212,9 @@ tls_domain_t cli_defaults = {
 	{0, 0},							 /* Certificate file */
 	{0, 0},							 /* Private key file */
 	{0, 0},							 /* Private key password */
+	{0, 0},							 /* Second certificate file */
+	{0, 0},							 /* Second private key file */
+	{0, 0},							 /* Second private key password */
 	0,								 /* Verify certificate */
 	9,								 /* Verify depth */
 	STR_STATIC_INIT(TLS_CA_FILE),	 /* CA file */


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Add dual-cert support to the TLS module, allowing a TLS domain to serve
both an RSA and an ECDSA certificate simultaneously. OpenSSL automatically
selects the appropriate certificate during the TLS handshake based on the
client's advertised signature algorithms.

**New tls.cfg options per domain:**
- `certificate2` / `cert_file2` — path to the second certificate
- `private_key2` / `pkey_file2` — path to the second private key
- `private_key_password2` / `pkey_password2` — password for the second key

The secondary certificate is optional and does not inherit from the parent
domain. When not configured, behavior is unchanged — fully backwards
compatible.

**Example tls.cfg:**
```
[server:default]
method = TLSv1.2+
certificate = /etc/kamailio/tls/rsa.crt
private_key = /etc/kamailio/tls/rsa.key
certificate2 = /etc/kamailio/tls/ecdsa.crt
private_key2 = /etc/kamailio/tls/ecdsa.key
```


**Changes:**
- `src/modules/tls/tls_domain.h` — added `cert_file2`, `pkey_file2`, `pkey_password2` fields
- `src/modules/tls/tls_config.c` — added config option entries and variable bindings
- `src/modules/tls/tls_domain.c` — extended cert/key loading, added password callback
- `src/modules/tls/tls_mod.c` — updated static domain initializers
- `src/modules/tls/doc/params.xml` — documented new parameters
- `src/modules/tls/doc/tls.xml` — updated overview with dual-cert info
- `src/modules/tls/README` — regenerated via `make README`

**Testing:**
Verified in devcontainer with OpenSSL 3.5.4. Unit test (62.sh) generates
self-signed RSA and ECDSA certs, starts kamailio with dual/single-cert
configs, and validates correct certificate selection using `openssl s_client`
with `-sigalgs`. Also tests SIP OPTIONS over TLS. All 6 sub-tests pass.

new tests can be found in https://github.com/kamailio/kamailio-tests/pull/20