### PR TITLE
htable: fix expire value assignment on string cell replacements

### DIFF
--- a/src/modules/htable/ht_api.c
+++ b/src/modules/htable/ht_api.c
@@ -547,7 +547,7 @@ int ht_set_cell_ex(
 						if(exv <= 0) {
 							HT_COPY_EXPIRE(ht, cell, now, it);
 						} else {
-							it->expire = now + exv;
+							cell->expire = now + exv;
 						}
 						if(it->prev)
 							it->prev->next = cell;
@@ -583,7 +583,7 @@ int ht_set_cell_ex(
 					if(exv <= 0) {
 						HT_COPY_EXPIRE(ht, cell, now, it);
 					} else {
-						it->expire = now + exv;
+						cell->expire = now + exv;
 					}
 
 					cell->next = it->next;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

## Summary
Fix explicit expire handling in `ht_set_cell_ex()` when an existing entry is
replaced with a newly allocated cell.

Finalizes fixes started in https://github.com/kamailio/kamailio/commit/13bb373

## Problem
For explicit-expire updates, the replacement branches updated `it->expire`
instead of `cell->expire`. In these branches, `it` is the old entry and is
freed after relinking, so the new cell would keep `expire == 0`.

User-visible symptom:
- `htable.get` reports `expire` as `NEVER` after updating an existing key with
  a longer string value via `htable.setxs`

## Reproducer
```
htable.sets  c somekey smallstr
htable.setxs c somekey longerstr111 100
htable.get   c somekey
```
Before the fix, expire will be reported as NEVER.
