### PR TITLE
Extended HAproxy protocol support

### DIFF
--- a/src/core/msg_translator.c
+++ b/src/core/msg_translator.c
@@ -115,6 +115,7 @@
 
 extern char version[];
 extern int version_len;
+extern int ksr_tcp_accept_haproxy;
 
 str _ksr_xavp_via_params = STR_NULL;
 str _ksr_xavp_via_fields = STR_NULL;
@@ -588,6 +589,9 @@ static inline int lumps_len(
 	int recv_proto_id = PROTO_NONE;
 	int recv_af = 0;
 	struct socket_info *send_sock;
+	char ip_buf[MAX_URI_SIZE] = {0};
+	str _recv_address_str = STR_NULL;
+	str _recv_port_str = STR_NULL;
 
 
 #ifdef USE_COMP
@@ -881,6 +885,12 @@ static inline int lumps_len(
 		if(msg->rcv.bind_address->useinfo.name.len > 0) {
 			recv_address_str = &(msg->rcv.bind_address->useinfo.name);
 			recv_af = msg->rcv.bind_address->useinfo.af;
+		} else if(ksr_tcp_accept_haproxy && msg->rcv.proto_reserved2) {
+			ip_addr2sbuf(&msg->rcv.dst_ip, ip_buf, MAX_URI_SIZE);
+			recv_address_str = &_recv_address_str;
+			recv_address_str->s = ip_buf;
+			recv_address_str->len = strlen(ip_buf);
+			recv_af = msg->rcv.dst_ip.af;
 		} else {
 			recv_address_str = &(msg->rcv.bind_address->address_str);
 			recv_af = msg->rcv.bind_address->address.af;
@@ -890,6 +900,10 @@ static inline int lumps_len(
 				recv_port_str = &(msg->rcv.bind_address->useinfo.port_no_str);
 				recv_port_no = msg->rcv.bind_address->useinfo.port_no;
 			}
+		} else if(ksr_tcp_accept_haproxy && msg->rcv.proto_reserved2) {
+			recv_port_str = &_recv_port_str;
+			recv_port_str->s = int2str(msg->rcv.dst_port, &recv_port_str->len);
+			recv_port_no = msg->rcv.dst_port;
 		} else {
 			recv_port_str = &(msg->rcv.bind_address->port_no_str);
 			recv_port_no = msg->rcv.bind_address->port_no;
@@ -1014,6 +1028,9 @@ void process_lumps(struct sip_msg *msg, struct lump *lumps, char *new_buf,
 	int recv_proto_id = PROTO_NONE;
 	int recv_af = 0;
 	struct socket_info *send_sock;
+	char ip_buf[MAX_URI_SIZE] = {0};
+	str _recv_address_str = STR_NULL;
+	str _recv_port_str = STR_NULL;
 
 #ifdef USE_COMP
 #define RCVCOMP_PARAM_ADD                                             \
@@ -1440,6 +1457,12 @@ void process_lumps(struct sip_msg *msg, struct lump *lumps, char *new_buf,
 		if(msg->rcv.bind_address->useinfo.name.len > 0) {
 			recv_address_str = &(msg->rcv.bind_address->useinfo.name);
 			recv_af = msg->rcv.bind_address->useinfo.af;
+		} else if(ksr_tcp_accept_haproxy && msg->rcv.proto_reserved2) {
+			ip_addr2sbuf(&msg->rcv.dst_ip, ip_buf, MAX_URI_SIZE);
+			recv_address_str = &_recv_address_str;
+			recv_address_str->s = ip_buf;
+			recv_address_str->len = strlen(ip_buf);
+			recv_af = msg->rcv.dst_ip.af;
 		} else {
 			recv_address_str = &(msg->rcv.bind_address->address_str);
 			recv_af = msg->rcv.bind_address->address.af;
@@ -1449,6 +1472,10 @@ void process_lumps(struct sip_msg *msg, struct lump *lumps, char *new_buf,
 				recv_port_str = &(msg->rcv.bind_address->useinfo.port_no_str);
 				recv_port_no = msg->rcv.bind_address->useinfo.port_no;
 			}
+		} else if(ksr_tcp_accept_haproxy && msg->rcv.proto_reserved2) {
+			recv_port_str = &_recv_port_str;
+			recv_port_str->s = int2str(msg->rcv.dst_port, &recv_port_str->len);
+			recv_port_no = msg->rcv.dst_port;
 		} else {
 			recv_port_str = &(msg->rcv.bind_address->port_no_str);
 			recv_port_no = msg->rcv.bind_address->port_no;
@@ -3731,6 +3758,8 @@ int sip_msg_update_buffer(sip_msg_t *msg, str *obuf)
 		msg->path_vec.s = NULL;
 		msg->path_vec.len = 0;
 	}
+	/* reset haproxy_rcv pointer to avoid freeing - restored later */
+	msg->haproxy_rcv = NULL;
 
 	/* free old msg structure */
 	free_sip_msg(msg);
@@ -3741,6 +3770,7 @@ int sip_msg_update_buffer(sip_msg_t *msg, str *obuf)
 	msg->id = tmp.id;
 	msg->pid = tmp.pid;
 	msg->rcv = tmp.rcv;
+	msg->haproxy_rcv = tmp.haproxy_rcv;
 	msg->set_global_address = tmp.set_global_address;
 	msg->set_global_port = tmp.set_global_port;
 	msg->flags = tmp.flags;

--- a/src/core/msg_translator.c
+++ b/src/core/msg_translator.c
@@ -3096,6 +3096,49 @@ int branch_builder(unsigned int hash_index,
 	return size;
 }
 
+static int is_haproxy(
+		struct dest_info *send_info, struct receive_info *haproxy_rcv)
+{
+	int port;
+	struct ip_addr ip;
+	union sockaddr_union *from = NULL;
+	union sockaddr_union local_addr;
+	struct tcp_connection *con = NULL;
+	int haproxy = 0;
+
+	if(!send_info || !haproxy_rcv) {
+		LM_ERR("wrong arguments\n");
+		return 0;
+	}
+
+	if(unlikely(send_info->send_flags.f & SND_F_FORCE_SOCKET
+				&& send_info->send_sock)) {
+		local_addr = send_info->send_sock->su;
+		su_setport(&local_addr, 0); /* any local port will do */
+		from = &local_addr;
+	}
+
+	port = su_getport(&send_info->to);
+	if(likely(port)) {
+		su2ip_addr(&ip, &send_info->to);
+		con = tcpconn_get(send_info->id, &ip, port, from, 0);
+	} else if(likely(send_info->id))
+		con = tcpconn_get(send_info->id, 0, 0, 0, 0);
+	else {
+		LM_CRIT("null_id & to\n");
+		return 0;
+	}
+
+	if(con == NULL) {
+		LM_DBG("TCP/TLS connection (id: %d) for is not found\n", send_info->id);
+		return 0;
+	}
+
+	*haproxy_rcv = con->rcv;
+	haproxy = con->rcv.proto_reserved2;
+	tcpconn_put(con);
+	return haproxy;
+}
 
 /* uses only the send_info->send_socket, send_info->proto, send_info->id and
  * send_info->comp (so that a send_info used for sending can be passed
@@ -3123,6 +3166,11 @@ char *via_builder(unsigned int *len, sip_msg_t *msg,
 	struct tcp_connection *con = NULL;
 	sr_xavp_t *rxavp = NULL;
 	str xname;
+	char ip_buf[MAX_URI_SIZE] = {0};
+	str haproxy_address_str = STR_NULL;
+	str haproxy_port_str = STR_NULL;
+	struct receive_info haproxy_rcv;
+	int haproxy = is_haproxy(send_info, &haproxy_rcv);
 
 	send_sock = send_info->send_sock;
 	/* use pre-set address in via, the outbound socket alias or address one */
@@ -3134,6 +3182,11 @@ char *via_builder(unsigned int *len, sip_msg_t *msg,
 		if(rxavp != NULL) {
 			address_str = &rxavp->val.v.s;
 		}
+	} else if(ksr_tcp_accept_haproxy && haproxy) {
+		ip_addr2sbuf(&haproxy_rcv.dst_ip, ip_buf, MAX_URI_SIZE);
+		address_str = &haproxy_address_str;
+		address_str->s = ip_buf;
+		address_str->len = strlen(ip_buf);
 	}
 	if(address_str == NULL) {
 		if(hp && hp->host->len) {
@@ -3159,6 +3212,9 @@ char *via_builder(unsigned int *len, sip_msg_t *msg,
 		if(rxavp != NULL) {
 			port_str = &rxavp->val.v.s;
 		}
+	} else if(ksr_tcp_accept_haproxy && haproxy) {
+		port_str = &haproxy_port_str;
+		port_str->s = int2str(haproxy_rcv.dst_port, &port_str->len);
 	}
 	if(port_str == NULL) {
 		if(hp && hp->port->len) {
@@ -3184,6 +3240,8 @@ char *via_builder(unsigned int *len, sip_msg_t *msg,
 		if(rxavp != NULL) {
 			proto = get_valid_proto_id(&rxavp->val.v.s);
 		}
+	} else if(ksr_tcp_accept_haproxy && haproxy) {
+		proto = haproxy_rcv.proto;
 	}
 	if(proto == PROTO_NONE) {
 		if(send_sock != NULL && send_sock->useinfo.proto != PROTO_NONE) {

--- a/src/core/parser/msg_parser.c
+++ b/src/core/parser/msg_parser.c
@@ -804,6 +804,10 @@ void free_sip_msg(struct sip_msg *const msg)
 	reset_new_uri(msg);
 	reset_dst_uri(msg);
 	reset_path_vector(msg);
+	if(msg->haproxy_rcv) {
+		pkg_free(msg->haproxy_rcv);
+		msg->haproxy_rcv = NULL;
+	}
 	reset_instance(msg);
 	reset_ruid(msg);
 	reset_ua(msg);

--- a/src/core/parser/msg_parser.h
+++ b/src/core/parser/msg_parser.h
@@ -403,6 +403,8 @@ typedef struct sip_msg
 	char *unparsed; /*!< here we stopped parsing*/
 
 	struct receive_info rcv; /*!< source & dest ip, ports, proto a.s.o*/
+	struct receive_info *
+			haproxy_rcv; /*!< source & dest ip, ports, proto a.s.o for the message from haproxy*/
 
 	char *buf;			   /*!< scratch pad, holds a modified message,
 						*  via, etc. point into it */

--- a/src/core/receive.c
+++ b/src/core/receive.c
@@ -308,7 +308,8 @@ int ksr_evrt_pre_routing(sip_msg_t *msg)
  *  WARNING: buf must be 0 terminated (buf[len]=0) or some things might
  * break (e.g.: modules/textops)
  */
-int receive_msg(char *buf, unsigned int len, receive_info_t *rcv_info)
+int _receive_msg(char *buf, unsigned int len, receive_info_t *rcv_info,
+		receive_info_t *haproxy_rcv_info)
 {
 	struct sip_msg *msg = NULL;
 	struct run_act_ctx ctx;
@@ -377,6 +378,15 @@ int receive_msg(char *buf, unsigned int len, receive_info_t *rcv_info)
 	msg->pid = my_pid();
 	msg->set_global_address = default_global_address;
 	msg->set_global_port = default_global_port;
+
+	if(haproxy_rcv_info) {
+		msg->haproxy_rcv = pkg_malloc(sizeof(receive_info_t));
+		if(msg->haproxy_rcv == NULL) {
+			PKG_MEM_ERROR;
+			goto error02;
+		}
+		*msg->haproxy_rcv = *haproxy_rcv_info;
+	}
 
 	if(likely(sr_msg_time == 1))
 		msg_set_time(msg);

--- a/src/core/receive.h
+++ b/src/core/receive.h
@@ -36,7 +36,9 @@
 #define KSR_EVRT_RECEIVED_DATAIN 2
 
 
-int receive_msg(char *buf, unsigned int len, struct receive_info *ri);
+#define receive_msg(_buf, _len, _ri) _receive_msg(_buf, _len, _ri, NULL)
+int _receive_msg(char *buf, unsigned int len, struct receive_info *ri,
+		struct receive_info *haproxy_ri);
 int sip_check_fline(char *buf, unsigned int len);
 unsigned int inc_msg_no(void);
 void ksr_msg_env_reset(void);

--- a/src/core/tcp_conn.h
+++ b/src/core/tcp_conn.h
@@ -300,6 +300,8 @@ typedef struct tcp_connection
 	enum tcp_closed_reason event; /* connection close reason */
 	int reader_pid;				  /* pid of the active reader process */
 	struct receive_info rcv;	  /* src & dst ip, ports, proto a.s.o*/
+	struct receive_info
+			haproxy_rcv;		  /* src & dst ip, ports, proto from haproxy*/
 	ksr_coninfo_t cinfo;		  /* additional info (for haproxy, tls, ...) */
 	struct tcp_req req;			  /* request data */
 	atomic_t refcnt;

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -2474,6 +2474,16 @@ int tcp_send(struct dest_info *dst, union sockaddr_union *from, const char *buf,
 		} else {
 			c = tcpconn_get(dst->id, &ip, port, from, con_lifetime);
 		}
+		/* force_socket local address may not match PROXY dst_ip on HAProxy conns */
+		if(unlikely(c == 0 && from != 0)) {
+			if(tcp_connection_match == TCPCONN_MATCH_STRICT
+					|| (dst->send_flags.f & SND_F_FORCE_PROTO)) {
+				c = tcpconn_lookup(dst->id, &ip, port, 0, try_local_port,
+						con_lifetime, dst->proto);
+			} else {
+				c = tcpconn_get(dst->id, &ip, port, 0, con_lifetime);
+			}
+		}
 	} else if(likely(dst->id)) {
 		c = tcpconn_get(dst->id, 0, 0, 0, con_lifetime);
 	} else {
@@ -2491,6 +2501,15 @@ int tcp_send(struct dest_info *dst, union sockaddr_union *from, const char *buf,
 							con_lifetime, dst->proto);
 				} else {
 					c = tcpconn_get(0, &ip, port, from, con_lifetime);
+				}
+				if(unlikely(c == 0 && from != 0)) {
+					if(tcp_connection_match == TCPCONN_MATCH_STRICT
+							|| (dst->send_flags.f & SND_F_FORCE_PROTO)) {
+						c = tcpconn_lookup(0, &ip, port, 0, try_local_port,
+								con_lifetime, dst->proto);
+					} else {
+						c = tcpconn_get(0, &ip, port, 0, con_lifetime);
+					}
 				}
 			} else {
 				LM_ERR("id %d not found, dropping\n", dst->id);

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -214,8 +214,9 @@ static int tcp_sockets_gworkers = 0;
 
 static ticks_t tcpconn_main_timeout(ticks_t, struct timer_ln *, void *);
 
-inline static int _tcpconn_add_alias_unsafe(struct tcp_connection *c, int port,
-		struct ip_addr *l_ip, int l_port, int flags);
+inline static int _tcpconn_add_alias_unsafe(struct tcp_connection *c,
+		struct ip_addr *peer_ip, int port, struct ip_addr *l_ip, int l_port,
+		int flags);
 
 static void tcp_log_action(
 		struct tcp_connection *c, const char *action, const char *reason)
@@ -1620,8 +1621,8 @@ int tcpconn_finish_connect(struct tcp_connection *c, union sockaddr_union *from)
 		/* add aliases */
 		TCPCONN_LOCK;
 		_tcpconn_add_alias_unsafe(
-				c, c->rcv.src_port, &c->rcv.dst_ip, 0, new_conn_alias_flags);
-		_tcpconn_add_alias_unsafe(c, c->rcv.src_port, &c->rcv.dst_ip,
+				c, 0, c->rcv.src_port, &c->rcv.dst_ip, 0, new_conn_alias_flags);
+		_tcpconn_add_alias_unsafe(c, 0, c->rcv.src_port, &c->rcv.dst_ip,
 				c->rcv.dst_port, new_conn_alias_flags);
 		TCPCONN_UNLOCK;
 	} else if(su_cmp(from, &local_addr) != 1) {
@@ -1639,8 +1640,8 @@ int tcpconn_finish_connect(struct tcp_connection *c, union sockaddr_union *from)
 		}
 		/* add the local_ip:0 and local_ip:local_port aliases */
 		_tcpconn_add_alias_unsafe(
-				c, c->rcv.src_port, &c->rcv.dst_ip, 0, new_conn_alias_flags);
-		_tcpconn_add_alias_unsafe(c, c->rcv.src_port, &c->rcv.dst_ip,
+				c, 0, c->rcv.src_port, &c->rcv.dst_ip, 0, new_conn_alias_flags);
+		_tcpconn_add_alias_unsafe(c, 0, c->rcv.src_port, &c->rcv.dst_ip,
 				c->rcv.dst_port, new_conn_alias_flags);
 		TCPCONN_UNLOCK;
 	}
@@ -1679,19 +1680,35 @@ inline static struct tcp_connection *tcpconn_add(struct tcp_connection *c)
 		 *   -- for finding if a fully specified connection exists using address
 		 *      and port stored into cinfo*/
 		_tcpconn_add_alias_unsafe(
-				c, c->rcv.src_port, &zero_ip, 0, new_conn_alias_flags);
+				c, 0, c->rcv.src_port, &zero_ip, 0, new_conn_alias_flags);
 		if(likely(c->rcv.dst_ip.af && !ip_addr_any(&c->rcv.dst_ip))) {
-			_tcpconn_add_alias_unsafe(c, c->rcv.src_port, &c->rcv.dst_ip, 0,
+			_tcpconn_add_alias_unsafe(c, 0, c->rcv.src_port, &c->rcv.dst_ip, 0,
 					new_conn_alias_flags);
-			_tcpconn_add_alias_unsafe(c, c->rcv.src_port, &c->rcv.dst_ip,
+			_tcpconn_add_alias_unsafe(c, 0, c->rcv.src_port, &c->rcv.dst_ip,
 					c->rcv.dst_port, new_conn_alias_flags);
 		}
 		if(unlikely(c->cinfo.dst_ip.af && !ip_addr_any(&c->cinfo.dst_ip)
 					&& !ip_addr_cmp(&c->rcv.dst_ip, &c->cinfo.dst_ip))) {
-			_tcpconn_add_alias_unsafe(c, c->rcv.src_port, &c->cinfo.dst_ip, 0,
-					new_conn_alias_flags);
-			_tcpconn_add_alias_unsafe(c, c->rcv.src_port, &c->cinfo.dst_ip,
-					c->cinfo.dst_port, new_conn_alias_flags);
+			_tcpconn_add_alias_unsafe(c, 0, c->haproxy_rcv.src_port,
+					&c->cinfo.dst_ip, 0, new_conn_alias_flags);
+			_tcpconn_add_alias_unsafe(c, 0, c->haproxy_rcv.src_port,
+					&c->cinfo.dst_ip, c->cinfo.dst_port, new_conn_alias_flags);
+		}
+		/* aliases keyed on haproxy_rcv peer (pre-PROXY tunnel) address */
+		if(unlikely(c->rcv.proto_reserved2
+					&& (!ip_addr_cmp(&c->rcv.src_ip, &c->haproxy_rcv.src_ip)
+							|| c->rcv.src_port != c->haproxy_rcv.src_port))) {
+			_tcpconn_add_alias_unsafe(c, &c->haproxy_rcv.src_ip,
+					c->haproxy_rcv.src_port, &zero_ip, 0, new_conn_alias_flags);
+			if(likely(c->haproxy_rcv.dst_ip.af
+					   && !ip_addr_any(&c->haproxy_rcv.dst_ip))) {
+				_tcpconn_add_alias_unsafe(c, &c->haproxy_rcv.src_ip,
+						c->haproxy_rcv.src_port, &c->haproxy_rcv.dst_ip, 0,
+						new_conn_alias_flags);
+				_tcpconn_add_alias_unsafe(c, &c->haproxy_rcv.src_ip,
+						c->haproxy_rcv.src_port, &c->haproxy_rcv.dst_ip,
+						c->haproxy_rcv.dst_port, new_conn_alias_flags);
+			}
 		}
 
 		/* ignore add_alias errors, there are some valid cases when one
@@ -1763,6 +1780,90 @@ void tcpconn_rm(struct tcp_connection *c)
 }
 
 
+static int tcpconn_peer_ip_match(struct ip_addr *ip, struct tcp_connection *p)
+{
+	if(ip_addr_cmp(ip, &p->rcv.src_ip))
+		return 1;
+	if(ip_addr_cmp(ip, &p->cinfo.src_ip))
+		return 1;
+	if(likely(!p->rcv.proto_reserved2))
+		return 0;
+	if(ip_addr_cmp(ip, &p->haproxy_rcv.src_ip))
+		return 1;
+	return 0;
+}
+
+static int tcpconn_peer_port_match(
+		int port, struct tcp_connection *p, struct tcp_conn_alias *a)
+{
+	if(port == a->port)
+		return 1;
+	if(port == p->rcv.src_port)
+		return 1;
+	if(p->rcv.proto_reserved2 && port == p->haproxy_rcv.src_port)
+		return 1;
+	return 0;
+}
+
+static int tcpconn_local_ip_match(
+		struct ip_addr *l_ip, int is_local_ip_any, struct tcp_connection *p)
+{
+	if(is_local_ip_any)
+		return 1;
+	if(ip_addr_cmp(l_ip, &p->rcv.dst_ip))
+		return 1;
+	if(ip_addr_cmp(l_ip, &p->cinfo.dst_ip))
+		return 1;
+	if(p->rcv.bind_address && ip_addr_cmp(l_ip, &p->rcv.bind_address->address))
+		return 1;
+	if(p->rcv.proto_reserved2 && ip_addr_cmp(l_ip, &p->haproxy_rcv.dst_ip))
+		return 1;
+	return 0;
+}
+
+static int tcpconn_local_port_match(int l_port, struct tcp_connection *p)
+{
+	if(l_port == 0)
+		return 1;
+	if(l_port == p->rcv.dst_port)
+		return 1;
+	if(l_port == p->cinfo.dst_port)
+		return 1;
+	if(p->rcv.proto_reserved2 && l_port == p->haproxy_rcv.dst_port)
+		return 1;
+	return 0;
+}
+
+/* scan id-hash when alias lookup misses (HAProxy peer / client port mismatch) */
+static struct tcp_connection *_tcpconn_find_haproxy_rcv(struct ip_addr *ip,
+		int port, struct ip_addr *l_ip, int l_port, sip_protos_t proto)
+{
+	struct tcp_connection *c;
+	int h;
+	int is_local_ip_any;
+
+	is_local_ip_any = ip_addr_any(l_ip);
+	for(h = 0; h < TCP_ID_HASH_SIZE; h++) {
+		for(c = tcpconn_id_hash[h]; c; c = c->id_next) {
+			if(c->state == S_CONN_BAD || !c->rcv.proto_reserved2)
+				continue;
+			if(!tcpconn_peer_ip_match(ip, c))
+				continue;
+			if(port != c->rcv.src_port && port != c->haproxy_rcv.src_port)
+				continue;
+			if(!tcpconn_local_ip_match(l_ip, is_local_ip_any, c))
+				continue;
+			if(!tcpconn_local_port_match(l_port, c))
+				continue;
+			if(proto != PROTO_NONE && c->rcv.proto != proto)
+				continue;
+			LM_DBG("found connection by haproxy_rcv address (id: %d)\n", c->id);
+			return c;
+		}
+	}
+	return 0;
+}
+
 /* finds a connection, if id=0 uses the ip addr, port, local_ip and local port
  *  (host byte order) and tries to find the connection that matches all of
  *   them. Wild cards can be used for local_ip, local_port and proto (a 0 filled
@@ -1795,7 +1896,8 @@ struct tcp_connection *_tcpconn_find(int id, struct ip_addr *ip, int port,
 				return c;
 			}
 		}
-	} else if(likely(ip)) {
+	}
+	if(likely(ip)) {
 		hash = tcp_addr_hash(ip, port, l_ip, l_port);
 		is_local_ip_any = ip_addr_any(l_ip);
 		for(a = tcpconn_aliases_hash[hash]; a; a = a->next) {
@@ -1804,13 +1906,11 @@ struct tcp_connection *_tcpconn_find(int id, struct ip_addr *ip, int port,
 					a->parent, a->parent->id, a->port, a->parent->rcv.src_port);
 			print_ip("ip=", &a->parent->rcv.src_ip, "\n");
 #endif
-			if((a->parent->state != S_CONN_BAD) && (port == a->port)
-					&& ((l_port == 0) || (l_port == a->parent->rcv.dst_port)
-							|| (l_port == a->parent->cinfo.dst_port))
-					&& (ip_addr_cmp(ip, &a->parent->rcv.src_ip))
-					&& (is_local_ip_any
-							|| ip_addr_cmp(l_ip, &a->parent->rcv.dst_ip)
-							|| ip_addr_cmp(l_ip, &a->parent->cinfo.dst_ip))
+			if((a->parent->state != S_CONN_BAD)
+					&& tcpconn_peer_port_match(port, a->parent, a)
+					&& tcpconn_local_port_match(l_port, a->parent)
+					&& tcpconn_peer_ip_match(ip, a->parent)
+					&& tcpconn_local_ip_match(l_ip, is_local_ip_any, a->parent)
 					&& (proto == PROTO_NONE || a->parent->rcv.proto == proto)) {
 				LM_DBG("found connection by peer address (id: %d)\n",
 						a->parent->id);
@@ -1823,6 +1923,7 @@ struct tcp_connection *_tcpconn_find(int id, struct ip_addr *ip, int port,
 				return a->parent;
 			}
 		}
+		return _tcpconn_find_haproxy_rcv(ip, port, l_ip, l_port, proto);
 	}
 	return 0;
 }
@@ -2084,13 +2185,15 @@ void tcpconn_log_candidates(int id, struct ip_addr *ip, int port,
  * returns 0 on success, <0 on failure ( -1  - null c, -2 too many aliases,
  *  -3 alias already present and pointing to another connection)
  * WARNING: must be called with TCPCONN_LOCK held */
-inline static int _tcpconn_add_alias_unsafe(struct tcp_connection *c, int port,
-		struct ip_addr *l_ip, int l_port, int flags)
+inline static int _tcpconn_add_alias_unsafe(struct tcp_connection *c,
+		struct ip_addr *peer_ip, int port, struct ip_addr *l_ip, int l_port,
+		int flags)
 {
 	unsigned hash;
 	struct tcp_conn_alias *a;
 	struct tcp_conn_alias *nxt;
 	struct tcp_connection *p;
+	struct ip_addr *peer;
 	int is_local_ip_any;
 	int i;
 	int r;
@@ -2098,13 +2201,18 @@ inline static int _tcpconn_add_alias_unsafe(struct tcp_connection *c, int port,
 	a = 0;
 	is_local_ip_any = ip_addr_any(l_ip);
 	if(likely(c)) {
-		hash = tcp_addr_hash(&c->rcv.src_ip, port, l_ip, l_port);
+		peer = peer_ip ? peer_ip : &c->rcv.src_ip;
+		hash = tcp_addr_hash(peer, port, l_ip, l_port);
+
 		/* search the aliases for an already existing one */
 		for(a = tcpconn_aliases_hash[hash], nxt = 0; a; a = nxt) {
 			nxt = a->next;
 			if((a->parent->state != S_CONN_BAD) && (port == a->port)
 					&& ((l_port == 0) || (l_port == a->parent->rcv.dst_port))
-					&& (ip_addr_cmp(&c->rcv.src_ip, &a->parent->rcv.src_ip))
+					&& (ip_addr_cmp(peer, &a->parent->rcv.src_ip)
+							|| (peer_ip && peer_ip != &c->rcv.src_ip
+									&& ip_addr_cmp(peer,
+											&a->parent->haproxy_rcv.src_ip)))
 					&& (is_local_ip_any
 							|| ip_addr_cmp(&a->parent->rcv.dst_ip, l_ip))) {
 				/* found */
@@ -2212,17 +2320,17 @@ int tcpconn_add_alias(int id, int port, int proto)
 		ip_addr_mk_any(c->rcv.src_ip.af, &zero_ip);
 		alias_flags = cfg_get(tcp, tcp_cfg, alias_flags);
 		/* alias src_ip:port, 0, 0 */
-		ret = _tcpconn_add_alias_unsafe(c, port, &zero_ip, 0, alias_flags);
+		ret = _tcpconn_add_alias_unsafe(c, 0, port, &zero_ip, 0, alias_flags);
 		if(ret < 0 && ret != -3)
 			goto error;
 		/* alias src_ip:port, local_ip, 0 */
 		ret = _tcpconn_add_alias_unsafe(
-				c, port, &c->rcv.dst_ip, 0, alias_flags);
+				c, 0, port, &c->rcv.dst_ip, 0, alias_flags);
 		if(ret < 0 && ret != -3)
 			goto error;
 		/* alias src_ip:port, local_ip, local_port */
 		ret = _tcpconn_add_alias_unsafe(
-				c, port, &c->rcv.dst_ip, c->rcv.dst_port, alias_flags);
+				c, 0, port, &c->rcv.dst_ip, c->rcv.dst_port, alias_flags);
 		if(unlikely(ret < 0))
 			goto error;
 	} else

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1059,6 +1059,8 @@ int tcpconn_read_haproxy(struct tcp_connection *c)
 	src_ip = &c->rcv.src_ip;
 	dst_ip = &c->rcv.dst_ip;
 
+	c->haproxy_rcv = c->rcv;
+
 	if(bytes >= 16 && memcmp(&hdr.v2, v2sig, 12) == 0
 			&& (hdr.v2.ver_cmd & 0xF0) == 0x20) {
 		LM_DBG("received PROXY protocol v2 header\n");
@@ -1252,7 +1254,8 @@ struct tcp_connection *tcpconn_new(int sock, union sockaddr_union *su,
 		int state)
 {
 	struct tcp_connection *c;
-	int rd_b_size, ret;
+	int rd_b_size;
+	int ret = -1;
 
 	rd_b_size = cfg_get(tcp, tcp_cfg, rd_buf_size);
 	c = shm_malloc(sizeof(struct tcp_connection) + rd_b_size);
@@ -1302,7 +1305,7 @@ struct tcp_connection *tcpconn_new(int sock, union sockaddr_union *su,
 	init_tcp_req(&c->req, (char *)c + sizeof(struct tcp_connection), rd_b_size);
 	c->id = (*connection_id)++;
 	c->rcv.proto_reserved1 = 0; /* this will be filled before receive_message*/
-	c->rcv.proto_reserved2 = 0;
+	c->rcv.proto_reserved2 = !ret ? 1 : 0; /* haproxy msg marker */
 	c->state = state;
 	c->initstate = state;
 	c->extra_data = 0;

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1061,6 +1061,7 @@ int tcpconn_read_haproxy(struct tcp_connection *c)
 	dst_ip = &c->rcv.dst_ip;
 
 	c->haproxy_rcv = c->rcv;
+	c->haproxy_rcv.proto = PROTO_TCP;
 
 	if(bytes >= 16 && memcmp(&hdr.v2, v2sig, 12) == 0
 			&& (hdr.v2.ver_cmd & 0xF0) == 0x20) {

--- a/src/core/tcp_read.c
+++ b/src/core/tcp_read.c
@@ -1673,7 +1673,7 @@ int receive_tcp_msg(char *tcpbuf, unsigned int len,
 #endif
 	if(unlikely(con->req.flags & F_TCP_REQ_HEP3))
 		return hep3_process_msg(tcpbuf, len, rcv_info, con);
-	ret = receive_msg(buf, len, rcv_info);
+	ret = _receive_msg(buf, len, rcv_info, &con->haproxy_rcv);
 	if(ksr_tcp_script_mode & TCP_SCRIPT_MODE_CONTINUE) {
 		return 0;
 	}

--- a/src/modules/rr/loose.c
+++ b/src/modules/rr/loose.c
@@ -40,6 +40,10 @@
 #include "../../core/parser/parse_param.h"
 #include "../../core/mem/mem.h"
 #include "../../core/dset.h"
+#include "../../core/parser/msg_parser.h"
+#ifdef USE_TCP
+#include "../../core/tcp_conn.h"
+#endif
 #include "loose.h"
 #include "rr_cb.h"
 #include "rr_mod.h"
@@ -519,8 +523,7 @@ static inline int process_outbound(struct sip_msg *_m, str flow_token)
 		return -1;
 	} else if(!ip_addr_cmp(&rcv->src_ip, &_m->rcv.src_ip)
 			  || rcv->src_port != _m->rcv.src_port) {
-		LM_DBG("\"incoming\" request found. Using flow-token for "
-			   "routing\n");
+		LM_DBG("outbound request: using flow-token for routing\n");
 
 		/* First, force the local socket */
 		si = find_si(&rcv->dst_ip, rcv->dst_port, rcv->proto);
@@ -550,6 +553,31 @@ static inline int process_outbound(struct sip_msg *_m, str flow_token)
 			return -1;
 		}
 		ruri_mark_new();
+
+#ifdef USE_TCP
+		/* Reuse existing TCP/TLS/WebSocket connection when available */
+		if(rcv->proto == PROTO_TCP || rcv->proto == PROTO_WS
+#ifdef USE_TLS
+				|| rcv->proto == PROTO_TLS || rcv->proto == PROTO_WSS
+#endif
+		) {
+			struct tcp_connection *con;
+			union sockaddr_union from;
+
+			from = si->su;
+			su_setport(&from, 0);
+			con = tcpconn_get(0, &rcv->src_ip, rcv->src_port, &from, 0);
+			if(con == NULL)
+				con = tcpconn_get(0, &rcv->src_ip, rcv->src_port, 0, 0);
+			if(con) {
+				_m->otcpid = con->id;
+				_m->msg_flags |= FL_USE_OTCPID;
+				tcpconn_put(con);
+				LM_DBG("reusing tcp connection id %d for flow-token dst\n",
+						_m->otcpid);
+			}
+		}
+#endif
 
 		return 1;
 	}

--- a/src/modules/siptrace/siptrace.c
+++ b/src/modules/siptrace/siptrace.c
@@ -45,6 +45,7 @@
 #include "../../core/rpc.h"
 #include "../../core/rpc_lookup.h"
 #include "../../lib/srdb1/db.h"
+#include "../../core/tcp_conn.h"
 #include "../../core/parser/parse_content.h"
 #include "../../core/parser/parse_from.h"
 #include "../../core/parser/parse_cseq.h"
@@ -211,6 +212,8 @@ static db_func_t db_funcs;		 /*!< Database functions */
 int trace_dialog_ack = 1;
 int trace_dialog_spiral = 1;
 static int spiral_tracked;
+
+extern int ksr_tcp_accept_haproxy;
 
 int pv_parse_siptrace_name(pv_spec_t *sp, str *in);
 int pv_get_siptrace(sip_msg_t *msg, pv_param_t *param, pv_value_t *res);
@@ -1279,6 +1282,109 @@ static int ki_sip_trace_msg(sip_msg_t *msg, str *vmsg, str *saddr, str *taddr,
 }
 
 /**
+ * Format proto:host:port for parse_phostport (IPv6 host in brackets).
+ * @return written length, or -1 on error
+ */
+static int siptrace_format_phostport_ip(
+		char *buf, int bufsize, int proto, struct ip_addr *ip, int port)
+{
+	int n;
+
+	if(buf == NULL || ip == NULL || bufsize <= 0)
+		return -1;
+
+	n = snprintf(buf, bufsize, "%s:%s:%d", siptrace_proto_name(proto),
+			ip_addr2strz(ip), port);
+	if(n < 0 || n >= bufsize)
+		return -1;
+	return n;
+}
+
+static int siptrace_is_conn_oriented(sip_protos_t proto)
+{
+	return proto == PROTO_TCP || proto == PROTO_TLS || proto == PROTO_WS
+		   || proto == PROTO_WSS;
+}
+
+static struct tcp_connection *siptrace_tcpcon_get(dest_info_t *dst)
+{
+	struct tcp_connection *con = NULL;
+	ip_addr_t ip;
+	int port;
+
+	if(dst == NULL || !siptrace_is_conn_oriented(dst->proto))
+		return NULL;
+
+	if(dst->id > 0)
+		con = tcpconn_get(dst->id, 0, 0, 0, 0);
+
+	if(con == NULL) {
+		port = su_getport(&dst->to);
+		if(port) {
+			su2ip_addr(&ip, &dst->to);
+			con = tcpconn_get(dst->id, &ip, port, 0, 0);
+			if(con == NULL && dst->send_sock)
+				con = tcpconn_get(dst->id, &ip, port, &dst->send_sock->su, 0);
+		}
+	}
+	return con;
+}
+
+/**
+ * Fill fromip for outbound traced messages.
+ * When the send path uses HAProxy, use the connection PROXY dst address
+ * (same as Via on HAProxy connections), not the local socket string.
+ * @return 1 if fromip was set, 0 if caller should use its default logic
+ */
+static int siptrace_fill_fromip_out(
+		siptrace_data_t *sto, dest_info_t *dst, sip_msg_t *msg)
+{
+	struct tcp_connection *con = NULL;
+	struct ip_addr *ip;
+	int proto;
+	unsigned short port;
+
+	if(trace_local_ip.s && trace_local_ip.len > 0) {
+		sto->fromip = trace_local_ip;
+		return 1;
+	}
+
+	if(ksr_tcp_accept_haproxy && dst && siptrace_is_conn_oriented(dst->proto)) {
+		con = siptrace_tcpcon_get(dst);
+		if(con) {
+			if(con->rcv.proto_reserved2) {
+				proto = con->rcv.proto;
+				ip = &con->rcv.dst_ip;
+				port = con->rcv.dst_port;
+				sto->fromip.len = siptrace_format_phostport_ip(sto->fromip_buff,
+						SIPTRACE_ADDR_MAX, proto, ip, (int)port);
+				tcpconn_put(con);
+				if(sto->fromip.len > 0 && sto->fromip.len < SIPTRACE_ADDR_MAX) {
+					sto->fromip.s = sto->fromip_buff;
+					return 1;
+				}
+			}
+			tcpconn_put(con);
+		}
+	}
+
+	if(msg && ksr_tcp_accept_haproxy && msg->rcv.proto_reserved2
+			&& siptrace_is_conn_oriented(msg->rcv.proto)) {
+		proto = msg->rcv.proto;
+		ip = &msg->rcv.dst_ip;
+		port = msg->rcv.dst_port;
+		sto->fromip.len = siptrace_format_phostport_ip(
+				sto->fromip_buff, SIPTRACE_ADDR_MAX, proto, ip, (int)port);
+		if(sto->fromip.len > 0 && sto->fromip.len < SIPTRACE_ADDR_MAX) {
+			sto->fromip.s = sto->fromip_buff;
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+/**
  * link call-id, method, from-tag and to-tag
  */
 static int sip_trace_msg_attrs(sip_msg_t *msg, siptrace_data_t *sto)
@@ -1345,9 +1451,9 @@ static int sip_trace(
 				&& strncmp(sto.dir, "out", 3) == 0) {
 			sto.fromip = trace_local_ip;
 		} else {
-			sto.fromip.len = snprintf(sto.fromip_buff, SIPTRACE_ADDR_MAX,
-					"%s:%s:%d", siptrace_proto_name(msg->rcv.proto),
-					ip_addr2a(&msg->rcv.src_ip), (int)msg->rcv.src_port);
+			sto.fromip.len = siptrace_format_phostport_ip(sto.fromip_buff,
+					SIPTRACE_ADDR_MAX, msg->rcv.proto, &msg->rcv.src_ip,
+					(int)msg->rcv.src_port);
 			if(sto.fromip.len < 0 || sto.fromip.len >= SIPTRACE_ADDR_MAX) {
 				LM_ERR("failed to format toip buffer (%d)\n", sto.fromip.len);
 				sto.fromip.s = SIPTRACE_ANYADDR;
@@ -1361,9 +1467,9 @@ static int sip_trace(
 				&& strncmp(sto.dir, "in", 2) == 0) {
 			sto.toip = trace_local_ip;
 		} else {
-			sto.toip.len = snprintf(sto.toip_buff, SIPTRACE_ADDR_MAX,
-					"%s:%s:%d", siptrace_proto_name(msg->rcv.proto),
-					ip_addr2a(&msg->rcv.dst_ip), (int)msg->rcv.dst_port);
+			sto.toip.len = siptrace_format_phostport_ip(sto.toip_buff,
+					SIPTRACE_ADDR_MAX, msg->rcv.proto, &msg->rcv.dst_ip,
+					(int)msg->rcv.dst_port);
 			if(sto.toip.len < 0 || sto.toip.len >= SIPTRACE_ADDR_MAX) {
 				LM_ERR("failed to format toip buffer (%d)\n", sto.toip.len);
 				sto.toip.s = SIPTRACE_ANYADDR;
@@ -1376,10 +1482,10 @@ static int sip_trace(
 		sto.body.s = snd_inf->buf;
 		sto.body.len = snd_inf->len;
 
-		if(trace_local_ip.s && trace_local_ip.len > 0) {
-			sto.fromip = trace_local_ip;
-		} else {
-			if(snd_inf->send_sock->sock_str.len >= SIPTRACE_ADDR_MAX - 1) {
+		if(!siptrace_fill_fromip_out(&sto, snd_inf->dst, snd_inf->msg)) {
+			if(snd_inf->send_sock == NULL
+					|| snd_inf->send_sock->sock_str.len
+							   >= SIPTRACE_ADDR_MAX - 1) {
 				LM_WARN("local socket address is too large\n");
 				sto.fromip.s = SIPTRACE_ANYADDR;
 				sto.fromip.len = SIPTRACE_ANYADDR_LEN;
@@ -1392,7 +1498,9 @@ static int sip_trace(
 		}
 
 		sto.toip.len = snprintf(sto.toip_buff, SIPTRACE_ADDR_MAX, "%s:%s:%d",
-				siptrace_proto_name(snd_inf->send_sock->proto),
+				siptrace_proto_name(snd_inf->send_sock
+											? snd_inf->send_sock->proto
+											: PROTO_UDP),
 				suip2a(snd_inf->to, sizeof(*snd_inf->to)),
 				(int)su_getport(snd_inf->to));
 		if(sto.toip.len < 0 || sto.toip.len >= SIPTRACE_ADDR_MAX) {
@@ -1577,13 +1685,11 @@ static void trace_onreq_out(struct cell *t, int type, struct tmcb_params *ps)
 	 * used to send the message */
 	dst = ps->dst;
 
-	if(trace_local_ip.s && trace_local_ip.len > 0) {
-		sto.fromip = trace_local_ip;
-	} else {
+	if(!siptrace_fill_fromip_out(&sto, dst, msg)) {
 		if(dst == 0 || dst->send_sock == 0 || dst->send_sock->sock_str.s == 0) {
-			sto.fromip.len = snprintf(sto.fromip_buff, SIPTRACE_ADDR_MAX,
-					"%s:%s:%d", siptrace_proto_name(msg->rcv.proto),
-					ip_addr2a(&msg->rcv.dst_ip), (int)msg->rcv.dst_port);
+			sto.fromip.len = siptrace_format_phostport_ip(sto.fromip_buff,
+					SIPTRACE_ADDR_MAX, msg->rcv.proto, &msg->rcv.dst_ip,
+					(int)msg->rcv.dst_port);
 			if(sto.fromip.len < 0 || sto.fromip.len >= SIPTRACE_ADDR_MAX) {
 				LM_ERR("failed to format toip buffer (%d)\n", sto.fromip.len);
 				sto.fromip.s = SIPTRACE_ANYADDR;
@@ -1601,9 +1707,9 @@ static void trace_onreq_out(struct cell *t, int type, struct tmcb_params *ps)
 		sto.toip.len = SIPTRACE_ANYADDR_LEN;
 	} else {
 		su2ip_addr(&to_ip, &dst->to);
-		sto.toip.len = snprintf(sto.toip_buff, SIPTRACE_ADDR_MAX, "%s:%s:%d",
-				siptrace_proto_name(dst->proto), ip_addr2a(&to_ip),
-				(int)su_getport(&dst->to));
+		sto.toip.len =
+				siptrace_format_phostport_ip(sto.toip_buff, SIPTRACE_ADDR_MAX,
+						dst->proto, &to_ip, (int)su_getport(&dst->to));
 		if(sto.toip.len < 0 || sto.toip.len >= SIPTRACE_ADDR_MAX) {
 			LM_ERR("failed to format toip buffer (%d)\n", sto.toip.len);
 			sto.toip.s = SIPTRACE_ANYADDR;
@@ -1686,9 +1792,9 @@ static void trace_onreply_in(struct cell *t, int type, struct tmcb_params *ps)
 		return;
 	}
 
-	sto.fromip.len = snprintf(sto.fromip_buff, SIPTRACE_ADDR_MAX, "%s:%s:%d",
-			siptrace_proto_name(msg->rcv.proto), ip_addr2a(&msg->rcv.src_ip),
-			(int)msg->rcv.src_port);
+	sto.fromip.len =
+			siptrace_format_phostport_ip(sto.fromip_buff, SIPTRACE_ADDR_MAX,
+					msg->rcv.proto, &msg->rcv.src_ip, (int)msg->rcv.src_port);
 	if(sto.fromip.len < 0 || sto.fromip.len >= SIPTRACE_ADDR_MAX) {
 		LM_ERR("failed to format fromip buffer (%d)\n", sto.fromip.len);
 		sto.fromip.s = SIPTRACE_ANYADDR;
@@ -1700,9 +1806,9 @@ static void trace_onreply_in(struct cell *t, int type, struct tmcb_params *ps)
 	if(trace_local_ip.s && trace_local_ip.len > 0) {
 		sto.toip = trace_local_ip;
 	} else {
-		sto.toip.len = snprintf(sto.toip_buff, SIPTRACE_ADDR_MAX, "%s:%s:%d",
-				siptrace_proto_name(msg->rcv.proto),
-				ip_addr2a(&msg->rcv.dst_ip), (int)msg->rcv.dst_port);
+		sto.toip.len = siptrace_format_phostport_ip(sto.toip_buff,
+				SIPTRACE_ADDR_MAX, msg->rcv.proto, &msg->rcv.dst_ip,
+				(int)msg->rcv.dst_port);
 		if(sto.toip.len < 0 || sto.toip.len >= SIPTRACE_ADDR_MAX) {
 			LM_ERR("failed to format toip buffer (%d)\n", sto.toip.len);
 			sto.toip.s = SIPTRACE_ANYADDR;
@@ -1810,12 +1916,11 @@ static void trace_onreply_out(struct cell *t, int type, struct tmcb_params *ps)
 		}
 	}
 
-	if(trace_local_ip.s && trace_local_ip.len > 0) {
-		sto.fromip = trace_local_ip;
-	} else {
-		sto.fromip.len = snprintf(sto.fromip_buff, SIPTRACE_ADDR_MAX,
-				"%s:%s:%d", siptrace_proto_name(msg->rcv.proto),
-				ip_addr2a(&req->rcv.dst_ip), (int)req->rcv.dst_port);
+	dst = ps->dst;
+	if(!siptrace_fill_fromip_out(&sto, dst, req)) {
+		sto.fromip.len = siptrace_format_phostport_ip(sto.fromip_buff,
+				SIPTRACE_ADDR_MAX, msg->rcv.proto, &req->rcv.dst_ip,
+				(int)req->rcv.dst_port);
 		if(sto.fromip.len < 0 || sto.fromip.len >= SIPTRACE_ADDR_MAX) {
 			LM_ERR("failed to format fromip buffer (%d)\n", sto.fromip.len);
 			sto.fromip.s = SIPTRACE_ANYADDR;
@@ -1833,15 +1938,14 @@ static void trace_onreply_out(struct cell *t, int type, struct tmcb_params *ps)
 	}
 
 	memset(&to_ip, 0, sizeof(struct ip_addr));
-	dst = ps->dst;
 	if(dst == 0) {
 		sto.toip.s = SIPTRACE_ANYADDR;
 		sto.toip.len = SIPTRACE_ANYADDR_LEN;
 	} else {
 		su2ip_addr(&to_ip, &dst->to);
-		sto.toip.len = snprintf(sto.toip_buff, SIPTRACE_ADDR_MAX, "%s:%s:%d",
-				siptrace_proto_name(dst->proto), ip_addr2a(&to_ip),
-				(int)su_getport(&dst->to));
+		sto.toip.len =
+				siptrace_format_phostport_ip(sto.toip_buff, SIPTRACE_ADDR_MAX,
+						dst->proto, &to_ip, (int)su_getport(&dst->to));
 		if(sto.toip.len < 0 || sto.toip.len >= SIPTRACE_ADDR_MAX) {
 			LM_ERR("failed to format toip buffer (%d)\n", sto.toip.len);
 			sto.toip.s = SIPTRACE_ANYADDR;
@@ -2005,12 +2109,10 @@ static void trace_sl_onreply_out(sl_cbp_t *slcbp)
 	sto.body.s = (slcbp->reply) ? slcbp->reply->s : "";
 	sto.body.len = (slcbp->reply) ? slcbp->reply->len : 0;
 
-	if(trace_local_ip.len > 0) {
-		sto.fromip = trace_local_ip;
-	} else {
-		sto.fromip.len = snprintf(sto.fromip_buff, SIPTRACE_ADDR_MAX,
-				"%s:%s:%d", siptrace_proto_name(req->rcv.proto),
-				ip_addr2a(&req->rcv.dst_ip), req->rcv.dst_port);
+	if(!siptrace_fill_fromip_out(&sto, slcbp->dst, req)) {
+		sto.fromip.len = siptrace_format_phostport_ip(sto.fromip_buff,
+				SIPTRACE_ADDR_MAX, req->rcv.proto, &req->rcv.dst_ip,
+				(int)req->rcv.dst_port);
 		if(sto.fromip.len < 0 || sto.fromip.len >= SIPTRACE_ADDR_MAX) {
 			LM_ERR("failed to format toip buffer (%d)\n", sto.fromip.len);
 			sto.fromip.s = SIPTRACE_ANYADDR;
@@ -2033,8 +2135,8 @@ static void trace_sl_onreply_out(sl_cbp_t *slcbp)
 		sto.toip.len = SIPTRACE_ANYADDR_LEN;
 	} else {
 		su2ip_addr(&to_ip, &slcbp->dst->to);
-		sto.toip.len = snprintf(sto.toip_buff, SIPTRACE_ADDR_MAX, "%s:%s:%d",
-				siptrace_proto_name(req->rcv.proto), ip_addr2a(&to_ip),
+		sto.toip.len = siptrace_format_phostport_ip(sto.toip_buff,
+				SIPTRACE_ADDR_MAX, req->rcv.proto, &to_ip,
 				(int)su_getport(&slcbp->dst->to));
 		if(sto.toip.len < 0 || sto.toip.len >= SIPTRACE_ADDR_MAX) {
 			LM_ERR("failed to format toip buffer (%d)\n", sto.toip.len);
@@ -2307,9 +2409,9 @@ int siptrace_net_data_recv(sr_event_param_t *evp)
 	sto.body.s = nd->data.s;
 	sto.body.len = nd->data.len;
 
-	sto.fromip.len = snprintf(sto.fromip_buff, SIPTRACE_ADDR_MAX, "%s:%s:%d",
-			siptrace_proto_name(nd->rcv->proto), ip_addr2strz(&nd->rcv->src_ip),
-			(int)nd->rcv->src_port);
+	sto.fromip.len =
+			siptrace_format_phostport_ip(sto.fromip_buff, SIPTRACE_ADDR_MAX,
+					nd->rcv->proto, &nd->rcv->src_ip, (int)nd->rcv->src_port);
 	if(sto.fromip.len < 0 || sto.fromip.len >= SIPTRACE_ADDR_MAX) {
 		LM_ERR("failed to format toip buffer (%d)\n", sto.fromip.len);
 		sto.fromip.s = SIPTRACE_ANYADDR;
@@ -2329,9 +2431,9 @@ int siptrace_net_data_recv(sr_event_param_t *evp)
 		sto.toip_buff[sto.toip.len] = '\0';
 		sto.toip.s = sto.toip_buff;
 	} else {
-		sto.toip.len = snprintf(sto.toip_buff, SIPTRACE_ADDR_MAX, "%s:%s:%d",
-				siptrace_proto_name(nd->rcv->proto),
-				ip_addr2strz(&nd->rcv->dst_ip), (int)nd->rcv->dst_port);
+		sto.toip.len = siptrace_format_phostport_ip(sto.toip_buff,
+				SIPTRACE_ADDR_MAX, nd->rcv->proto, &nd->rcv->dst_ip,
+				(int)nd->rcv->dst_port);
 		if(sto.toip.len < 0 || sto.toip.len >= SIPTRACE_ADDR_MAX) {
 			LM_ERR("failed to format toip buffer (%d)\n", sto.toip.len);
 			sto.toip.s = SIPTRACE_ANYADDR;
@@ -2454,38 +2556,40 @@ int siptrace_net_data_sent(sr_event_param_t *evp)
 	sto.body.s = nd->data.s;
 	sto.body.len = nd->data.len;
 
-	if(unlikely(new_dst.send_sock == 0)) {
-		LM_WARN("no sending socket found\n");
-		strcpy(sto.fromip_buff, SIPTRACE_ANYADDR);
-		sto.fromip.len = SIPTRACE_ANYADDR_LEN;
-		proto = PROTO_UDP;
-	} else if(trace_ephemeral_socket && new_dst.ephemeral.vset) {
-		/* use actual local address (ephemeral port) for outbound TCP/TLS */
-		sto.fromip.len = snprintf(sto.fromip_buff, SIPTRACE_ADDR_MAX,
-				"%s:%s:%d", siptrace_proto_name(new_dst.ephemeral.proto),
-				ip_addr2strz(&new_dst.ephemeral.ip),
-				(int)new_dst.ephemeral.port);
-		if(sto.fromip.len < 0 || sto.fromip.len >= SIPTRACE_ADDR_MAX) {
-			LM_ERR("failed to format fromip buffer (%d)\n", sto.fromip.len);
+	proto = new_dst.proto;
+	if(!siptrace_fill_fromip_out(&sto, &new_dst, NULL)) {
+		if(unlikely(new_dst.send_sock == 0)) {
+			LM_WARN("no sending socket found\n");
 			strcpy(sto.fromip_buff, SIPTRACE_ANYADDR);
 			sto.fromip.len = SIPTRACE_ANYADDR_LEN;
-		}
-		proto = new_dst.ephemeral.proto;
-	} else {
-		if((_siptrace_data_mode & SIPTRACE_DATA_MODE_ADVADDR)
-				&& new_dst.send_sock->useinfo.sock_str.len > 0) {
-			vsock = new_dst.send_sock->useinfo.sock_str;
+			proto = PROTO_UDP;
+		} else if(trace_ephemeral_socket && new_dst.ephemeral.vset) {
+			/* use actual local address (ephemeral port) for outbound TCP/TLS */
+			sto.fromip.len = siptrace_format_phostport_ip(sto.fromip_buff,
+					SIPTRACE_ADDR_MAX, new_dst.ephemeral.proto,
+					&new_dst.ephemeral.ip, (int)new_dst.ephemeral.port);
+			if(sto.fromip.len < 0 || sto.fromip.len >= SIPTRACE_ADDR_MAX) {
+				LM_ERR("failed to format fromip buffer (%d)\n", sto.fromip.len);
+				strcpy(sto.fromip_buff, SIPTRACE_ANYADDR);
+				sto.fromip.len = SIPTRACE_ANYADDR_LEN;
+			}
+			proto = new_dst.ephemeral.proto;
 		} else {
-			vsock = new_dst.send_sock->sock_str;
+			if((_siptrace_data_mode & SIPTRACE_DATA_MODE_ADVADDR)
+					&& new_dst.send_sock->useinfo.sock_str.len > 0) {
+				vsock = new_dst.send_sock->useinfo.sock_str;
+			} else {
+				vsock = new_dst.send_sock->sock_str;
+			}
+			if(vsock.len >= SIPTRACE_ADDR_MAX - 1) {
+				LM_ERR("socket string is too large: %d\n", vsock.len);
+				return -1;
+			}
+			memcpy(sto.fromip_buff, vsock.s, vsock.len);
+			sto.fromip.len = vsock.len;
+			sto.fromip_buff[sto.fromip.len] = '\0';
+			proto = new_dst.send_sock->proto;
 		}
-		if(vsock.len >= SIPTRACE_ADDR_MAX - 1) {
-			LM_ERR("socket string is too large: %d\n", vsock.len);
-			return -1;
-		}
-		memcpy(sto.fromip_buff, vsock.s, vsock.len);
-		sto.fromip.len = vsock.len;
-		sto.fromip_buff[sto.fromip.len] = '\0';
-		proto = new_dst.send_sock->proto;
 	}
 	sto.fromip.s = sto.fromip_buff;
 

--- a/src/modules/websocket/ws_frame.c
+++ b/src/modules/websocket/ws_frame.c
@@ -602,6 +602,14 @@ static int handle_pong(ws_frame_t *frame)
 	return 0;
 }
 
+static int ws_receive_sip_msg(
+		char *buf, unsigned int len, tcp_event_info_t *tcpinfo)
+{
+	if(unlikely(tcpinfo->rcv->proto_reserved2 && tcpinfo->con))
+		return _receive_msg(buf, len, tcpinfo->rcv, &tcpinfo->con->haproxy_rcv);
+	return receive_msg(buf, len, tcpinfo->rcv);
+}
+
 int ws_frame_receive(sr_event_param_t *evp)
 {
 	ws_frame_t frame;
@@ -664,8 +672,8 @@ int ws_frame_receive(sr_event_param_t *evp)
 				frame.wsc->frag_buf.s[frame.wsc->frag_buf.len] = '\0';
 
 				if(frame.fin) {
-					ret = receive_msg(frame.wsc->frag_buf.s,
-							frame.wsc->frag_buf.len, tcpinfo->rcv);
+					ret = ws_receive_sip_msg(frame.wsc->frag_buf.s,
+							frame.wsc->frag_buf.len, tcpinfo);
 					frame.wsc->frag_buf.len = 0;
 					frame.wsc->frag_progress = 0;
 					wsconn_put(frame.wsc);
@@ -708,8 +716,8 @@ int ws_frame_receive(sr_event_param_t *evp)
 
 					wsconn_put(frame.wsc);
 
-					return receive_msg(frame.payload_data, frame.payload_len,
-							tcpinfo->rcv);
+					return ws_receive_sip_msg(
+							frame.payload_data, frame.payload_len, tcpinfo);
 				} else {
 					memcpy(frame.wsc->frag_buf.s, frame.payload_data,
 							frame.payload_len);


### PR DESCRIPTION
#### Pre-Submission Checklist
- [ ] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #xxxx

#### Description
In PR extended HAproxy protocol support.
For server and client IP addresses used values from HAproxy header.
Via headers generated by the values from Haproxy protol.
Adjusted `path`, `rr`, `siptrace` module to use IP address values from HAproxy protocol.

For PR recommended review by commits.