### PR TITLE
dispatcher: allow dns check from multiple address for ds_is_from_list

### DIFF
--- a/src/modules/dispatcher/dispatch.c
+++ b/src/modules/dispatcher/dispatch.c
@@ -128,6 +128,7 @@ extern param_t *ds_db_extra_attrs_list;
 extern int ds_load_mode;
 extern uint32_t ds_dns_mode;
 extern int ds_dns_ttl;
+extern int ds_dns_match_all;
 extern int ds_event_callback_mode;
 
 static db_func_t ds_dbf;
@@ -157,6 +158,25 @@ void shuffle_char100array(char *arr);
 int ds_reinit_rweight_on_state_change(
 		int old_state, int new_state, ds_set_t *dset);
 
+
+/**
+ * Populate all resolved addresses from a hostent into a ds_dest_t.
+ * Stores up to DS_DNS_MAX_ADDRS addresses. The first address is also
+ * copied into dp->ip_address for backward compatibility.
+ */
+static int ds_hostent2ip_addrs(ds_dest_t *dp, struct hostent *he)
+{
+	int i;
+
+	for(i = 0; he->h_addr_list[i] != NULL && i < DS_DNS_MAX_ADDRS; i++) {
+		hostent2ip_addr(&dp->ip_addrs[i], he, i);
+	}
+	dp->ip_addrs_num = i;
+	if(i > 0) {
+		dp->ip_address = dp->ip_addrs[0];
+	}
+	return i;
+}
 
 /**
  *
@@ -753,8 +773,11 @@ ds_dest_t *pack_dest(str iuri, int flags, int priority, str *attrs, int dload)
 					puri.host.len, puri.host.s);
 			goto err;
 		} else {
-			/* Store hostent in the dispatcher structure */
-			hostent2ip_addr(&dp->ip_address, he, 0);
+			if(ds_dns_match_all) {
+				ds_hostent2ip_addrs(dp, he);
+			} else {
+				hostent2ip_addr(&dp->ip_address, he, 0);
+			}
 		}
 	}
 
