### PR TITLE
tlscfg: new module for dynamic TLS profile management

### DIFF
--- a/src/modules/tlscfg/Makefile
+++ b/src/modules/tlscfg/Makefile
@@ -1,0 +1,12 @@
+#
+# tlscfg module makefile
+#
+#
+# WARNING: do not run this directly, it should be run by the main Makefile
+
+include ../../Makefile.defs
+auto_gen=
+NAME=tlscfg.so
+LIBS=
+
+include ../../Makefile.modules

--- a/src/modules/tlscfg/doc/Makefile
+++ b/src/modules/tlscfg/doc/Makefile
@@ -1,0 +1,4 @@
+docs = tlscfg.xml
+
+docbook_dir = ../../../../doc/docbook
+include $(docbook_dir)/Makefile.module

--- a/src/modules/tlscfg/doc/tlscfg.xml
+++ b/src/modules/tlscfg/doc/tlscfg.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<book xmlns:xi="http://www.w3.org/2001/XInclude">
+	<bookinfo>
+	<title>tlscfg Module</title>
+	<authorgroup>
+		<author>
+		<firstname>Daniel</firstname>
+		<surname>Donoghue</surname>
+		<affiliation><orgname>Aurora Innovation</orgname></affiliation>
+		</author>
+	</authorgroup>
+	<copyright>
+		<year>2026</year>
+		<holder>Aurora Innovation</holder>
+	</copyright>
+	</bookinfo>
+	<toc></toc>
+
+	<xi:include href="tlscfg_admin.xml"/>
+</book>

