### PR TITLE
dmq: added init_with_single parameter

### DIFF
--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -35,7 +35,7 @@ dmq_api_t dlg_dmqb;
 dmq_peer_t *dlg_dmq_peer = NULL;
 
 int dmq_send_all_dlgs(dmq_node_t *dmq_node);
-int dlg_dmq_request_sync();
+int dlg_dmq_request_sync(dmq_node_t *dmq_node);
 
 extern int dlg_enable_stats;
 
@@ -436,7 +436,7 @@ error:
 }
 
 
-int dlg_dmq_request_sync()
+int dlg_dmq_request_sync(dmq_node_t *dmq_node)
 {
 	srjson_doc_t jdoc;
 
@@ -458,7 +458,7 @@ int dlg_dmq_request_sync()
 	}
 	jdoc.buf.len = strlen(jdoc.buf.s);
 	LM_DBG("sending serialized data %.*s\n", jdoc.buf.len, jdoc.buf.s);
-	if(dlg_dmq_send(&jdoc.buf, 0) != 0) {
+	if(dlg_dmq_send(&jdoc.buf, dmq_node) != 0) {
 		goto error;
 	}
 

--- a/src/modules/dmq/dmq.c
+++ b/src/modules/dmq/dmq.c
@@ -72,6 +72,7 @@ int dmq_remove_inactive = 1;
 int dmq_fail_count_enabled = 0;
 int dmq_fail_count_threshold_not_active = 0;
 int dmq_fail_count_threshold_disabled = 1;
+int dmq_init_with_single = 0;
 
 /* TM bind */
 struct tm_binds _dmq_tmb = {0};
@@ -133,6 +134,7 @@ static param_export_t params[] = {
 	{"fail_count_enabled", PARAM_INT, &dmq_fail_count_enabled},
 	{"fail_count_threshold_not_active", PARAM_INT, &dmq_fail_count_threshold_not_active},
 	{"fail_count_threshold_disabled", PARAM_INT, &dmq_fail_count_threshold_disabled},
+	{"init_with_single", PARAM_INT, &dmq_init_with_single},
 	{0, 0, 0}
 };
 

--- a/src/modules/dmq/doc/dmq_admin.xml
+++ b/src/modules/dmq/doc/dmq_admin.xml
@@ -420,6 +420,23 @@ modparam("dmq", "fail_count_threshold_disabled", 105)
 		</programlisting>
 		</example>
 	</section>
+	<section id="dmq.p.init_with_single">
+		<title><varname>init_with_single</varname>(int)</title>
+		<para>
+			A non-zero value enables init and sync with single DMQ node (first pinged or answered) instead of all nodes in a node list.
+		</para>
+		<para>
+		<emphasis>Default value is <quote>0</quote> (init and sync with all nodes in a node list).</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>init_with_single</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dmq", "init_with_single", 1)
+...
+		</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>

--- a/src/modules/dmq/notification_peer.c
+++ b/src/modules/dmq/notification_peer.c
@@ -37,6 +37,7 @@ dmq_resp_cback_t dmq_default_resp_callback = {&default_resp_callback_f, 0};
 int *dmq_init_callback_done = 0;
 
 extern str dmq_notification_channel;
+extern int dmq_init_with_single;
 
 /**
  * @brief add notification peer
@@ -461,7 +462,7 @@ error:
 }
 
 
-int run_init_callbacks()
+int run_init_callbacks(dmq_node_t *dmq_node)
 {
 	dmq_peer_t *crt;
 
@@ -472,7 +473,7 @@ int run_init_callbacks()
 	crt = dmq_peer_list->peers;
 	while(crt) {
 		if(crt->init_callback) {
-			crt->init_callback();
+			crt->init_callback(dmq_node);
 		}
 		crt = crt->next;
 	}
@@ -525,7 +526,7 @@ int dmq_notification_callback_f(
 	pkg_free(response_body);
 	if(dmq_init_callback_done && !*dmq_init_callback_done) {
 		*dmq_init_callback_done = 1;
-		run_init_callbacks();
+		run_init_callbacks(dmq_init_with_single ? dmq_node : NULL);
 	}
 	return 0;
 error:
@@ -637,7 +638,7 @@ int notification_resp_callback_f(
 		LM_DBG("received %d new or changed nodes\n", nodes_recv);
 		if(dmq_init_callback_done && !*dmq_init_callback_done) {
 			*dmq_init_callback_done = 1;
-			run_init_callbacks();
+			run_init_callbacks(dmq_init_with_single ? node : NULL);
 		}
 	} else if(code == 408) {
 		LM_WARN("timeout: previous fail_count=%d fail_threshold_not_active=%d "

--- a/src/modules/dmq_usrloc/usrloc_sync.c
+++ b/src/modules/dmq_usrloc/usrloc_sync.c
@@ -44,7 +44,7 @@ dmq_api_t usrloc_dmqb;
 dmq_peer_t *usrloc_dmq_peer = NULL;
 
 int usrloc_dmq_send_all();
-int usrloc_dmq_request_sync();
+int usrloc_dmq_request_sync(dmq_node_t *node);
 int usrloc_dmq_send_contact(
 		ucontact_t *ptr, str aor, int action, dmq_node_t *node);
 int usrloc_dmq_send_multi_contact(
@@ -605,7 +605,7 @@ error:
 }
 
 
-int usrloc_dmq_request_sync()
+int usrloc_dmq_request_sync(dmq_node_t *node)
 {
 	srjson_doc_t jdoc;
 
@@ -629,7 +629,7 @@ int usrloc_dmq_request_sync()
 	}
 	jdoc.buf.len = strlen(jdoc.buf.s);
 	LM_DBG("sending serialized data %.*s\n", jdoc.buf.len, jdoc.buf.s);
-	if(usrloc_dmq_send(&jdoc.buf, 0) != 0) {
+	if(usrloc_dmq_send(&jdoc.buf, node) != 0) {
 		goto error;
 	}
 

--- a/src/modules/dmq_usrloc/usrloc_sync.h
+++ b/src/modules/dmq_usrloc/usrloc_sync.h
@@ -46,7 +46,7 @@ typedef enum
 int usrloc_dmq_initialize();
 int usrloc_dmq_handle_msg(
 		struct sip_msg *msg, peer_reponse_t *resp, dmq_node_t *node);
-int usrloc_dmq_request_sync();
+int usrloc_dmq_request_sync(dmq_node_t *node);
 void dmq_ul_cb_contact(ucontact_t *c, int type, void *param);
 
 #endif

--- a/src/modules/htable/ht_dmq.c
+++ b/src/modules/htable/ht_dmq.c
@@ -458,7 +458,7 @@ int ht_dmq_replay_action(ht_dmq_action_t action, str *htname, str *cname,
 	}
 }
 
-int ht_dmq_request_sync(str *htname)
+int ht_dmq_request_sync(str *htname, dmq_node_t *dmq_node)
 {
 
 	srjson_doc_t jdoc;
@@ -484,7 +484,7 @@ int ht_dmq_request_sync(str *htname)
 	}
 	jdoc.buf.len = strlen(jdoc.buf.s);
 	LM_DBG("sending serialized data %.*s\n", jdoc.buf.len, jdoc.buf.s);
-	if(ht_dmq_send(&jdoc.buf, 0) != 0) {
+	if(ht_dmq_send(&jdoc.buf, dmq_node) != 0) {
 		goto error;
 	}
 
@@ -502,9 +502,9 @@ error:
 	return -1;
 }
 
-int ht_dmq_request_sync_all()
+int ht_dmq_request_sync_all(dmq_node_t *dmq_node)
 {
-	return ht_dmq_request_sync(NULL);
+	return ht_dmq_request_sync(NULL, dmq_node);
 }
 
 int ht_dmq_send_sync(dmq_node_t *node, str *htname)

--- a/src/modules/htable/ht_dmq.h
+++ b/src/modules/htable/ht_dmq.h
@@ -52,7 +52,7 @@ int ht_dmq_replicate_action(ht_dmq_action_t action, str *htname, str *cname,
 		int type, int_str *val, int mode);
 int ht_dmq_replay_action(ht_dmq_action_t action, str *htname, str *cname,
 		int type, int_str *val, int mode);
-int ht_dmq_request_sync(str *htname);
-int ht_dmq_request_sync_all();
+int ht_dmq_request_sync(str *htname, dmq_node_t *dmq_node);
+int ht_dmq_request_sync_all(dmq_node_t *dmq_node);
 
 #endif

--- a/src/modules/htable/htable.c
+++ b/src/modules/htable/htable.c
@@ -2298,7 +2298,7 @@ static void htable_rpc_dmqsync(rpc_t *rpc, void *c)
 	if(n != 1) {
 		htname.len = 0;
 	}
-	if(ht_dmq_request_sync(&htname) < 0) {
+	if(ht_dmq_request_sync(&htname, NULL) < 0) {
 		rpc->fault(c, 500, "HTable DMQ Sync Failed");
 		return;
 	}
@@ -2324,7 +2324,7 @@ static void htable_rpc_dmqresync(rpc_t *rpc, void *c)
 		rpc->fault(c, 500, "Htable flush failed.");
 		return;
 	}
-	if(ht_dmq_request_sync(&htname) < 0) {
+	if(ht_dmq_request_sync(&htname, NULL) < 0) {
 		rpc->fault(c, 500, "HTable DMQ Sync Failed");
 		return;
 	}

--- a/src/modules/presence/presence_dmq.c
+++ b/src/modules/presence/presence_dmq.c
@@ -36,7 +36,7 @@ dmq_peer_t *pres_dmq_peer = NULL;
 
 int pres_dmq_send_all_presentities(dmq_node_t *dmq_node);
 int pres_dmq_send_all_subscriptions(dmq_node_t *dmq_node);
-int pres_dmq_request_sync();
+int pres_dmq_request_sync(dmq_node_t *dmq_node);
 
 /**
 * @brief add notification peer
@@ -490,7 +490,7 @@ cleanup:
 }
 
 
-int pres_dmq_request_method_sync(int action)
+int pres_dmq_request_method_sync(int action, dmq_node_t *dmq_node)
 {
 	srjson_doc_t jdoc;
 
@@ -512,7 +512,7 @@ int pres_dmq_request_method_sync(int action)
 	}
 	jdoc.buf.len = strlen(jdoc.buf.s);
 	LM_DBG("sending serialized data %.*s\n", jdoc.buf.len, jdoc.buf.s);
-	if(pres_dmq_send(&jdoc.buf, 0) != 0) {
+	if(pres_dmq_send(&jdoc.buf, dmq_node) != 0) {
 		goto error;
 	}
 
@@ -531,16 +531,18 @@ error:
 }
 
 
-int pres_dmq_request_sync()
+int pres_dmq_request_sync(dmq_node_t *dmq_node)
 {
 	if(pres_enable_pres_dmq > 0 && pres_enable_pres_sync_dmq > 0) {
-		if(pres_dmq_request_method_sync(PRES_DMQ_SYNC_PRESENTITY) != 0) {
+		if(pres_dmq_request_method_sync(PRES_DMQ_SYNC_PRESENTITY, dmq_node)
+				!= 0) {
 			LM_ERR("cannot send presence sync request\n");
 			return -1;
 		}
 	}
 	if(pres_enable_subs_dmq > 0 && pres_enable_subs_sync_dmq > 0) {
-		if(pres_dmq_request_method_sync(PRES_DMQ_SYNC_SUBSCRIPTION) != 0) {
+		if(pres_dmq_request_method_sync(PRES_DMQ_SYNC_SUBSCRIPTION, dmq_node)
+				!= 0) {
 			LM_ERR("cannot send subscription sync request\n");
 			return -1;
 		}

--- a/src/modules/rtpengine/rtpengine_dmq.c
+++ b/src/modules/rtpengine/rtpengine_dmq.c
@@ -31,7 +31,7 @@ static str rtpengine_dmq_500_rpl = str_init("Server Internal Error");
 dmq_api_t rtpengine_dmqb;
 dmq_peer_t *rtpengine_dmq_peer = NULL;
 
-int rtpengine_dmq_request_sync();
+int rtpengine_dmq_request_sync(dmq_node_t *node);
 
 /**
 * @brief add rtpengine notification peer
@@ -64,7 +64,7 @@ int rtpengine_dmq_init()
 	return 0;
 }
 
-int rtpengine_dmq_request_sync()
+int rtpengine_dmq_request_sync(dmq_node_t *node)
 {
 	return 0;
 }


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Right now synchronization during dmq init is done with all available nodes in dmq node list.
In this PR the new parameter init_with_single introduced that force sync with single node that first answered on ping or is first pinged.