### PR TITLE
textopsx: fix segfault in pv_get_hf_iterator_hname()

### DIFF
--- a/src/modules/textopsx/textopsx.c
+++ b/src/modules/textopsx/textopsx.c
@@ -2483,10 +2483,10 @@ static int pv_get_hf_iterator_hname(
 		return pv_get_null(msg, param, res);
 	}
 
-	if(_hf_iterators[i].it == NULL) {
+	if(_hf_iterators[k].it == NULL) {
 		return pv_get_null(msg, param, res);
 	}
-	return pv_get_strval(msg, param, res, &_hf_iterators[i].it->name);
+	return pv_get_strval(msg, param, res, &_hf_iterators[k].it->name);
 }
 
 /**


### PR DESCRIPTION
Use correct array index [k] instead of [i] after loop exit. Variable 'i' contains undefined value after the search loop completes, causing segfault when dereferencing _hf_iterators[i].it->name.

The loop finds the iterator at index i and stores it in k (line 2476), but then incorrectly uses _hf_iterators[i] instead of _hf_iterators[k] after the loop (lines 2486, 2489).

Crash backtrace:
#0  pv_get_strval() - dereferencing invalid pointer #1  pv_get_hf_iterator_hname() at textopsx.c:2489
    Passing garbage pointer &_hf_iterators[i].it->name where i is undefined

This bug causes crashes when processing SIP replies with header iterators.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This is not tested, I was getting the crash when I was doing something like this.
This patch was made by AI and is not tested, I changed to another simpler solution but this new feature is great.
Would be nice to patch it to work well in reply_route !

@miconda 
Can you have a look ?


This is what I was testing at that time :

```
onreply_route[DEFAULT] {
    hf_iterator_start("i1");
    while(hf_iterator_next("i1")) {
        if ($hfitname(i1) == "Record-Route") {
                if (is_ip_rfc1918("$si")) {
                        $var(regex) = $_s(/$shv(private)/$shv(public)/sg);
                } else {
                        $var(regex) = $_s(/$shv(public)/$shv(private)/sg);
                }
                hf_iterator_rm("i1");
                $avp(rr) = $hfitbody(i1);
                $avp(rr) =  $(avp(rr){re.subst,$var(regex)});
                hf_iterator_append("i1", "Record-Route: $avp(rr)\r\n");
                xinfo("rr hdr[$hfitname(i1)] is: $avp(rr) [$dd] [$var(regex)]\n");
                msg_apply_changes();
        }
    }
    hf_iterator_end("i1");
```