### PR TITLE
tls_wolfssl: make tcp_main_threads = 1 only

### DIFF
--- a/src/modules/tls_wolfssl/doc/tls_wolfssl.xml
+++ b/src/modules/tls_wolfssl/doc/tls_wolfssl.xml
@@ -42,7 +42,7 @@
         with the <emphasis>tls</emphasis> module.
 			</para>
 			<para>
-	It is highly recommended to run this module with MT-mode (<code>tcp_main_threads = 1</code>).
+	The module no longer supports multi-process mode and requires the global config <code>tcp_main_threads = 1</code>. All wolfSSL functions run in the <code>PROC_TCP_MAIN</code> process. Shared memory and pthreads monkey-patching are not used.
 			</para>
 			<para>
 	This module is derived from the &tls-url;
@@ -85,16 +85,20 @@ loadmodule "tls_wolfssl.so"
 	The wolfSSL TLS module is intended to be compiled with a
 	recent version of wolfSSL - 5.8.4+ is recommended.
 			</para>
-			<para>Kamailio shared memory allocators, used in MP-mode(<code>tcp_main_threads = 0</code>), support
-                        16-byte alignment - it is possible to use this module with either the internal submodule
-                        or distro provided packages. For reference the ideal build flags are:
+			<para>For reference the ideal build flags are:
 
                         <programlisting>
 ...
-# - this assumes the allocators are 16-byte aligned
 # - Debian currently does not use -DWOLF_CRYPTO_CB_RSA_PAD: this affects use of RSA
 #   padding mechanisms on HSMs
 EXTRA_CFLAGS="-g -O2 -DWOLF_CRYPTO_CB_RSA_PAD" ./configure --enable-distro --enable-pkcs11
+
+# additional flags may be used: e.g. what Debian uses on forky for its libwolfssl44 / libwolfssl-dev
+EXTRA_CFLAGS="-g -O2 -DWOLF_CRYPTO_CB_RSA_PAD" ./configure \
+    --enable-distro --enable-ech --enable-hpke --enable-jni \
+    --enable-jobserver=no --enable-memcached --enable-quic --enable-qt --enable-pkcs11 \
+    --enable-writedup --disable-asm --disable-crl-monitor --disable-examples \
+    --disable-silent-rules
 ...
                         </programlisting>
 			</para>
@@ -129,13 +133,12 @@ cd build; make WOLFSSL_INTERNAL=ON tls_wolfssl
 
                         <para>The module supports loading keys from PKCS#11 and
                         up to 8 tokens are supported.
