### PR TITLE
siptrace: fix segfault when hep tracing in transaction mode

### DIFF
--- a/src/modules/siptrace/siptrace_hep.c
+++ b/src/modules/siptrace/siptrace_hep.c
@@ -173,7 +173,7 @@ int trace_send_hep3_duplicate(str *body, str *from, str *to,
 	HEP3_PACK_CHUNK_DATA(0, 0x000f, body->s, body->len);
 	HEP3_PACK_FINALIZE(buffer, &len);
 
-	if(!dst2) {
+	if(!dst2 && trace_dup_uri) {
 		init_dest_info(&dst);
 		dst.proto = trace_dup_uri->proto;
 		p = mk_proxy(&trace_dup_uri->host, trace_dup_uri->port_no, dst.proto);
@@ -186,8 +186,11 @@ int trace_send_hep3_duplicate(str *body, str *from, str *to,
 				&dst.to, &p->host, p->addr_idx, (p->port) ? p->port : SIP_PORT);
 		LM_DBG("setting up the socket_info\n");
 		dst_fin = &dst;
-	} else {
+	} else if(dst2) {
 		dst_fin = dst2;
+	} else {
+		LM_ERR("Don't have anywhere to send the trace to\n");
+		goto error;
 	}
 
 	si = NULL;


### PR DESCRIPTION


<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
If the siptrace module is enabled and tracing to HEP, the duplicate_uri is not set, you trace to a URI in transaction mode and reply without creating a transaction, the siptrace module segfaults. This pull request fixes that.
