### PR TITLE
dmq: add peer-up and peer-down event_routes

### DIFF
--- a/src/modules/dmq/dmq.c
+++ b/src/modules/dmq/dmq.c
@@ -533,13 +533,13 @@ static sr_kemi_t sr_kemi_dmq_exports[] = {
 /* clang-format on */
 
 /**
- * Run peer event route. @a evt is which route to run (DMQ_NODE_ACTIVE ->
- * dmq:peer-up, DMQ_NODE_NOT_ACTIVE -> dmq:peer-down, DMQ_NODE_DISABLED ->
- * dmq:peer-disabled). Pass the transition decided under dmq_node_list lock (or
- * when queuing extract callbacks); do not derive from node->status after
- * lock_release — other workers may change SHM before this runs.
+ * Run peer event route from @a node->status (DMQ_NODE_ACTIVE -> dmq:peer-up,
+ * DMQ_NODE_NOT_ACTIVE -> dmq:peer-down, DMQ_NODE_DISABLED -> dmq:peer-disabled).
+ * Callers must set node->status to the intended announcement before calling
+ * (e.g. under dmq_node_list lock, or after applying a transition).
+ * Duplicate for the same status are suppressed using last_peer_evt.
  */
-void dmq_peer_run_event_route(int evt, dmq_node_t *node)
+void dmq_peer_run_event_route(dmq_node_t *node)
 {
 	const char *rtname;
 	int rt, backup_rt;
@@ -547,11 +547,14 @@ void dmq_peer_run_event_route(int evt, dmq_node_t *node)
 	sip_msg_t *fmsg = NULL;
 	sr_kemi_eng_t *keng = NULL;
 	str evname;
+	int evt;
 
 	if(node == NULL || node->local)
 		return;
 	if(node->orig_uri.s == NULL || node->orig_uri.len <= 0)
 		return;
+
+	evt = node->status;
 
 	/* Same announcement twice (timer/body oscillation). */
 	if(node->last_peer_evt == evt) {

--- a/src/modules/dmq/dmq.c
+++ b/src/modules/dmq/dmq.c
@@ -42,6 +42,10 @@
 #include "../../core/cfg/cfg_struct.h"
 #include "../../core/rpc_lookup.h"
 #include "../../core/kemi.h"
+#include "../../core/route.h"
+#include "../../core/dset.h"
+#include "../../core/fmsg.h"
+#include "../../core/action.h"
 
 #include "dmq.h"
 #include "dmq_funcs.h"
@@ -73,6 +77,7 @@ int dmq_fail_count_enabled = 0;
 int dmq_fail_count_threshold_not_active = 0;
 int dmq_fail_count_threshold_disabled = 1;
 int dmq_init_with_single = 0;
+str dmq_event_callback = STR_NULL;
 
 /* TM bind */
 struct tm_binds _dmq_tmb = {0};
@@ -135,6 +140,7 @@ static param_export_t params[] = {
 	{"fail_count_threshold_not_active", PARAM_INT, &dmq_fail_count_threshold_not_active},
 	{"fail_count_threshold_disabled", PARAM_INT, &dmq_fail_count_threshold_disabled},
 	{"init_with_single", PARAM_INT, &dmq_init_with_single},
+	{"event_callback", PARAM_STR, &dmq_event_callback},
 	{0, 0, 0}
 };
 
@@ -525,6 +531,105 @@ static sr_kemi_t sr_kemi_dmq_exports[] = {
 	{ {0, 0}, {0, 0}, 0, NULL, { 0, 0, 0, 0, 0, 0 } }
 };
 /* clang-format on */
+
+/**
+ * Run peer event route. @a evt is which route to run (DMQ_NODE_ACTIVE ->
+ * dmq:peer-up, DMQ_NODE_NOT_ACTIVE -> dmq:peer-down, DMQ_NODE_DISABLED ->
+ * dmq:peer-disabled). Pass the transition decided under dmq_node_list lock (or
+ * when queuing extract callbacks); do not derive from node->status after
+ * lock_release — other workers may change SHM before this runs.
+ */
+void dmq_peer_run_event_route(int evt, dmq_node_t *node)
+{
+	const char *rtname;
+	int rt, backup_rt;
+	struct run_act_ctx ctx;
+	sip_msg_t *fmsg = NULL;
+	sr_kemi_eng_t *keng = NULL;
+	str evname;
+
+	if(node == NULL || node->local)
+		return;
+	if(node->orig_uri.s == NULL || node->orig_uri.len <= 0)
+		return;
+
+	/* Same announcement twice (timer/body oscillation). */
+	if(node->last_peer_evt == evt) {
+		LM_DBG("peer event %d skipped (duplicate) for %.*s\n", evt,
+				STR_FMT(&node->orig_uri));
+		return;
+	}
+	/* After peer-disabled, only peer-up is a valid next announcement. */
+	if(node->last_peer_evt == DMQ_NODE_DISABLED && evt != DMQ_NODE_ACTIVE) {
+		LM_DBG("peer event %d skipped (post-disabled) for %.*s\n", evt,
+				STR_FMT(&node->orig_uri));
+		return;
+	}
+
+	/* Logical transition recorded even if no event_route (suppression still applies). */
+	node->last_peer_evt = evt;
+
+	switch(evt) {
+		case DMQ_NODE_ACTIVE:
+			rtname = "dmq:peer-up";
+			break;
+		case DMQ_NODE_NOT_ACTIVE:
+			rtname = "dmq:peer-down";
+			break;
+		case DMQ_NODE_DISABLED:
+			rtname = "dmq:peer-disabled";
+			break;
+		default:
+			LM_BUG("dmq peer event: unexpected evt %d\n", evt);
+			return;
+	}
+
+	LM_DBG("executing event_route[%s] for %.*s\n", rtname,
+			STR_FMT(&node->orig_uri));
+
+	rt = -1;
+	if(dmq_event_callback.s == NULL || dmq_event_callback.len <= 0) {
+		rt = route_lookup(&event_rt, (char *)rtname);
+		if(rt < 0 || event_rt.rlist[rt] == NULL) {
+			LM_DBG("event_route[%s] not defined - skip\n", rtname);
+			return;
+		}
+	} else {
+		keng = sr_kemi_eng_get();
+		if(keng == NULL) {
+			LM_DBG("dmq event_callback set but no kemi engine\n");
+			return;
+		}
+	}
+
+	if(faked_msg_init() < 0) {
+		LM_ERR("faked_msg_init failed\n");
+		return;
+	}
+	fmsg = faked_msg_next();
+	if(rewrite_uri(fmsg, &node->orig_uri) < 0) {
+		LM_ERR("rewrite_uri failed\n");
+		return;
+	}
+
+	if(rt >= 0 || dmq_event_callback.len > 0) {
+		backup_rt = get_route_type();
+		set_route_type(REQUEST_ROUTE);
+		init_run_actions_ctx(&ctx);
+		if(rt >= 0) {
+			run_top_route(event_rt.rlist[rt], fmsg, 0);
+		} else if(keng != NULL) {
+			evname.s = (char *)rtname;
+			evname.len = strlen(rtname);
+			if(sr_kemi_route(
+					   keng, fmsg, EVENT_ROUTE, &dmq_event_callback, &evname)
+					< 0)
+				LM_ERR("dmq kemi event route failed\n");
+		}
+		set_route_type(backup_rt);
+	}
+	reset_uri(fmsg);
+}
 
 int mod_register(char *path, int *dlflags, void *p1, void *p2)
 {

--- a/src/modules/dmq/dmq.h
+++ b/src/modules/dmq/dmq.h
@@ -64,6 +64,6 @@ extern str dmq_500_rpl;
 extern str dmq_404_rpl;
 
 extern str dmq_event_callback;
-void dmq_peer_run_event_route(int evt, dmq_node_t *node);
+void dmq_peer_run_event_route(dmq_node_t *node);
 
 #endif

--- a/src/modules/dmq/dmq.h
+++ b/src/modules/dmq/dmq.h
@@ -63,4 +63,7 @@ extern str dmq_400_rpl;
 extern str dmq_500_rpl;
 extern str dmq_404_rpl;
 
+extern str dmq_event_callback;
+void dmq_peer_run_event_route(int evt, dmq_node_t *node);
+
 #endif

--- a/src/modules/dmq/dmqnode.c
+++ b/src/modules/dmq/dmqnode.c
@@ -367,8 +367,15 @@ int dmq_node_del_filter(dmq_node_list_t *list, dmq_node_t *node, int filter)
 	while(cur) {
 		if(cmp_dmq_node(cur, node)) {
 			if(filter == 0 || cur->local == 0) {
+				int down = (!cur->local && cur->status == DMQ_NODE_ACTIVE);
+
 				*prev = cur->next;
+				lock_release(&list->lock);
+				LM_DBG("released dmq_node_list->lock\n");
+				if(down)
+					dmq_peer_run_event_route(DMQ_NODE_NOT_ACTIVE, cur);
 				destroy_dmq_node(cur, 1);
+				return 1;
 			}
 			lock_release(&list->lock);
 			LM_DBG("released dmq_node_list->lock\n");
@@ -409,7 +416,7 @@ int dmq_node_del_by_uri(dmq_node_list_t *list, str *suri)
 /**
  * @brief add dmq node
  */
-dmq_node_t *add_dmq_node(dmq_node_list_t *list, str *uri)
+dmq_node_t *add_dmq_node(dmq_node_list_t *list, str *uri, int no_peer_evt)
 {
 	dmq_node_t *newnode;
 
@@ -427,6 +434,8 @@ dmq_node_t *add_dmq_node(dmq_node_list_t *list, str *uri)
 	list->count++;
 	lock_release(&list->lock);
 	LM_DBG("released dmq_node_list->lock\n");
+	if(!no_peer_evt && !newnode->local && newnode->status == DMQ_NODE_ACTIVE)
+		dmq_peer_run_event_route(DMQ_NODE_ACTIVE, newnode);
 	return newnode;
 error:
 	return NULL;
@@ -438,15 +447,31 @@ error:
 int update_dmq_node_status(dmq_node_list_t *list, dmq_node_t *node, int status)
 {
 	dmq_node_t *cur;
+	int oldst;
+	int pending_evt = 0;
 	LM_DBG("trying to acquire dmq_node_list->lock\n");
 	lock_get(&list->lock);
 	LM_DBG("acquired dmq_node_list->lock\n");
 	cur = list->nodes;
 	while(cur) {
 		if(cmp_dmq_node(cur, node)) {
+			oldst = cur->status;
 			cur->status = status;
+			if(!cur->local) {
+				if(oldst != DMQ_NODE_ACTIVE && status == DMQ_NODE_ACTIVE)
+					pending_evt = DMQ_NODE_ACTIVE;
+				else if(oldst == DMQ_NODE_ACTIVE
+						&& status == DMQ_NODE_NOT_ACTIVE)
+					pending_evt = DMQ_NODE_NOT_ACTIVE;
+				else if((oldst == DMQ_NODE_ACTIVE
+								|| oldst == DMQ_NODE_NOT_ACTIVE)
+						&& status == DMQ_NODE_DISABLED)
+					pending_evt = DMQ_NODE_DISABLED;
+			}
 			lock_release(&list->lock);
 			LM_DBG("released dmq_node_list->lock\n");
+			if(pending_evt)
+				dmq_peer_run_event_route(pending_evt, cur);
 			return 1;
 		}
 		cur = cur->next;
@@ -463,6 +488,7 @@ int update_dmq_node_status_on_timeout(
 		dmq_node_list_t *list, dmq_node_t *node, int fail_count_status)
 {
 	dmq_node_t *cur;
+	int pending_evt = 0;
 	lock_get(&list->lock);
 	cur = list->nodes;
 	while(cur) {
@@ -486,6 +512,8 @@ int update_dmq_node_status_on_timeout(
 							node->uri.host.len, node->uri.host.s,
 							node->uri.port.len, node->uri.port.s);
 					cur->status = DMQ_NODE_DISABLED;
+					if(!cur->local)
+						pending_evt = DMQ_NODE_DISABLED;
 
 					/* put the node from active to not_active state */
 				} else if(cur->fail_count > dmq_fail_count_threshold_not_active
@@ -500,9 +528,13 @@ int update_dmq_node_status_on_timeout(
 							node->uri.host.len, node->uri.host.s,
 							node->uri.port.len, node->uri.port.s);
 					cur->status = DMQ_NODE_NOT_ACTIVE;
+					if(!cur->local)
+						pending_evt = DMQ_NODE_NOT_ACTIVE;
 				}
 			}
 			lock_release(&list->lock);
+			if(pending_evt)
+				dmq_peer_run_event_route(pending_evt, cur);
 			return 1;
 		}
 		cur = cur->next;

--- a/src/modules/dmq/dmqnode.c
+++ b/src/modules/dmq/dmqnode.c
@@ -367,13 +367,21 @@ int dmq_node_del_filter(dmq_node_list_t *list, dmq_node_t *node, int filter)
 	while(cur) {
 		if(cmp_dmq_node(cur, node)) {
 			if(filter == 0 || cur->local == 0) {
-				int down = (!cur->local && cur->status == DMQ_NODE_ACTIVE);
+				/* README: "disabled" = node will be deleted from dmq node list.
+				 * On removal we announce peer-disabled only when status was not
+				 * already disabled (ACTIVE/NOT_ACTIVE -> removed); if already
+				 * DISABLED, dmq:peer-disabled was emitted on that transition. */
+				int notify_peer = !cur->local;
+				int need_peer_evt =
+						notify_peer && cur->status != DMQ_NODE_DISABLED;
 
+				if(need_peer_evt)
+					cur->status = DMQ_NODE_DISABLED;
 				*prev = cur->next;
 				lock_release(&list->lock);
 				LM_DBG("released dmq_node_list->lock\n");
-				if(down)
-					dmq_peer_run_event_route(DMQ_NODE_NOT_ACTIVE, cur);
+				if(need_peer_evt)
+					dmq_peer_run_event_route(cur);
 				destroy_dmq_node(cur, 1);
 				return 1;
 			}
@@ -434,8 +442,11 @@ dmq_node_t *add_dmq_node(dmq_node_list_t *list, str *uri, int no_peer_evt)
 	list->count++;
 	lock_release(&list->lock);
 	LM_DBG("released dmq_node_list->lock\n");
-	if(!no_peer_evt && !newnode->local && newnode->status == DMQ_NODE_ACTIVE)
-		dmq_peer_run_event_route(DMQ_NODE_ACTIVE, newnode);
+	/* Initial status may come from URI (;status=...) or default (active).
+	 * dmq_peer_run_event_route() dedupes via last_peer_evt so the same state
+	 * is never announced twice (e.g. add then notification). */
+	if(!no_peer_evt && !newnode->local)
+		dmq_peer_run_event_route(newnode);
 	return newnode;
 error:
 	return NULL;
@@ -471,7 +482,7 @@ int update_dmq_node_status(dmq_node_list_t *list, dmq_node_t *node, int status)
 			lock_release(&list->lock);
 			LM_DBG("released dmq_node_list->lock\n");
 			if(pending_evt)
-				dmq_peer_run_event_route(pending_evt, cur);
+				dmq_peer_run_event_route(cur);
 			return 1;
 		}
 		cur = cur->next;
@@ -534,7 +545,7 @@ int update_dmq_node_status_on_timeout(
 			}
 			lock_release(&list->lock);
 			if(pending_evt)
-				dmq_peer_run_event_route(pending_evt, cur);
+				dmq_peer_run_event_route(cur);
 			return 1;
 		}
 		cur = cur->next;

--- a/src/modules/dmq/dmqnode.h
+++ b/src/modules/dmq/dmqnode.h
@@ -49,6 +49,7 @@ typedef struct dmq_node
 	struct ip_addr ip_address; /* resolved IP address */
 	int status; /* reserved - maybe something like active,timeout,disabled */
 	int last_notification; /* last notification received from the node */
+	int last_peer_evt; /* last DMQ_NODE_* peer event_route emitted; 0 = none */
 	struct dmq_node *next; /* pointer to the next struct dmq_node */
 } dmq_node_t;
 
@@ -66,7 +67,7 @@ extern dmq_node_list_t *dmq_node_list;
 dmq_node_list_t *init_dmq_node_list();
 dmq_node_t *build_dmq_node(str *uri, int shm);
 int update_node_list(dmq_node_list_t *remote_list);
-dmq_node_t *add_dmq_node(dmq_node_list_t *list, str *uri);
+dmq_node_t *add_dmq_node(dmq_node_list_t *list, str *uri, int no_peer_evt);
 dmq_node_t *find_dmq_node(dmq_node_list_t *list, dmq_node_t *node);
 dmq_node_t *find_dmq_node_uri(dmq_node_list_t *list, str *uri);
 dmq_node_t *find_dmq_node_uri2(str *uri);

--- a/src/modules/dmq/doc/dmq_admin.xml
+++ b/src/modules/dmq/doc/dmq_admin.xml
@@ -437,6 +437,38 @@ modparam("dmq", "init_with_single", 1)
 		</programlisting>
 		</example>
 	</section>
+	<section id="dmq.p.event_callback">
+		<title><varname>event_callback</varname> (str)</title>
+		<para>
+			The name of the function in the kemi configuration file (embedded
+			scripting language such as Lua, Python, &hellip;) to be executed instead
+			of event_route[...] blocks.
+		</para>
+		<para>
+			The function receives a string parameter with the name of the event,
+			the values are: <literal>dmq:peer-down</literal>,
+			<literal>dmq:peer-up</literal>, <literal>dmq:peer-disabled</literal>.
+		</para>
+		<para>
+		<emphasis>
+			Default value is empty (no function is executed for events).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>event_callback</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dmq", "event_callback", "ksr_dmq_event")
+...
+-- event callback function implemented in Lua
+function ksr_dmq_event(evname)
+	KSR.info("===== dmq module triggered event: " .. evname .. "\n");
+	return 1;
+end
+...
+</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>
@@ -655,6 +687,75 @@ modparam("dmq", "init_with_single", 1)
                 </example>
         </section>
 
+	</section>
+
+	<section id="dmq.ex.event_routes">
+		<title>Event routes</title>
+		<section>
+			<title>
+			<function moreinfo="none">dmq:peer-down</function>
+			</title>
+			<para>
+			When defined, the module calls event_route[dmq:peer-down] when a
+			remote peer (from <varname>notification_address</varname> or the learned
+			list, not <varname>server_address</varname>) transitions from active to
+			not active (but not when it becomes disabled; see
+			<literal>dmq:peer-disabled</literal>).
+			</para>
+			<para>
+			Execution uses <varname>event_callback</varname> when that modparam is
+			set, otherwise event_route blocks.
+			</para>
+			<programlisting format="linespecific">
+...
+event_route[dmq:peer-down] {
+	xlog("L_INFO", "DMQ peer down: $ru\n");
+}
+...
+</programlisting>
+		</section>
+		<section>
+			<title>
+			<function moreinfo="none">dmq:peer-up</function>
+			</title>
+			<para>
+			When defined, the module calls event_route[dmq:peer-up] when such a
+			remote peer becomes active or is added as active (never for this
+			instance's own server entry).
+			</para>
+			<para>
+			Execution uses <varname>event_callback</varname> when that modparam is
+			set, otherwise event_route blocks.
+			</para>
+			<programlisting format="linespecific">
+...
+event_route[dmq:peer-up] {
+	xlog("L_INFO", "DMQ peer up: $ru\n");
+}
+...
+</programlisting>
+		</section>
+		<section>
+			<title>
+			<function moreinfo="none">dmq:peer-disabled</function>
+			</title>
+			<para>
+			When defined, the module calls event_route[dmq:peer-disabled] when a
+			remote peer enters the disabled state (<literal>DMQ_NODE_DISABLED</literal>),
+			for example after fail-count thresholds.
+			</para>
+			<para>
+			Execution uses <varname>event_callback</varname> when that modparam is
+			set, otherwise event_route blocks.
+			</para>
+			<programlisting format="linespecific">
+...
+event_route[dmq:peer-disabled] {
+	xlog("L_INFO", "DMQ peer disabled: $ru\n");
+}
+...
+</programlisting>
+		</section>
 	</section>
 
 	<section>

--- a/src/modules/dmq/notification_peer.c
+++ b/src/modules/dmq/notification_peer.c
@@ -57,7 +57,7 @@ int add_notification_peer()
 		goto error;
 	}
 	/* add itself to the node list */
-	dmq_self_node = add_dmq_node(dmq_node_list, &dmq_server_address);
+	dmq_self_node = add_dmq_node(dmq_node_list, &dmq_server_address, 1);
 	if(!dmq_self_node) {
 		LM_ERR("error adding self node\n");
 		goto error;
@@ -310,7 +310,7 @@ dmq_node_t *add_server_and_notify(str_list_t *server_list)
 		while(server_list != NULL) {
 			LM_DBG("adding notification node %.*s\n", server_list->s.len,
 					server_list->s.s);
-			pfirst = add_dmq_node(dmq_node_list, &server_list->s);
+			pfirst = add_dmq_node(dmq_node_list, &server_list->s, 0);
 			server_list = server_list->next;
 		}
 	} else {
@@ -336,7 +336,7 @@ dmq_node_t *add_server_and_notify(str_list_t *server_list)
 			pstr->len = strlen(puri_list[index]);
 			if(!find_dmq_node_uri(
 					   dmq_node_list, pstr)) { // check for duplicates
-				pnode = add_dmq_node(dmq_node_list, pstr);
+				pnode = add_dmq_node(dmq_node_list, pstr, 0);
 				if(pnode && !pfirst) {
 					pfirst = pnode;
 				}
@@ -381,6 +381,17 @@ int extract_node_list(dmq_node_list_t *update_list, struct sip_msg *msg)
 	dmq_node_t *cur = NULL;
 	dmq_node_t *ret, *find;
 	char *tmp, *end, *match;
+#define DMQ_EXTRACT_PEER_EVT_MAX 128
+	dmq_node_t *peer_upv[DMQ_EXTRACT_PEER_EVT_MAX];
+	dmq_node_t *peer_downv[DMQ_EXTRACT_PEER_EVT_MAX];
+	dmq_node_t *peer_disabledv[DMQ_EXTRACT_PEER_EVT_MAX];
+	int peer_upc = 0;
+	int peer_up_dropped = 0;
+	int peer_downc = 0;
+	int peer_down_dropped = 0;
+	int peer_disabledc = 0;
+	int peer_disabled_dropped = 0;
+	int pi;
 
 	if(!msg->content_length
 			&& (parse_headers(msg, HDR_CONTENTLENGTH_F, 0) < 0
@@ -439,14 +450,43 @@ int extract_node_list(dmq_node_list_t *update_list, struct sip_msg *msg)
 			update_list->nodes = cur;
 			update_list->count++;
 			total_nodes++;
+			if(!cur->local && cur->status == DMQ_NODE_ACTIVE) {
+				if(peer_upc < DMQ_EXTRACT_PEER_EVT_MAX)
+					peer_upv[peer_upc++] = cur;
+				else
+					peer_up_dropped++;
+			}
 		} else if(!ret->local && find->uri.params.s
 				  && ret->status != find->status
-				  && ret->status != DMQ_NODE_DISABLED) {
-			/* don't update the node if it is in ending state */
+				  && (ret->status != DMQ_NODE_DISABLED
+						  || find->status == DMQ_NODE_ACTIVE)) {
+			/* while disabled, ignore body except recovery to active */
+			int old_status = ret->status;
+
 			LM_DBG("updating status on %.*s from %d to %d\n", STR_FMT(&tmp_uri),
 					ret->status, find->status);
 			ret->status = find->status;
 			total_nodes++;
+			if(old_status != DMQ_NODE_ACTIVE
+					&& ret->status == DMQ_NODE_ACTIVE) {
+				if(peer_upc < DMQ_EXTRACT_PEER_EVT_MAX)
+					peer_upv[peer_upc++] = ret;
+				else
+					peer_up_dropped++;
+			} else if(old_status == DMQ_NODE_ACTIVE
+					  && ret->status == DMQ_NODE_NOT_ACTIVE) {
+				if(peer_downc < DMQ_EXTRACT_PEER_EVT_MAX)
+					peer_downv[peer_downc++] = ret;
+				else
+					peer_down_dropped++;
+			} else if((old_status == DMQ_NODE_ACTIVE
+							  || old_status == DMQ_NODE_NOT_ACTIVE)
+					  && ret->status == DMQ_NODE_DISABLED) {
+				if(peer_disabledc < DMQ_EXTRACT_PEER_EVT_MAX)
+					peer_disabledv[peer_disabledc++] = ret;
+				else
+					peer_disabled_dropped++;
+			}
 		}
 		destroy_dmq_node(find, 0);
 	}
@@ -454,6 +494,28 @@ int extract_node_list(dmq_node_list_t *update_list, struct sip_msg *msg)
 	/* release big list lock */
 	lock_release(&update_list->lock);
 	LM_DBG("released dmq_node_list->lock\n");
+	for(pi = 0; pi < peer_upc; pi++) {
+		if(!peer_upv[pi]->local && peer_upv[pi]->status == DMQ_NODE_ACTIVE)
+			dmq_peer_run_event_route(DMQ_NODE_ACTIVE, peer_upv[pi]);
+	}
+	for(pi = 0; pi < peer_downc; pi++) {
+		if(!peer_downv[pi]->local && peer_downv[pi]->status != DMQ_NODE_ACTIVE)
+			dmq_peer_run_event_route(DMQ_NODE_NOT_ACTIVE, peer_downv[pi]);
+	}
+	for(pi = 0; pi < peer_disabledc; pi++) {
+		if(!peer_disabledv[pi]->local
+				&& peer_disabledv[pi]->status == DMQ_NODE_DISABLED)
+			dmq_peer_run_event_route(DMQ_NODE_DISABLED, peer_disabledv[pi]);
+	}
+	if(peer_up_dropped > 0)
+		LM_WARN("dmq extract: %d peers skipped peer-up (max %d)\n",
+				peer_up_dropped, DMQ_EXTRACT_PEER_EVT_MAX);
+	if(peer_down_dropped > 0)
+		LM_WARN("dmq extract: %d peers skipped peer-down (max %d)\n",
+				peer_down_dropped, DMQ_EXTRACT_PEER_EVT_MAX);
+	if(peer_disabled_dropped > 0)
+		LM_WARN("dmq extract: %d peers skipped peer-disabled (max %d)\n",
+				peer_disabled_dropped, DMQ_EXTRACT_PEER_EVT_MAX);
 	return total_nodes;
 error:
 	lock_release(&update_list->lock);
@@ -621,7 +683,6 @@ int request_nodelist(dmq_node_t *node, int forward)
 int notification_resp_callback_f(
 		struct sip_msg *msg, int code, dmq_node_t *node, void *param)
 {
-	int ret;
 	int nodes_recv;
 	str_list_t *slp;
 
@@ -649,11 +710,11 @@ int notification_resp_callback_f(
 				node->uri.host.s, node->uri.port.len, node->uri.port.s);
 
 		if(node->status == DMQ_NODE_DISABLED) {
-			/* deleting node - the server did not respond */
-			LM_ERR("deleting server node %.*s because of failed request\n",
+			/* Keep the node disabled; do not delete. Deleting and re-adding from
+			 * a stale cluster body retriggers peer-up/down while the peer is
+			 * still unreachable. Recovery is DISABLED -> ACTIVE via extract. */
+			LM_DBG("timeout on disabled node %.*s - keep disabled, no delete\n",
 					STR_FMT(&node->orig_uri));
-			ret = del_dmq_node(dmq_node_list, node);
-			LM_DBG("del_dmq_node returned %d\n", ret);
 			return 0;
 		}
 

--- a/src/modules/dmq/notification_peer.c
+++ b/src/modules/dmq/notification_peer.c
@@ -461,31 +461,33 @@ int extract_node_list(dmq_node_list_t *update_list, struct sip_msg *msg)
 				  && (ret->status != DMQ_NODE_DISABLED
 						  || find->status == DMQ_NODE_ACTIVE)) {
 			/* while disabled, ignore body except recovery to active */
-			int old_status = ret->status;
-
 			LM_DBG("updating status on %.*s from %d to %d\n", STR_FMT(&tmp_uri),
 					ret->status, find->status);
 			ret->status = find->status;
 			total_nodes++;
-			if(old_status != DMQ_NODE_ACTIVE
-					&& ret->status == DMQ_NODE_ACTIVE) {
-				if(peer_upc < DMQ_EXTRACT_PEER_EVT_MAX)
-					peer_upv[peer_upc++] = ret;
-				else
-					peer_up_dropped++;
-			} else if(old_status == DMQ_NODE_ACTIVE
-					  && ret->status == DMQ_NODE_NOT_ACTIVE) {
-				if(peer_downc < DMQ_EXTRACT_PEER_EVT_MAX)
-					peer_downv[peer_downc++] = ret;
-				else
-					peer_down_dropped++;
-			} else if((old_status == DMQ_NODE_ACTIVE
-							  || old_status == DMQ_NODE_NOT_ACTIVE)
-					  && ret->status == DMQ_NODE_DISABLED) {
-				if(peer_disabledc < DMQ_EXTRACT_PEER_EVT_MAX)
-					peer_disabledv[peer_disabledc++] = ret;
-				else
-					peer_disabled_dropped++;
+			/* Peer event follows new status; legal edges are fixed by the outer
+			 * condition above (e.g. no DISABLED -> not_active in this branch). */
+			switch(ret->status) {
+				case DMQ_NODE_ACTIVE:
+					if(peer_upc < DMQ_EXTRACT_PEER_EVT_MAX)
+						peer_upv[peer_upc++] = ret;
+					else
+						peer_up_dropped++;
+					break;
+				case DMQ_NODE_NOT_ACTIVE:
+					if(peer_downc < DMQ_EXTRACT_PEER_EVT_MAX)
+						peer_downv[peer_downc++] = ret;
+					else
+						peer_down_dropped++;
+					break;
+				case DMQ_NODE_DISABLED:
+					if(peer_disabledc < DMQ_EXTRACT_PEER_EVT_MAX)
+						peer_disabledv[peer_disabledc++] = ret;
+					else
+						peer_disabled_dropped++;
+					break;
+				default:
+					break;
 			}
 		}
 		destroy_dmq_node(find, 0);
@@ -494,19 +496,12 @@ int extract_node_list(dmq_node_list_t *update_list, struct sip_msg *msg)
 	/* release big list lock */
 	lock_release(&update_list->lock);
 	LM_DBG("released dmq_node_list->lock\n");
-	for(pi = 0; pi < peer_upc; pi++) {
-		if(!peer_upv[pi]->local && peer_upv[pi]->status == DMQ_NODE_ACTIVE)
-			dmq_peer_run_event_route(DMQ_NODE_ACTIVE, peer_upv[pi]);
-	}
-	for(pi = 0; pi < peer_downc; pi++) {
-		if(!peer_downv[pi]->local && peer_downv[pi]->status != DMQ_NODE_ACTIVE)
-			dmq_peer_run_event_route(DMQ_NODE_NOT_ACTIVE, peer_downv[pi]);
-	}
-	for(pi = 0; pi < peer_disabledc; pi++) {
-		if(!peer_disabledv[pi]->local
-				&& peer_disabledv[pi]->status == DMQ_NODE_DISABLED)
-			dmq_peer_run_event_route(DMQ_NODE_DISABLED, peer_disabledv[pi]);
-	}
+	for(pi = 0; pi < peer_upc; pi++)
+		dmq_peer_run_event_route(peer_upv[pi]);
+	for(pi = 0; pi < peer_downc; pi++)
+		dmq_peer_run_event_route(peer_downv[pi]);
+	for(pi = 0; pi < peer_disabledc; pi++)
+		dmq_peer_run_event_route(peer_disabledv[pi]);
 	if(peer_up_dropped > 0)
 		LM_WARN("dmq extract: %d peers skipped peer-up (max %d)\n",
 				peer_up_dropped, DMQ_EXTRACT_PEER_EVT_MAX);


### PR DESCRIPTION
#### Description

This PR introduces `event_routes` that will trigger when `dmq peers` go up and down during the time.

Really useful to detect problems between `peers` and allows addition of prometheus metrics for example, to add automatic visibility.

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Tests

Tested locally simulating crashes and startups to evaluate the trigger of routes.

Couldn't found any problems or strange cases, on ping intervals the status validation, gives the correct output. 