### PR TITLE
core: re-attempt the lock if EINTR occurs (POSIX_SEM)

### DIFF
--- a/src/core/lock_ops.h
+++ b/src/core/lock_ops.h
@@ -136,6 +136,8 @@ inline static gen_lock_t *lock_init(gen_lock_t *lock)
 
 #elif defined USE_POSIX_SEM
 #include <semaphore.h>
+#include <errno.h>
+#include "dprint.h"
 
 typedef sem_t gen_lock_t;
 
@@ -148,8 +150,30 @@ inline static gen_lock_t *lock_init(gen_lock_t *lock)
 	return lock;
 }
 
-#define lock_try(lock) sem_trywait(lock)
-#define lock_get(lock) sem_wait(lock)
+inline static int lock_try(gen_lock_t *lock)
+{
+	int ret;
+
+	do {
+		ret = sem_trywait(lock);
+		if(ret == -1 && errno != EINTR && errno != EAGAIN)
+			LM_CRIT("posix: %s (%d)\n", strerror(errno), errno);
+	} while(ret == -1 && errno == EINTR);
+
+	return ret;
+}
+
+inline static void lock_get(gen_lock_t *lock)
+{
+	while(sem_wait(lock) == -1) {
+		if(errno == EINTR) {
+			continue;
+		} else {
+			LM_CRIT("posix: %s (%d)\n", strerror(errno), errno);
+		}
+	}
+}
+
 #define lock_release(lock) sem_post(lock)
 
 


### PR DESCRIPTION
#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [X] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
`sem_wait` and `sem_trywait `POSIX semaphore functions can be interrupted by EINTR signal.
We need to re-attempt the lock if EINTR occurs.
Similar implementation to SYSV_SEM.