### PR TITLE
sipt: use the actual calculated encoded length

### DIFF
--- a/src/modules/sipt/ss7_parser.c
+++ b/src/modules/sipt/ss7_parser.c
@@ -74,13 +74,6 @@ static int isup_put_number(
 {
 	int i = 0;
 	int numlen = strlen(src);
-	int encoded_len = (numlen + 1) / 2;
-
-	if(encoded_len > dest_len) {
-		LM_ERR("phone number too long (%d chars, max %d bytes)\n", numlen,
-				dest_len);
-		return -1;
-	}
 
 	if(numlen % 2) {
 		*oddeven = 1;
@@ -88,6 +81,12 @@ static int isup_put_number(
 	} else {
 		*oddeven = 0;
 		*len = numlen / 2;
+	}
+
+	if(*len > dest_len) {
+		LM_ERR("phone number too long (%d chars, max %d bytes)\n", numlen,
+				dest_len);
+		return -1;
 	}
 
 
@@ -100,7 +99,7 @@ static int isup_put_number(
 		i++;
 	}
 
-	return encoded_len;
+	return 1;
 }
 
 static int encode_called_party(char *number, unsigned char *flags, int nai,
@@ -772,6 +771,8 @@ int isup_update_calling(struct sdp_mangler *mangle, char *origin, int nai,
 				case ISUP_PARM_CALLING_PARTY_NUM:
 					res2 = encode_calling_party(origin, nai, presentation,
 							screening, &new_party[1], 255 - 1);
+					if(res2 < 0)
+						return -1;
 					new_party[0] = (char)res2;
 					replace_body_segment(mangle, offset + 1,
 							(int)buf[offset + 1] + 1, new_party, res2 + 1);
@@ -793,6 +794,8 @@ int isup_update_calling(struct sdp_mangler *mangle, char *origin, int nai,
 			new_party[0] = ISUP_PARM_CALLING_PARTY_NUM;
 			res = encode_calling_party(origin, nai, presentation, screening,
 					new_party + 2, 255 - 2);
+			if(res < 0)
+				return -1;
 			new_party[1] = (char)res;
 
 			add_body_segment(mangle, offset, new_party, res + 2);
@@ -847,6 +850,8 @@ int isup_update_forwarding(struct sdp_mangler *mangle, char *forwardn, int nai,
 				case ISUP_PARM_REDIRECTING_NUMBER:
 					res2 = encode_forwarding_number(
 							forwardn, nai, &new_party[1], 255 - 1);
+					if(res2 < 0)
+						return -1;
 					new_party[0] = (char)res2;
 					replace_body_segment(mangle, offset + 1,
 							(int)buf[offset + 1] + 1, new_party, res2 + 1);
@@ -854,6 +859,8 @@ int isup_update_forwarding(struct sdp_mangler *mangle, char *forwardn, int nai,
 				case ISUP_PARM_ORIGINAL_CALLED_NUM:
 					res2 = encode_forwarding_number(
 							forwardn, nai, &new_party[1], 255 - 1);
+					if(res2 < 0)
+						return -1;
 					new_party[0] = (char)res2;
 					replace_body_segment(mangle, offset + 1,
 							(int)buf[offset + 1] + 1, new_party, res2 + 1);


### PR DESCRIPTION


#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [*] Commit message has the format required by CONTRIBUTING guide
- [*] Commits are split per component (core, individual modules, libs, utils, ...)
- [*] Each component has a single commit (if not, squash them into one commit)
- [*] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [*] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [*] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Description
removed a redundant & less accurate length calculation
