### PR TITLE
sanity: Add RFC3261 compliance checks

### DIFF
--- a/src/modules/sanity/doc/sanity_admin.xml
+++ b/src/modules/sanity/doc/sanity_admin.xml
@@ -119,14 +119,13 @@
 		<listitem>
 			<para>
 			first Via header (16384 [0x4000 / 2^14]) - checks if the first Via header is
-			available, can be parsed and has an address value.
+			available, can be parsed, has an address value, and the branch parameter is present.
 			</para>
 		</listitem>
 		<listitem>
 			<para>
-			first Via header branch parameter (32768 [0x8000 / 2^15]) - checks if the branch
-			parameter of the first Via header is present, can be parsed by the &kamailio;
-			and starts with magic cookie: 'z9hG4bK'.
+			RFC3261 compliance related checks (32768 [0x8000 / 2^15]) - checks if the branch parameter of the first Via header starts with magic cookie: 'z9hG4bK'.
+			Also checks that the lr parameter is present in Record-Route headers if they are present.
 			</para>
 		</listitem>
 		</itemizedlist>

--- a/src/modules/sanity/sanity.c
+++ b/src/modules/sanity/sanity.c
@@ -36,6 +36,7 @@
 #include "../../core/parser/contact/parse_contact.h"
 #include "../../core/parser/parse_to.h"
 #include "../../core/parser/parse_from.h"
+#include "../../core/parser/parse_rr.h"
 
 #define UNSUPPORTED_HEADER "Unsupported: "
 #define UNSUPPORTED_HEADER_LEN (sizeof(UNSUPPORTED_HEADER) - 1)
@@ -376,13 +377,25 @@ int check_via1_header(sip_msg_t *msg)
 		return SANITY_CHECK_FAILED;
 	}
 
+	if(msg->via1->branch == NULL || msg->via1->branch->value.len <= 0) {
+		LM_WARN("failed to parse the Via1 branch\n");
+		msg->msg_flags |= FL_MSG_NOREPLY;
+		return SANITY_CHECK_FAILED;
+	}
+
 	return SANITY_CHECK_PASSED;
 }
 
-/* check if the Via header contains a branch parameter
-and that it starts with the magic cookie */
-int check_via1_branch(sip_msg_t *msg)
+/* check multiple conditions regarding RFC3261
+	1. via branch parameter starts with the magic cookie
+	2. for Record-Route headers check that the lr parameter is present
+*/
+int check_rfc3261_compliance(sip_msg_t *msg)
 {
+	hdr_field_t *hf;
+	rr_t *rr;
+	sip_uri_t parsed_uri;
+
 	LM_DBG("check via1 branch\n");
 	if(parse_headers(msg, HDR_VIA1_F, 0) != 0) {
 		LM_WARN("failed to parse the Via1 header\n");
@@ -390,11 +403,6 @@ int check_via1_branch(sip_msg_t *msg)
 		return SANITY_CHECK_FAILED;
 	}
 
-	if(msg->via1->branch == NULL || msg->via1->branch->value.len <= 0) {
-		LM_WARN("failed to parse the Via1 branch\n");
-		msg->msg_flags |= FL_MSG_NOREPLY;
-		return SANITY_CHECK_FAILED;
-	}
 
 	if(msg->via1->branch->value.len < 7
 			|| memcmp(msg->via1->branch->value.s, "z9hG4bK", 7) != 0) {
@@ -402,6 +410,39 @@ int check_via1_branch(sip_msg_t *msg)
 		msg->msg_flags |= FL_MSG_NOREPLY;
 		return SANITY_CHECK_FAILED;
 	}
+
+	/* Check lr parameter for Record-Route */
+	LM_DBG("check Record-Route lr parameter for all RR headers\n");
+
+	if(parse_record_route_headers(msg) != 0) {
+		LM_WARN("failed to parse the Record-Route headers\n");
+		msg->msg_flags |= FL_MSG_NOREPLY;
+		return SANITY_CHECK_FAILED;
+	}
+
+	hf = msg->record_route;
+	while(hf) {
+		if(hf->parsed == NULL) {
+			LM_WARN("failed to parse the Record-Route header body\n");
+			msg->msg_flags |= FL_MSG_NOREPLY;
+			return SANITY_CHECK_FAILED;
+		}
+		rr = hf->parsed;
+		if(parse_uri(rr->nameaddr.uri.s, rr->nameaddr.uri.len, &parsed_uri)
+				!= 0) {
+			LM_WARN("failed to parse the Record-Route URI\n");
+			msg->msg_flags |= FL_MSG_NOREPLY;
+			return SANITY_CHECK_FAILED;
+		}
+
+		if(parsed_uri.lr.len == 0 || parsed_uri.lr.s == NULL) {
+			LM_WARN("missing lr parameter in Record-Route URI\n");
+			msg->msg_flags |= FL_MSG_NOREPLY;
+			return SANITY_CHECK_FAILED;
+		}
+		hf = next_sibling_hdr(hf);
+	}
+
 	return SANITY_CHECK_PASSED;
 }
 

--- a/src/modules/sanity/sanity.h
+++ b/src/modules/sanity/sanity.h
@@ -45,7 +45,7 @@ str_list_t *parse_str_list(str *_string);
 int check_via1_header(sip_msg_t *msg);
 
 /* check if the Via header contains a branch parameter */
-int check_via1_branch(sip_msg_t *msg);
+int check_rfc3261_compliance(sip_msg_t *msg);
 
 /* compare the protocol string in the Via header with the transport */
 int check_via_protocol(struct sip_msg *_msg);

--- a/src/modules/sanity/sanity_mod.c
+++ b/src/modules/sanity/sanity_mod.c
@@ -313,8 +313,8 @@ int sanity_check(struct sip_msg *_msg, int msg_checks, int uri_checks)
 			&& (ret = check_via1_header(_msg)) != SANITY_CHECK_PASSED) {
 		goto done;
 	}
-	if(SANITY_VIA1_BRANCH & msg_checks
-			&& (ret = check_via1_branch(_msg)) != SANITY_CHECK_PASSED) {
+	if(SANITY_RFC3261_COMPLIANCE & msg_checks
+			&& (ret = check_rfc3261_compliance(_msg)) != SANITY_CHECK_PASSED) {
 		goto done;
 	}
 	if(SANITY_VIA_SIP_VERSION & msg_checks

--- a/src/modules/sanity/sanity_mod.h
+++ b/src/modules/sanity/sanity_mod.h
@@ -46,7 +46,7 @@
 #define SANITY_CHECK_DUPTAGS (1 << 12)
 #define SANITY_CHECK_AUTHORIZATION (1 << 13)
 #define SANITY_VIA1_HEADER (1 << 14)
-#define SANITY_VIA1_BRANCH (1 << 15)
+#define SANITY_RFC3261_COMPLIANCE (1 << 15)
 #define SANITY_CHECK_SIZES (1 << 16)
 #define SANITY_MAX_CHECKS (1 << 17) /* Make sure this is the highest value */
 


### PR DESCRIPTION
- Move via1 branch to via1 valitidy
- Add via branch magic cookie check to rf3261
- Add RR lr parameter check to rf3261

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue https://github.com/kamailio/kamailio/pull/4681#issuecomment-4175197568

#### Description
<!-- Describe your changes in detail -->
