### PR TITLE
topos: Documentation for event_mode [skip ci]

### DIFF
--- a/src/modules/topos/doc/topos_admin.xml
+++ b/src/modules/topos/doc/topos_admin.xml
@@ -279,19 +279,29 @@ end
 ...
 </programlisting>
 		</example>
-	</section>
+    </section>
 	<section id="topos.p.event_mode">
 		<title><varname>event_mode</varname> (int)</title>
 		<para>
-			Control what event_route blocks to be executed. It is a bitmask of:
-			1 - execute event_route[topos:msg-outgoing]; 2 - execute
-			event_route[topos:msg-sending]; 4 execute
-			event_route[topos:msg-incoming]; 8 execute
-			event_route[topos:msg-receiving];.
+            Control what event_route blocks to be executed. It is a bitmask of:
+			<itemizedlist>
+				<listitem>
+					<para>1 - execute event_route[topos:msg-outgoing]</para>
+				</listitem>
+				<listitem>
+					<para>2 - execute event_route[topos:msg-sending]</para>
+				</listitem>
+				<listitem>
+					<para>4 - execute event_route[topos:msg-incoming]</para>
+				</listitem>
+				<listitem>
+					<para>8 - execute event_route[topos:msg-receiving]</para>
+				</listitem>
+			</itemizedlist>
 		</para>
 		<para>
 		<emphasis>
-			Default value is 3 (execute both event_route blocks).
+			Default value is 15 (execute all event_route blocks).
 		</emphasis>
 		</para>
 		<example>
@@ -302,7 +312,7 @@ modparam("topos", "event_mode", 2)
 ...
 </programlisting>
 		</example>
-	</section>
+    </section>
 	<section id="topos.p.contact_host">
 		<title><varname>contact_host</varname> (str)</title>
 		<para>


### PR DESCRIPTION
- Update documenation for default value of event_mode param #4738

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4738

#### Description
Update documentation for topos parameter `event_mode`:
- Update the documented default value from `3` to `15`
- Format the bitwise values as a list for readability.
