### PR TITLE
Add dmq_peer_id modparams

### DIFF
--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -117,6 +117,7 @@ int dlg_noack_timeout = 60;
 int dlg_end_timeout = 300;
 
 int dlg_enable_dmq = 0;
+str dlg_dmq_peer_id = str_init("dialog");
 
 int dlg_event_rt[DLG_EVENTRT_MAX];
 str dlg_event_callback = STR_NULL;
@@ -388,6 +389,7 @@ static param_export_t mod_params[]={
 	{ "dlg_ctxiuid_mode",      PARAM_INT, &dlg_ctxiuid_mode         },
 	{ "debug_variables",       PARAM_INT, &debug_variables_list     },
 	{ "dlg_mode",              PARAM_INT, &dlg_process_mode         },
+	{ "dmq_peer_id",           PARAM_STR, &dlg_dmq_peer_id          },
 
 	{ 0,0,0 }
 };

--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -38,6 +38,7 @@ int dmq_send_all_dlgs(dmq_node_t *dmq_node);
 int dlg_dmq_request_sync(dmq_node_t *dmq_node);
 
 extern int dlg_enable_stats;
+extern str dlg_dmq_peer_id;
 
 /**
 * @brief add notification peer
@@ -56,10 +57,8 @@ int dlg_dmq_initialize()
 
 	not_peer.callback = dlg_dmq_handle_msg;
 	not_peer.init_callback = dlg_dmq_request_sync;
-	not_peer.description.s = "dialog";
-	not_peer.description.len = 6;
-	not_peer.peer_id.s = "dialog";
-	not_peer.peer_id.len = 6;
+	not_peer.peer_id = dlg_dmq_peer_id;
+	not_peer.description = dlg_dmq_peer_id;
 	dlg_dmq_peer = dlg_dmqb.register_dmq_peer(&not_peer);
 	if(!dlg_dmq_peer) {
 		LM_ERR("error in register_dmq_peer\n");

--- a/src/modules/dialog/doc/dialog_admin.xml
+++ b/src/modules/dialog/doc/dialog_admin.xml
@@ -1748,6 +1748,27 @@ modparam("dialog", "dlg_mode", 1)
 </programlisting>
 		</example>
 	</section>
+	<section id="dialog.p.dmq_peer_id">
+		<title><varname>dmq_peer_id</varname> (string)</title>
+		<para>
+			The DMQ peer identifier for dialog replication. This allows
+			customizing the peer name used in DMQ communication, which can be useful
+			to avoid compatibility conflicts, and for a better partitioning.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>dialog</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>dmq_peer_id</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dialog", "dmq_peer_id", "dialog_6.1.1")
+...
+</programlisting>
+		</example>
+	</section>
 
 	</section>
 

--- a/src/modules/dmq/message.c
+++ b/src/modules/dmq/message.c
@@ -38,7 +38,7 @@
 str dmq_200_rpl = str_init("OK");
 str dmq_400_rpl = str_init("Bad request");
 str dmq_500_rpl = str_init("Server Internal Error");
-str dmq_404_rpl = str_init("User Not Found");
+str dmq_404_rpl = str_init("Not Found Peer ID");
 
 /**
  * @brief set the body of a response

--- a/src/modules/dmq_usrloc/dmq_usrloc.c
+++ b/src/modules/dmq_usrloc/dmq_usrloc.c
@@ -43,6 +43,7 @@ int _dmq_usrloc_batch_msg_contacts = 1;
 int _dmq_usrloc_batch_msg_size = 60000;
 int _dmq_usrloc_batch_usleep = 0;
 str _dmq_usrloc_domain = str_init("location");
+str _dmq_usrloc_peer_id = str_init("usrloc");
 int _dmq_usrloc_delete = 1;
 int _dmq_usrloc_delete_expired = 0;
 
@@ -63,6 +64,7 @@ static param_export_t params[] = {
 	{"usrloc_domain", PARAM_STR, &_dmq_usrloc_domain},
 	{"usrloc_delete", PARAM_INT, &_dmq_usrloc_delete},
 	{"usrloc_delete_expired", PARAM_INT, &_dmq_usrloc_delete_expired},
+	{"dmq_peer_id", PARAM_STR, &_dmq_usrloc_peer_id},
 	{0, 0, 0}
 };
 

--- a/src/modules/dmq_usrloc/doc/dmq_usrloc_admin.xml
+++ b/src/modules/dmq_usrloc/doc/dmq_usrloc_admin.xml
@@ -368,6 +368,27 @@ modparam("dmq_usrloc", "usrloc_delete_expired", 1)
 </programlisting>
 		</example>
 	</section>
+	<section id="usrloc_dmq.p.dmq_peer_id">
+		<title><varname>dmq_peer_id</varname> (string)</title>
+		<para>
+			The DMQ peer identifier for usrloc replication. This allows
+			customizing the peer name used in DMQ communication, which can be useful
+			to avoid compatibility conflicts, and for a better partitioning.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>usrloc</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>dmq_peer_id</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dmq_usrloc", "dmq_peer_id", "usrloc_6.1.1")
+...
+</programlisting>
+		</example>
+	</section>
 	</section>
 
 </chapter>

--- a/src/modules/dmq_usrloc/usrloc_sync.c
+++ b/src/modules/dmq_usrloc/usrloc_sync.c
@@ -65,6 +65,7 @@ extern int _dmq_usrloc_batch_msg_size;
 extern int _dmq_usrloc_batch_size;
 extern int _dmq_usrloc_batch_usleep;
 extern str _dmq_usrloc_domain;
+extern str _dmq_usrloc_peer_id;
 extern int _dmq_usrloc_delete;
 extern int _dmq_usrloc_delete_expired;
 
@@ -303,10 +304,8 @@ int usrloc_dmq_initialize()
 	}
 	not_peer.callback = usrloc_dmq_handle_msg;
 	not_peer.init_callback = usrloc_dmq_request_sync;
-	not_peer.description.s = "usrloc";
-	not_peer.description.len = 6;
-	not_peer.peer_id.s = "usrloc";
-	not_peer.peer_id.len = 6;
+	not_peer.peer_id = _dmq_usrloc_peer_id;
+	not_peer.description = _dmq_usrloc_peer_id;
 	usrloc_dmq_peer = usrloc_dmqb.register_dmq_peer(&not_peer);
 	if(!usrloc_dmq_peer) {
 		LM_ERR("error in register_dmq_peer\n");

--- a/src/modules/htable/doc/htable_admin.xml
+++ b/src/modules/htable/doc/htable_admin.xml
@@ -807,6 +807,27 @@ modparam("htable", "event_callback_mode", 1)
 </programlisting>
 		</example>
 	</section>
+	<section id="htable.p.dmq_peer_id">
+		<title><varname>dmq_peer_id</varname> (string)</title>
+		<para>
+			The DMQ peer identifier for htable replication. This allows
+			customizing the peer name used in DMQ communication, which can be useful
+			to avoid compatibility conflicts, and for a better partitioning.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>htable</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>dmq_peer_id</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("htable", "dmq_peer_id", "htable_6.1.1")
+...
+</programlisting>
+		</example>
+	</section>
 	</section>
 	<section>
 	<title>Functions</title>

--- a/src/modules/htable/ht_dmq.c
+++ b/src/modules/htable/ht_dmq.c
@@ -53,6 +53,7 @@ static int dmq_cell_group_empty_size = 12; // {"cells":[]}
 static int dmq_cell_group_max_size = 60000;
 static ht_dmq_jdoc_cell_group_t ht_dmq_jdoc_cell_group;
 extern int ht_dmq_init_sync;
+extern str ht_dmq_peer_id;
 
 dmq_api_t ht_dmqb;
 dmq_peer_t *ht_dmq_peer = NULL;
@@ -220,10 +221,8 @@ int ht_dmq_initialize()
 	not_peer.callback = ht_dmq_handle_msg;
 	not_peer.init_callback =
 			(ht_dmq_init_sync ? ht_dmq_request_sync_all : NULL);
-	not_peer.description.s = "htable";
-	not_peer.description.len = 6;
-	not_peer.peer_id.s = "htable";
-	not_peer.peer_id.len = 6;
+	not_peer.peer_id = ht_dmq_peer_id;
+	not_peer.description = ht_dmq_peer_id;
 	ht_dmq_peer = ht_dmqb.register_dmq_peer(&not_peer);
 	if(!ht_dmq_peer) {
 		LM_ERR("error in register_dmq_peer\n");

--- a/src/modules/htable/htable.c
+++ b/src/modules/htable/htable.c
@@ -55,6 +55,7 @@ int ht_timer_interval = 20;
 int ht_db_expires_flag = 0;
 int ht_enable_dmq = 0;
 int ht_dmq_init_sync = 0;
+str ht_dmq_peer_id = str_init("htable");
 int ht_timer_procs = 0;
 static int ht_event_callback_mode = 0;
 
@@ -194,6 +195,7 @@ static param_export_t params[] = {
 	{"timer_procs", PARAM_INT, &ht_timer_procs},
 	{"event_callback", PARAM_STR, &ht_event_callback},
 	{"event_callback_mode", PARAM_INT, &ht_event_callback_mode},
+	{"dmq_peer_id", PARAM_STR, &ht_dmq_peer_id},
 	{0, 0, 0}
 };
 

--- a/src/modules/presence/doc/presence_admin.xml
+++ b/src/modules/presence/doc/presence_admin.xml
@@ -1143,6 +1143,28 @@ modparam("presence", "subs_respond_200", 0)
 	</example>
 </section>
 
+<section id="presence.p.dmq_peer_id">
+	<title><varname>dmq_peer_id</varname> (string)</title>
+	<para>
+		The DMQ peer identifier for presence replication. This allows
+		customizing the peer name used in DMQ communication, which can be useful
+		to avoid compatibility conflicts, and for a better partitioning.
+	</para>
+	<para>
+	<emphasis>
+		Default value is <quote>presence</quote>.
+	</emphasis>
+	</para>
+	<example>
+		<title>Set <varname>dmq_peer_id</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("presence", "dmq_peer_id", "presence_6.1.1")
+...
+</programlisting>
+	</example>
+</section>
+
 </section>
 
 <section>

--- a/src/modules/presence/presence.c
+++ b/src/modules/presence/presence.c
@@ -171,6 +171,7 @@ str pres_xavp_cfg = {0};
 int pres_retrieve_order = 0;
 str pres_retrieve_order_by = str_init("priority");
 int pres_enable_dmq = 0;
+str pres_dmq_peer_id = str_init("presence");
 int pres_enable_pres_dmq = 1;
 int pres_enable_pres_sync_dmq = 1;
 int pres_enable_subs_dmq = 0;
@@ -263,6 +264,7 @@ static param_export_t params[]={
 	{ "delete_same_subs",       PARAM_INT, &pres_delete_same_subs},
 	{ "timer_mode",             PARAM_INT, &pres_timer_mode},
 	{ "subs_respond_200",       PARAM_INT, &pres_subs_respond_200},
+	{ "dmq_peer_id",            PARAM_STR, &pres_dmq_peer_id},
 
 	{0,0,0}
 };

--- a/src/modules/presence/presence_dmq.c
+++ b/src/modules/presence/presence_dmq.c
@@ -34,6 +34,8 @@ static int *pres_dmq_recv = 0;
 dmq_api_t pres_dmqb;
 dmq_peer_t *pres_dmq_peer = NULL;
 
+extern str pres_dmq_peer_id;
+
 int pres_dmq_send_all_presentities(dmq_node_t *dmq_node);
 int pres_dmq_send_all_subscriptions(dmq_node_t *dmq_node);
 int pres_dmq_request_sync(dmq_node_t *dmq_node);
@@ -55,10 +57,8 @@ int pres_dmq_initialize()
 
 	not_peer.callback = pres_dmq_handle_msg;
 	not_peer.init_callback = pres_dmq_request_sync;
-	not_peer.description.s = "presence";
-	not_peer.description.len = 8;
-	not_peer.peer_id.s = "presence";
-	not_peer.peer_id.len = 8;
+	not_peer.peer_id = pres_dmq_peer_id;
+	not_peer.description = pres_dmq_peer_id;
 	pres_dmq_peer = pres_dmqb.register_dmq_peer(&not_peer);
 	if(!pres_dmq_peer) {
 		LM_ERR("error in register_dmq_peer\n");

--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -2510,6 +2510,28 @@ modparam("rtpengine", "enable_dmq", 1)
 	</para>
 </section>
 
+<section id="rtpengine.p.dmq_peer_id">
+	<title><varname>dmq_peer_id</varname> (string)</title>
+	<para>
+		The DMQ peer identifier for rtpengine replication. This allows
+		customizing the peer name used in DMQ communication, which can be useful
+		to avoid compatibility conflicts, and for a better partitioning.
+	</para>
+	<para>
+	<emphasis>
+		Default value is <quote>rtpengine</quote>.
+	</emphasis>
+	</para>
+	<example>
+	<title>Set <varname>dmq_peer_id</varname> parameter</title>
+	<programlisting format="linespecific">
+...
+modparam("rtpengine", "dmq_peer_id", "rtpengine_6.1.1")
+...
+</programlisting>
+	</example>
+</section>
+
 	<section>
 	<title>Functions</title>
 	<section id="rtpengine.f.set_rtpengine_set">

--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -426,6 +426,7 @@ int dtmf_event_rt = -1; /* default disabled */
 static int rtpengine_ping_mode = 1;
 static int rtpengine_ping_interval = 60;
 static int rtpengine_enable_dmq = 0;
