### PR TITLE
Last write win checks

### DIFF
--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -3565,6 +3565,7 @@ static void rpc_dlg_set_state(rpc_t *rpc, void *c)
 	/* setting new state for this dialog */
 	ostate = dlg->state;
 	dlg->state = sval;
+	dlg->last_modified = (unsigned int)time(NULL);
 
 	/* updates for terminated dialogs */
 	if(ostate == DLG_STATE_CONFIRMED && sval == DLG_STATE_DELETED) {

--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -25,6 +25,7 @@
 #include "dlg_hash.h"
 #include "dlg_profile.h"
 #include "dlg_var.h"
+#include <time.h>
 
 static str dlg_dmq_content_type = str_init("application/json");
 static str dmq_200_rpl = str_init("OK");
@@ -115,6 +116,7 @@ int dlg_dmq_handle_msg(
 		req_uri = {0, 0};
 	unsigned int init_ts = 0, start_ts = 0, lifetime = 0;
 	unsigned int state = 1;
+	unsigned int lm = 0;
 	srjson_t *vj;
 	int newdlg = 0;
 	dlg_entry_t *d_entry = NULL;
@@ -213,8 +215,10 @@ int dlg_dmq_handle_msg(
 		} else if(strcmp(it->string, "req_uri") == 0) {
 			req_uri.s = it->valuestring;
 			req_uri.len = strlen(req_uri.s);
+		} else if(strcmp(it->string, "last_modified") == 0) {
+			lm = SRJSON_GET_UINT(it);
 		} else {
-			LM_ERR("unrecognized field in json object\n");
+			LM_WARN("unrecognized field in json object: %s\n", it->string);
 		}
 	}
 
@@ -223,6 +227,17 @@ int dlg_dmq_handle_msg(
 		LM_DBG("found dialog [%u:%u] at %p\n", iuid.h_entry, iuid.h_id, dlg);
 		d_entry = &(d_table->entries[dlg->h_entry]);
 		unref++;
+
+		if(lm > 0 && dlg->last_modified > lm && action != DLG_DMQ_SYNC) {
+			/* LWW: skip if local dialog is newer */
+			LM_DBG("LWW: skipping stale action %d for dlg [%u:%u] "
+				   "local=%u incoming=%u\n",
+					action, iuid.h_entry, iuid.h_id, dlg->last_modified, lm);
+			goto skip;
+		}
+		if(lm > 0 && lm > dlg->last_modified) {
+			dlg->last_modified = lm;
+		}
 	}
 
 	switch(action) {
@@ -253,6 +268,9 @@ int dlg_dmq_handle_msg(
 				/* prevent DB sync */
 				dlg->dflags &= ~(DLG_FLAG_NEW | DLG_FLAG_CHANGED);
 				dlg->iflags |= DLG_IFLAG_DMQ_SYNC;
+				if(lm > 0) {
+					dlg->last_modified = lm;
+				}
 				newdlg = 1;
 			} else {
 				/* remove existing profiles */
@@ -404,6 +422,7 @@ int dlg_dmq_handle_msg(
 		case DLG_DMQ_NONE:
 			break;
 	}
+skip:
 	if(dlg) {
 		if(unref) {
 			dlg_unref(dlg, unref);
@@ -519,6 +538,8 @@ int dlg_dmq_replicate_action(dlg_dmq_action_t action, dlg_cell_t *dlg,
 	srjson_AddNumberToObject(&jdoc, jdoc.root, "action", action);
 	srjson_AddNumberToObject(&jdoc, jdoc.root, "h_entry", dlg->h_entry);
 	srjson_AddNumberToObject(&jdoc, jdoc.root, "h_id", dlg->h_id);
+	srjson_AddNumberToObject(
+			&jdoc, jdoc.root, "last_modified", dlg->last_modified);
 
 	switch(action) {
 		case DLG_DMQ_UPDATE:

--- a/src/modules/dialog/dlg_handlers.c
+++ b/src/modules/dialog/dlg_handlers.c
@@ -599,7 +599,7 @@ static void dlg_onreply(struct cell *t, int type, struct tmcb_params *param)
 
 done:
 	if(dlg_enable_dmq && (dlg->iflags & DLG_IFLAG_DMQ_SYNC)
-			&& new_state > old_state) {
+			&& new_state >= old_state) {
 		dlg_dmq_replicate_action(DLG_DMQ_STATE, dlg, 0, 0);
 	}
 
@@ -1579,7 +1579,7 @@ void dlg_onroute(struct sip_msg *req, str *route_params, void *param)
 
 done:
 	if(dlg_enable_dmq && (dlg->iflags & DLG_IFLAG_DMQ_SYNC)
-			&& new_state > old_state) {
+			&& new_state >= old_state) {
 		dlg_dmq_replicate_action(DLG_DMQ_STATE, dlg, 0, 0);
 	}
 
@@ -1699,7 +1699,7 @@ void dlg_ontimeout(struct dlg_tl *tl)
 	}
 
 	if(dlg_enable_dmq && (dlg->iflags & DLG_IFLAG_DMQ_SYNC)
-			&& new_state > old_state) {
+			&& new_state >= old_state) {
 		dlg_dmq_replicate_action(DLG_DMQ_STATE, dlg, 0, 0);
 	}
 

--- a/src/modules/dialog/dlg_handlers.c
+++ b/src/modules/dialog/dlg_handlers.c
@@ -761,6 +761,8 @@ static void dlg_on_send(struct cell *t, int type, struct tmcb_params *param)
 	if(dlg == NULL)
 		return;
 
+	dlg->last_modified = (unsigned int)time(NULL);
+
 	/* sync over dmq */
 	if(dlg_enable_dmq) {
 		dlg_dmq_replicate_action(DLG_DMQ_UPDATE, dlg, 1, 0);

--- a/src/modules/dialog/dlg_hash.c
+++ b/src/modules/dialog/dlg_hash.c
@@ -478,6 +478,7 @@ struct dlg_cell *build_new_dlg(
 	memset(dlg, 0, len);
 	dlg->state = DLG_STATE_UNCONFIRMED;
 	dlg->init_ts = ksr_time_uint(NULL, NULL);
+	dlg->last_modified = (unsigned int)time(NULL);
 
 	dlg->h_entry = core_hash(callid, 0, d_table->size);
 	LM_DBG("new dialog on hash %u\n", dlg->h_entry);
@@ -1327,6 +1328,8 @@ void next_state_dlg(
 					dlg->tag[DLG_CALLEE_LEG].len, dlg->tag[DLG_CALLEE_LEG].s);
 	}
 	*new_state = dlg->state;
+
+	dlg->last_modified = (unsigned int)time(NULL);
 
 	/* remove the dialog from profiles when is not no longer active */
 	if(*new_state == DLG_STATE_DELETED && dlg->profile_links != NULL

--- a/src/modules/dialog/dlg_hash.h
+++ b/src/modules/dialog/dlg_hash.h
@@ -143,6 +143,7 @@ typedef struct dlg_cell
 	struct cell *t;				 /*!< Reference to Transaction of the INVITE */
 	unsigned int ka_src_counter; /*!< keepalive src (caller) counter */
 	unsigned int ka_dst_counter; /*!< keepalive dst (callee) counter */
+	unsigned int last_modified;	 /*!< LWW timestamp for DMQ sync */
 } dlg_cell_t;
 
 

--- a/src/modules/dmq_usrloc/usrloc_sync.c
+++ b/src/modules/dmq_usrloc/usrloc_sync.c
@@ -90,6 +90,18 @@ static int add_contact(str aor, ucontact_info_t *ci)
 		res = dmq_ul.get_urecord_by_ruid(
 				_d, dmq_ul.get_aorhash(&aor), &ci->ruid, &r, &c);
 		if(res == 0) {
+			/* LWW: skip update if local contact is newer */
+			if(ci->last_modified > 0 && c->last_modified > ci->last_modified) {
+				LM_DBG("LWW: skipping stale update for contact=[%.*s] "
+					   "ruid=[%.*s] "
+					   "local=%u incoming=%u\n",
+						c->c.len, c->c.s, c->ruid.len, c->ruid.s,
+						(unsigned int)c->last_modified,
+						(unsigned int)ci->last_modified);
+				dmq_ul.release_urecord(r);
+				dmq_ul.unlock_udomain(_d, &aor);
+				return 0;
+			}
 			LM_DBG("Found contact\n");
 			dmq_ul.update_ucontact(r, c, ci);
 			LM_DBG("Release record\n");
@@ -115,8 +127,18 @@ static int add_contact(str aor, ucontact_info_t *ci)
 			contact.len = ci->c->len;
 			dmq_ul.insert_ucontact(r, &contact, ci, &c);
 		} else if(res == 0) {
-			LM_DBG("Found contact\n");
-			dmq_ul.update_ucontact(r, c, ci);
+			/* LWW: skip update if local contact is newer */
+			if(ci->last_modified > 0 && c->last_modified > ci->last_modified) {
+				LM_DBG("LWW: skipping stale update for contact=[%.*s] "
+					   "ruid=[%.*s] "
+					   "local=%u incoming=%u\n",
+						c->c.len, c->c.s, c->ruid.len, c->ruid.s,
+						(unsigned int)c->last_modified,
+						(unsigned int)ci->last_modified);
+			} else {
+				LM_DBG("Found contact\n");
+				dmq_ul.update_ucontact(r, c, ci);
+			}
 		}
 	} else {
 		LM_DBG("'%.*s' Not found in usrloc\n", aor.len, ZSW(aor.s));
@@ -161,6 +183,17 @@ static int delete_contact(str aor, ucontact_info_t *ci)
 			!= 0) {
 		LM_DBG("AOR/Contact [%.*s] not found\n", aor.len, aor.s);
 		return -1;
+	}
+	/* LWW: skip delete if local contact is newer */
+	if(ci->last_modified > 0 && c->last_modified > ci->last_modified) {
+		LM_DBG("LWW: skipping stale delete for contact=[%.*s] ruid=[%.*s] "
+			   "local=%u incoming=%u\n",
+				c->c.len, c->c.s, c->ruid.len, c->ruid.s,
+				(unsigned int)c->last_modified,
+				(unsigned int)ci->last_modified);
+		dmq_ul.release_urecord(r);
+		dmq_ul.unlock_udomain(_d, &aor);
+		return 0;
 	}
 	if(dmq_ul.delete_ucontact(r, c) != 0) {
 		dmq_ul.unlock_udomain(_d, &aor);

--- a/src/modules/presence/hash.c
+++ b/src/modules/presence/hash.c
@@ -177,6 +177,7 @@ subs_t *mem_copy_subs(subs_t *s, int mem_type)
 	dest->expires = s->expires;
 	dest->db_flag = s->db_flag;
 	dest->flags = s->flags;
+	dest->received_time = s->received_time;
 
 	return dest;
 
@@ -233,6 +234,7 @@ subs_t *mem_copy_subs_noc(subs_t *s)
 	dest->expires = s->expires;
 	dest->db_flag = s->db_flag;
 	dest->flags = s->flags;
+	dest->received_time = s->received_time;
 
 	dest->contact.s = (char *)shm_malloc(s->contact.len * sizeof(char));
 	if(dest->contact.s == NULL) {
@@ -269,6 +271,10 @@ int insert_and_replace_shtable(
 
 	subs_t *rec = NULL, *prev_rec = NULL;
 
+	if(subs->received_time == 0) {
+		subs->received_time = (unsigned int)time(NULL);
+	}
+
 	new_rec = mem_copy_subs_noc(subs);
 	if(new_rec == NULL) {
 		LM_ERR("copying in share memory a subs_t structure\n");
@@ -297,6 +303,26 @@ int insert_and_replace_shtable(
 						new_rec->callid.len, new_rec->callid.s,
 						new_rec->from_tag.len, new_rec->from_tag.s,
 						new_rec->to_tag.len, new_rec->to_tag.s);
+
+				/* LWW: skip replace if local record is newer */
+				if(rec->received_time > new_rec->received_time) {
+					LM_DBG("LWW: skipping stale subscription replace "
+						   "for contact=[%.*s] pres_uri="
+						   "[%.*s] local_recv=%u incoming_recv=%u\n",
+							rec->contact.len, rec->contact.s, rec->pres_uri.len,
+							rec->pres_uri.s, rec->received_time,
+							new_rec->received_time);
+					lock_release(&htable[hash_code].lock);
+					if(new_rec->contact.s != NULL) {
+						shm_free(new_rec->contact.s);
+					}
+					if(new_rec->record_route.s != NULL) {
+						shm_free(new_rec->record_route.s);
+					}
+					shm_free(new_rec);
+					return 0;
+				}
+
 				/* delete this record */
 
 				if(prev_rec) {
@@ -352,6 +378,10 @@ int delete_shtable(shtable_t htable, unsigned int hash_code, subs_t *subs)
 	subs_t *s = NULL, *ps = NULL;
 	int found = -1;
 
+	if(subs->received_time == 0) {
+		subs->received_time = (unsigned int)time(NULL);
+	}
+
 	lock_get(&htable[hash_code].lock);
 
 	ps = htable[hash_code].entries;
@@ -381,6 +411,16 @@ int delete_shtable(shtable_t htable, unsigned int hash_code, subs_t *subs)
 			}
 		}
 		if(found == 0) {
+			/* LWW: skip delete if local record is newer */
+			if(s->received_time > subs->received_time) {
+				LM_DBG("LWW: skipping stale subscription delete for contact="
+					   "[%.*s] pres_uri="
+					   "[%.*s] local_recv=%u incoming_recv=%u\n",
+						s->contact.len, s->contact.s, s->pres_uri.len,
+						s->pres_uri.s, s->received_time, subs->received_time);
+				lock_release(&htable[hash_code].lock);
+				return 0;
+			}
 			found = s->local_cseq + 1;
 			ps->next = s->next;
 			if(s) {
@@ -434,6 +474,10 @@ int update_shtable(
 {
 	subs_t *s;
 
+	if(subs->received_time == 0) {
+		subs->received_time = (unsigned int)time(NULL);
+	}
+
 	lock_get(&htable[hash_code].lock);
 
 	s = search_shtable(
@@ -444,6 +488,17 @@ int update_shtable(
 		return -1;
 	}
 
+	/* LWW: skip update if local record is newer */
+	if((type & REMOTE_TYPE) && s->received_time > subs->received_time) {
+		LM_DBG("LWW: skipping stale subscription update for contact="
+			   "[%.*s] pres_uri="
+			   "[%.*s] local_recv=%u incoming_recv=%u\n",
+				s->contact.len, s->contact.s, s->pres_uri.len, s->pres_uri.s,
+				s->received_time, subs->received_time);
+		lock_release(&htable[hash_code].lock);
+		return 0;
+	}
+
 	if(type & REMOTE_TYPE) {
 		s->expires = subs->expires + ksr_time_sint(NULL, NULL);
 		s->remote_cseq = subs->remote_cseq;
@@ -451,6 +506,7 @@ int update_shtable(
 		subs->local_cseq = ++s->local_cseq;
 		subs->version = ++s->version;
 	}
+	s->received_time = subs->received_time;
 
 	if(presence_sip_uri_match(&s->contact, &subs->contact)) {
 		shm_free(s->contact.s);
@@ -793,6 +849,9 @@ ps_presentity_t *ps_presentity_new(ps_presentity_t *pt, int mtype)
 	ptn->hashid = core_case_hash(&pt->user, &pt->domain, 0);
 	ptn->expires = pt->expires;
 	ptn->received_time = pt->received_time;
+	if(ptn->received_time == 0) {
+		ptn->received_time = (int)time(NULL);
+	}
 	ptn->priority = pt->priority;
 
 	p = (char *)ptn + sizeof(ps_presentity_t);
@@ -1081,6 +1140,15 @@ int ps_ptable_replace(ps_presentity_t *ptm, ps_presentity_t *pt)
 	ptn = _ps_ptable->slots[idx].plist;
 	while(ptn != NULL) {
 		if(ps_presentity_match(ptn, &ptc, 2) == 1) {
+			/* LWW: skip replace if local record is newer */
+			if(ptn->received_time > ptv.received_time) {
+				LM_DBG("LWW: skipping stale presentity replace for "
+					   "%.*s@%.*s local_recv=%d incoming_recv=%d\n",
+						ptn->user.len, ptn->user.s, ptn->domain.len,
+						ptn->domain.s, ptn->received_time, ptv.received_time);
+				lock_release(&_ps_ptable->slots[idx].lock);
+				return 0;
+			}
 			if(ptn->next) {
 				ptn->next->prev = ptn->prev;
 			}
@@ -1145,6 +1213,15 @@ int ps_ptable_update(ps_presentity_t *ptm, ps_presentity_t *pt)
 	ptn = _ps_ptable->slots[idx].plist;
 	while(ptn != NULL) {
 		if(ps_presentity_match(ptn, &ptc, 2) == 1) {
+			/* LWW: skip update if local record is newer */
+			if(ptn->received_time > ptv.received_time) {
+				LM_DBG("LWW: skipping stale presentity update for "
+					   "%.*s@%.*s local_recv=%d incoming_recv=%d\n",
+						ptn->user.len, ptn->user.s, ptn->domain.len,
+						ptn->domain.s, ptn->received_time, ptv.received_time);
+				lock_release(&_ps_ptable->slots[idx].lock);
+				return 0;
+			}
 			if(ptn->next) {
 				ptn->next->prev = ptn->prev;
 			}
@@ -1201,6 +1278,15 @@ int ps_ptable_remove(ps_presentity_t *pt)
 	ptn = _ps_ptable->slots[idx].plist;
 	while(ptn != NULL) {
 		if(ps_presentity_match(ptn, &ptc, 2) == 1) {
+			/* LWW: skip delete if local record is newer */
+			if(ptn->received_time > ptc.received_time) {
+				LM_DBG("LWW: skipping stale presentity delete for "
+					   "%.*s@%.*s local_recv=%d incoming_recv=%d\n",
+						ptn->user.len, ptn->user.s, ptn->domain.len,
+						ptn->domain.s, ptn->received_time, ptc.received_time);
+				lock_release(&_ps_ptable->slots[idx].lock);
+				return 0;
+			}
 			if(ptn->next) {
 				ptn->next->prev = ptn->prev;
 			}

--- a/src/modules/presence/notify.c
+++ b/src/modules/presence/notify.c
@@ -152,6 +152,7 @@ void printf_subs(subs_t *subs)
 	LM_DBG("reason: %.*s\n", subs->reason.len, subs->reason.s);
 	LM_DBG("version: %u\n", subs->version);
 	LM_DBG("expires: %u\n", subs->expires);
+	LM_DBG("recv: %u\n", subs->received_time);
 
 	LM_DBG("updated/updated_winfo: %d/%d\n", subs->updated,
 			subs->updated_winfo);
@@ -2000,8 +2001,13 @@ void p_tm_callback(struct cell *t, int type, struct tmcb_params *ps)
 			|| (ps->code == 408 && pres_timeout_rm_subs
 					&& subs->status != TERMINATED_STATUS)
 			|| pres_get_delete_sub()) {
+
+		if(subs->received_time == 0) {
+			subs->received_time = (unsigned int)time(NULL);
+		}
+
 		delete_subs(&subs->pres_uri, &subs->event->name, &subs->to_tag,
-				&subs->from_tag, &subs->callid);
+				&subs->from_tag, &subs->callid, subs->received_time);
 		if(pres_enable_dmq > 0 && pres_enable_subs_dmq > 0) {
 			subs->expires = 0;
 			pres_dmq_replicate_subscription(subs, NULL);

--- a/src/modules/presence/presence_dmq.c
+++ b/src/modules/presence/presence_dmq.c
@@ -194,8 +194,9 @@ presentity_t *pres_parse_json_presentity(srjson_t *in)
 				return NULL;
 			}
 		} else {
-			LM_ERR("unrecognized field in json object\n");
-			return NULL;
+			LM_WARN("unrecognized field [%s] in presentity json object"
+					" - skipping\n",
+					p_it->string);
 		}
 	}
 
@@ -302,6 +303,8 @@ subs_t *pres_parse_json_subscription(srjson_t *in)
 			subscription.updated = SRJSON_GET_INT(s_it);
 		} else if(strcmp(s_it->string, "updated_winfo") == 0) {
 			subscription.updated_winfo = SRJSON_GET_INT(s_it);
+		} else if(strcmp(s_it->string, "recv") == 0) {
+			subscription.received_time = SRJSON_GET_INT(s_it);
 		} else if(strcmp(s_it->string, "event") == 0) {
 			s_event_str.s = s_it->valuestring;
 			s_event_str.len = strlen(s_it->valuestring);
@@ -311,8 +314,8 @@ subs_t *pres_parse_json_subscription(srjson_t *in)
 				return NULL;
 			}
 		} else {
-			LM_ERR("unrecognized field in json object\n");
-			return NULL;
+			LM_WARN("unrecognized field [%s] in json object - skipping\n",
+					s_it->string);
 		}
 	}
 
@@ -427,8 +430,9 @@ int pres_dmq_handle_msg(
 				p_body.s = NULL;
 			}
 		} else {
-			LM_ERR("unrecognized field in json object\n");
-			goto invalid;
+			LM_WARN("unrecognized field [%s] in dmq json object"
+					" - skipping\n",
+					it->string);
 		}
 	}
 
@@ -732,6 +736,8 @@ int pres_dmq_replicate_subscription(subs_t *subscription, dmq_node_t *node)
 	srjson_AddNumberToObject(&jdoc, s_json, "updated", subscription->updated);
 	srjson_AddNumberToObject(
 			&jdoc, s_json, "updated_winfo", subscription->updated_winfo);
+	srjson_AddNumberToObject(
+			&jdoc, s_json, "recv", subscription->received_time);
 
 	srjson_AddItemToObject(&jdoc, jdoc.root, "subscription", s_json);
 

--- a/src/modules/presence/presentity.c
+++ b/src/modules/presence/presentity.c
@@ -2495,6 +2495,7 @@ int ps_cache_delete_presentity(presentity_t *pres, str *ruid)
 	ptc.domain = pres->domain;
 	ptc.event = pres->event->name;
 	ptc.etag = pres->etag;
+	ptc.received_time = pres->received_time;
 
 	if(ps_ptable_remove(&ptc) < 0) {
 		return -1;

--- a/src/modules/presence/subscribe.c
+++ b/src/modules/presence/subscribe.c
@@ -476,8 +476,8 @@ int update_subs_db(subs_t *subs, int type)
 	return 0;
 }
 
-void delete_subs(
-		str *pres_uri, str *ev_name, str *to_tag, str *from_tag, str *callid)
+void delete_subs(str *pres_uri, str *ev_name, str *to_tag, str *from_tag,
+		str *callid, unsigned int received_time)
 {
 	subs_t subs;
 
@@ -486,6 +486,7 @@ void delete_subs(
 	subs.from_tag = *from_tag;
 	subs.to_tag = *to_tag;
 	subs.callid = *callid;
+	subs.received_time = received_time;
 
 	/* delete record from hash table also if not in dbonly mode */
 	if(pres_subs_dbmode != DB_ONLY) {
@@ -585,8 +586,12 @@ int update_subscription(
 		if(subs->expires == 0) {
 			LM_DBG("expires =0 -> deleting record\n");
 
+			if(subs->received_time == 0) {
+				subs->received_time = (unsigned int)time(NULL);
+			}
+
 			delete_subs(&subs->pres_uri, &subs->event->name, &subs->to_tag,
-					&subs->from_tag, &subs->callid);
+					&subs->from_tag, &subs->callid, subs->received_time);
 
 			if(subs->event->type & PUBL_TYPE) {
 				reply_code = get_ok_reply_code();
@@ -741,8 +746,13 @@ int replace_subscription(subs_t *subs)
 
 	if(subs->expires == 0) {
 		LM_DBG("expires =0 -> deleting record\n");
+
+		if(subs->received_time == 0) {
+			subs->received_time = (unsigned int)time(NULL);
+		}
+
 		delete_subs(&subs->pres_uri, &subs->event->name, &subs->to_tag,
-				&subs->from_tag, &subs->callid);
+				&subs->from_tag, &subs->callid, subs->received_time);
 		return 1;
 	} else {
 		/* if subscriptions are stored in memory, replace them */

--- a/src/modules/presence/subscribe.h
+++ b/src/modules/presence/subscribe.h
@@ -84,6 +84,7 @@ struct subscription
 	int internal_update_flag;
 	int updated;
 	int updated_winfo;
+	unsigned int received_time;
 	flag_t flags;
 	str user_agent;
 	struct subscription *next;
@@ -122,8 +123,8 @@ int extract_sdialog_info(subs_t *subs, struct sip_msg *msg, int max_expire,
 typedef int (*extract_sdialog_info_t)(subs_t *subs, struct sip_msg *msg,
 		int max_expire, int *to_tag_gen, str scontact, str watcher_user,
 		str watcher_domain);
-void delete_subs(
-		str *pres_uri, str *ev_name, str *to_tag, str *from_tag, str *callid);
+void delete_subs(str *pres_uri, str *ev_name, str *to_tag, str *from_tag,
+		str *callid, unsigned int received_time);
 int get_subscribers_count(struct sip_msg *msg, str pres_uri, str event);
 int replace_subscription(subs_t *subs);
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Add last write win checks, that will skip sync of DMQ, if the DMQ message is old (e.g. in case of network timeouts)

Tested so far in lab environment, 3 x kamailio DMQ cluster, 16 UDP children, 64 DMQ workers:
1. for usrloc: re-REGISTERs load test
2. for dialog: re-INVITEs load test
3. for presence subscriptions: re-SUBSCRIBEs load test

TODO:
4. for presence presentities