### PR TITLE
fix tls_connection_match_domain

### DIFF
--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1781,7 +1781,7 @@ struct tcp_connection *_tcpconn_find(int id, struct ip_addr *ip, int port,
 						a->parent->id);
 
 #ifdef USE_TLS
-				if(tls_connection_match_domain && proto == PROTO_TLS
+				if(tls_connection_match_domain && a->parent->type == PROTO_TLS
 						&& !tls_hook_call(match_domain, 1, a->parent, ip, port))
 					continue;
 #endif

--- a/src/modules/tls/tls_server.c
+++ b/src/modules/tls/tls_server.c
@@ -1036,7 +1036,7 @@ static char *get_tls_domain_str(
 	atomic_inc(&cfg->ref_count);
 	lock_release(tls_domains_cfg_lock);
 
-	if(c->flags & F_CONN_PASSIVE) {
+	if(c && (c->flags & F_CONN_PASSIVE)) {
 		dom = tls_lookup_cfg(cfg, TLS_DOMAIN_SRV, ip, port, 0, 0);
 	} else {
 		sname = tls_get_connect_server_name(c);
@@ -1070,7 +1070,7 @@ int tls_h_match_domain_f(
 		return 0;
 	}
 
-	dom_str = get_tls_domain_str(c, ip, port);
+	dom_str = get_tls_domain_str(NULL /* to use XAVPs only */, ip, port);
 	STR_SET(dom, dom_str);
 
 	return STR_EQ(tls_c->dom, dom);

--- a/src/modules/tls_wolfssl/tls_server.c
+++ b/src/modules/tls_wolfssl/tls_server.c
@@ -908,7 +908,7 @@ static char *get_tls_domain_str(
 	atomic_inc(&cfg->ref_count);
 	lock_release(tls_domains_cfg_lock);
 
-	if(c->flags & F_CONN_PASSIVE) {
+	if(c && (c->flags & F_CONN_PASSIVE)) {
 		dom = tls_lookup_cfg(cfg, TLS_DOMAIN_SRV, ip, port, 0, 0);
 	} else {
 		sname = tls_get_connect_server_name();
@@ -942,7 +942,7 @@ int tls_h_match_domain_f(
 		return 0;
 	}
 
-	dom_str = get_tls_domain_str(c, ip, port);
+	dom_str = get_tls_domain_str(NULL /* to use XAVPs only */, ip, port);
 	STR_SET(dom, dom_str);
 
 	return STR_EQ(tls_c->dom, dom);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

fix wrong connections reuse in tls_connection_match_domain=yes mode and add test for it

* change related places for tls and tls_wolfssl modules
* fix protocol checking in _tcpconn_find
* add test/unit/62.sh

test/unit/62.sh execution time:
```
test/unit$ time make run UNIT=62.sh
Run test 62: checks tls_connection_match_domain=yes creates new connection to the same dst ip:port for another tls domain
Test unit file 62.sh: ok

real    0m1.191s
user    0m0.048s
sys     0m0.019s
```

was wrongly reusing the same TLS connection even between different TLS domains because:
* invalid proto check in _tcpconn_find was skipping tls hook match_domain when it called with proto:0
* passing connection ptr to the get_tls_domain_str in tls_h_match_domain_f was causing tls_get_connect_server_name,tls_get_connect_server_id to check connection against itself instead of XAVPs lookup for the new connection context