### PR TITLE
nats: add shared mTLS configuration and fix worker cleanup

### DIFF
--- a/src/modules/nats/doc/nats_admin.xml
+++ b/src/modules/nats/doc/nats_admin.xml
@@ -122,6 +122,143 @@ modparam("nats", "nats_url", "nats://127.1.2.3:4222")
 		</section>
 		<section>
 			<title>
+				<varname>tls</varname>
+				(int)
+			</title>
+			<para>
+				Enable TLS for all configured NATS servers.
+			</para>
+			<para>
+				When enabled, <varname>tls_ca_file</varname> must also be set. If
+				client authentication is required, <varname>tls_cert_file</varname>
+				and <varname>tls_key_file</varname> must be set together.
+			</para>
+			<para>
+				<emphasis>Default value is <quote>0</quote>.</emphasis>
+			</para>
+			<example>
+				<title>
+					Set
+					<varname>tls</varname>
+					parameter
+				</title>
+				<programlisting format="linespecific">
+...
+modparam("nats", "tls", 1)
+...
+</programlisting>
+			</example>
+		</section>
+		<section>
+			<title>
+				<varname>tls_ca_file</varname>
+				(str)
+			</title>
+			<para>
+				Path to the CA certificate bundle used to validate the NATS server
+				certificate.
+			</para>
+			<para>
+				This parameter is required when <varname>tls</varname> is enabled.
+			</para>
+			<para>
+				<emphasis>Default value is not set.</emphasis>
+			</para>
+			<example>
+				<title>
+					Set
+					<varname>tls_ca_file</varname>
+					parameter
+				</title>
+				<programlisting format="linespecific">
+...
+modparam("nats", "tls_ca_file", "/etc/kamailio/nats/ca.crt")
+...
+</programlisting>
+			</example>
+		</section>
+		<section>
+			<title>
+				<varname>tls_cert_file</varname>
+				(str)
+			</title>
+			<para>
+				Path to the client certificate presented to the NATS server for mTLS.
+			</para>
+			<para>
+				If set, <varname>tls_key_file</varname> must also be set.
+			</para>
+			<para>
+				<emphasis>Default value is not set.</emphasis>
+			</para>
+			<example>
+				<title>
+					Set
+					<varname>tls_cert_file</varname>
+					parameter
+				</title>
+				<programlisting format="linespecific">
+...
+modparam("nats", "tls_cert_file", "/etc/kamailio/nats/client.crt")
+...
+</programlisting>
+			</example>
+		</section>
+		<section>
+			<title>
+				<varname>tls_key_file</varname>
+				(str)
+			</title>
+			<para>
+				Path to the client private key used with
+				<varname>tls_cert_file</varname>.
+			</para>
+			<para>
+				If set, <varname>tls_cert_file</varname> must also be set.
+			</para>
+			<para>
+				<emphasis>Default value is not set.</emphasis>
+			</para>
+			<example>
+				<title>
+					Set
+					<varname>tls_key_file</varname>
+					parameter
+				</title>
+				<programlisting format="linespecific">
+...
+modparam("nats", "tls_key_file", "/etc/kamailio/nats/client.key")
+...
+</programlisting>
+			</example>
+		</section>
+		<section>
+			<title>
+				<varname>tls_expected_hostname</varname>
+				(str)
+			</title>
+			<para>
+				Expected hostname in the NATS server certificate. Use it when the
+				server certificate hostname should be pinned explicitly.
+			</para>
+			<para>
+				<emphasis>Default value is not set.</emphasis>
+			</para>
+			<example>
+				<title>
+					Set
+					<varname>tls_expected_hostname</varname>
+					parameter
+				</title>
+				<programlisting format="linespecific">
+...
+modparam("nats", "tls_expected_hostname", "nats.internal")
+...
+</programlisting>
+			</example>
+		</section>
+		<section>
+			<title>
 				<varname>num_publish_workers</varname>
 				(int)
 			</title>
@@ -143,6 +280,20 @@ modparam("nats", "nats_url", "nats://127.1.2.3:4222")
 				<programlisting format="linespecific">
 ...
 modparam("nats", "num_publish_workers", 4)
+...
+</programlisting>
+			</example>
+			<example>
+				<title>TLS configuration example</title>
+				<programlisting format="linespecific">
+...
+modparam("nats", "nats_url", "nats://nats-1:4222")
+modparam("nats", "nats_url", "nats://nats-2:4222")
+modparam("nats", "tls", 1)
+modparam("nats", "tls_ca_file", "/etc/kamailio/nats/ca.crt")
+modparam("nats", "tls_cert_file", "/etc/kamailio/nats/client.crt")
+modparam("nats", "tls_key_file", "/etc/kamailio/nats/client.key")
+modparam("nats", "tls_expected_hostname", "nats.internal")
 ...
 </programlisting>
 			</example>

