### PR TITLE
tm: support custom callid and fromtag in req_outside

### DIFF
--- a/src/modules/tm/uac.c
+++ b/src/modules/tm/uac.c
@@ -1181,8 +1181,16 @@ int req_outside(uac_req_t *uac_r, str *ruri, str *to, str *from, str *next_hop)
 	if(check_params(uac_r, to, from) < 0)
 		goto err;
 
-	generate_callid(&callid);
-	generate_fromtag(&fromtag, &callid, ruri);
+	if(uac_r->callid == NULL || uac_r->callid->len <= 0) {
+		generate_callid(&callid);
+	} else {
+		callid = *uac_r->callid;
+	}
+	if(uac_r->fromtag == NULL || uac_r->fromtag->len <= 0) {
+		generate_fromtag(&fromtag, &callid, ruri);
+	} else {
+		fromtag = *uac_r->fromtag;
+	}
 
 	if(new_dlg_uac(&callid, &fromtag, DEFAULT_CSEQ, from, to, &uac_r->dialog)
 			< 0) {


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This PR checks if uac_r contains a custom callid or fromtag before generating new ones in req_outside(). If they are provided and have a valid length, they are used directly. Otherwise, it falls back to generating new ones.
