### PR TITLE
xlog: add auto_newline modparam

### DIFF
--- a/src/modules/xlog/doc/xlog_admin.xml
+++ b/src/modules/xlog/doc/xlog_admin.xml
@@ -262,6 +262,28 @@ modparam("xlog", "methods_filter", 15)
 		</example>
 	</section>
 
+
+	<section id="xlog.p.auto_newline">
+		<title><varname>auto_newline</varname> (str)</title>
+        <para>
+            If set to 1, then all xlog logging functions will automatically append a newline character (<varname>\n</varname>). Any lines that already end in <varname>\n</varname> should not receive an additional newline.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0 (no automatic newline).
+		</emphasis>
+		</para>
+		<example>
+		    <title>Set <varname>auto_newline</varname> parameter</title>
+		    <programlisting format="linespecific">
+...
+modparam("xlog", "auto_newline", 1)
+...
+            </programlisting>
+		</example>
+	</section>
+
+
 	</section>
 	<section>
 	<title>Functions</title>

--- a/src/modules/xlog/xlog.c
+++ b/src/modules/xlog/xlog.c
@@ -72,6 +72,7 @@ static int force_color = 0;
 static int long_format = 0;
 static int xlog_facility = DEFAULT_FACILITY;
 static char *xlog_facility_name = NULL;
+static int xlog_auto_newline = 0;
 
 /** cfg dynamic parameters */
 struct cfg_group_xlog
@@ -176,6 +177,7 @@ static param_export_t params[] = {
 	{"log_colors", PARAM_STRING | PARAM_USE_FUNC, (void *)xlog_log_colors_param},
 	{"methods_filter", PARAM_INT, &xlog_default_cfg.methods_filter},
 	{"prefix_mode", PARAM_INT, &_xlog_prefix_mode},
+	{"auto_newline", PARAM_INT, &xlog_auto_newline},
 	{0, 0, 0}
 };
 
@@ -253,6 +255,13 @@ static inline int xlog_helper(
 
 	if(xl_print_log(msg, xm->m, _xlog_buf, &txt.len) < 0)
 		return -1;
+
+	if(xlog_auto_newline != 0 && txt.len > 0 && txt.s[txt.len - 1] != '\n') {
+		if(txt.len < buf_size) {
+			txt.s[txt.len] = '\n';
+			txt.len++;
+		}
+	}
 
 	if(_xlog_prefix_mode) {
 		str _xlog_prefix_str;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4734

#### Description
Add module parameter `auto_newline` to append a new line to all xlog logging functions.
