### PR TITLE
Fix memory leak in pv_headers

### DIFF
--- a/src/modules/pv_headers/pvh_xavp.c
+++ b/src/modules/pv_headers/pvh_xavp.c
@@ -713,7 +713,13 @@ xavp_c_data_t *pvh_set_parsed(
 	return c_data;
 
 err:
-	// how can I call?? pvh_xavi_free_data(c_data, shm_free);
+	if(c_data != NULL) {
+		if(c_data->value.s != NULL) {
+			shm_free(c_data->value.s);
+		}
+		shm_free(c_data);
+		c_data = NULL;
+	}
 	return NULL;
 }
 
@@ -886,6 +892,13 @@ int pvh_set_uri(struct sip_msg *msg, pv_param_t *param, int op, pv_value_t *val)
 err:
 	if(pv_format)
 		pv_elem_free_all(pv_format);
+	if(c_data != NULL) {
+		if(c_data->value.s != NULL) {
+			shm_free(c_data->value.s);
+		}
+		shm_free(c_data);
+		c_data = NULL;
+	}
 	return -1;
 }
 


### PR DESCRIPTION
pv_headers: fix shm memory leak in pvh_merge_uri error paths

Before calling pvh_merge_uri(), memory is allocated in shared memory
for c_data and related structures. In case pvh_merge_uri() returns -1,
these allocations are not released, leading to a leak in SHM under load.

Additionally, pvh_merge_uri() may allocate memory for c_data->value.s,
which is not freed on early error returns.

This patch ensures that all previously allocated SHM memory is properly
released on error paths when pvh_merge_uri() fails, preventing memory
growth under sustained traffic conditions.


#### Pre-Submission Checklist

- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #4741 

#### Description

Before calling pvh_merge_uri(), c_data is allocated in shared memory.
If an error occurs inside pvh_merge_uri(), this allocation is not released,leading to a potential leak.
Additionally, pvh_merge_uri() may allocate further memory inside c_data->value.s,which also needs to be freed on failure.
This commit ensures that all allocated memory is properly released in error paths,preventing potential memory leaks.