### PR TITLE
siputils: validate SIP URI produced by tel2sip and tel2sip2

### DIFF
--- a/src/modules/siputils/checks.c
+++ b/src/modules/siputils/checks.c
@@ -645,6 +645,7 @@ int tel2sip(struct sip_msg *_msg, char *_uri, char *_hostpart, char *_res)
 	int i, j, in_tel_parameters = 0;
 	pv_spec_t *res;
 	pv_value_t res_val;
+	struct sip_uri parsed_check;
 
 	/* get parameters */
 	if(get_str_fparam(&uri, _msg, (fparam_t *)_uri) < 0) {
@@ -708,6 +709,11 @@ int tel2sip(struct sip_msg *_msg, char *_uri, char *_hostpart, char *_res)
 
 	/* tel_uri is not needed anymore */
 	pkg_free(tel_uri.s);
+
+	if(parse_uri(sip_uri.s, sip_uri.len, &parsed_check) < 0) {
+		pkg_free(sip_uri.s);
+		return -1;
+	}
 
 	/* set result pv value and write sip uri to result pv */
 	res_val.rs = sip_uri;
@@ -823,6 +829,7 @@ int tel2sip2(struct sip_msg *_msg, char *_uri, char *_hostpart, char *_res)
 	pv_value_t res_val;
 	char *tmp_ptr = NULL;
 	tel_param_t params[MAX_TEL_PARAMS];
+	struct sip_uri parsed_check;
 
 	/* get parameters */
 	if(get_str_fparam(&uri, _msg, (fparam_t *)_uri) < 0) {
@@ -934,6 +941,11 @@ int tel2sip2(struct sip_msg *_msg, char *_uri, char *_hostpart, char *_res)
 
 	/* tel_uri is not needed anymore */
 	pkg_free(tel_uri.s);
+
+	if(parse_uri(sip_uri.s, sip_uri.len, &parsed_check) < 0) {
+		pkg_free(sip_uri.s);
+		return -1;
+	}
 
 	sip_uri.len = strlen(sip_uri.s);
 


### PR DESCRIPTION


#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4743 

#### Description
After constructing the SIP URI, call parse_uri() to verify the result is well-formed before writing it to the output pvar. 
If validation fails, free the allocated pkg memory and return -1.
