### PR TITLE
core: ksr_tcp_main_threads default to 1

### DIFF
--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -173,7 +173,7 @@ int tcp_main_max_fd_no = 0;
 int tcp_max_connections = DEFAULT_TCP_MAX_CONNECTIONS;
 int tls_max_connections = DEFAULT_TLS_MAX_CONNECTIONS;
 int tcp_accept_unique = 0;
-int ksr_tcp_main_threads = 0;
+int ksr_tcp_main_threads = 1;
 int ksr_tcp_listen_backlog = TCP_LISTEN_BACKLOG;
 int tcp_connection_match = TCPCONN_MATCH_DEFAULT;
 


### PR DESCRIPTION
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [X] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This sets the default value of `ksr_tcp_main_threads` to 1. This means that OpenSSL (tls) or wolfSSL(tls_wolfssl), will by default, run in tcp_mtops mode(single process). I have tested that normal functions and tls.reload are working for both TLS modules. In addition running with OpenSSL 4 ~~betas~~ has been verified. The niche use cases of using externalized keys (engine, pkcs11-provider, wolfSSL PKCS#11) have also been verified, including tls.reload.

With this flag on, the main changes are:

- no use of shared memory allocators in OpenSSL/wolfSSL; the functions are confined to PROC_TCP_MAIN
-  the pthread monkey patches become no-ops; these are needed in multi-process mode so that `SSL *` objects can be shared by workers

Multi-process mode is still fully supported (including tls.reload) and also tested with OpenSSL 4 ~~beta~~.

The user can revert to the previous behaviour by setting `tcp_main_threads` to 0 in the config. 

This is part of the long term strategy that Kamailio be less exposed to the (fragile) internals of OpenSSL.