+str rtpengine_dmq_peer_id = str_init("rtpengine");
 
 /* clang-format off */
 typedef struct rtpp_set_link {
@@ -700,6 +701,7 @@ static param_export_t params[] = {
 			&side_B_mos_stats.average.samples_param},
 
 	{"wsapi", PARAM_STR, &_rtpe_wsapi},
+	{"dmq_peer_id", PARAM_STR, &rtpengine_dmq_peer_id},
 
 	{0, 0, 0}
 };

--- a/src/modules/rtpengine/rtpengine_dmq.c
+++ b/src/modules/rtpengine/rtpengine_dmq.c
@@ -31,6 +31,8 @@ static str rtpengine_dmq_500_rpl = str_init("Server Internal Error");
 dmq_api_t rtpengine_dmqb;
 dmq_peer_t *rtpengine_dmq_peer = NULL;
 
+extern str rtpengine_dmq_peer_id;
+
 int rtpengine_dmq_request_sync(dmq_node_t *node);
 
 /**
@@ -50,10 +52,8 @@ int rtpengine_dmq_init()
 
 	not_peer.callback = rtpengine_dmq_handle_msg;
 	not_peer.init_callback = rtpengine_dmq_request_sync;
-	not_peer.description.s = "rtpengine";
-	not_peer.description.len = 9;
-	not_peer.peer_id.s = "rtpengine";
-	not_peer.peer_id.len = 9;
+	not_peer.peer_id = rtpengine_dmq_peer_id;
+	not_peer.description = rtpengine_dmq_peer_id;
 	rtpengine_dmq_peer = rtpengine_dmqb.register_dmq_peer(&not_peer);
 	if(!rtpengine_dmq_peer) {
 		LM_ERR("error in register_dmq_peer\n");


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Add new dmq_peer_id modparams for modules that use DMQ.
Useful when one wants to add new kamailio node in existing DMQ cluster, but not sync with (some) old kamailio node peers.