### PR TITLE
topos: restore port/transport in contact URI for contact_mode=0

### DIFF
--- a/src/modules/topos/tps_storage.c
+++ b/src/modules/topos/tps_storage.c
@@ -317,7 +317,9 @@ int tps_storage_fill_contact(
 			vavu = get_xavu_host(dir);
 		}
 
-		append_host_info(td, &puri, vavu, 0);
+		/* ctmode=0 preserves port/transport from original URI; ctmode=3 does not */
+		append_host_info(
+				td, &puri, vavu, (ctmode == TPS_CONTACT_MODE_SKEYUSER) ? 1 : 0);
 	}
 
 	/* Finalize the contact header */


### PR DESCRIPTION
In 6.1 the contact-building logic in tps_storage_fill_contact was refactored into helper functions. The else branch (ctmode=0 SKEYUSER and ctmode=3 XAVPHOST) was unified into a single append_host_info call with append_port_proto=0, which silently dropped port and transport from the generated contact URI for ctmode=0.

In 6.0 the equivalent inline code always appended port and transport, producing contacts like <sip:bXXX@host:port;transport=tcp>. ctmode=3 (XAVPHOST) did not exist in 6.0, so its omission of port/transport is intentional and is kept as-is.

Fix: pass append_port_proto=1 for TPS_CONTACT_MODE_SKEYUSER only.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to pull request https://github.com/kamailio/kamailio/pull/4246

#### Description
<!-- Describe your changes in detail -->
