### PR TITLE
dmq: check for duplicates when adding a single node

### DIFF
--- a/src/modules/dmq/notification_peer.c
+++ b/src/modules/dmq/notification_peer.c
@@ -310,7 +310,9 @@ dmq_node_t *add_server_and_notify(str_list_t *server_list)
 		while(server_list != NULL) {
 			LM_DBG("adding notification node %.*s\n", server_list->s.len,
 					server_list->s.s);
-			pfirst = add_dmq_node(dmq_node_list, &server_list->s, 0);
+			if(!find_dmq_node_uri(
+					   dmq_node_list, &server_list->s)) // check for duplicates
+				pfirst = add_dmq_node(dmq_node_list, &server_list->s, 0);
 			server_list = server_list->next;
 		}
 	} else {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
There is no check for duplicates when adding notification address in case multi_notify=0 (that is by default).
As it is allowed to add notification_address multiple times in a script, changes in this PR are preventing accidentally adding duplicates.   