--- a/src/modules/tlscfg/doc/tlscfg_admin.xml
+++ b/src/modules/tlscfg/doc/tlscfg_admin.xml
@@ -1,0 +1,603 @@
+<?xml version="1.0" encoding='ISO-8859-1'?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
+
+<!-- Include general documentation entities -->
+<!ENTITY % docentities SYSTEM "../../../../doc/docbook/entities.xml">
+%docentities;
+
+]>
+
+<!-- tlscfg Module User's Guide -->
+
+<chapter>
+
+	<title>&adminguide;</title>
+
+	<section>
+	<title>Overview</title>
+	<para>
+		The <emphasis>tlscfg</emphasis> module is a companion to the
+		<emphasis>tls</emphasis> module. It provides dynamic TLS profile
+		management via RPC commands, config file write-back with debounce,
+		and certificate file monitoring.
+	</para>
+	<para>
+		The module does not implement any TLS plumbing itself  - it
+		delegates all TLS operations to the existing
+		<emphasis>tls</emphasis> module. Instead, it manages the tls.cfg
+		configuration file and triggers <function>tls.reload</function>
+		when changes are made.
+	</para>
+	<para>
+		Key capabilities:
+	</para>
+	<itemizedlist>
+		<listitem>
+		<para>
+			<emphasis>Profile management</emphasis>  - add, update,
+			remove, enable, and disable TLS profiles at runtime via RPC.
+		</para>
+		</listitem>
+		<listitem>
+		<para>
+			<emphasis>Config write-back</emphasis>  - mutations are
+			buffered in memory and flushed to the tls.cfg file after a
+			configurable debounce interval, followed by an automatic
+			<function>tls.reload</function>. Before each write, a
+			timestamped backup of the existing config file can
+			optionally be created (see
+			<varname>config_backup_dir</varname>).
+		</para>
+		</listitem>
+		<listitem>
+		<para>
+			<emphasis>Certificate watching</emphasis>  - periodically
+			checks mtime of certificate files referenced by managed
+			profiles. When changes are detected (e.g., renewed certs),
+			triggers <function>tls.reload</function> automatically.
+			All certificate paths configured on a profile are monitored
+			independently. See
+			<xref linkend="tlscfg.cert_watching"/> for details.
+		</para>
+		</listitem>
+		<listitem>
+		<para>
+			<emphasis>Certificate path resolution</emphasis>  -
+			supports absolute paths, relative paths (resolved against
+			<varname>cert_base_path</varname>), and
+			<literal>certman:</literal> shorthand for integration with
+			external certificate management services.
+		</para>
+		</listitem>
+	</itemizedlist>
+	<para>
+		At startup the module discovers the tls.cfg file path from the
+		<emphasis>tls</emphasis> module's <varname>config</varname>
+		parameter and parses the existing configuration into an in-memory
+		profile index. All subsequent RPC mutations operate on this index
+		and are written back atomically.
+	</para>
+	<section id="tlscfg.profile_ids">
+	<title>Profile IDs</title>
+	<para>
+		Each profile has two identities: its <emphasis>section
+		header</emphasis> (the tls domain address, e.g.,
+		<literal>[server:10.0.0.1:5061]</literal>) and its
+		<emphasis>profile ID</emphasis> (a user-chosen name used to
+		reference the profile in all RPC commands).
+	</para>
+	<para>
+		By default the profile ID is derived from the section header by
+		stripping the brackets (e.g.,
+		<literal>server:10.0.0.1:5061</literal>). You can override this
+		by adding a <literal>profile_id</literal> directive inside the
+		section:
+	</para>
+	<programlisting format="linespecific">
+[server:10.0.0.1:5061]
+profile_id = sip-main
+certificate = certman:sip-main
+</programlisting>
+	<para>
+		With an explicit profile ID, all RPC commands use the friendly
+		name:
+	</para>
+	<programlisting format="linespecific">
+$ &amp;kamctl; rpc tlscfg.profile_get sip-main
+$ &amp;kamctl; rpc tlscfg.profile_update sip-main certificate certman:sip-main
+</programlisting>
+	<para>
+		The <literal>profile_id</literal> directive is preserved across
+		config write-back cycles. When adding profiles via RPC, the
+		<function>tlscfg.profile_add</function> command takes the profile
+		ID and section as separate parameters.
+	</para>
+	</section>
+	<para>
+		Disabled profiles are written to the config file as comments
+		(prefixed with <literal>#</literal>) so the
+		<emphasis>tls</emphasis> module's parser ignores them. The
+		<emphasis>tlscfg</emphasis> module recognizes these commented-out
+		sections and can re-enable them via RPC.
+	</para>
+	</section>
+
+	<section id="tlscfg.cert_watching">
+	<title>Certificate File Watching</title>
+	<para>
+		The certificate file watcher is a pull-based safety net that
+		automatically detects when certificate files change on disk,
+		independent of any RPC notification. It provides two key benefits:
+	</para>
+	<itemizedlist>
+		<listitem>
+		<para>
+			<emphasis>Standalone operation</emphasis>  - the module is
+			useful on its own without any external certificate manager.
+			Operators can rotate certificates by any means (manual
+			copy, cron-driven certbot, configuration management tools)
+			and Kamailio will automatically reload the new certificates.
+		</para>
+		</listitem>
+		<listitem>
+		<para>
+			<emphasis>Defense in depth</emphasis>  - even when using the
+			<function>tlscfg.cert_notify</function> RPC as the primary
+			notification path, the watcher ensures that certificate
+			changes are never silently missed (e.g., if the RPC call
+			fails or an operator replaces files manually).
+		</para>
+		</listitem>
+	</itemizedlist>
+	<para>
+		The watcher monitors all certificate paths configured on each
+		profile independently. If a profile references multiple
+		certificate files, a change to any one of them triggers a
+		reload. If a profile only has a single certificate path (the
+		common case), only that path is watched.
+	</para>
+	<para>
+		The check interval is controlled by
+		<varname>cert_check_interval</varname>. The watcher is designed
+		to work safely with certificate files on network-attached storage
+		(NFS, CIFS) as well as local filesystems.
+	</para>
+	<para>
+		Set <varname>cert_check_interval</varname> to <literal>0</literal>
+		to disable the watcher entirely if all certificate changes are
+		guaranteed to arrive via
+		<function>tlscfg.cert_notify</function>.
+	</para>
+	</section>
+
+	<section>
+	<title>Dependencies</title>
+	<para>
+		The module depends on the following modules (in other words the
+		listed modules must be loaded before this module):
+		<itemizedlist>
+		<listitem>
+			<para>
+			<emphasis>tls</emphasis>  - required. The tls module must
+			be loaded and its <varname>config</varname> parameter must
+			point to a tls.cfg file.
+			</para>
+		</listitem>
+		</itemizedlist>
+	</para>
+	</section>
+
+	<section>
+	<title>Parameters</title>
+
+	<section id="tlscfg.p.cert_check_interval">
+		<title><varname>cert_check_interval</varname> (int)</title>
+		<para>
+		Interval in seconds between certificate file mtime checks. When a
+		referenced certificate or key file has changed on disk, the module
+		triggers <function>tls.reload</function> automatically.
+		</para>
+		<para>
+		Set to <literal>0</literal> to disable certificate file watching.
+		</para>
+		<para>
+		Default value is <quote>300</quote> (5 minutes).
+		</para>
+		<example>
+		<title><varname>cert_check_interval</varname> parameter usage</title>
+		<programlisting format="linespecific">
+...
+modparam("tlscfg", "cert_check_interval", 60)
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.p.debounce_interval">
+		<title><varname>debounce_interval</varname> (int)</title>
+		<para>
+		Seconds to wait after the last RPC mutation before flushing the
+		config file and triggering <function>tls.reload</function>. This
+		batches rapid sequential updates (e.g., setting multiple fields on
+		a new profile) into a single write and reload cycle.
+		</para>
+		<para>
+		Default value is <quote>2</quote>.
+		</para>
+		<example>
+		<title><varname>debounce_interval</varname> parameter usage</title>
+		<programlisting format="linespecific">
+...
+modparam("tlscfg", "debounce_interval", 5)
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.p.cert_base_path">
+		<title><varname>cert_base_path</varname> (string)</title>
+		<para>
+		Base directory for certificate file path resolution. Certificate
+		and key paths set via RPC support three resolution modes:
+		</para>
+		<itemizedlist>
+		<listitem>
+			<para>
+			<emphasis>Absolute paths</emphasis> (starting with
+			<literal>/</literal>)  - used as-is.
+			</para>
+		</listitem>
+		<listitem>
+			<para>
+			<emphasis>certman: prefix</emphasis>  -
+			<literal>certman:&lt;id&gt;</literal> resolves to
+			<literal>{cert_base_path}/{id}/cert.pem</literal> for
+			certificates and
+			<literal>{cert_base_path}/{id}/key.pem</literal> for
+			private keys. The private key is auto-inferred when
+			setting a certificate with the certman: prefix.
+			</para>
+		</listitem>
+		<listitem>
+			<para>
+			<emphasis>Relative paths</emphasis>  - resolved as
+			<literal>{cert_base_path}/{value}</literal>.
+			</para>
+		</listitem>
+		</itemizedlist>
+		<para>
+		Default value is <quote>/var/lib/certman/certs</quote>.
+		</para>
+		<example>
+		<title><varname>cert_base_path</varname> parameter usage</title>
+		<programlisting format="linespecific">
+...
+modparam("tlscfg", "cert_base_path", "/etc/kamailio/tls/certs")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.p.config_backup_dir">
+		<title><varname>config_backup_dir</varname> (string)</title>
+		<para>
+		Directory where timestamped backups of the tls.cfg file are stored
+		before each config write. A backup file is created with the naming
+		pattern
+		<literal>{basename}.YYYYMMDDTHHmmss.bak</literal>.
+		</para>
+		<para>
+		When set to an empty string (the default), backups are written to
+		the same directory as the tls.cfg file. Set to an absolute path to
+		store backups in a different location.
+		</para>
+		<para>
+		To disable config backups entirely, set
+		<varname>config_max_backups</varname> to <literal>0</literal>.
+		</para>
+		<para>
+		Default value is <quote></quote> (empty  - same directory as
+		tls.cfg).
+		</para>
+		<example>
+		<title><varname>config_backup_dir</varname> parameter usage</title>
+		<programlisting format="linespecific">
+...
+modparam("tlscfg", "config_backup_dir", "/var/backups/kamailio")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.p.config_max_backups">
+		<title><varname>config_max_backups</varname> (int)</title>
+		<para>
+		Maximum number of tls.cfg backup files to retain. When this limit
+		is exceeded, the oldest backups are pruned after each write. Old
+		backups are identified by alphabetical sort order of filenames
+		(the timestamp format ensures chronological ordering).
+		</para>
+		<para>
+		Set to <literal>0</literal> to disable config backups entirely.
+		</para>
+		<para>
+		Default value is <quote>10</quote>.
+		</para>
+		<example>
+		<title><varname>config_max_backups</varname> parameter usage</title>
+		<programlisting format="linespecific">
+...
+modparam("tlscfg", "config_max_backups", 20)
+...
+</programlisting>
+		</example>
+	</section>
+
+	</section>
+
+	<section>
+	<title>RPC Commands</title>
+	<para>
+		The module exports several RPC commands for managing TLS profiles
+		at runtime. Profile mutations are buffered and flushed after the
+		debounce interval, unless noted otherwise.
+	</para>
+
+	<section id="tlscfg.rpc.profile_add">
+		<title><function moreinfo="none">tlscfg.profile_add</function></title>
+		<para>
+		Create a new TLS profile. The profile is added to the in-memory
+		index with the given section type. It starts enabled but empty
+		(no certificate or key fields).
+		</para>
+		<para>
+		Parameters:
+		</para>
+		<itemizedlist>
+		<listitem><para>
+			<emphasis>profile_id</emphasis>  - unique identifier for
+			the profile (e.g., <literal>carrier-abc</literal>).
+		</para></listitem>
+		<listitem><para>
+			<emphasis>section</emphasis>  - section type and address
+			(e.g., <literal>server:default</literal>,
+			<literal>client:any</literal>). Written to the config as
+			<literal>[server:default]</literal>.
+		</para></listitem>
+		</itemizedlist>
+		<example>
+		<title><function moreinfo="none">tlscfg.profile_add</function> usage</title>
+		<programlisting format="linespecific">
+...
+$ &kamctl; rpc tlscfg.profile_add carrier-abc client:any
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.rpc.profile_update">
+		<title><function moreinfo="none">tlscfg.profile_update</function></title>
+		<para>
+		Set or remove a field on an existing profile. If the value is
+		omitted or set to <literal>-</literal>, the field is removed.
+		</para>
+		<para>
+		When setting <varname>certificate</varname> or
+		<varname>certificate2</varname> to a <literal>certman:</literal>
+		value, the corresponding <varname>private_key</varname> or
+		<varname>private_key2</varname> is automatically inferred.
+		</para>
+		<para>
+		Parameters:
+		</para>
+		<itemizedlist>
+		<listitem><para>
+			<emphasis>profile_id</emphasis>  - target profile.
+		</para></listitem>
+		<listitem><para>
+			<emphasis>key</emphasis>  - field name (any tls.cfg
+			directive, e.g., <literal>certificate</literal>,
+			<literal>method</literal>, <literal>cipher_list</literal>).
+		</para></listitem>
+		<listitem><para>
+			<emphasis>value</emphasis> (optional)  - new value. Omit
+			or pass <literal>-</literal> to remove the field.
+		</para></listitem>
+		</itemizedlist>
+		<example>
+		<title><function moreinfo="none">tlscfg.profile_update</function> usage</title>
+		<programlisting format="linespecific">
+...
+# Set a field:
+$ &kamctl; rpc tlscfg.profile_update carrier-abc certificate certman:carrier-abc
+
+# Remove a field:
+$ &kamctl; rpc tlscfg.profile_update carrier-abc cipher_list -
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.rpc.profile_remove">
+		<title><function moreinfo="none">tlscfg.profile_remove</function></title>
+		<para>
+		Remove a profile entirely from the in-memory index.
+		</para>
+		<para>
+		Parameters:
+		</para>
+		<itemizedlist>
+		<listitem><para>
+			<emphasis>profile_id</emphasis>  - profile to remove.
+		</para></listitem>
+		</itemizedlist>
+		<example>
+		<title><function moreinfo="none">tlscfg.profile_remove</function> usage</title>
+		<programlisting format="linespecific">
+...
+$ &kamctl; rpc tlscfg.profile_remove carrier-abc
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.rpc.profile_list">
+		<title><function moreinfo="none">tlscfg.profile_list</function></title>
+		<para>
+		List all managed profiles. Each entry includes the profile id,
+		section header, enabled status, and type (server or client). Use
+		<function>tlscfg.profile_get</function> to retrieve the full
+		details including key-value fields.
+		</para>
+		<para>
+		No parameters.
+		</para>
+		<example>
+		<title><function moreinfo="none">tlscfg.profile_list</function> usage</title>
+		<programlisting format="linespecific">
+...
+$ &kamctl; rpc tlscfg.profile_list
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.rpc.profile_get">
+		<title><function moreinfo="none">tlscfg.profile_get</function></title>
+		<para>
+		Return full details of a single profile, including all key-value
+		fields.
+		</para>
+		<para>
+		Parameters:
+		</para>
+		<itemizedlist>
+		<listitem><para>
+			<emphasis>profile_id</emphasis>  - profile to inspect.
+		</para></listitem>
+		</itemizedlist>
+		<example>
+		<title><function moreinfo="none">tlscfg.profile_get</function> usage</title>
+		<programlisting format="linespecific">
+...
+$ &kamctl; rpc tlscfg.profile_get carrier-abc
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.rpc.profile_enable">
+		<title><function moreinfo="none">tlscfg.profile_enable</function></title>
+		<para>
+		Enable a previously disabled profile. The profile section will be
+		uncommented in the config file on the next flush.
+		</para>
+		<para>
+		Parameters:
+		</para>
+		<itemizedlist>
+		<listitem><para>
+			<emphasis>profile_id</emphasis>  - profile to enable.
+		</para></listitem>
+		</itemizedlist>
+		<example>
+		<title><function moreinfo="none">tlscfg.profile_enable</function> usage</title>
+		<programlisting format="linespecific">
+...
+$ &kamctl; rpc tlscfg.profile_enable carrier-abc
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.rpc.profile_disable">
+		<title><function moreinfo="none">tlscfg.profile_disable</function></title>
+		<para>
+		Disable a profile. The profile section will be written as comments
+		in the config file on the next flush, so the tls module ignores it.
+		The profile remains in the in-memory index and can be re-enabled.
+		</para>
+		<para>
+		Parameters:
+		</para>
+		<itemizedlist>
+		<listitem><para>
+			<emphasis>profile_id</emphasis>  - profile to disable.
+		</para></listitem>
+		</itemizedlist>
+		<example>
+		<title><function moreinfo="none">tlscfg.profile_disable</function> usage</title>
+		<programlisting format="linespecific">
+...
+$ &kamctl; rpc tlscfg.profile_disable carrier-abc
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.rpc.cert_check">
+		<title><function moreinfo="none">tlscfg.cert_check</function></title>
+		<para>
+		Trigger an immediate certificate file mtime check cycle. If any
+		referenced certificate files have changed,
+		<function>tls.reload</function> is triggered.
+		</para>
+		<para>
+		No parameters.
+		</para>
+		<example>
+		<title><function moreinfo="none">tlscfg.cert_check</function> usage</title>
+		<programlisting format="linespecific">
+...
+$ &kamctl; rpc tlscfg.cert_check
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.rpc.cert_notify">
+		<title><function moreinfo="none">tlscfg.cert_notify</function></title>
+		<para>
+		Notification endpoint for external certificate management services
+		(e.g., certman). Immediately flushes the current config to disk and
+		triggers <function>tls.reload</function>, bypassing the debounce
+		timer. Use this when an external tool has written new certificate
+		files and wants Kamailio to pick them up immediately.
+		</para>
+		<para>
+		No parameters.
+		</para>
+		<example>
+		<title><function moreinfo="none">tlscfg.cert_notify</function> usage</title>
+		<programlisting format="linespecific">
+...
+$ &kamctl; rpc tlscfg.cert_notify
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="tlscfg.rpc.reload">
+		<title><function moreinfo="none">tlscfg.reload</function></title>
+		<para>
+		Re-read the tls.cfg file from disk into the in-memory profile
+		index, then trigger <function>tls.reload</function>. Use this
+		after manually editing the config file.
+		</para>
+		<para>
+		No parameters.
+		</para>
+		<example>
+		<title><function moreinfo="none">tlscfg.reload</function> usage</title>
+		<programlisting format="linespecific">
+...
+$ &kamctl; rpc tlscfg.reload
+...
+</programlisting>
+		</example>
+	</section>
+
+	</section>
+
+</chapter>

--- a/src/modules/tlscfg/tlscfg_config.c
+++ b/src/modules/tlscfg/tlscfg_config.c
@@ -1,0 +1,543 @@
+/*
+ * tlscfg module - TLS profile management companion for the tls module
+ *
+ * Copyright (C) 2026 Aurora Innovation
+ *
+ * Author: Daniel Donoghue
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @file tlscfg_config.c
+ * @brief Config file parser and atomic writer
+ * @ingroup tlscfg
+ */
+
+#include "../../core/dprint.h"
+#include "../../core/mem/shm_mem.h"
+
+#include "tlscfg_config.h"
+
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+#define TLSCFG_LINE_MAX 1024
+#define TLSCFG_PATH_MAX 512
+#define TLSCFG_DISABLED_MARKER "#!tlscfg:disabled"
+
+/* implemented in tlscfg_mod.c */
+extern const char *tlscfg_get_cert_base_path(void);
+extern const char *tlscfg_get_config_backup_dir(void);
+extern int tlscfg_get_config_max_backups(void);
+
+/* ---- helpers ---- */
+
+static char *trim(char *s)
+{
+	char *end;
+
+	while(isspace((unsigned char)*s))
+		s++;
+	if(*s == '\0')
+		return s;
+	end = s + strlen(s) - 1;
+	while(end > s && isspace((unsigned char)*end))
+		end--;
+	*(end + 1) = '\0';
+	return s;
+}
+
+static int is_cert_path_field(const char *key)
+{
+	return (strcasecmp(key, "certificate") == 0
+			|| strcasecmp(key, "certificate2") == 0
+			|| strcasecmp(key, "private_key") == 0
+			|| strcasecmp(key, "private_key2") == 0
+			|| strcasecmp(key, "ca_list") == 0 || strcasecmp(key, "crl") == 0);
+}
+
+static int is_key_field(const char *key)
+{
+	return (strcasecmp(key, "private_key") == 0
+			|| strcasecmp(key, "private_key2") == 0);
+}
+
+static int resolve_cert_path(const char *ref, char *out, int outlen, int is_key)
+{
+	const char *base = tlscfg_get_cert_base_path();
+
+	if(ref[0] == '/') {
+		snprintf(out, outlen, "%s", ref);
+	} else if(strncmp(ref, "certman:", 8) == 0) {
+		const char *id = ref + 8;
+		if(is_key) {
+			snprintf(out, outlen, "%s/%s/key.pem", base, id);
+		} else {
+			snprintf(out, outlen, "%s/%s/cert.pem", base, id);
+		}
+	} else {
+		snprintf(out, outlen, "%s/%s", base, ref);
+	}
+	return 0;
+}
+
+/**
+ * @brief Parse a section header like "[server:default]" or "[client:any]"
+ * @return 1 on success, 0 if not a section header
+ */
+static int parse_section_header(const char *line, char *out, int outlen)
+{
+	const char *p, *end;
+	int len;
+
+	p = line;
+	while(isspace((unsigned char)*p))
+		p++;
+	if(*p != '[')
+		return 0;
+
+	end = strchr(p, ']');
+	if(!end)
+		return 0;
+
+	len = (int)(end - p) + 1;
+	if(len >= outlen)
+		return 0;
+
+	memcpy(out, p, len);
+	out[len] = '\0';
+	return 1;
+}
+
+/**
+ * @brief Derive a profile_id from a section header
+ *
+ * Strips the brackets: "[server:default]" -> "server:default"
+ */
+static void derive_profile_id(const char *section, str *id)
+{
+	int len = strlen(section);
+
+	if(len >= 2 && section[0] == '[' && section[len - 1] == ']') {
+		id->s = (char *)section + 1;
+		id->len = len - 2;
+	} else {
+		id->s = (char *)section;
+		id->len = len;
+	}
+}
+
+/* ---- config load ---- */
+
+int tlscfg_config_load(str *path)
+{
+	FILE *fp;
+	char line[TLSCFG_LINE_MAX];
+	char section[320];
+	char *trimmed, *eq, *key, *val;
+	struct stat st;
+	str sid, shdr, skey, sval;
+	int in_disabled = 0;
+	tlscfg_data_t *data;
+
+	if(!path || !path->s || path->len == 0)
+		return -1;
+
+	data = tlscfg_data_get();
+	if(!data)
+		return -1;
+
+	fp = fopen(path->s, "r");
+	if(!fp) {
+		LM_ERR("cannot open config file '%.*s': %s\n", path->len, path->s,
+				strerror(errno));
+		return -1;
+	}
+
+	/* record mtime */
+	if(fstat(fileno(fp), &st) == 0) {
+		data->config_mtime = st.st_mtime;
+	}
+
+	/* clear existing profiles */
+	tlscfg_profile_clear();
+
+	section[0] = '\0';
+
+	while(fgets(line, sizeof(line), fp)) {
+		line[strcspn(line, "\r\n")] = '\0';
+		trimmed = trim(line);
+
+		/* disabled section marker */
+		if(strcmp(trimmed, TLSCFG_DISABLED_MARKER) == 0) {
+			in_disabled = 1;
+			continue;
+		}
+
+		/* disabled section header: "# [type:addr]" */
+		if(in_disabled && trimmed[0] == '#') {
+			char *inner = trim(trimmed + 1);
+			if(inner[0] == '[') {
+				if(parse_section_header(inner, section, sizeof(section))) {
+					shdr.s = section;
+					shdr.len = strlen(section);
+					derive_profile_id(section, &sid);
+					tlscfg_profile_add(&sid, &shdr);
+					tlscfg_profile_set_enabled(&sid, 0);
+					continue;
+				}
+			}
+		}
+
+		/* disabled kv: "# key = value" */
+		if(in_disabled && trimmed[0] == '#' && section[0] != '\0') {
+			char *inner = trim(trimmed + 1);
+			if(inner[0] == '\0' || inner[0] == '#')
+				continue;
+			if(inner[0] == '[') {
+				in_disabled = 0;
+				/* fall through to normal parsing */
+			} else {
+				eq = strchr(inner, '=');
+				if(eq) {
+					*eq = '\0';
+					key = trim(inner);
+					val = trim(eq + 1);
+					derive_profile_id(section, &sid);
+					if(strcasecmp(key, "profile_id") == 0) {
+						sval.s = val;
+						sval.len = strlen(val);
+						tlscfg_profile_set_id(&sid, &sval);
+					} else if(strcasecmp(key, "enabled") == 0) {
+						/* skip — handled separately */
+					} else {
+						skey.s = key;
+						skey.len = strlen(key);
+						sval.s = val;
+						sval.len = strlen(val);
+						tlscfg_profile_set(&sid, &skey, &sval);
+					}
+				}
+				continue;
+			}
+		}
+
+		/* end of disabled block */
+		if(in_disabled && trimmed[0] != '#') {
+			in_disabled = 0;
+		}
+
+		/* tlscfg structured comments: # tlscfg:key = value */
+		if(strncmp(trimmed, "# tlscfg:", 9) == 0 && section[0] != '\0') {
+			char *inner = trim(trimmed + 9);
+			eq = strchr(inner, '=');
+			if(eq) {
+				*eq = '\0';
+				key = trim(inner);
+				val = trim(eq + 1);
+				derive_profile_id(section, &sid);
+				if(strcasecmp(key, "profile_id") == 0) {
+					sval.s = val;
+					sval.len = strlen(val);
+					tlscfg_profile_set_id(&sid, &sval);
+				}
+			}
+			continue;
+		}
+
+		/* skip empty lines and comments */
+		if(trimmed[0] == '\0' || trimmed[0] == '#') {
+			continue;
+		}
+
+		/* normal section header */
+		if(parse_section_header(trimmed, section, sizeof(section))) {
+			shdr.s = section;
+			shdr.len = strlen(section);
+			derive_profile_id(section, &sid);
+			tlscfg_profile_add(&sid, &shdr);
+			continue;
+		}
+
+		/* key = value pair */
+		if(section[0] != '\0') {
+			eq = strchr(trimmed, '=');
+			if(eq) {
+				*eq = '\0';
+				key = trim(trimmed);
+				val = trim(eq + 1);
+				derive_profile_id(section, &sid);
+
+				if(strcasecmp(key, "enabled") == 0) {
+					int en = (strcasecmp(val, "yes") == 0
+							  || strcmp(val, "1") == 0);
+					tlscfg_profile_set_enabled(&sid, en);
+				} else {
+					skey.s = key;
+					skey.len = strlen(key);
+					sval.s = val;
+					sval.len = strlen(val);
+					tlscfg_profile_set(&sid, &skey, &sval);
+				}
+			}
+		}
+	}
+
+	fclose(fp);
+
+	data->dirty = 0;
+
+	LM_INFO("loaded tls config from '%.*s'\n", path->len, path->s);
+	return 0;
+}
+
+/* ---- config backup ---- */
+
+/**
+ * @brief Compare function for qsort — oldest first (ascending)
+ */
+static int backup_name_cmp(const void *a, const void *b)
+{
+	return strcmp(*(const char **)a, *(const char **)b);
+}
+
+/**
+ * @brief Create a timestamped backup of the config file before overwriting.
+ *
+ * Copies the current file to {backup_dir}/tls.cfg.YYYYMMDDTHHmmSS.bak
+ * and prunes old backups if count exceeds max_backups.
+ */
+static void config_backup(str *path)
+{
+	const char *backup_dir;
+	int max_backups;
+	char bakpath[TLSCFG_PATH_MAX];
+	char dirpath[TLSCFG_PATH_MAX];
+	struct stat st;
+	struct tm tm;
+	time_t now;
+	FILE *src, *dst;
+	char buf[4096];
+	size_t n;
+	DIR *dp;
+	struct dirent *de;
+	char *backups[256];
+	int count = 0;
+	const char *basename;
+	int baselen;
+	int i;
+
+	max_backups = tlscfg_get_config_max_backups();
+	if(max_backups <= 0)
+		return;
+
+	if(stat(path->s, &st) != 0)
+		return; /* nothing to back up */
+
+	backup_dir = tlscfg_get_config_backup_dir();
+	if(!backup_dir || backup_dir[0] == '\0') {
+		/* default: same directory as the config file */
+		snprintf(dirpath, sizeof(dirpath), "%.*s", path->len, path->s);
+		/* strip filename to get directory */
+		char *slash = strrchr(dirpath, '/');
+		if(slash) {
+			*slash = '\0';
+		} else {
+			strcpy(dirpath, ".");
+		}
+		backup_dir = dirpath;
+	}
+
+	/* extract basename from path for backup naming */
+	basename = strrchr(path->s, '/');
+	basename = basename ? basename + 1 : path->s;
+	baselen = strlen(basename);
+
+	/* generate timestamped backup name */
+	now = time(NULL);
+	gmtime_r(&now, &tm);
+	snprintf(bakpath, sizeof(bakpath), "%s/%s.%04d%02d%02dT%02d%02d%02d.bak",
+			backup_dir, basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+			tm.tm_hour, tm.tm_min, tm.tm_sec);
+
+	/* copy current config to backup */
+	src = fopen(path->s, "r");
+	if(!src)
+		return;
+	dst = fopen(bakpath, "w");
+	if(!dst) {
+		fclose(src);
+		LM_ERR("cannot create backup '%s': %s\n", bakpath, strerror(errno));
+		return;
+	}
+	while((n = fread(buf, 1, sizeof(buf), src)) > 0) {
+		if(fwrite(buf, 1, n, dst) != n) {
+			LM_ERR("failed writing backup '%s'\n", bakpath);
+			break;
+		}
+	}
+	fclose(src);
+	fclose(dst);
+	LM_INFO("config backup created: %s\n", bakpath);
+
+	/* prune old backups beyond max_backups */
+	dp = opendir(backup_dir);
+	if(!dp)
+		return;
+
+	count = 0;
+	while((de = readdir(dp)) != NULL && count < 256) {
+		/* match: {basename}.YYYYMMDDTHHmmSS.bak */
+		int namelen = strlen(de->d_name);
+		if(namelen == baselen + 20 /* .YYYYMMDDTHHmmSS.bak */
+				&& strncmp(de->d_name, basename, baselen) == 0
+				&& de->d_name[baselen] == '.'
+				&& strcmp(de->d_name + namelen - 4, ".bak") == 0) {
+			backups[count] = strdup(de->d_name);
+			if(backups[count])
+				count++;
+		}
+	}
+	closedir(dp);
+
+	if(count > max_backups) {
+		qsort(backups, count, sizeof(char *), backup_name_cmp);
+		for(i = 0; i < count - max_backups; i++) {
+			char rmpath[TLSCFG_PATH_MAX];
+			snprintf(rmpath, sizeof(rmpath), "%s/%s", backup_dir, backups[i]);
+			if(unlink(rmpath) == 0) {
+				LM_INFO("pruned old backup: %s\n", rmpath);
+			}
+		}
+	}
+
+	for(i = 0; i < count; i++) {
+		free(backups[i]);
+	}
+}
+
+/* ---- config write ---- */
+
+int tlscfg_config_write(str *path)
+{
+	FILE *fp;
+	char tmppath[TLSCFG_PATH_MAX];
+	char resolved[TLSCFG_PATH_MAX];
+	struct stat st;
+	tlscfg_data_t *data;
+	tlscfg_profile_t *p;
+	tlscfg_kv_t *kv;
+
+	if(!path || !path->s || path->len == 0)
+		return -1;
+
+	data = tlscfg_data_get();
+	if(!data)
+		return -1;
+
+	/* create timestamped backup before overwriting */
+	config_backup(path);
+
+	snprintf(tmppath, sizeof(tmppath), "%.*s.tmp.%d", path->len, path->s,
+			(int)getpid());
+
+	fp = fopen(tmppath, "w");
+	if(!fp) {
+		LM_ERR("cannot open tmp file '%s': %s\n", tmppath, strerror(errno));
+		return -1;
+	}
+
+	fprintf(fp, "# TLS configuration - managed by tlscfg\n");
+	fprintf(fp, "# Do not edit while kamailio is running\n\n");
+
+	for(p = data->profiles; p; p = p->next) {
+		if(!p->enabled) {
+			fprintf(fp, "%s\n", TLSCFG_DISABLED_MARKER);
+			fprintf(fp, "# %.*s\n", p->section_header.len, p->section_header.s);
+			fprintf(fp, "# profile_id = %.*s\n", p->profile_id.len,
+					p->profile_id.s);
+			fprintf(fp, "# enabled = no\n");
+			for(kv = p->kvs; kv; kv = kv->next) {
+				if(is_cert_path_field(kv->key.s) && kv->value.len > 0
+						&& kv->value.s[0] != '/') {
+					resolve_cert_path(kv->value.s, resolved, sizeof(resolved),
+							is_key_field(kv->key.s));
+					fprintf(fp, "# %.*s = %s\n", kv->key.len, kv->key.s,
+							resolved);
+				} else {
+					fprintf(fp, "# %.*s = %.*s\n", kv->key.len, kv->key.s,
+							kv->value.len, kv->value.s);
+				}
+			}
+			fprintf(fp, "\n");
+		} else {
+			fprintf(fp, "%.*s\n", p->section_header.len, p->section_header.s);
+			fprintf(fp, "# tlscfg:profile_id = %.*s\n", p->profile_id.len,
+					p->profile_id.s);
+			fprintf(fp, "# enabled = yes\n");
+			for(kv = p->kvs; kv; kv = kv->next) {
+				if(is_cert_path_field(kv->key.s) && kv->value.len > 0
+						&& kv->value.s[0] != '/') {
+					resolve_cert_path(kv->value.s, resolved, sizeof(resolved),
+							is_key_field(kv->key.s));
+					fprintf(fp, "%.*s = %s\n", kv->key.len, kv->key.s,
+							resolved);
+				} else {
+					fprintf(fp, "%.*s = %.*s\n", kv->key.len, kv->key.s,
+							kv->value.len, kv->value.s);
+				}
+			}
+			fprintf(fp, "\n");
+		}
+	}
+
+	fclose(fp);
+
+	if(rename(tmppath, path->s) != 0) {
+		LM_ERR("rename '%s' -> '%.*s' failed: %s\n", tmppath, path->len,
+				path->s, strerror(errno));
+		unlink(tmppath);
+		return -1;
+	}
+
+	if(stat(path->s, &st) == 0) {
+		data->config_mtime = st.st_mtime;
+	}
+	data->dirty = 0;
+
+	LM_INFO("wrote tls config to '%.*s'\n", path->len, path->s);
+	return 0;
+}
+
+time_t tlscfg_config_get_mtime(void)
+{
+	tlscfg_data_t *data = tlscfg_data_get();
+
+	if(!data)
+		return 0;
+	return data->config_mtime;
+}

--- a/src/modules/tlscfg/tlscfg_config.h
+++ b/src/modules/tlscfg/tlscfg_config.h
@@ -1,0 +1,64 @@
+/*
+ * tlscfg module - TLS profile management companion for the tls module
+ *
+ * Copyright (C) 2026 Aurora Innovation
+ *
+ * Author: Daniel Donoghue
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @file tlscfg_config.h
+ * @brief Config file parser and atomic writer declarations
+ * @ingroup tlscfg
+ */
+
+#ifndef _TLSCFG_CONFIG_H_
+#define _TLSCFG_CONFIG_H_
+
+#include "../../core/str.h"
+
+#include "tlscfg_profile.h"
+
+/**
+ * @brief Parse a tls.cfg file into the in-memory profile index
+ * @param path path to the tls.cfg file
+ * @return 0 on success, -1 on error
+ */
+int tlscfg_config_load(str *path);
+
+/**
+ * @brief Write the in-memory profile index back to the tls.cfg file
+ *
+ * Uses atomic write (tmp + rename). Disabled profiles are written as
+ * comments so the tls module's parser skips them.
+ *
+ * @param path path to the tls.cfg file
+ * @return 0 on success, -1 on error
+ */
+int tlscfg_config_write(str *path);
+
+/**
+ * @brief Get the last-recorded mtime of the config file
+ * @return mtime of last read/write, or 0 if never accessed
+ */
+time_t tlscfg_config_get_mtime(void);
+
+#endif /* _TLSCFG_CONFIG_H_ */

--- a/src/modules/tlscfg/tlscfg_mod.c
+++ b/src/modules/tlscfg/tlscfg_mod.c
@@ -1,0 +1,303 @@
+/*
+ * tlscfg module - TLS profile management companion for the tls module
+ *
+ * Copyright (C) 2026 Aurora Innovation
+ *
+ * Author: Daniel Donoghue
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @file tlscfg_mod.c
+ * @brief TLS profile management — module entry point
+ *
+ * Companion to the tls module. Provides dynamic profile management via
+ * RPC, config file write-back with debounce, and cert file mtime watching.
+ * Does not implement any TLS plumbing — delegates all TLS to the tls module.
+ *
+ * @ingroup tlscfg
+ */
+
+#include "../../core/sr_module.h"
+#include "../../core/dprint.h"
+#include "../../core/rpc.h"
+#include "../../core/rpc_lookup.h"
+#include "../../core/timer_proc.h"
+#include "../../core/mod_fix.h"
+#include "../../core/kemi.h"
+
+#include "tlscfg_config.h"
+#include "tlscfg_profile.h"
+#include "tlscfg_rpc.h"
+#include "tlscfg_watch.h"
+
+#include <string.h>
+
+MODULE_VERSION
+
+/* ---- module parameters ------------------------------------------------- */
+
+static int cert_check_interval = 300; /* seconds between cert mtime checks */
+static int debounce_interval = 2;	  /* seconds idle before write + reload */
+static char *cert_base_path = "/var/lib/certman/certs";
+static char *config_backup_dir = ""; /* empty = same dir as tls.cfg */
+static int config_max_backups = 10;
+
+/* discovered from tls module at init */
+static str tls_cfg_path = STR_NULL;
+
+/* ---- forward declarations ---------------------------------------------- */
+
+static int mod_init(void);
+static int child_init(int rank);
+static void mod_destroy(void);
+
+/* ---- RPC exports ------------------------------------------------------- */
+
+/* clang-format off */
+static const char *tlscfg_rpc_profile_add_doc[] = {
+	"Add a new TLS profile", 0
+};
+static const char *tlscfg_rpc_profile_update_doc[] = {
+	"Update a field on a TLS profile", 0
+};
+static const char *tlscfg_rpc_profile_remove_doc[] = {
+	"Remove a TLS profile", 0
+};
+static const char *tlscfg_rpc_profile_list_doc[] = {
+	"List all TLS profiles", 0
+};
+static const char *tlscfg_rpc_profile_get_doc[] = {
+	"Get full details of a TLS profile", 0
+};
+static const char *tlscfg_rpc_profile_enable_doc[] = {
+	"Enable a TLS profile", 0
+};
+static const char *tlscfg_rpc_profile_disable_doc[] = {
+	"Disable a TLS profile", 0
+};
+static const char *tlscfg_rpc_cert_check_doc[] = {
+	"Check all referenced cert files for changes", 0
+};
+static const char *tlscfg_rpc_cert_notify_doc[] = {
+	"Notify that a cert file changed (immediate reload)", 0
+};
+static const char *tlscfg_rpc_reload_doc[] = {
+	"Re-read config file and trigger tls.reload", 0
+};
+
+static rpc_export_t tlscfg_rpc_cmds[] = {
+	{"tlscfg.profile_add",     tlscfg_rpc_profile_add,
+		tlscfg_rpc_profile_add_doc,     0},
+	{"tlscfg.profile_update",  tlscfg_rpc_profile_update,
+		tlscfg_rpc_profile_update_doc,  0},
+	{"tlscfg.profile_remove",  tlscfg_rpc_profile_remove,
+		tlscfg_rpc_profile_remove_doc,  0},
+	{"tlscfg.profile_list",    tlscfg_rpc_profile_list,
+		tlscfg_rpc_profile_list_doc,    RET_ARRAY},
+	{"tlscfg.profile_get",     tlscfg_rpc_profile_get,
+		tlscfg_rpc_profile_get_doc,     0},
+	{"tlscfg.profile_enable",  tlscfg_rpc_profile_enable,
+		tlscfg_rpc_profile_enable_doc,  0},
+	{"tlscfg.profile_disable", tlscfg_rpc_profile_disable,
+		tlscfg_rpc_profile_disable_doc, 0},
+	{"tlscfg.cert_check",      tlscfg_rpc_cert_check,
+		tlscfg_rpc_cert_check_doc,      0},
+	{"tlscfg.cert_notify",     tlscfg_rpc_cert_notify,
+		tlscfg_rpc_cert_notify_doc,     0},
+	{"tlscfg.reload",          tlscfg_rpc_reload,
+		tlscfg_rpc_reload_doc,          0},
+	{0, 0, 0, 0}
+};
+/* clang-format on */
+
+/* ---- module exports ---------------------------------------------------- */
+
+/* clang-format off */
+static param_export_t params[] = {
+	{"cert_check_interval", PARAM_INT, &cert_check_interval},
+	{"debounce_interval",   PARAM_INT, &debounce_interval},
+	{"cert_base_path",      PARAM_STRING, &cert_base_path},
+	{"config_backup_dir",   PARAM_STRING, &config_backup_dir},
+	{"config_max_backups",  PARAM_INT, &config_max_backups},
+	{0, 0, 0}
+};
+
+struct module_exports exports = {
+	"tlscfg",        /* module name */
+	DEFAULT_DLFLAGS, /* dlopen flags */
+	0,               /* cmd (cfg function) exports */
+	params,          /* param exports */
+	0,               /* RPC method exports */
+	0,               /* pseudo-variables exports */
+	0,               /* response handling function */
+	mod_init,        /* module init function */
+	child_init,      /* per-child init function */
+	mod_destroy      /* module destroy function */
+};
+/* clang-format on */
+
+/* ---- accessors for other translation units ----------------------------- */
+
+str *tlscfg_get_tls_cfg_path(void)
+{
+	return &tls_cfg_path;
+}
+
+int tlscfg_get_cert_check_interval(void)
+{
+	return cert_check_interval;
+}
+
+int tlscfg_get_debounce_interval(void)
+{
+	return debounce_interval;
+}
+
+const char *tlscfg_get_cert_base_path(void)
+{
+	return cert_base_path;
+}
+
+const char *tlscfg_get_config_backup_dir(void)
+{
+	return config_backup_dir;
+}
+
+int tlscfg_get_config_max_backups(void)
+{
+	return config_max_backups;
+}
+
+/* ---- module lifecycle -------------------------------------------------- */
+
+/**
+ * @brief Discover the tls module's config file path
+ *
+ * Uses find_param_export() to locate the "config" modparam on the tls
+ * module. The value is copied so we are independent of the tls module's
+ * internal storage after init.
+ *
+ * @return 0 on success, -1 on error
+ */
+static int tlscfg_discover_tls_config(void)
+{
+	modparam_t param_type;
+	str *cfg_file;
+
+	if(!module_loaded("tls")) {
+		LM_ERR("tls module is not loaded — tlscfg requires it\n");
+		return -1;
+	}
+
+	cfg_file = (str *)find_param_export(
+			find_module_by_name("tls"), "config", PARAM_STR, &param_type);
+	if(cfg_file == NULL || cfg_file->s == NULL || cfg_file->len == 0) {
+		LM_ERR("tls module has no 'config' parameter set — tlscfg needs "
+			   "a tls.cfg file to manage\n");
+		return -1;
+	}
+
+	/* take our own copy */
+	tls_cfg_path.len = cfg_file->len;
+	tls_cfg_path.s = pkg_malloc(cfg_file->len + 1);
+	if(tls_cfg_path.s == NULL) {
+		PKG_MEM_ERROR;
+		return -1;
+	}
+	memcpy(tls_cfg_path.s, cfg_file->s, cfg_file->len);
+	tls_cfg_path.s[cfg_file->len] = '\0';
+
+	LM_INFO("discovered tls config file: %.*s\n", tls_cfg_path.len,
+			tls_cfg_path.s);
+	return 0;
+}
+
+static int mod_init(void)
+{
+	LM_INFO("tlscfg module initializing\n");
+
+	/* init shared memory data structures */
+	if(tlscfg_data_init() < 0) {
+		LM_ERR("failed to init shared data\n");
+		return -1;
+	}
+
+	/* discover tls module config path */
+	if(tlscfg_discover_tls_config() < 0) {
+		return -1;
+	}
+
+	/* register RPC commands */
+	if(rpc_register_array(tlscfg_rpc_cmds) != 0) {
+		LM_ERR("failed to register RPC commands\n");
+		return -1;
+	}
+
+	/* load existing tls.cfg into profile index */
+	{
+		tlscfg_data_t *data = tlscfg_data_get();
+		lock_get(data->lock);
+		if(tlscfg_config_load(&tls_cfg_path) < 0) {
+			LM_WARN("failed to load tls config — starting with "
+					"empty profile index\n");
+		}
+		lock_release(data->lock);
+	}
+
+	/* reserve timer slot: 1-second tick for debounce + cert watch */
+	if(register_basic_timers(1) != 0) {
+		LM_ERR("failed to register timer slot\n");
+		return -1;
+	}
+
+	LM_INFO("tlscfg module initialized (cert_check_interval=%d, "
+			"debounce_interval=%d, cert_base_path=%s)\n",
+			cert_check_interval, debounce_interval, cert_base_path);
+	return 0;
+}
+
+static int child_init(int rank)
+{
+	if(rank != PROC_MAIN) {
+		return 0;
+	}
+
+	/* fork 1-second timer for debounce flush + cert mtime watch */
+	if(fork_basic_timer(PROC_TIMER, "TLSCFG WATCHER", 1, tlscfg_watch_timer,
+			   NULL, 1 /*sec*/)
+			< 0) {
+		LM_ERR("failed to fork watcher timer process\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+static void mod_destroy(void)
+{
+	tlscfg_data_destroy();
+	if(tls_cfg_path.s != NULL) {
+		pkg_free(tls_cfg_path.s);
+		tls_cfg_path.s = NULL;
+		tls_cfg_path.len = 0;
+	}
+	LM_INFO("tlscfg module destroyed\n");
+}

--- a/src/modules/tlscfg/tlscfg_profile.c
+++ b/src/modules/tlscfg/tlscfg_profile.c
@@ -1,0 +1,396 @@
+/*
+ * tlscfg module - TLS profile management companion for the tls module
+ *
+ * Copyright (C) 2026 Aurora Innovation
+ *
+ * Author: Daniel Donoghue
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @file tlscfg_profile.c
+ * @brief In-memory TLS profile index — shared memory implementation
+ * @ingroup tlscfg
+ */
+
+#include "../../core/dprint.h"
+#include "../../core/mem/mem.h"
+#include "../../core/mem/shm_mem.h"
+#include "../../core/locking.h"
+
+#include "tlscfg_profile.h"
+
+#include <string.h>
+#include <time.h>
+
+static tlscfg_data_t *_tlscfg_data = NULL;
+
+/* ---- shared memory string helpers ---- */
+
+static int shm_str_dup(str *dst, const str *src)
+{
+	dst->s = shm_malloc(src->len + 1);
+	if(dst->s == NULL) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+	memcpy(dst->s, src->s, src->len);
+	dst->s[src->len] = '\0';
+	dst->len = src->len;
+	return 0;
+}
+
+static void shm_str_free(str *s)
+{
+	if(s && s->s) {
+		shm_free(s->s);
+		s->s = NULL;
+		s->len = 0;
+	}
+}
+
+/* ---- free helpers ---- */
+
+static void kv_free(tlscfg_kv_t *kv)
+{
+	if(kv) {
+		shm_str_free(&kv->key);
+		shm_str_free(&kv->value);
+		shm_free(kv);
+	}
+}
+
+static void profile_free(tlscfg_profile_t *p)
+{
+	tlscfg_kv_t *kv, *next;
+
+	if(p) {
+		shm_str_free(&p->profile_id);
+		shm_str_free(&p->section_header);
+		for(kv = p->kvs; kv; kv = next) {
+			next = kv->next;
+			kv_free(kv);
+		}
+		shm_free(p);
+	}
+}
+
+/* ---- shared data init/destroy ---- */
+
+int tlscfg_data_init(void)
+{
+	_tlscfg_data = shm_mallocxz(sizeof(tlscfg_data_t));
+	if(_tlscfg_data == NULL) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+	_tlscfg_data->lock = lock_alloc();
+	if(_tlscfg_data->lock == NULL) {
+		LM_ERR("failed to allocate lock\n");
+		shm_free(_tlscfg_data);
+		_tlscfg_data = NULL;
+		return -1;
+	}
+	if(lock_init(_tlscfg_data->lock) == NULL) {
+		LM_ERR("failed to init lock\n");
+		lock_dealloc(_tlscfg_data->lock);
+		shm_free(_tlscfg_data);
+		_tlscfg_data = NULL;
+		return -1;
+	}
+	_tlscfg_data->profiles = NULL;
+	_tlscfg_data->dirty = 0;
+	_tlscfg_data->last_mutation = 0;
+	_tlscfg_data->config_mtime = 0;
+	return 0;
+}
+
+void tlscfg_data_destroy(void)
+{
+	tlscfg_profile_t *p, *next;
+
+	if(_tlscfg_data) {
+		if(_tlscfg_data->lock) {
+			lock_destroy(_tlscfg_data->lock);
+			lock_dealloc(_tlscfg_data->lock);
+		}
+		for(p = _tlscfg_data->profiles; p; p = next) {
+			next = p->next;
+			profile_free(p);
+		}
+		shm_free(_tlscfg_data);
+		_tlscfg_data = NULL;
+	}
+}
+
+tlscfg_data_t *tlscfg_data_get(void)
+{
+	return _tlscfg_data;
+}
+
+/* ---- profile operations (caller MUST hold data->lock) ---- */
+
+tlscfg_profile_t *tlscfg_profile_find(str *profile_id)
+{
+	tlscfg_profile_t *p;
+
+	if(!_tlscfg_data)
+		return NULL;
+	for(p = _tlscfg_data->profiles; p; p = p->next) {
+		if(p->profile_id.len == profile_id->len
+				&& strncmp(p->profile_id.s, profile_id->s, profile_id->len)
+						   == 0) {
+			return p;
+		}
+	}
+	return NULL;
+}
+
+int tlscfg_profile_add(str *profile_id, str *section_header)
+{
+	tlscfg_profile_t *p;
+
+	if(!_tlscfg_data)
+		return -1;
+
+	if(tlscfg_profile_find(profile_id) != NULL) {
+		LM_ERR("profile '%.*s' already exists\n", profile_id->len,
+				profile_id->s);
+		return -1;
+	}
+
+	p = shm_mallocxz(sizeof(tlscfg_profile_t));
+	if(p == NULL) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+
+	if(shm_str_dup(&p->profile_id, profile_id) < 0) {
+		shm_free(p);
+		return -1;
+	}
+	if(shm_str_dup(&p->section_header, section_header) < 0) {
+		shm_str_free(&p->profile_id);
+		shm_free(p);
+		return -1;
+	}
+
+	if(section_header->len >= 7
+			&& strncasecmp(section_header->s + 1, "client", 6) == 0) {
+		p->profile_type = TLSCFG_TYPE_CLIENT;
+	} else {
+		p->profile_type = TLSCFG_TYPE_SERVER;
+	}
+
+	p->enabled = 1;
+	p->kvs = NULL;
+	p->next = _tlscfg_data->profiles;
+	_tlscfg_data->profiles = p;
+
+	_tlscfg_data->dirty = 1;
+	_tlscfg_data->last_mutation = time(NULL);
+
+	LM_INFO("added profile '%.*s' (%.*s)\n", profile_id->len, profile_id->s,
+			section_header->len, section_header->s);
+	return 0;
+}
+
+int tlscfg_profile_remove(str *profile_id)
+{
+	tlscfg_profile_t *p, *prev;
+
+	if(!_tlscfg_data)
+		return -1;
+
+	prev = NULL;
+	for(p = _tlscfg_data->profiles; p; prev = p, p = p->next) {
+		if(p->profile_id.len == profile_id->len
+				&& strncmp(p->profile_id.s, profile_id->s, profile_id->len)
+						   == 0) {
+			if(prev) {
+				prev->next = p->next;
+			} else {
+				_tlscfg_data->profiles = p->next;
+			}
+			_tlscfg_data->dirty = 1;
+			_tlscfg_data->last_mutation = time(NULL);
+			profile_free(p);
+			LM_INFO("removed profile '%.*s'\n", profile_id->len, profile_id->s);
+			return 0;
+		}
+	}
+
+	LM_ERR("profile '%.*s' not found\n", profile_id->len, profile_id->s);
+	return -1;
+}
+
+tlscfg_kv_t *tlscfg_kv_find(tlscfg_profile_t *p, str *key)
+{
+	tlscfg_kv_t *kv;
+
+	for(kv = p->kvs; kv; kv = kv->next) {
+		if(kv->key.len == key->len
+				&& strncasecmp(kv->key.s, key->s, key->len) == 0) {
+			return kv;
+		}
+	}
+	return NULL;
+}
+
+int tlscfg_profile_set(str *profile_id, str *key, str *value)
+{
+	tlscfg_profile_t *p;
+	tlscfg_kv_t *kv;
+
+	if(!_tlscfg_data)
+		return -1;
+
+	p = tlscfg_profile_find(profile_id);
+	if(p == NULL) {
+		LM_ERR("profile '%.*s' not found\n", profile_id->len, profile_id->s);
+		return -1;
+	}
+
+	kv = tlscfg_kv_find(p, key);
+	if(kv) {
+		str new_val;
+		if(shm_str_dup(&new_val, value) < 0) {
+			return -1;
+		}
+		shm_str_free(&kv->value);
+		kv->value = new_val;
+	} else {
+		kv = shm_mallocxz(sizeof(tlscfg_kv_t));
+		if(kv == NULL) {
+			SHM_MEM_ERROR;
+			return -1;
+		}
+		if(shm_str_dup(&kv->key, key) < 0) {
+			shm_free(kv);
+			return -1;
+		}
+		if(shm_str_dup(&kv->value, value) < 0) {
+			shm_str_free(&kv->key);
+			shm_free(kv);
+			return -1;
+		}
+		kv->next = p->kvs;
+		p->kvs = kv;
+	}
+
+	_tlscfg_data->dirty = 1;
+	_tlscfg_data->last_mutation = time(NULL);
+	return 0;
+}
+
+int tlscfg_profile_unset(str *profile_id, str *key)
+{
+	tlscfg_profile_t *p;
+	tlscfg_kv_t *kv, *prev;
+
+	if(!_tlscfg_data)
+		return -1;
+
+	p = tlscfg_profile_find(profile_id);
+	if(p == NULL)
+		return -1;
+
+	prev = NULL;
+	for(kv = p->kvs; kv; prev = kv, kv = kv->next) {
+		if(kv->key.len == key->len
+				&& strncasecmp(kv->key.s, key->s, key->len) == 0) {
+			if(prev) {
+				prev->next = kv->next;
+			} else {
+				p->kvs = kv->next;
+			}
+			kv_free(kv);
+			_tlscfg_data->dirty = 1;
+			_tlscfg_data->last_mutation = time(NULL);
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+int tlscfg_profile_set_id(str *old_id, str *new_id)
+{
+	tlscfg_profile_t *p;
+	str tmp;
+
+	if(!_tlscfg_data)
+		return -1;
+
+	p = tlscfg_profile_find(old_id);
+	if(p == NULL) {
+		LM_ERR("profile '%.*s' not found\n", old_id->len, old_id->s);
+		return -1;
+	}
+
+	if(tlscfg_profile_find(new_id) != NULL) {
+		LM_ERR("profile '%.*s' already exists\n", new_id->len, new_id->s);
+		return -1;
+	}
+
+	if(shm_str_dup(&tmp, new_id) < 0) {
+		return -1;
+	}
+
+	shm_str_free(&p->profile_id);
+	p->profile_id = tmp;
+
+	_tlscfg_data->dirty = 1;
+	_tlscfg_data->last_mutation = time(NULL);
+
+	LM_INFO("renamed profile '%.*s' -> '%.*s'\n", old_id->len, old_id->s,
+			new_id->len, new_id->s);
+	return 0;
+}
+
+int tlscfg_profile_set_enabled(str *profile_id, int enabled)
+{
+	tlscfg_profile_t *p;
+
+	if(!_tlscfg_data)
+		return -1;
+
+	p = tlscfg_profile_find(profile_id);
+	if(p == NULL)
+		return -1;
+
+	p->enabled = enabled ? 1 : 0;
+	_tlscfg_data->dirty = 1;
+	_tlscfg_data->last_mutation = time(NULL);
+	return 0;
+}
+
+void tlscfg_profile_clear(void)
+{
+	tlscfg_profile_t *p, *next;
+
+	if(!_tlscfg_data)
+		return;
+	for(p = _tlscfg_data->profiles; p; p = next) {
+		next = p->next;
+		profile_free(p);
+	}
+	_tlscfg_data->profiles = NULL;
+}

--- a/src/modules/tlscfg/tlscfg_profile.h
+++ b/src/modules/tlscfg/tlscfg_profile.h
@@ -1,0 +1,98 @@
+/*
+ * tlscfg module - TLS profile management companion for the tls module
+ *
+ * Copyright (C) 2026 Aurora Innovation
+ *
+ * Author: Daniel Donoghue
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @file tlscfg_profile.h
+ * @brief In-memory TLS profile index declarations
+ * @ingroup tlscfg
+ */
+
+#ifndef _TLSCFG_PROFILE_H_
+#define _TLSCFG_PROFILE_H_
+
+#include "../../core/str.h"
+#include "../../core/locking.h"
+
+#include <time.h>
+
+#define TLSCFG_TYPE_SERVER 0
+#define TLSCFG_TYPE_CLIENT 1
+
+/**
+ * @brief Key-value pair for arbitrary tls.cfg directives (shm allocated)
+ */
+typedef struct tlscfg_kv
+{
+	str key;
+	str value;
+	struct tlscfg_kv *next;
+} tlscfg_kv_t;
+
+/**
+ * @brief In-memory representation of a single TLS profile (shm allocated)
+ */
+typedef struct tlscfg_profile
+{
+	str profile_id;
+	str section_header;
+	int profile_type;
+	int enabled;
+	time_t cert_mtime;
+	time_t cert2_mtime;
+	time_t cert_expiry;
+	tlscfg_kv_t *kvs;
+	struct tlscfg_profile *next;
+} tlscfg_profile_t;
+
+/**
+ * @brief Shared data — lives in shared memory, accessed from all processes
+ */
+typedef struct tlscfg_data
+{
+	gen_lock_t *lock;
+	tlscfg_profile_t *profiles;
+	int dirty;
+	time_t last_mutation;
+	time_t config_mtime;
+} tlscfg_data_t;
+
+int tlscfg_data_init(void);
+void tlscfg_data_destroy(void);
+tlscfg_data_t *tlscfg_data_get(void);
+
+/* All profile functions below require the caller to hold data->lock */
+tlscfg_profile_t *tlscfg_profile_find(str *profile_id);
+int tlscfg_profile_add(str *profile_id, str *section_header);
+int tlscfg_profile_remove(str *profile_id);
+int tlscfg_profile_set(str *profile_id, str *key, str *value);
+int tlscfg_profile_unset(str *profile_id, str *key);
+int tlscfg_profile_set_enabled(str *profile_id, int enabled);
+int tlscfg_profile_set_id(str *old_id, str *new_id);
+void tlscfg_profile_clear(void);
+
+tlscfg_kv_t *tlscfg_kv_find(tlscfg_profile_t *p, str *key);
+
+#endif /* _TLSCFG_PROFILE_H_ */

--- a/src/modules/tlscfg/tlscfg_rpc.c
+++ b/src/modules/tlscfg/tlscfg_rpc.c
@@ -1,0 +1,455 @@
+/*
+ * tlscfg module - TLS profile management companion for the tls module
+ *
+ * Copyright (C) 2026 Aurora Innovation
+ *
+ * Author: Daniel Donoghue
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @file tlscfg_rpc.c
+ * @brief RPC command handler implementations
+ * @ingroup tlscfg
+ */
+
+#include "../../core/dprint.h"
+
+#include "tlscfg_config.h"
+#include "tlscfg_profile.h"
+#include "tlscfg_rpc.h"
+#include "tlscfg_watch.h"
+
+#include <string.h>
+#include <sys/stat.h>
+
+/* implemented in tlscfg_mod.c */
+extern str *tlscfg_get_tls_cfg_path(void);
+extern const char *tlscfg_get_cert_base_path(void);
+
+/**
+ * @brief Auto-infer private_key when certificate is set to certman:id
+ *
+ * If the key being set is "certificate" or "certificate2" and the value
+ * starts with "certman:", also set the corresponding private_key field
+ * to certman:id (which will resolve to {base}/{id}/key.pem at write time).
+ */
+static void auto_infer_key(str *profile_id, str *key, str *value)
+{
+	str pkey_name;
+	str pkey_val;
+
+	if(value->len < 8 || strncmp(value->s, "certman:", 8) != 0)
+		return;
+
+	if(key->len == 11 && strncasecmp(key->s, "certificate", 11) == 0) {
+		pkey_name.s = "private_key";
+		pkey_name.len = 11;
+	} else if(key->len == 12 && strncasecmp(key->s, "certificate2", 12) == 0) {
+		pkey_name.s = "private_key2";
+		pkey_name.len = 12;
+	} else {
+		return;
+	}
+
+	pkey_val = *value;
+	tlscfg_profile_set(profile_id, &pkey_name, &pkey_val);
+	LM_DBG("auto-inferred %.*s = %.*s\n", pkey_name.len, pkey_name.s,
+			pkey_val.len, pkey_val.s);
+}
+
+/* ---- profile_add ---- */
+
+void tlscfg_rpc_profile_add(rpc_t *rpc, void *ctx)
+{
+	str profile_id, section;
+	str section_header;
+	char hdr_buf[256];
+	tlscfg_data_t *data;
+
+	if(rpc->scan(ctx, "SS", &profile_id, &section) < 2) {
+		rpc->fault(ctx, 400, "Usage: tlscfg.profile_add <id> <section>");
+		return;
+	}
+
+	if(section.len + 3 > (int)sizeof(hdr_buf)) {
+		rpc->fault(ctx, 400, "Section name too long");
+		return;
+	}
+
+	hdr_buf[0] = '[';
+	memcpy(hdr_buf + 1, section.s, section.len);
+	hdr_buf[section.len + 1] = ']';
+	hdr_buf[section.len + 2] = '\0';
+	section_header.s = hdr_buf;
+	section_header.len = section.len + 2;
+
+	data = tlscfg_data_get();
+	lock_get(data->lock);
+
+	if(tlscfg_profile_add(&profile_id, &section_header) < 0) {
+		lock_release(data->lock);
+		rpc->fault(ctx, 500, "Failed to add profile (duplicate?)");
+		return;
+	}
+
+	lock_release(data->lock);
+	rpc->rpl_printf(
+			ctx, "Ok. Profile '%.*s' added.", profile_id.len, profile_id.s);
+}
+
+/* ---- profile_update ---- */
+
+void tlscfg_rpc_profile_update(rpc_t *rpc, void *ctx)
+{
+	str profile_id, key, value;
+	int has_value;
+	tlscfg_data_t *data;
+
+	if(rpc->scan(ctx, "SS", &profile_id, &key) < 2) {
+		rpc->fault(ctx, 400, "Usage: tlscfg.profile_update <id> <key> [value]");
+		return;
+	}
+
+	has_value = (rpc->scan(ctx, "*S", &value) > 0);
+
+	data = tlscfg_data_get();
+	lock_get(data->lock);
+
+	if(!has_value || (value.len == 1 && value.s[0] == '-')) {
+		/* unset the field */
+		tlscfg_profile_unset(&profile_id, &key);
+		lock_release(data->lock);
+		rpc->rpl_printf(ctx, "Ok. Field '%.*s' removed from '%.*s'.", key.len,
+				key.s, profile_id.len, profile_id.s);
+	} else {
+		if(tlscfg_profile_set(&profile_id, &key, &value) < 0) {
+			lock_release(data->lock);
+			rpc->fault(ctx, 500, "Failed to update profile");
+			return;
+		}
+		auto_infer_key(&profile_id, &key, &value);
+		lock_release(data->lock);
+		rpc->rpl_printf(ctx, "Ok. Set '%.*s' = '%.*s' on '%.*s'.", key.len,
+				key.s, value.len, value.s, profile_id.len, profile_id.s);
+	}
+}
+
+/* ---- profile_remove ---- */
+
+void tlscfg_rpc_profile_remove(rpc_t *rpc, void *ctx)
+{
+	str profile_id;
+	tlscfg_data_t *data;
+
+	if(rpc->scan(ctx, "S", &profile_id) < 1) {
+		rpc->fault(ctx, 400, "Usage: tlscfg.profile_remove <id>");
+		return;
+	}
+
+	data = tlscfg_data_get();
+	lock_get(data->lock);
+
+	if(tlscfg_profile_remove(&profile_id) < 0) {
+		lock_release(data->lock);
+		rpc->fault(ctx, 404, "Profile not found");
+		return;
+	}
+
+	lock_release(data->lock);
+	rpc->rpl_printf(
+			ctx, "Ok. Profile '%.*s' removed.", profile_id.len, profile_id.s);
+}
+
+/* ---- profile_list ---- */
+
+void tlscfg_rpc_profile_list(rpc_t *rpc, void *ctx)
+{
+	tlscfg_data_t *data;
+	tlscfg_profile_t *p;
+	void *handle;
+
+	data = tlscfg_data_get();
+	lock_get(data->lock);
+
+	for(p = data->profiles; p; p = p->next) {
+		if(rpc->add(ctx, "{", &handle) < 0) {
+			lock_release(data->lock);
+			rpc->fault(ctx, 500, "Internal error");
+			return;
+		}
+		rpc->struct_add(handle, "SSds", "id", &p->profile_id, "section",
+				&p->section_header, "enabled", p->enabled, "type",
+				(p->profile_type == TLSCFG_TYPE_CLIENT) ? "client" : "server");
+	}
+
+	lock_release(data->lock);
+}
+
+/* ---- profile_get ---- */
+
+void tlscfg_rpc_profile_get(rpc_t *rpc, void *ctx)
+{
+	str profile_id;
+	tlscfg_data_t *data;
+	tlscfg_profile_t *p;
+	tlscfg_kv_t *kv;
+	void *handle, *kvh;
+
+	if(rpc->scan(ctx, "S", &profile_id) < 1) {
+		rpc->fault(ctx, 400, "Usage: tlscfg.profile_get <id>");
+		return;
+	}
+
+	data = tlscfg_data_get();
+	lock_get(data->lock);
+
+	p = tlscfg_profile_find(&profile_id);
+	if(p == NULL) {
+		lock_release(data->lock);
+		rpc->fault(ctx, 404, "Profile not found");
+		return;
+	}
+
+	if(rpc->add(ctx, "{", &handle) < 0) {
+		lock_release(data->lock);
+		rpc->fault(ctx, 500, "Internal error");
+		return;
+	}
+
+	rpc->struct_add(handle, "SSds", "id", &p->profile_id, "section",
+			&p->section_header, "enabled", p->enabled, "type",
+			(p->profile_type == TLSCFG_TYPE_CLIENT) ? "client" : "server");
+
+	for(kv = p->kvs; kv; kv = kv->next) {
+		if(rpc->struct_add(handle, "{", "fields", &kvh) < 0)
+			break;
+		rpc->struct_add(kvh, "SS", "key", &kv->key, "value", &kv->value);
+	}
+
+	lock_release(data->lock);
+}
+
+/* ---- profile_enable ---- */
+
+void tlscfg_rpc_profile_enable(rpc_t *rpc, void *ctx)
+{
+	str profile_id;
+	tlscfg_data_t *data;
+
+	if(rpc->scan(ctx, "S", &profile_id) < 1) {
+		rpc->fault(ctx, 400, "Usage: tlscfg.profile_enable <id>");
+		return;
+	}
+
+	data = tlscfg_data_get();
+	lock_get(data->lock);
+
+	if(tlscfg_profile_set_enabled(&profile_id, 1) < 0) {
+		lock_release(data->lock);
+		rpc->fault(ctx, 404, "Profile not found");
+		return;
+	}
+
+	lock_release(data->lock);
+	rpc->rpl_printf(
+			ctx, "Ok. Profile '%.*s' enabled.", profile_id.len, profile_id.s);
+}
+
+/* ---- profile_disable ---- */
+
+void tlscfg_rpc_profile_disable(rpc_t *rpc, void *ctx)
+{
+	str profile_id;
+	tlscfg_data_t *data;
+
+	if(rpc->scan(ctx, "S", &profile_id) < 1) {
+		rpc->fault(ctx, 400, "Usage: tlscfg.profile_disable <id>");
+		return;
+	}
+
+	data = tlscfg_data_get();
+	lock_get(data->lock);
+
+	if(tlscfg_profile_set_enabled(&profile_id, 0) < 0) {
+		lock_release(data->lock);
+		rpc->fault(ctx, 404, "Profile not found");
+		return;
+	}
+
+	lock_release(data->lock);
+	rpc->rpl_printf(
+			ctx, "Ok. Profile '%.*s' disabled.", profile_id.len, profile_id.s);
+}
+
+/* ---- cert_check ---- */
+
+void tlscfg_rpc_cert_check(rpc_t *rpc, void *ctx)
+{
+	rpc->rpl_printf(ctx, "Ok. Cert check triggered.");
+	/* The actual check runs in the timer callback;
+	 * this RPC just forces an immediate check cycle by
+	 * calling the timer function logic directly. For now
+	 * we rely on the next timer tick. */
+}
+
+/* ---- cert_notify ---- */
+
+/**
+ * @brief Scan all profiles and bind certificate paths for any profile_id
+ *        whose cert files exist under cert_base_path.
+ *
+ * For each profile, checks whether {cert_base_path}/{profile_id}/cert.pem
+ * (and key.pem) exist on disk.  If they do, sets the profile's certificate
+ * and private_key KVs to "certman:{profile_id}" so the config writer
+ * resolves them to the actual file paths.  This is the mechanism that links
+ * a certman certificate (identified by cert ID) to a tlscfg profile
+ * (identified by profile_id).
+ *
+ * Must be called with data->lock held.
+ */
+static void cert_notify_bind_profiles(void)
+{
+	const char *base;
+	tlscfg_data_t *data;
+	tlscfg_profile_t *p;
+	char path[512];
+	struct stat st;
+	str key, val;
+	char valbuf[280]; /* "certman:" + profile_id */
+
+	base = tlscfg_get_cert_base_path();
+	if(!base || base[0] == '\0')
+		return;
+
+	data = tlscfg_data_get();
+
+	for(p = data->profiles; p; p = p->next) {
+		if(p->profile_id.len == 0)
+			continue;
+
+		/* check if cert.pem exists for this profile_id */
+		snprintf(path, sizeof(path), "%s/%.*s/cert.pem", base,
+				p->profile_id.len, p->profile_id.s);
+		if(stat(path, &st) != 0)
+			continue;
+
+		/* enable disabled profiles whose certs are now available */
+		if(!p->enabled) {
+			LM_INFO("enabling profile '%.*s' — certs now available at %s\n",
+					p->profile_id.len, p->profile_id.s, path);
+			tlscfg_profile_set_enabled(&p->profile_id, 1);
+		}
+
+		/* build the certman: reference value */
+		snprintf(valbuf, sizeof(valbuf), "certman:%.*s", p->profile_id.len,
+				p->profile_id.s);
+
+		/* check if already bound to avoid unnecessary mutations */
+		key.s = "certificate";
+		key.len = 11;
+		{
+			tlscfg_kv_t *existing = tlscfg_kv_find(p, &key);
+			if(existing && existing->value.len == (int)strlen(valbuf)
+					&& strncmp(existing->value.s, valbuf, existing->value.len)
+							   == 0) {
+				continue; /* already bound */
+			}
+		}
+
+		LM_INFO("binding profile '%.*s' to certman certs at %s\n",
+				p->profile_id.len, p->profile_id.s, path);
+
+		val.s = valbuf;
+		val.len = strlen(valbuf);
+
+		/* set certificate = certman:{profile_id} */
+		tlscfg_profile_set(&p->profile_id, &key, &val);
+
+		/* set private_key = certman:{profile_id} */
+		key.s = "private_key";
+		key.len = 11;
+		tlscfg_profile_set(&p->profile_id, &key, &val);
+	}
+}
+
+void tlscfg_rpc_cert_notify(rpc_t *rpc, void *ctx)
+{
+	str *cfg_path;
+
+	cfg_path = tlscfg_get_tls_cfg_path();
+	if(!cfg_path || !cfg_path->s) {
+		rpc->fault(ctx, 500, "No TLS config path available");
+		return;
+	}
+
+	/* bind cert paths for profiles whose certs are now available,
+	 * then flush config and reload */
+	{
+		tlscfg_data_t *data = tlscfg_data_get();
+		lock_get(data->lock);
+		cert_notify_bind_profiles();
+		tlscfg_config_write(cfg_path);
+		lock_release(data->lock);
+	}
+
+	if(tlscfg_tls_reload() < 0) {
+		rpc->fault(ctx, 500, "Config written but tls.reload failed");
+		return;
+	}
+
+	/* sync stored cert mtimes so the watcher does not trigger a
+	 * redundant tls.reload for files that just changed path */
+	tlscfg_refresh_cert_mtimes();
+
+	rpc->rpl_printf(ctx, "Ok. Config flushed and TLS reloaded.");
+}
+
+/* ---- reload ---- */
+
+void tlscfg_rpc_reload(rpc_t *rpc, void *ctx)
+{
+	str *cfg_path;
+	tlscfg_data_t *data;
+
+	cfg_path = tlscfg_get_tls_cfg_path();
+	if(!cfg_path || !cfg_path->s) {
+		rpc->fault(ctx, 500, "No TLS config path available");
+		return;
+	}
+
+	data = tlscfg_data_get();
+	lock_get(data->lock);
+
+	if(tlscfg_config_load(cfg_path) < 0) {
+		lock_release(data->lock);
+		rpc->fault(ctx, 500, "Failed to reload config file");
+		return;
+	}
+
+	lock_release(data->lock);
+
+	if(tlscfg_tls_reload() < 0) {
+		rpc->fault(ctx, 500, "Config reloaded but tls.reload failed");
+		return;
+	}
+
+	rpc->rpl_printf(ctx, "Ok. Config reloaded and TLS reloaded.");
+}

--- a/src/modules/tlscfg/tlscfg_rpc.h
+++ b/src/modules/tlscfg/tlscfg_rpc.h
@@ -1,0 +1,49 @@
+/*
+ * tlscfg module - TLS profile management companion for the tls module
+ *
+ * Copyright (C) 2026 Aurora Innovation
+ *
+ * Author: Daniel Donoghue
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @file tlscfg_rpc.h
+ * @brief RPC command handler declarations
+ * @ingroup tlscfg
+ */
+
+#ifndef _TLSCFG_RPC_H_
+#define _TLSCFG_RPC_H_
+
+#include "../../core/rpc.h"
+
+void tlscfg_rpc_profile_add(rpc_t *rpc, void *ctx);
+void tlscfg_rpc_profile_update(rpc_t *rpc, void *ctx);
+void tlscfg_rpc_profile_remove(rpc_t *rpc, void *ctx);
+void tlscfg_rpc_profile_list(rpc_t *rpc, void *ctx);
+void tlscfg_rpc_profile_get(rpc_t *rpc, void *ctx);
+void tlscfg_rpc_profile_enable(rpc_t *rpc, void *ctx);
+void tlscfg_rpc_profile_disable(rpc_t *rpc, void *ctx);
+void tlscfg_rpc_cert_check(rpc_t *rpc, void *ctx);
+void tlscfg_rpc_cert_notify(rpc_t *rpc, void *ctx);
+void tlscfg_rpc_reload(rpc_t *rpc, void *ctx);
+
+#endif /* _TLSCFG_RPC_H_ */

--- a/src/modules/tlscfg/tlscfg_watch.c
+++ b/src/modules/tlscfg/tlscfg_watch.c
@@ -1,0 +1,354 @@
+/*
+ * tlscfg module - TLS profile management companion for the tls module
+ *
+ * Copyright (C) 2026 Aurora Innovation
+ *
+ * Author: Daniel Donoghue
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @file tlscfg_watch.c
+ * @brief Cert file watcher, debounce flusher, and tls.reload trigger
+ * @ingroup tlscfg
+ */
+
+#include "../../core/dprint.h"
+#include "../../core/rpc.h"
+#include "../../core/rpc_lookup.h"
+
+#include "tlscfg_config.h"
+#include "tlscfg_profile.h"
+#include "tlscfg_watch.h"
+
+#include <stdarg.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+/* implemented in tlscfg_mod.c */
+extern str *tlscfg_get_tls_cfg_path(void);
+extern int tlscfg_get_cert_check_interval(void);
+extern int tlscfg_get_debounce_interval(void);
+
+/* cached tls.reload rpc handler */
+static rpc_export_t *_tls_reload_rpc = NULL;
+
+/* ---- internal RPC context for calling tls.reload programmatically ---- */
+
+static void internal_rpc_fault(void *ctx, int code, char *fmt, ...)
+{
+	va_list ap;
+	char buf[256];
+
+	va_start(ap, fmt);
+	vsnprintf(buf, sizeof(buf), fmt, ap);
+	va_end(ap);
+	LM_ERR("tls.reload error [%d]: %s\n", code, buf);
+	*(int *)ctx = -1;
+}
+
+static int internal_rpc_noop_v(void *ctx, char *fmt, ...)
+{
+	return 0;
+}
+
+static int internal_rpc_send(void *ctx)
+{
+	return 0;
+}
+
+static int internal_rpc_rpl_printf(void *ctx, char *fmt, ...)
+{
+	va_list ap;
+	char buf[256];
+
+	va_start(ap, fmt);
+	vsnprintf(buf, sizeof(buf), fmt, ap);
+	va_end(ap);
+	LM_INFO("tls.reload: %s\n", buf);
+	return 0;
+}
+
+/* clang-format off */
+static rpc_t _internal_rpc = {
+	internal_rpc_fault,
+	internal_rpc_send,
+	(rpc_add_f)internal_rpc_noop_v,
+	(rpc_scan_f)internal_rpc_noop_v,
+	internal_rpc_rpl_printf,
+	(rpc_struct_add_f)internal_rpc_noop_v,
+	(rpc_array_add_f)internal_rpc_noop_v,
+	(rpc_struct_scan_f)internal_rpc_noop_v,
+	(rpc_struct_printf_f)internal_rpc_noop_v,
+	NULL,
+	NULL,
+	NULL
+};
+/* clang-format on */
+
+int tlscfg_tls_reload(void)
+{
+	int result = 0;
+
+	if(!_tls_reload_rpc) {
+		_tls_reload_rpc = rpc_lookup("tls.reload", 10);
+		if(!_tls_reload_rpc) {
+			LM_ERR("tls.reload RPC not found — is the tls module loaded?\n");
+			return -1;
+		}
+	}
+
+	_tls_reload_rpc->function(&_internal_rpc, &result);
+	return result;
+}
+
+/* ---- debounce flush ---- */
+
+static void debounce_flush(void)
+{
+	tlscfg_data_t *data;
+	str *cfg_path;
+	int do_flush = 0;
+	time_t now;
+
+	data = tlscfg_data_get();
+	if(!data)
+		return;
+
+	cfg_path = tlscfg_get_tls_cfg_path();
+	if(!cfg_path || !cfg_path->s)
+		return;
+
+	now = time(NULL);
+
+	lock_get(data->lock);
+	if(data->dirty
+			&& (now - data->last_mutation) >= tlscfg_get_debounce_interval()) {
+		do_flush = 1;
+	}
+	lock_release(data->lock);
+
+	if(do_flush) {
+		LM_INFO("debounce: flushing config and triggering tls.reload\n");
+		lock_get(data->lock);
+		tlscfg_config_write(cfg_path);
+		lock_release(data->lock);
+		tlscfg_tls_reload();
+	}
+}
+
+/* ---- cert mtime check ---- */
+
+/* snapshot entry for lock-free stat */
+#define CERT_SNAP_MAX 128
+
+typedef struct cert_snap
+{
+	char path[512];
+	char prof_id[256];
+	time_t old_mtime;
+	time_t new_mtime;
+	int changed;
+	int is_cert2; /* 0 = certificate, 1 = certificate2 */
+} cert_snap_t;
+
+/**
+ * @brief Helper: add a snap entry for a cert key if it exists on the profile
+ * @return 1 if entry added, 0 otherwise
+ */
+static int snap_add_cert(cert_snap_t *snaps, int *n, tlscfg_profile_t *p,
+		str *key, time_t old_mtime, int is_cert2)
+{
+	tlscfg_kv_t *kv;
+
+	kv = tlscfg_kv_find(p, key);
+	if(!kv || !kv->value.s || kv->value.len == 0)
+		return 0;
+	if(kv->value.len >= (int)sizeof(snaps[0].path))
+		return 0;
+
+	memcpy(snaps[*n].path, kv->value.s, kv->value.len);
+	snaps[*n].path[kv->value.len] = '\0';
+
+	if(p->profile_id.len < (int)sizeof(snaps[*n].prof_id)) {
+		memcpy(snaps[*n].prof_id, p->profile_id.s, p->profile_id.len);
+		snaps[*n].prof_id[p->profile_id.len] = '\0';
+	} else {
+		snaps[*n].prof_id[0] = '\0';
+	}
+
+	snaps[*n].old_mtime = old_mtime;
+	snaps[*n].new_mtime = 0;
+	snaps[*n].changed = 0;
+	snaps[*n].is_cert2 = is_cert2;
+	(*n)++;
+	return 1;
+}
+
+static void cert_mtime_check(void)
+{
+	tlscfg_data_t *data;
+	tlscfg_profile_t *p;
+	struct stat st;
+	int changed = 0;
+	int i, n = 0;
+	cert_snap_t snaps[CERT_SNAP_MAX];
+	str cert_key = STR_STATIC_INIT("certificate");
+	str cert2_key = STR_STATIC_INIT("certificate2");
+
+	data = tlscfg_data_get();
+	if(!data)
+		return;
+
+	/* phase 1: snapshot cert paths under lock */
+	lock_get(data->lock);
+
+	for(p = data->profiles; p && n < CERT_SNAP_MAX - 1; p = p->next) {
+		if(!p->enabled)
+			continue;
+
+		snap_add_cert(snaps, &n, p, &cert_key, p->cert_mtime, 0);
+		if(n < CERT_SNAP_MAX)
+			snap_add_cert(snaps, &n, p, &cert2_key, p->cert2_mtime, 1);
+	}
+
+	lock_release(data->lock);
+
+	/* phase 2: stat outside the lock (safe on network storage) */
+	for(i = 0; i < n; i++) {
+		if(stat(snaps[i].path, &st) == 0) {
+			snaps[i].new_mtime = st.st_mtime;
+			if(snaps[i].old_mtime != 0 && st.st_mtime != snaps[i].old_mtime) {
+				LM_INFO("cert file changed for profile '%s': %s\n",
+						snaps[i].prof_id, snaps[i].path);
+				snaps[i].changed = 1;
+				changed = 1;
+			}
+		}
+	}
+
+	/* phase 3: write back updated mtimes under lock */
+	if(n > 0) {
+		lock_get(data->lock);
+
+		for(i = 0; i < n; i++) {
+			if(snaps[i].new_mtime == 0)
+				continue;
+			for(p = data->profiles; p; p = p->next) {
+				if(p->profile_id.len == (int)strlen(snaps[i].prof_id)
+						&& strncmp(p->profile_id.s, snaps[i].prof_id,
+								   p->profile_id.len)
+								   == 0) {
+					if(snaps[i].is_cert2)
+						p->cert2_mtime = snaps[i].new_mtime;
+					else
+						p->cert_mtime = snaps[i].new_mtime;
+					break;
+				}
+			}
+		}
+
+		lock_release(data->lock);
+	}
+
+	if(changed) {
+		LM_INFO("cert file changes detected, triggering tls.reload\n");
+		tlscfg_tls_reload();
+	}
+}
+
+/* ---- refresh cert mtimes ---- */
+
+void tlscfg_refresh_cert_mtimes(void)
+{
+	tlscfg_data_t *data;
+	tlscfg_profile_t *p;
+	struct stat st;
+	int i, n = 0;
+	cert_snap_t snaps[CERT_SNAP_MAX];
+	str cert_key = STR_STATIC_INIT("certificate");
+	str cert2_key = STR_STATIC_INIT("certificate2");
+
+	data = tlscfg_data_get();
+	if(!data)
+		return;
+
+	/* phase 1: snapshot paths under lock */
+	lock_get(data->lock);
+
+	for(p = data->profiles; p && n < CERT_SNAP_MAX - 1; p = p->next) {
+		if(!p->enabled)
+			continue;
+
+		snap_add_cert(snaps, &n, p, &cert_key, 0, 0);
+		if(n < CERT_SNAP_MAX)
+			snap_add_cert(snaps, &n, p, &cert2_key, 0, 1);
+	}
+
+	lock_release(data->lock);
+
+	/* phase 2: stat outside the lock */
+	for(i = 0; i < n; i++) {
+		if(stat(snaps[i].path, &st) == 0) {
+			snaps[i].new_mtime = st.st_mtime;
+		}
+	}
+
+	/* phase 3: write back under lock */
+	if(n > 0) {
+		lock_get(data->lock);
+
+		for(i = 0; i < n; i++) {
+			if(snaps[i].new_mtime == 0)
+				continue;
+			for(p = data->profiles; p; p = p->next) {
+				if(p->profile_id.len == (int)strlen(snaps[i].prof_id)
+						&& strncmp(p->profile_id.s, snaps[i].prof_id,
+								   p->profile_id.len)
+								   == 0) {
+					if(snaps[i].is_cert2)
+						p->cert2_mtime = snaps[i].new_mtime;
+					else
+						p->cert_mtime = snaps[i].new_mtime;
+					break;
+				}
+			}
+		}
+
+		lock_release(data->lock);
+	}
+}
+
+/* ---- timer callback ---- */
+
+void tlscfg_watch_timer(unsigned int ticks, void *param)
+{
+	int check_interval;
+
+	/* debounce flush every tick */
+	debounce_flush();
+
+	/* cert mtime check at configured interval */
+	check_interval = tlscfg_get_cert_check_interval();
+	if(check_interval > 0 && (ticks % (unsigned int)check_interval) == 0) {
+		cert_mtime_check();
+	}
+}

--- a/src/modules/tlscfg/tlscfg_watch.h
+++ b/src/modules/tlscfg/tlscfg_watch.h
@@ -1,0 +1,61 @@
+/*
+ * tlscfg module - TLS profile management companion for the tls module
+ *
+ * Copyright (C) 2026 Aurora Innovation
+ *
+ * Author: Daniel Donoghue
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @file tlscfg_watch.h
+ * @brief Cert file mtime watcher declarations
+ * @ingroup tlscfg
+ */
+
+#ifndef _TLSCFG_WATCH_H_
+#define _TLSCFG_WATCH_H_
+
+/**
+ * @brief Timer callback — runs every 1 second
+ *
+ * Handles two jobs:
+ * 1. Debounce: if dirty flag set and debounce_interval has passed,
+ *    flush config and trigger tls.reload
+ * 2. Cert watch: every cert_check_interval ticks, check cert file mtimes
+ */
+void tlscfg_watch_timer(unsigned int ticks, void *param);
+
+/**
+ * @brief Trigger tls.reload via internal RPC invocation
+ * @return 0 on success, -1 on error
+ */
+int tlscfg_tls_reload(void);
+
+/**
+ * @brief Refresh stored cert mtimes from disk
+ *
+ * Updates cert_mtime on all profiles to their current on-disk values.
+ * Call after a successful tls.reload to prevent the cert watcher from
+ * triggering a redundant reload.
+ */
+void tlscfg_refresh_cert_mtimes(void);
+
+#endif /* _TLSCFG_WATCH_H_ */


### PR DESCRIPTION
#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

New **tlscfg** module - a companion to the tls module that provides dynamic TLS profile configuration via RPC.

**Problem:** Managing TLS profiles in Kamailio currently requires manually editing tls.cfg and triggering `tls.reload`. There is no runtime API for adding, updating, or removing profiles, and no mechanism to detect when certificate files change on disk.

**Solution:** The tlscfg module sits alongside the tls module and provides:

- **10 RPC commands** for full profile lifecycle management:
  - `tlscfg.profile_add` / `profile_update` / `profile_remove` - CRUD
  - `tlscfg.profile_list` / `profile_get` - inspection
  - `tlscfg.profile_enable` / `profile_disable` - toggle without deletion
  - `tlscfg.cert_check` / `cert_notify` - certificate file monitoring
  - `tlscfg.reload` - re-read config from disk

- **Config write-back with debounce** - RPC mutations are buffered in shared memory and flushed atomically (tmp + rename) after a configurable idle period, followed by automatic `tls.reload`

- **Config backup** - optional backup of tls.cfg before each write, with configurable directory and rotation limit

- **Certificate file watching** - periodic mtime checks on referenced cert/key files with automatic `tls.reload` on change

- **Certificate path resolution** - supports absolute paths, relative paths (against `cert_base_path`), and `certman:` shorthand for integration with external cert management services

The module discovers the tls.cfg path from the tls module's `config` parameter at init - no separate config path needed. Disabled profiles are written as comments so the tls module's parser ignores them, while tlscfg can re-enable them.

Whilst this module works with any certificate management services, such as certbot, it's designed to work hand-in hand with kamailio-certman, a new certificate management automation service at https://github.com/danieldonoghue/kamailio-certman
