### PR TITLE
janssonrpcc: support tcp md5 password

### DIFF
--- a/src/modules/janssonrpcc/doc/janssonrpcc_admin.xml
+++ b/src/modules/janssonrpcc/doc/janssonrpcc_admin.xml
@@ -132,6 +132,9 @@ modparam("janssonrpcc", "result_pv", "$var(result)")
 						<emphasis>priority</emphasis> - server are grouped by priority. Servers with higher priority (lower number) are used first. Default is 0. (optional when using addr, invalid otherwise).
 					</listitem>
 					<listitem>
+						<emphasis>md5_password</emphasis> - password for tcp md5 authorization (optional).
+					</listitem>
+					<listitem>
 						<emphasis>weight</emphasis> - functions the same as a DNS SRV weight. Requests are distributed between servers of the same priority proportional to their weight. Default is 1. (optional when using addr, invalid otherwise).
 					</listitem>
 				</itemizedlist>

--- a/src/modules/janssonrpcc/janssonrpc_connect.c
+++ b/src/modules/janssonrpcc/janssonrpc_connect.c
@@ -28,6 +28,10 @@
 #include <fcntl.h>
 #include <event.h>
 #include <netinet/tcp.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netdb.h>
 
 #include "../../core/sr_module.h"
 #include "../../core/route.h"
@@ -82,10 +86,10 @@ void force_disconnect(jsonrpc_server_t *server)
 	server->buffer = NULL;
 
 	server->status = JSONRPC_SERVER_DISCONNECTED;
-	if(server->keep_alive_socket_fd >= 0) {
+	if(server->socket_fd >= 0) {
 		INFO("closing socket");
-		close(server->keep_alive_socket_fd);
-		server->keep_alive_socket_fd = -1;
+		close(server->socket_fd);
+		server->socket_fd = -1;
 	}
 
 	// close bufferevent
@@ -255,10 +259,10 @@ void connect_failed(jsonrpc_server_t *server)
 
 	server->status = JSONRPC_SERVER_RECONNECTING;
 	// close socket
-	if(server->keep_alive_socket_fd >= 0) {
+	if(server->socket_fd >= 0) {
 		INFO("closing socket");
-		close(server->keep_alive_socket_fd);
-		server->keep_alive_socket_fd = -1;
+		close(server->socket_fd);
+		server->socket_fd = -1;
 	}
 	wait_server_backoff(JSONRPC_RECONNECT_INTERVAL, server, true);
 }
@@ -333,6 +337,41 @@ int set_keepalive(int fd, int keepalive, int cnt, int idle, int intvl)
 	return res;
 }
 