-                        This feature is available in both MT- and MP- modes.
                         The key naming convention follows <ulink url="https://www.rfc-editor.org/rfc/rfc7512.html">RFC 7512 (PKCS#11 URI)</ulink>:
                         <programlisting>
 ...
 # - in tls.cfg these URIs to refer to PKCS#11 keys
 # - this format is a subset of RFC 7512
-# 
+#
 private_key = pkcs11:token=MyToken;object=MyPrivateKey?module-path=/usr/lib64/libsoftokn3.so&amp;pin-value=12345678[pin-source=....]
 ...
                         </programlisting>

--- a/src/modules/tls_wolfssl/tls_domain.c
+++ b/src/modules/tls_wolfssl/tls_domain.c
@@ -131,19 +131,7 @@ void tls_free_domain(tls_domain_t *d)
 {
 	if(!d)
 		return;
-	if(d->ctx && ksr_tcp_main_threads == 0) {
-		if(d->ctx[0]) {
-			void *ext = wolfSSL_CTX_get_ex_data(d->ctx[0], 0);
-			if(ext) {
-				shm_free(((pkcs11_context_t *)ext)->index);
-				shm_free(ext);
-			}
-
-			wolfSSL_CTX_free(d->ctx[0]);
-		}
-		shm_free(d->ctx);
-	}
-	if(d->ctx && ksr_tcp_main_threads > 0 && process_no == PROC_TCP_MAIN) {
+	if(d->ctx && process_no == PROC_TCP_MAIN) {
 		if(d->ctx[0]) {
 			void *ext = wolfSSL_CTX_get_ex_data(d->ctx[0], 0);
 			if(ext) {
@@ -1005,21 +993,8 @@ static int load_private_key(tls_domain_t *d)
 						d->ctx[0], d->pkey_file.s, SSL_FILETYPE_PEM);
 			} else {
 				pkcs11_context_t *ctxd;
-				if(ksr_tcp_main_threads == 0) {
-					LM_WARN("%s: for wolfSSL HSM[key = %s] keys it is strongly "
-							"recommended to use  "
-							"MT-mode: tcp_main_threads=1\n",
-							tls_domain_str(d), d->pkey_file.s);
-					ctxd = shm_malloc(sizeof(pkcs11_context_t));
-					memset(ctxd, 0, sizeof(pkcs11_context_t));
-					ctxd->index = shm_malloc(sizeof(int) * procs_no);
-					for(i2 = 0; i2 < procs_no; i2++) {
-						ctxd->index[i2] = -1;
-					}
-				} else {
-					ctxd = pkg_malloc(sizeof(pkcs11_context_t));
-					memset(ctxd, 0, sizeof(pkcs11_context_t));
-				}
+				ctxd = pkg_malloc(sizeof(pkcs11_context_t));
+				memset(ctxd, 0, sizeof(pkcs11_context_t));
 				if(ctxd == NULL) {
 					ERR("%s: Cannot allocate memory for PKCS#11 context\n",
 							tls_domain_str(d));

--- a/src/modules/tls_wolfssl/tls_init.c
+++ b/src/modules/tls_wolfssl/tls_init.c
@@ -371,16 +371,8 @@ int tls_pre_init(void)
 	mf = NULL;
 	rf = NULL;
 	ff = NULL;
-	if(ksr_tcp_main_threads == 0
-			&& wolfSSL_SetAllocators(ser_malloc, ser_free, ser_realloc)) {
-		LM_ERR("Unable to set the memory allocation functions\n");
-		// CRYPTO_get_mem_functions(&mf, &rf, &ff);
-		LM_ERR("libssl current mem functions - m: %p r: %p f: %p\n", mf, rf,
-				ff);
-		LM_ERR("module mem functions - m: %p r: %p f: %p\n", ser_malloc,
-				ser_realloc, ser_free);
-		LM_ERR("Be sure tls module is loaded before any other module using"
-			   " libssl (can be loaded first to be safe)\n");
+	if(ksr_tcp_main_threads == 0) {
+		LM_ERR("tls_wolfssl requires tcp_main_threads = 1\n");
 		return -1;
 	}
 	LM_DBG("updated memory functions - malloc: %p realloc: %p free: %p\n",

--- a/src/modules/tls_wolfssl/tls_rpc.c
+++ b/src/modules/tls_wolfssl/tls_rpc.c
@@ -42,7 +42,6 @@
 #include "tls_rpc.h"
 #include "tls_cfg.h"
 
-extern int ksr_tcp_main_threads;
 static const char *tls_reload_doc[2] = {"Reload TLS configuration file", 0};
 
 static int tls_reload_do(str *config_file, char *errmsg, int errmsg_size)
@@ -201,21 +200,8 @@ static void tls_reload(rpc_t *rpc, void *ctx)
 		return;
 	}
 
-	if(ksr_tcp_main_threads > 0) {
-		/* SSL_CTX owned by PROC_TCP_MAIN — use client stub */
-		LM_INFO("tcp_main_threads=%d: proxying tls.reload to"
-				" PROC_TCP_MAIN\n",
-				ksr_tcp_main_threads);
-		tls_reload_mt(rpc, ctx, &config_file);
-		return;
-	}
-
-	/* tcp_main_threads == 0: execute locally (in-process server) */
-	if(tls_reload_do(&config_file, errmsg, sizeof(errmsg)) < 0) {
-		rpc->fault(ctx, 500, errmsg);
-		return;
-	}
-	rpc->rpl_printf(ctx, "Ok. TLS configuration reloaded.");
+	/* SSL_CTX owned by PROC_TCP_MAIN — use client stub */
+	tls_reload_mt(rpc, ctx, &config_file);
 }
 
 

--- a/src/modules/tls_wolfssl/tls_server.c
+++ b/src/modules/tls_wolfssl/tls_server.c
@@ -779,10 +779,10 @@ void tls_h_tcpconn_clean_f(struct tcp_connection *c)
 {
 	/* At shutdown in MT mode, PROC_TCP_MAIN is already dead and the OS
          * reclaims all memory. Avoid touching its heap entirely. */
-	if(_ksr_is_main && ksr_tcp_main_threads != 0)
+	if(_ksr_is_main)
 		return;
 
-	if(ksr_tcp_main_threads != 0 && !is_tcp_main() && !_ksr_is_main) {
+	if(!is_tcp_main() && !_ksr_is_main) {
 		int dsize = 0;
 		tcpx_task_t *ptask = NULL;
 		tcpx_task_result_t *rtask = NULL;
@@ -1371,11 +1371,7 @@ int tls_h_encode_f(struct tcp_connection *c, const char **pbuf,
 		unsigned int *plen, const char **rest_buf, unsigned int *rest_len,
 		snd_flags_t *send_flags)
 {
-	if(ksr_tcp_main_threads == 0) {
-		return tls_h_encode_mp_f(c, pbuf, plen, rest_buf, rest_len, send_flags);
-	} else {
-		return tls_h_encode_mt_f(c, pbuf, plen, rest_buf, rest_len, send_flags);
-	}
+	return tls_h_encode_mt_f(c, pbuf, plen, rest_buf, rest_len, send_flags);
 }
 
 
@@ -1886,11 +1882,7 @@ int tls_h_read_mt_f(struct tcp_connection *c, rd_conn_flags_t *flags)
 
 int tls_h_read_f(struct tcp_connection *c, rd_conn_flags_t *flags)
 {
-	if(ksr_tcp_main_threads == 0) {
-		return tls_h_read_mp_f(c, flags);
-	} else {
-		return tls_h_read_mt_f(c, flags);
-	}
+	return tls_h_read_mt_f(c, flags);
 }
 
 static int _tls_evrt_connection_out = -1; /* default disabled */

--- a/src/modules/tls_wolfssl/tls_wolfssl_mod.c
+++ b/src/modules/tls_wolfssl/tls_wolfssl_mod.c
@@ -397,20 +397,15 @@ static int mod_child(int rank)
 	 * the exact process number and before any other process starts*/
 	wolfssl_child_rank = rank;
 
-	if(rank == PROC_INIT && ksr_tcp_main_threads == 0) {
-		return mod_child_hook(rank);
-	}
-	if(rank == PROC_TCP_MAIN && ksr_tcp_main_threads > 0) {
+	if(rank == PROC_TCP_MAIN) {
 		if(mod_child_hook(rank) < 0) {
 			LM_ERR("failed to fix TLS configuration in TCP main thread\n");
 			return -1;
 		}
-		// fall-through to PKCS#11
 	}
 
 
-	if((rank > 0 && ksr_tcp_main_threads == 0)
-			|| (rank == PROC_TCP_MAIN && ksr_tcp_main_threads > 0)) {
+	if(rank == PROC_TCP_MAIN) {
 		if(tls_load_pkcs11_keys(*tls_domains_cfg, &srv_defaults, &cli_defaults)
 				< 0) {
 			LM_ERR("failed to load PKCS#11 keys in child process\n");

--- a/src/modules/tls_wolfssl/wolfssl_pkcs11.c
+++ b/src/modules/tls_wolfssl/wolfssl_pkcs11.c
@@ -81,7 +81,6 @@ static pkcs11_token_t _pkcs11_tokens[PKCS11_MAX_DEVS];
 
 static pkcs11_device_t _pkcs11_devices[PKCS11_MAX_DEVS];
 extern _Thread_local int thread_etask_pidx;
-extern int ksr_tcp_main_threads;
 extern int wolfssl_child_rank;
 
 
@@ -286,15 +285,7 @@ int tls_pkcs11_open_token(WOLFSSL *ssl)
 		return -1;
 
 	int idx;
-	if(ksr_tcp_main_threads > 0) {
-		idx = ctxd->token_id;
-	} else {
-		idx = ctxd->index[process_no];
-		if(idx < 0) {
-			tls_pkcs11_set_key(ctx, ctxd->config_key, 0);
-		}
-		idx = ctxd->index[process_no];
-	}
+	idx = ctxd->token_id;
 
 
 	wolfSSL_use_PrivateKey_Label(ssl, ctxd->private_key, idx);
@@ -440,30 +431,16 @@ int tls_pkcs11_set_key(WOLFSSL_CTX *ctx, char *key, int check_key)
 	int devId = token_slot;
 	Pkcs11Token *token = &_pkcs11_devices[token_slot].tok;
 	pkcs11_context_t *ctxd = NULL;
-	if(ksr_tcp_main_threads > 0) {
-		ctxd = wolfSSL_CTX_get_ex_data(ctx, 0);
 
-		if(ctxd == NULL) {
-			LM_ERR("tls_pkcs11_set_key: ex data was not allocated!\n");
-			return -1;
-		}
-		ctxd->token_id = cur_token->token_id;
-		strncpy(ctxd->private_key, obj_name, sizeof(ctxd->private_key) - 1);
-		ctxd->private_key[sizeof(ctxd->private_key) - 1] = '\0';
-	} else if(ksr_tcp_main_threads == 0) {
-		ctxd = wolfSSL_CTX_get_ex_data(ctx, 0);
+	ctxd = wolfSSL_CTX_get_ex_data(ctx, 0);
 
-		if(ctxd == NULL) {
-			LM_ERR("tls_pkcs11_set_key: ex data was not allocated!\n");
-			return -1;
-		}
-		ctxd->index[process_no] = cur_token->token_id;
-		strncpy(ctxd->private_key, obj_name, sizeof(ctxd->private_key) - 1);
-		ctxd->private_key[sizeof(ctxd->private_key) - 1] = '\0';
-
-		LM_INFO("[%d] Storing WOLFSSL_CTX*[%p] key data: devId[%d][%d]\n",
-				wolfssl_child_rank, ctx, cur_token->token_id, process_no);
+	if(ctxd == NULL) {
+		LM_ERR("tls_pkcs11_set_key: ex data was not allocated!\n");
+		return -1;
 	}
+	ctxd->token_id = cur_token->token_id;
+	strncpy(ctxd->private_key, obj_name, sizeof(ctxd->private_key) - 1);
+	ctxd->private_key[sizeof(ctxd->private_key) - 1] = '\0';
 
 	if(wc_CryptoCb_RegisterDevice(devId, my_FilterPk, token) != 0) {
 		LM_ERR("pkcs11: failed to register runtime devId=%d token='%s'\n", 0,


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
In this PR make the tls_wolfssl module MT-mode only (i.e. support only tcp_main_threads = 1). In other words — all wolfSSL functions are executed in PROC_TCP_MAIN via use of tcp_mtops callbacks.

The goal is to simplify and future-proof the code and remove dependency on use of shared memory or pthreads shims.

For the future,  this module can be used as a model if users want other OpenSSL(1.1.1)-like  stacks like AWS-LC (chosen by HAProxy for its high-performance builds). These OpenSSL(1.1.1) look-alikes do not support  shared memory.