--- a/src/modules/nats/nats_mod.c
+++ b/src/modules/nats/nats_mod.c
@@ -37,6 +37,11 @@ int nats_pub_workers_num = DEFAULT_NUM_PUB_WORKERS;
 
 static int _nats_proc_count = 0;
 char *eventData = NULL;
+static int nats_tls = 0;
+static char *nats_tls_ca_file = NULL;
+static char *nats_tls_cert_file = NULL;
+static char *nats_tls_key_file = NULL;
+static char *nats_tls_expected_hostname = NULL;
 
 int *nats_pub_worker_pipes_fds = NULL;
 int *nats_pub_worker_pipes = NULL;
@@ -53,6 +58,11 @@ static pv_export_t nats_mod_pvs[] = {
 
 static param_export_t params[] = {
 	{"nats_url", PARAM_STRING|PARAM_USE_FUNC, (void*)_init_nats_server_url_add},
+	{"tls", PARAM_INT, &nats_tls},
+	{"tls_ca_file", PARAM_STRING, &nats_tls_ca_file},
+	{"tls_cert_file", PARAM_STRING, &nats_tls_cert_file},
+	{"tls_key_file", PARAM_STRING, &nats_tls_key_file},
+	{"tls_expected_hostname", PARAM_STRING, &nats_tls_expected_hostname},
 	{"num_publish_workers", PARAM_INT, &nats_pub_workers_num},
 	{"subject_queue_group", PARAM_STRING|PARAM_USE_FUNC, (void*)_init_nats_sub_add},
 	{"event_callback", PARAM_STR,   &nats_event_callback},
@@ -118,11 +128,86 @@ static void reconnectedCb(natsConnection *nc, void *closure)
 
 static void closedCB(natsConnection *nc, void *closure)
 {
-	bool *closed = (bool *)closure;
 	const char *err = NULL;
 	natsConnection_GetLastError(nc, &err);
 	LM_INFO("connect failed: %s\n", err);
-	*closed = true;
+}
+
+static int nats_has_value(const char *value)
+{
+	return (value != NULL && value[0] != '\0');
+}
+
+static int nats_validate_tls_config(void)
+{
+	if(!nats_tls) {
+		if(nats_has_value(nats_tls_ca_file)
+				|| nats_has_value(nats_tls_cert_file)
+				|| nats_has_value(nats_tls_key_file)
+				|| nats_has_value(nats_tls_expected_hostname)) {
+			LM_ERR("tls parameters require tls=1\n");
+			return -1;
+		}
+		return 0;
+	}
+
+	if(!nats_has_value(nats_tls_ca_file)) {
+		LM_ERR("tls_ca_file is required when tls=1\n");
+		return -1;
+	}
+
+	if(nats_has_value(nats_tls_cert_file)
+			!= nats_has_value(nats_tls_key_file)) {
+		LM_ERR("tls_cert_file and tls_key_file must be set together\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int nats_apply_tls_options(nats_connection_ptr c)
+{
+	natsStatus s = NATS_OK;
+	natsStatus err_st = NATS_OK;
+	const char *detail = NULL;
+
+	if(!nats_tls) {
+		return 0;
+	}
+
+	if((s = natsOptions_SetSecure(c->opts, true)) != NATS_OK) {
+		LM_ERR("could not enable nats tls [%s]\n", natsStatus_GetText(s));
+		return -1;
+	}
+
+	if((s = natsOptions_LoadCATrustedCertificates(c->opts, nats_tls_ca_file))
+			!= NATS_OK) {
+		detail = nats_GetLastError(&err_st);
+		LM_ERR("could not load nats tls ca file [%s] [%s]\n",
+				natsStatus_GetText(s), (detail != NULL) ? detail : "");
+		return -1;
+	}
+
+	if(nats_has_value(nats_tls_cert_file)
+			&& (s = natsOptions_LoadCertificatesChain(
+						c->opts, nats_tls_cert_file, nats_tls_key_file))
+					   != NATS_OK) {
+		detail = nats_GetLastError(&err_st);
+		LM_ERR("could not load nats tls client certificate chain [%s] [%s]\n",
+				natsStatus_GetText(s), (detail != NULL) ? detail : "");
+		return -1;
+	}
+
+	if(nats_has_value(nats_tls_expected_hostname)
+			&& (s = natsOptions_SetExpectedHostname(
+						c->opts, nats_tls_expected_hostname))
+					   != NATS_OK) {
+		LM_ERR("could not set nats tls expected hostname [%s]\n",
+				natsStatus_GetText(s));
+		return -1;
+	}
+
+	return 0;
 }
 
 void nats_consumer_worker_proc(nats_consumer_worker_t *worker)
@@ -180,6 +265,9 @@ static int mod_init(void)
 {
 	int i = 0;
 	int total_procs = _nats_proc_count + nats_pub_workers_num;
+	if(nats_validate_tls_config() < 0) {
+		return -1;
+	}
 	if(faked_msg_init() < 0) {
 		LM_ERR("failed to init faked sip message\n");
 		return -1;
@@ -425,7 +513,7 @@ int nats_cleanup_init_sub()
 int nats_init_connection(nats_connection_ptr c)
 {
 	natsStatus s = NATS_OK;
-	bool closed = false;
+	int i;
 	int len;
 	char *sc;
 	int num_servers = 0;
@@ -457,6 +545,7 @@ int nats_init_connection(nats_connection_ptr c)
 		strcpy(sc, NATS_DEFAULT_URL);
 		sc[len] = '\0';
 		c->servers[0] = sc;
+		num_servers = 1;
 		LM_INFO("using default server [%s]\n", sc);
 	}
 
@@ -468,7 +557,6 @@ int nats_init_connection(nats_connection_ptr c)
 
 	// use these defaults
 	natsOptions_SetAllowReconnect(c->opts, true);
-	natsOptions_SetSecure(c->opts, false);
 	natsOptions_SetMaxReconnect(c->opts, 10000);
 	natsOptions_SetReconnectWait(c->opts, 2 * 1000);	 // 2s
 	natsOptions_SetPingInterval(c->opts, 2 * 60 * 1000); // 2m
@@ -478,13 +566,18 @@ int nats_init_connection(nats_connection_ptr c)
 	natsOptions_SetTimeout(c->opts, 2 * 1000);				   // 2s
 	natsOptions_SetReconnectBufSize(c->opts, 8 * 1024 * 1024); // 8 MB;
 	natsOptions_SetReconnectJitter(c->opts, 100, 1000);		   // 100ms, 1s;
+	natsOptions_SetSecure(c->opts, false);
+
+	if(nats_apply_tls_options(c) < 0) {
+		goto error;
+	}
 
 	// nats set servers and options
 	if((s = natsOptions_SetServers(
 				c->opts, (const char **)c->servers, num_servers))
 			!= NATS_OK) {
 		LM_ERR("could not set nats server[%s]\n", natsStatus_GetText(s));
-		return -1;
+		goto error;
 	}
 
 	// nats set callbacks
@@ -506,11 +599,24 @@ int nats_init_connection(nats_connection_ptr c)
 				natsStatus_GetText(s));
 	}
 
-	s = natsOptions_SetClosedCB(c->opts, closedCB, (void *)&closed);
+	s = natsOptions_SetClosedCB(c->opts, closedCB, NULL);
 	if(s != NATS_OK) {
 		LM_ERR("could not set closed callback [%s]\n", natsStatus_GetText(s));
 	}
 	return 0;
+
+error:
+	if(c->opts != NULL) {
+		natsOptions_Destroy(c->opts);
+		c->opts = NULL;
+	}
+	for(i = 0; i < NATS_MAX_SERVERS; i++) {
+		if(c->servers[i] != NULL) {
+			shm_free(c->servers[i]);
+			c->servers[i] = NULL;
+		}
+	}
+	return -1;
 }
 
 int nats_cleanup_init_servers()
@@ -587,9 +693,10 @@ int nats_destroy_workers()
 					}
 					shm_free(worker->on_message);
 				}
-				shm_free(worker);
 			}
 		}
+		shm_free(nats_workers);
+		nats_workers = NULL;
 	}
 
 	if(nats_pub_workers != NULL) {
@@ -604,9 +711,10 @@ int nats_destroy_workers()
 				if(uv_is_active((uv_handle_t *)&pub_worker->poll)) {
 					uv_poll_stop(&pub_worker->poll);
 				}
-				shm_free(pub_worker);
 			}
 		}
+		shm_free(nats_pub_workers);
+		nats_pub_workers = NULL;
 	}
 	return 0;
 }


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Add shared TLS/mTLS configuration support to the `nats` module for all configured NATS servers.

This introduces new module parameters for `tls`, `tls_ca_file`, `tls_cert_file`, `tls_key_file`, and `tls_expected_hostname`, validates their combinations at startup, and applies the TLS options during NATS connection setup. The change also improves connection cleanup on initialization errors.

In addition, fix worker cleanup by freeing the allocated worker arrays only once instead of attempting to `shm_free()` individual embedded worker entries. Module documentation was updated for the new parameters.