### PR TITLE
rtpengine: add DMQ sync support for hash table replication

### DIFF
--- a/src/modules/rtpengine/rtpengine_dmq.c
+++ b/src/modules/rtpengine/rtpengine_dmq.c
@@ -22,6 +22,7 @@
 
 #include "rtpengine.h"
 #include "rtpengine_dmq.h"
+#include "../../core/timer.h"
 
 static str rtpengine_dmq_content_type = str_init("application/json");
 static str rtpengine_dmq_200_rpl = str_init("OK");
@@ -32,6 +33,7 @@ dmq_api_t rtpengine_dmqb;
 dmq_peer_t *rtpengine_dmq_peer = NULL;
 
 int rtpengine_dmq_request_sync();
+int rtpengine_dmq_send(str *body, dmq_node_t *node);
 
 /**
 * @brief add rtpengine notification peer
@@ -66,7 +68,42 @@ int rtpengine_dmq_init()
 
 int rtpengine_dmq_request_sync()
 {
+	srjson_doc_t jdoc;
+
+	LM_DBG("requesting sync from dmq peers\n");
+
+	srjson_InitDoc(&jdoc, NULL);
+
+	jdoc.root = srjson_CreateObject(&jdoc);
+	if(jdoc.root == NULL) {
+		LM_ERR("cannot create json root\n");
+		goto error;
+	}
+
+	srjson_AddNumberToObject(&jdoc, jdoc.root, "action", RTPENGINE_DMQ_SYNC);
+	jdoc.buf.s = srjson_PrintUnformatted(&jdoc, jdoc.root);
+	if(jdoc.buf.s == NULL) {
+		LM_ERR("unable to serialize data\n");
+		goto error;
+	}
+	jdoc.buf.len = strlen(jdoc.buf.s);
+	LM_DBG("sending serialized data %.*s\n", jdoc.buf.len, jdoc.buf.s);
+	if(rtpengine_dmq_send(&jdoc.buf, 0) != 0) {
+		goto error;
+	}
+
+	jdoc.free_fn(jdoc.buf.s);
+	jdoc.buf.s = NULL;
+	srjson_DestroyDoc(&jdoc);
 	return 0;
+
+error:
+	if(jdoc.buf.s != NULL) {
+		jdoc.free_fn(jdoc.buf.s);
+		jdoc.buf.s = NULL;
+	}
+	srjson_DestroyDoc(&jdoc);
+	return -1;
 }
 
 int rtpengine_dmq_handle_msg(
@@ -197,6 +234,11 @@ int rtpengine_dmq_handle_msg(
 				goto error;
 			break;
 		case RTPENGINE_DMQ_SYNC:
+            if(rtpengine_dmq_replicate_sync() != 0) {
+                LM_ERR("failed to replicate sync\n");
+                goto error;
+            }
+            break;
 		case RTPENGINE_DMQ_NONE:
 			break;
 	}
@@ -309,4 +351,50 @@ int rtpengine_dmq_replicate_remove(str callid, str viabranch)
 {
 	return rtpengine_dmq_replicate_action(
 			RTPENGINE_DMQ_REMOVE, callid, viabranch, NULL, NULL);
+}
+
+int rtpengine_dmq_replicate_sync()
+{
+	int i;
+	struct rtpengine_hash_entry *entry, **last_next;
+
+	LM_DBG("replicating all hash entries to dmq peers\n");
+
+	if(!rtpengine_hash_table_sanity_checks()) {
+		LM_ERR("sanity checks failed\n");
+		return -1;
+	}
+
+	for(i = 0; i < rtpengine_hash_table->size; i++) {
+		lock_get(&rtpengine_hash_table->row_locks[i]);
+
+		last_next = &rtpengine_hash_table->row_entry_list[i];
+
+		while((entry = *last_next)) {
+			if(entry->tout < get_ticks()) {
+				/* skip expired entries — do not replicate stale data */
+				last_next = &entry->next;
+				continue;
+			}
+
+			LM_DBG("replicating hash entry callid=%.*s viabranch=%.*s\n",
+					entry->callid.len, entry->callid.s,
+					entry->viabranch.len, entry->viabranch.s);
+
+			if(rtpengine_dmq_replicate_insert(
+					   entry->callid, entry->viabranch, entry)
+					!= 0) {
+				LM_ERR("failed to replicate hash entry callid=%.*s "
+					   "viabranch=%.*s\n",
+						entry->callid.len, entry->callid.s,
+						entry->viabranch.len, entry->viabranch.s);
+			}
+
+			last_next = &entry->next;
+		}
+
+		lock_release(&rtpengine_hash_table->row_locks[i]);
+	}
+
+	return 0;
 }

--- a/src/modules/rtpengine/rtpengine_hash.c
+++ b/src/modules/rtpengine/rtpengine_hash.c
@@ -7,7 +7,7 @@
 #include "../../core/timer.h"
 
 
-static struct rtpengine_hash_table *rtpengine_hash_table;
+struct rtpengine_hash_table *rtpengine_hash_table;
 
 /* from sipwise rtpengine */
 static unsigned int str_hash(str s)

--- a/src/modules/rtpengine/rtpengine_hash.h
+++ b/src/modules/rtpengine/rtpengine_hash.h
@@ -28,6 +28,8 @@ struct rtpengine_hash_table
 };
 
 
+extern struct rtpengine_hash_table *rtpengine_hash_table;
+
 int rtpengine_hash_table_init(int size);
 int rtpengine_hash_table_destroy();
 int rtpengine_hash_table_insert(


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Add DMQ-based synchronization of the rtpengine hash table across Kamailio cluster nodes.

When a new Kamailio node starts up and joins the DMQ mesh, it broadcasts a `RTPENGINE_DMQ_SYNC`
request to all peers. Each peer that receives this request responds by replicating its entire
local rtpengine hash table back to the requesting node using `RTPENGINE_DMQ_INSERT` messages.
Expired entries (past their timeout) are skipped and not replicated to avoid propagating stale
call state.

Changes:

- `rtpengine_dmq.c`:
  - Implement `rtpengine_dmq_request_sync()`: builds and broadcasts a `{"action": SYNC}` JSON
    message to all DMQ peers via `rtpengine_dmq_send()`; previously this function was a no-op stub
  - Handle `RTPENGINE_DMQ_SYNC` case in `rtpengine_dmq_handle_msg()`: calls
    `rtpengine_dmq_replicate_sync()` to push the full local hash table to the requesting peer
  - Implement `rtpengine_dmq_replicate_sync()`: iterates all hash table buckets under their
    respective row locks and calls `rtpengine_dmq_replicate_insert()` for each non-expired entry
  - Add forward declaration for `rtpengine_dmq_send()` and include `../../core/timer.h` for
    `get_ticks()`

- `rtpengine_hash.c`:
  - Remove `static` qualifier from `rtpengine_hash_table` so it can be referenced from DMQ code

- `rtpengine_hash.h`:
  - Add `extern struct rtpengine_hash_table *rtpengine_hash_table;` declaration