+int set_md5_password(int fd, str passwd, str addr_)
+{
+	struct tcp_md5sig md5sig;
+	struct addrinfo hints, *res = NULL;
+	struct sockaddr_in addr;
+	int ret;
+
+	memset(&md5sig, 0, sizeof(md5sig));
+	memset(&addr, 0, sizeof(addr));
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	ret = getaddrinfo(addr_.s, NULL, &hints, &res);
+	assert(ret == 0);
+	addr = *(struct sockaddr_in *)(res->ai_addr);
+
+	memcpy(&md5sig.tcpm_addr, &addr, sizeof(addr));
+
+	md5sig.tcpm_keylen = passwd.len;
+	if(md5sig.tcpm_keylen > TCP_MD5SIG_MAXKEYLEN) {
+		ERR("Password too long\n");
+		return -1;
+	}
+
+	memcpy(md5sig.tcpm_key, passwd.s, md5sig.tcpm_keylen);
+
+	ret = setsockopt(fd, IPPROTO_TCP, TCP_MD5SIG, &md5sig, sizeof(md5sig));
+	assert(ret == 0);
+
+	freeaddrinfo(res);
+
+	return 0;
+}
+
 void bev_connect(jsonrpc_server_t *server)
 {
 	if(!server) {
@@ -340,17 +379,17 @@ void bev_connect(jsonrpc_server_t *server)
 		return;
 	}
 	int fd = -1;
-	if(jsonrpc_keep_alive > 0) {
-		if(server->keep_alive_socket_fd > 0) {
-			fd = server->keep_alive_socket_fd;
+	if(jsonrpc_keep_alive > 0 || server->md5_password.s) {
+		if(server->socket_fd > 0) {
+			fd = server->socket_fd;
 		} else {
 			INFO("setting up socket");
 			fd = socket(AF_INET, SOCK_STREAM, 0);
 			if(fd < 0) {
-				server->keep_alive_socket_fd = -1;
+				server->socket_fd = -1;
 				ERR("could not set up socket");
 			} else {
-				server->keep_alive_socket_fd = fd; // track fd to close later
+				server->socket_fd = fd; // track fd to close later
 			}
 		}
 		if(!fd_is_valid(fd)) { // make sure socket is valid
@@ -358,7 +397,7 @@ void bev_connect(jsonrpc_server_t *server)
 				close(fd);
 			}
 			fd = -1;
-			server->keep_alive_socket_fd = -1;
+			server->socket_fd = -1;
 		}
 	}
 
@@ -367,7 +406,10 @@ void bev_connect(jsonrpc_server_t *server)
 
 	if(fd > 0) {
 		set_linger(fd, 1, 0);
-		set_keepalive(fd, 1, 1, jsonrpc_keep_alive, jsonrpc_keep_alive);
+		if(jsonrpc_keep_alive > 0)
+			set_keepalive(fd, 1, 1, jsonrpc_keep_alive, jsonrpc_keep_alive);
+		if(server->md5_password.s)
+			set_md5_password(fd, server->md5_password, server->addr);
 	}
 
 	server->bev =

--- a/src/modules/janssonrpcc/janssonrpc_server.c
+++ b/src/modules/janssonrpcc/janssonrpc_server.c
@@ -133,6 +133,8 @@ int jsonrpc_parse_server(char *server_s, jsonrpc_server_group_t **group_ptr)
 	conn.s = NULL;
 	str addr;
 	addr.s = NULL;
+	str md5_password;
+	md5_password.s = NULL;
 	str srv;
 	srv.s = NULL;
 
@@ -165,6 +167,10 @@ int jsonrpc_parse_server(char *server_s, jsonrpc_server_group_t **group_ptr)
 		} else if PIT_MATCHES("addr") {
 			shm_str_dup(&addr, &pit->body);
 			CHECK_MALLOC(addr.s);
+
+		} else if PIT_MATCHES("md5_password") {
+			shm_str_dup(&md5_password, &pit->body);
+			CHECK_MALLOC(md5_password.s);
 
 		} else if PIT_MATCHES("port") {
 			port = atoi(pit->body.s);
@@ -223,6 +229,7 @@ int jsonrpc_parse_server(char *server_s, jsonrpc_server_group_t **group_ptr)
 		server->port = port;
 		server->priority = priority;
 		server->weight = weight;
+		server->md5_password = md5_password;
 		server->hwm = hwm;
 
 		if(jsonrpc_add_server(server, group_ptr) < 0)

--- a/src/modules/janssonrpcc/janssonrpc_server.h
+++ b/src/modules/janssonrpcc/janssonrpc_server.h
@@ -40,13 +40,13 @@
 
 typedef struct jsonrpc_server
 {
-	str conn, addr, srv; /* shared mem */
+	str conn, addr, srv, md5_password; /* shared mem */
 	int port;
 	unsigned int status, ttl, hwm;
 	unsigned int req_count;
 	unsigned int priority, weight;
 	bool added;
-	int keep_alive_socket_fd;
+	int socket_fd;
 	struct bufferevent *bev; /* local mem */
 	netstring_t *buffer;
 } jsonrpc_server_t;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Support for TCP MD5 passwords has been added to the janssonrpcc module, with the mechanism implemented according to [RFC 2385](https://datatracker.ietf.org/doc/html/rfc2385). The functionality was tested using a local configuration.
```
# vim: tabstop=4 softtabstop=0 expandtab shiftwidth=4 smarttab

#!KAMAILIO

#own IPs
listen=udp:127.0.0.1:5060 advertise 127.0.0.1:5060
alias=127.0.0.1:5060

mpath="/usr/lib64/kamailio/modules:/usr/lib/x86_64-linux-gnu/kamailio/modules"

loadmodule "tm.so"
loadmodule "pv.so"
loadmodule "jansson.so"
loadmodule "janssonrpcc.so"
loadmodule "xlog.so"
modparam("janssonrpcc", "server", "conn=local;addr=localhost;port=7080;md5_password=1234;priority=10;weight=10;")
modparam("janssonrpcc", "result_pv", "$var(jsrpc_result)")

# Routing configuration
route {
    janssonrpc_request("local", "core.show.version", "","route=RESPONSE;retry=1");
}

route[RESPONSE] {
	xlog("Result received: $var(jsrpc_result)");
}
```
