### PR TITLE
core: add support for pre-processor undefines

### DIFF
--- a/src/core/cfg.lex
+++ b/src/core/cfg.lex
@@ -66,6 +66,8 @@
 	#define IFDEF_SKIP_S            15
 	#define DEFINE_DATA_S           16
 	#define EVRT_NAME_S             17
+	#define UNDEF_S                 18
+	#define UNDEF_EOL_S             19
 
 	#define STR_BUF_ALLOC_UNIT	128
 	struct str_buf{
@@ -119,6 +121,21 @@
 		struct sr_yy_fname *next;
 	} *sr_yy_fname_list = 0;
 
+    /* define/ifdef support */
+    #define MAX_DEFINES    512
+    static ksr_ppdefine_t pp_defines[MAX_DEFINES];
+    static int pp_num_defines = 0;
+    static int pp_define_type = 0;
+    static int pp_define_index = -1;
+
+    /* pp_ifdef_stack[i] is 1 if the ifdef test at depth i is either
+     * ifdef(defined), ifndef(undefined), or the opposite of these
+     * two, but in an else branch
+     */
+    #define MAX_IFDEFS    512
+    static int pp_ifdef_stack[MAX_IFDEFS];
+    static int pp_sptr = 0; /* stack pointer */
+
 	static int  pp_ifdef_type(int pos);
 	static void pp_ifdef_var(int len, const char * text);
 	static void pp_ifdef();
@@ -132,8 +149,8 @@
 /* start conditions */
 %x STRING1 STRING2 STR_BETWEEN COMMENT COMMENT_LN ATTR SELECT AVP_PVAR PVAR_P
 %x PVARID INCLF IMPTF EVRTNAME CFGPRINTMODE CFGPRINTLOADMOD DEFENV_ID DEFENVS_ID
-%x TRYDEFENV_ID TRYDEFENVS_ID LINECOMMENT DEFINE_ID DEFINE_EOL DEFINE_DATA
-%x IFDEF_ID IFDEF_EOL IFDEF_SKIP IFEXP_STM
+%x TRYDEFENV_ID TRYDEFENVS_ID LINECOMMENT DEFINE_ID UNDEF_ID DEFINE_EOL
+%x UNDEF_EOL DEFINE_DATA IFDEF_ID IFDEF_EOL IFDEF_SKIP IFEXP_STM
 
 /* config script types : #!SER  or #!KAMAILIO or #!MAX_COMPAT */
 SER_CFG			SER
@@ -603,6 +620,8 @@ IFEXP        ifexp
 ENDIF        endif
 TRYDEF       "trydefine"|"trydef"
 REDEF        "redefine"|"redef"
+UNDEF        "undefine"|"undef"
+TRYUNDEF     "tryundefine"|"tryundef"
 DEFEXP       defexp
 DEFEXPS      defexps
 DEFENV       defenv
@@ -1397,6 +1416,14 @@ IMPORTFILE      "import_file"
 											ksr_cfg_print_part(yytext);
 											pp_define_set_type(KSR_PPDEF_REDEF);
 											state = DEFINE_S; BEGIN(DEFINE_ID); }
+<INITIAL,CFGPRINTMODE>{PREP_START}{UNDEF}{EAT_ABLE}+	{	count();
+											ksr_cfg_print_part(yytext);
+											pp_define_set_type(KSR_PPDEF_UNDEF);
+											state = UNDEF_S; BEGIN(UNDEF_ID); }
+<INITIAL,CFGPRINTMODE>{PREP_START}{TRYUNDEF}{EAT_ABLE}+	{	count();
+											ksr_cfg_print_part(yytext);
+											pp_define_set_type(KSR_PPDEF_TRYUNDEF);
+											state = UNDEF_S; BEGIN(UNDEF_ID); }
 <INITIAL,CFGPRINTMODE>{PREP_START}{DEFEXP}{EAT_ABLE}+	{	count();
 											ksr_cfg_print_part(yytext);
 											pp_define_set_type(KSR_PPDEF_DEFEXP);
@@ -1437,6 +1464,31 @@ IMPORTFILE      "import_file"
 <DEFINE_DATA>.          {	count();
 							ksr_cfg_print_part(yytext);
 							addstr(&s_buf, yytext, yyleng); }
+<UNDEF_ID>{ID}{MINUS}           {	count();
+									ksr_cfg_print_part(yytext);
+									LM_CRIT(
+										"error at %s line %d: '-' not allowed\n",
+										(finame)?finame:"cfg", line);
+									ksr_exit(-1);
+								}
+<UNDEF_ID>{ID}                  {	count();
+									ksr_cfg_print_part(yytext);
+									if (pp_undefine(yyleng, yytext)) return 1;
+									state = UNDEF_EOL_S; BEGIN(UNDEF_EOL); }
+<UNDEF_EOL>{EAT_ABLE}           {	count(); ksr_cfg_print_part(yytext); }
+<UNDEF_EOL>{CR}					{	count();
+									ksr_cfg_print_part(yytext);
+									state = INITIAL_S;
+									ksr_cfg_print_initial_state();
+								}
+<UNDEF_EOL>.					{	count();
+									ksr_cfg_print_part(yytext);
+									LM_CRIT(
+										"error at %s line %d: unexpected character"
+										" after ID in undefine\n",
+										(finame)?finame:"cfg", line);
+									ksr_exit(-1);
+								}
 
 <INITIAL>{PREP_START}{SUBST}	{ count();  return SUBST;}
 <INITIAL>{PREP_START}{SUBSTDEF}	{ count();  return SUBSTDEF;}
@@ -2061,22 +2113,6 @@ static int sr_pop_yy_state()
 	return 0;
 }
 
