### PR TITLE
http_async_client: freeing event upon request completion

### DIFF
--- a/src/modules/http_async_client/http_multi.c
+++ b/src/modules/http_async_client/http_multi.c
@@ -682,6 +682,13 @@ void check_multi_info(struct http_m_global *g)
 
 			if(cell != 0) {
 				LM_DBG("cleaning up cell %p\n", cell);
+				if(cell->evset && cell->ev) {
+					LM_DBG("freeing event %p\n", cell->ev);
+					event_del(cell->ev);
+					event_free(cell->ev);
+					cell->ev = NULL;
+					cell->evset = 0;
+				}
 				unlink_http_m_cell(cell);
 				free_http_m_cell(cell);
 			}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue [#4701](https://github.com/kamailio/kamailio/issues/4701) 

#### Description
<!-- Describe your changes in detail -->
check_multi_info does not free the libevent event upon normal request completion.

However, the event is registered with the EV_PERSIST flag (setsock, line 703) — it is not deleted automatically. As a result, libevent continues to call event_cb with the same pointer, but the cell no longer exists in the table.
This leads to a large number of the following messages:
`4(123386) INFO: http_async_client [http_multi.c:88]: event_cb(): Cell for handler 0xffff7adeddb0 not found in table`