@@ -4276,22 +4299,31 @@ int ds_is_addr_from_set(sip_msg_t *_m, struct ip_addr *pipaddr,
 		unsigned short tport, unsigned short tproto, ds_set_t *node, int mode,
 		int export_set_pv)
 {
-	ip_addr_t *ipa;
 	ip_addr_t ipaddress;
 	char hn[DS_HN_SIZE];
 	struct hostent *he;
-	int j;
+	int j, k;
+	int ip_matched;
 	int node_strictness;
 	unsigned short sport = 0;
 	char sproto = PROTO_NONE;
 
 	for(j = 0; j < node->nr; j++) {
 		if(node->dlist[j].irmode & DS_IRMODE_NOIPADDR) {
-			/* dst record using hotname with dns not done - no ip to match */
 			continue;
 		}
+		ip_matched = 0;
 		if(!(ds_dns_mode & DS_DNS_MODE_ALWAYS)) {
-			ipa = &node->dlist[j].ip_address;
+			if(ds_dns_match_all && node->dlist[j].ip_addrs_num > 0) {
+				for(k = 0; k < node->dlist[j].ip_addrs_num; k++) {
+					if(ip_addr_cmp(pipaddr, &node->dlist[j].ip_addrs[k])) {
+						ip_matched = 1;
+						break;
+					}
+				}
+			} else {
+				ip_matched = ip_addr_cmp(pipaddr, &node->dlist[j].ip_address);
+			}
 		} else {
 			dns_set_local_ttl(ds_dns_ttl);
 			if(ds_dns_mode & DS_DNS_MODE_QSRV) {
@@ -4322,13 +4354,21 @@ int ds_is_addr_from_set(sip_msg_t *_m, struct ip_addr *pipaddr,
 				LM_WARN("could not resolve %.*s (skipping)\n",
 						node->dlist[j].host.len, node->dlist[j].host.s);
 				continue;
+			}
+			if(ds_dns_match_all) {
+				for(k = 0; he->h_addr_list[k] != NULL; k++) {
+					hostent2ip_addr(&ipaddress, he, k);
+					if(ip_addr_cmp(pipaddr, &ipaddress)) {
+						ip_matched = 1;
+						break;
+					}
+				}
 			} else {
-				/* Store hostent in the dispatcher structure */
 				hostent2ip_addr(&ipaddress, he, 0);
-				ipa = &ipaddress;
+				ip_matched = ip_addr_cmp(pipaddr, &ipaddress);
 			}
 		}
-		if(ip_addr_cmp(pipaddr, ipa)
+		if(ip_matched
 				&& ((mode & DS_MATCH_NOPORT) || node->dlist[j].port == 0
 						|| tport == node->dlist[j].port
 						|| (mode & DS_MATCH_MIXSOCKPRPORT))
@@ -4422,8 +4462,9 @@ int ds_is_addr_from_list(sip_msg_t *_m, int group, str *uri, int mode)
 	char sproto = PROTO_NONE;
 	sip_uri_t puri;
 	char hn[DS_HN_SIZE];
-	struct hostent *he;
+	struct hostent *he = NULL;
 	int rc = -1;
+	int k, naddrs;
 
 	if(uri == NULL || uri->len <= 0) {
 		pipaddr = &_m->rcv.src_ip;
@@ -4464,19 +4505,45 @@ int ds_is_addr_from_list(sip_msg_t *_m, int group, str *uri, int mode)
 		pipaddr = &aipaddr;
 	}
 
+	naddrs = 0;
+	if(ds_dns_match_all && he != NULL) {
+		for(naddrs = 0; he->h_addr_list[naddrs] != NULL; naddrs++)
+			;
+	}
 
 	if(mode & DS_MATCH_MIXSOCKPRPORT) {
 		ds_strictest_match = 0;
 		ds_strictest_node = NULL;
 	}
 
-	if(group == -1) {
-		rc = ds_is_addr_from_set_r(
-				_m, pipaddr, tport, tproto, _ds_list, mode, 1);
+	if(naddrs > 1) {
+		for(k = 0; k < naddrs; k++) {
+			hostent2ip_addr(&aipaddr, he, k);
+			pipaddr = &aipaddr;
+			if(group == -1) {
+				rc = ds_is_addr_from_set_r(
+						_m, pipaddr, tport, tproto, _ds_list, mode, 1);
+			} else {
+				list = ds_avl_find(_ds_list, group);
+				if(list) {
+					rc = ds_is_addr_from_set(
+							_m, pipaddr, tport, tproto, list, mode, 0);
+				}
+			}
+			if(rc != -1) {
+				break;
+			}
+		}
 	} else {
-		list = ds_avl_find(_ds_list, group);
-		if(list) {
-			rc = ds_is_addr_from_set(_m, pipaddr, tport, tproto, list, mode, 0);
+		if(group == -1) {
+			rc = ds_is_addr_from_set_r(
+					_m, pipaddr, tport, tproto, _ds_list, mode, 1);
+		} else {
+			list = ds_avl_find(_ds_list, group);
+			if(list) {
+				rc = ds_is_addr_from_set(
+						_m, pipaddr, tport, tproto, list, mode, 0);
+			}
 		}
 	}
 
@@ -4958,8 +5025,11 @@ void ds_dns_update_set(ds_set_t *node)
 					node->dlist[j].host.s);
 			continue;
 		} else {
-			/* Store hostent in the dispatcher structure */
-			hostent2ip_addr(&node->dlist[j].ip_address, he, 0);
+			if(ds_dns_match_all) {
+				ds_hostent2ip_addrs(&node->dlist[j], he);
+			} else {
+				hostent2ip_addr(&node->dlist[j].ip_address, he, 0);
+			}
 			gettimeofday(&node->dlist[j].dnstime, NULL);
 		}
 	}

--- a/src/modules/dispatcher/dispatch.h
+++ b/src/modules/dispatcher/dispatch.h
@@ -85,6 +85,8 @@
 #define DS_DNS_MODE_TIMER  (1<<2)
 #define DS_DNS_MODE_QSRV   (1<<3)
 
+#define DS_DNS_MAX_ADDRS 32
+
 #define DS_STATE_MODE_SET  1
 #define DS_STATE_MODE_FUNC (1<<1)
 
@@ -269,7 +271,9 @@ typedef struct _ds_dest {
 	ds_latency_stats_t latency_stats; /*!< latency statistics */
 	int irmode;       /*!< internal runtime mode (flags) */
 	struct socket_info *sock; /*!< pointer to local socket */
-	struct ip_addr ip_address; 	/*!< IP of the address */
+	struct ip_addr ip_address; 	/*!< IP of the address (first resolved) */
+	struct ip_addr ip_addrs[DS_DNS_MAX_ADDRS]; /*!< all resolved IP addresses */
+	int ip_addrs_num;          /*!< number of resolved addresses in ip_addrs */
 	unsigned short int port; 	/*!< port of the URI */
 	unsigned short int proto; 	/*!< protocol of the URI */
 	int probing_count;

--- a/src/modules/dispatcher/dispatcher.c
+++ b/src/modules/dispatcher/dispatcher.c
@@ -129,6 +129,7 @@ int ds_load_mode = 0;
 uint32_t ds_dns_mode = DS_DNS_MODE_INIT;
 static int ds_dns_interval = 600;
 int ds_dns_ttl = 0;
+int ds_dns_match_all = 0;
 
 str ds_outbound_proxy = STR_NULL;
 
@@ -333,6 +334,7 @@ static param_export_t params[]={
 	{"ds_dns_mode",        PARAM_INT, &ds_dns_mode},
 	{"ds_dns_interval",    PARAM_INT, &ds_dns_interval},
 	{"ds_dns_ttl",         PARAM_INT, &ds_dns_ttl},
+	{"ds_dns_match_all",   PARAM_INT, &ds_dns_match_all},
 	{0,0,0}
 };
 

--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -1270,6 +1270,37 @@ modparam("dispatcher", "ds_interval_mode", 1800)
 		</example>
 	</section>
 
+	<section id="dispatcher.p.ds_dns_match_all">
+		<title><varname>ds_dns_match_all</varname> (int)</title>
+		<para>
+			When set to 1, enables matching against all IP addresses resolved
+			from a DNS lookup for dispatcher destinations. By default, only the
+			first resolved address from the DNS response is used when comparing
+			against the source IP address in functions like ds_is_from_list().
+			If a destination hostname resolves to multiple A/AAAA records (e.g.,
+			round-robin DNS or multi-homed hosts), enabling this parameter
+			ensures that a request from any of those addresses is correctly
+			recognized as coming from a dispatcher destination.
+		</para>
+		<para>
+			When enabled, up to 32 resolved addresses per destination are
+			stored and checked during matching.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote> (disabled).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set the <quote>ds_dns_match_all</quote> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("dispatcher", "ds_dns_match_all", 1)
+...
+</programlisting>
+		</example>
+	</section>
+
 	<section id="dispatcher.p.ds_dns_ttl">
 		<title><varname>ds_dns_ttl</varname> (int)</title>
 		<para>


### PR DESCRIPTION
#### Description

This PR introduces a new feature to solve the old issue: #4338 .

A new `modparam` was introduced: `ds_dns_match_all`. When enabled, it will be possible to use `ds_is_from_list` to auth traffic from a DNS that points to multiple and different addresses. Currently, it only resolves to one.

The existent behaviour was kept, and its the default value (`0`). To enable, pass `1` as value.

This is quiet useful for developments using `Kubernetes` or in distributed setup, when DNS is used for internal hops.

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4338 