-/* define/ifdef support */
-
-#define MAX_DEFINES    512
-static ksr_ppdefine_t pp_defines[MAX_DEFINES];
-static int pp_num_defines = 0;
-static int pp_define_type = 0;
-static int pp_define_index = -1;
-
-/* pp_ifdef_stack[i] is 1 if the ifdef test at depth i is either
- * ifdef(defined), ifndef(undefined), or the opposite of these
- * two, but in an else branch
- */
-#define MAX_IFDEFS    512
-static int pp_ifdef_stack[MAX_IFDEFS];
-static int pp_sptr = 0; /* stack pointer */
-
 str* pp_get_define_name(int idx)
 {
 	if(idx<0 || idx>=pp_num_defines)
@@ -2321,6 +2357,50 @@ str *pp_define_get(int len, const char *text)
 		}
 	}
 	return NULL;
+}
+
+int pp_undefine(int len, const char *text)
+{
+	int ppos;
+	int i;
+
+	if(len <= 0 || text == NULL) {
+		LM_ERR("invalid parameters\n");
+		return -1;
+	}
+
+	ppos = pp_lookup(len, text);
+	if(ppos < 0) {
+		if(pp_define_type == KSR_PPDEF_TRYUNDEF) {
+			LM_DBG("ID [%.*s] not defined - ignoring\n", len, text);
+			return 0;
+		} else {
+			LM_CRIT("ID [%.*s] not defined, cannot undefine\n", len, text);
+			return -1;
+		}
+	}
+
+	LM_DBG("undefining ID: %.*s\n", len, text);
+	if(pp_defines[ppos].name.s) {
+		pkg_free(pp_defines[ppos].name.s);
+		pp_defines[ppos].name.len = 0;
+		pp_defines[ppos].name.s = NULL;
+	}
+	if(pp_defines[ppos].value.s) {
+		pkg_free(pp_defines[ppos].value.s);
+		pp_defines[ppos].value.len = 0;
+		pp_defines[ppos].value.s = NULL;
+	}
+
+	/*
+	 * shift remaining elements to maintain contiguous array O(n)
+	 * TODO: consider refactoring pp_defines as a hash table
+	 */
+	for(i = ppos; i < pp_num_defines - 1; i++) {
+		pp_defines[i] = pp_defines[i + 1];
+	}
+	pp_num_defines--;
+	return 0;
 }
 
 static int pp_ifdef_type(int type)

--- a/src/core/ppcfg.h
+++ b/src/core/ppcfg.h
@@ -34,8 +34,10 @@
 #define KSR_PPDEF_DEFINE 0
 #define KSR_PPDEF_TRYDEF 1
 #define KSR_PPDEF_REDEF 2
-#define KSR_PPDEF_DEFEXP 3
-#define KSR_PPDEF_DEFEXPS 4
+#define KSR_PPDEF_UNDEF 3
+#define KSR_PPDEF_TRYUNDEF 4
+#define KSR_PPDEF_DEFEXP 5
+#define KSR_PPDEF_DEFEXPS 6
 
 typedef struct ksr_ppdefine
 {
@@ -59,6 +61,8 @@ int pp_define_set(int len, char *text, int mode);
 int pp_define_set_type(int type);
 str *pp_define_get(int len, const char *text);
 int pp_define_env(const char *text, int len, int qmode, int vmode);
+
+int pp_undefine(int len, const char *text);
 
 void pp_ifdef_level_update(int val);
 int pp_ifdef_level_check(void);


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Adds support for undefining pre-processor IDs.  

New directives:
- `#!undefine <ID>`
- `#!tryundefine <ID>`

Useful for testing scenarios or local override configs.