### PR TITLE
Latency metrics

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,8 @@ FROM mcr.microsoft.com/devcontainers/base:trixie
 RUN apt-get update && \
   export DEBIAN_FRONTEND=noninteractive && \
   apt-get -y install --no-install-recommends \
-    apt-utils dialog clang-format clang pbuilder cmake docbook-xsl lynx
+    apt-utils dialog clang-format clang pbuilder cmake docbook-xsl lynx \
+    libxml2-utils
 
 # trixie packaging
 RUN mkdir -p /usr/local/src/pkg

--- a/doc/tutorials/cfg_list/docbook/cfg_core.xml
+++ b/doc/tutorials/cfg_list/docbook/cfg_core.xml
@@ -581,6 +581,10 @@
     <para>
         log level for printing latency of routing blocks.
     </para>
+    <para>
+        Route latency telemetry for core statistics is generated only when this
+        parameter is set to a printable log level.
+    </para>
     <para>Default value: 3.</para>
     <para>Type: integer.</para>
     <para>
@@ -615,6 +619,27 @@
         limit is ms for alerting on time consuming config actions.
     </para>
     <para>Default value: 0.</para>
+    <para>Type: integer.</para>
+    <para>
+    </para>
+</section>
+
+<section id="core.latency_sample_n">
+    <title>core.latency_sample_n</title>
+    <para>
+        sampling factor for route latency telemetry. One latency observation is
+        recorded for each N processed requests/replies.
+    </para>
+    <para>
+        This parameter applies only to route latency metrics sampling and does
+        not change existing latency log messages or their thresholds.
+    </para>
+    <para>
+        Sampling applies only when <emphasis>core.latency_cfg_log</emphasis>
+        enables route latency telemetry generation.
+    </para>
+    <para>Default value: 1.</para>
+    <para>Range: 1 - 2147483647.</para>
     <para>Type: integer.</para>
     <para>
     </para>

--- a/src/core/cfg.lex
+++ b/src/core/cfg.lex
@@ -524,6 +524,7 @@ LATENCY_LOG				latency_log
 LATENCY_LIMIT_DB		latency_limit_db
 LATENCY_LIMIT_ACTION	latency_limit_action
 LATENCY_LIMIT_CFG		latency_limit_cfg
+LATENCY_SAMPLE_N		latency_sample_n
 
 RPC_EXEC_DELTA_CFG		"rpc_exec_delta"
 
@@ -1094,6 +1095,7 @@ IMPORTFILE      "import_file"
 <INITIAL>{LATENCY_LIMIT_DB}  { count(); yylval.strval=yytext; return LATENCY_LIMIT_DB;}
 <INITIAL>{LATENCY_LIMIT_ACTION}  { count(); yylval.strval=yytext; return LATENCY_LIMIT_ACTION;}
 <INITIAL>{LATENCY_LIMIT_CFG}  { count(); yylval.strval=yytext; return LATENCY_LIMIT_CFG;}
+<INITIAL>{LATENCY_SAMPLE_N}  { count(); yylval.strval=yytext; return LATENCY_SAMPLE_N;}
 <INITIAL>{RPC_EXEC_DELTA_CFG}  { count(); yylval.strval=yytext; return RPC_EXEC_DELTA_CFG;}
 <INITIAL>{CFG_DESCRIPTION}	{ count(); yylval.strval=yytext; return CFG_DESCRIPTION; }
 <INITIAL>{LOADMODULE}	{ count(); yylval.strval=yytext; return LOADMODULE; }

--- a/src/core/cfg.y
+++ b/src/core/cfg.y
@@ -555,6 +555,7 @@ extern char *default_routename;
 %token LATENCY_LIMIT_DB
 %token LATENCY_LIMIT_ACTION
 %token LATENCY_LIMIT_CFG
+%token LATENCY_SAMPLE_N
 %token RPC_EXEC_DELTA_CFG
 %token MSG_TIME
 %token ONSEND_RT_REPLY
@@ -2159,6 +2160,8 @@ assign_stm:
 	| LATENCY_LIMIT_ACTION EQUAL error  { yyerror("number  expected"); }
     | LATENCY_LIMIT_CFG EQUAL NUMBER { default_core_cfg.latency_limit_cfg=$3; }
 	| LATENCY_LIMIT_CFG EQUAL error  { yyerror("number  expected"); }
+	| LATENCY_SAMPLE_N EQUAL NUMBER { default_core_cfg.latency_sample_n=$3; }
+	| LATENCY_SAMPLE_N EQUAL error  { yyerror("number  expected"); }
     | RPC_EXEC_DELTA_CFG EQUAL NUMBER { ksr_rpc_exec_delta=$3; }
 	| RPC_EXEC_DELTA_CFG EQUAL error  { yyerror("number  expected"); }
     | MSG_TIME EQUAL NUMBER { sr_msg_time=$3; }

--- a/src/core/cfg_core.c
+++ b/src/core/cfg_core.c
@@ -124,6 +124,7 @@ struct cfg_group_core default_core_cfg = {
 		0,	   /*!< latency limit db */
 		0,	   /*!< latency limit action */
 		0,	   /*!< latency limit cfg */
+		1,	   /*!< latency sample n */
 		0,	   /*!< pv_cache_dump */
 		2048,  /*!< pv_cache_limit */
 		0	   /*!< pv_cache_action */
@@ -340,6 +341,8 @@ cfg_def_t core_cfg_def[] = {
 				"limit in ms for alerting on time consuming config actions"},
 		{"latency_limit_cfg", CFG_VAR_INT | CFG_ATOMIC, 0, 0, 0, 0,
 				"limit in ms for alerting on time consuming config execution"},
+		{"latency_sample_n", CFG_VAR_INT | CFG_ATOMIC, 1, 0, 0, 0,
+				"sample one in N route latency updates (1 means all)"},
 		{"pv_cache_dump", CFG_VAR_INT, 0, 0, 0, pv_cache_dump_cb,
 				"dump process pv cache, parameter: pid_number"},
 		{"pv_cache_limit", CFG_VAR_INT | CFG_ATOMIC, 0, 0, 0, 0,

--- a/src/core/cfg_core.h
+++ b/src/core/cfg_core.h
@@ -114,7 +114,8 @@ struct cfg_group_core
 	int latency_limit_db;	  /*!< alert limit of running db commands */
 	int latency_limit_action; /*!< alert limit of running cfg actions */
 	int latency_limit_cfg;	  /*!< alert limit of running cfg routing script */
-	int pv_cache_dump;	 /*!< dump process pv cache, parameter: pid_number */
+	int latency_sample_n; /*!< sampling factor for route latency telemetry */
+	int pv_cache_dump;	  /*!< dump process pv cache, parameter: pid_number */
 	int pv_cache_limit;	 /*!< alert limit of having too many vars in pv cache */
 	int pv_cache_action; /*!< action to be taken on pv cache limit */
 };

--- a/src/core/core_stats.h
+++ b/src/core/core_stats.h
@@ -41,20 +41,43 @@
 #define STATS_BAD_RPL()
 #define STATS_BAD_URI()
 #define STATS_BAD_MSG_HDR()
+#define STATS_REQ_ROUTE_LATENCY(_method, _latency_us)
+#define STATS_RPL_ROUTE_LATENCY(_method, _status_class, _latency_us)
 
 #else /* USE_CORE_STATS */
 
 #include "events.h"
 
+#define CORE_STATS_EV_FWD_REQ_OK 1
+#define CORE_STATS_EV_FWD_RPL_OK 2
+#define CORE_STATS_EV_DROP_REQ 3
+#define CORE_STATS_EV_DROP_RPL 4
+#define CORE_STATS_EV_ERR_REQ 5
+#define CORE_STATS_EV_ERR_RPL 6
+#define CORE_STATS_EV_BAD_URI 7
+#define CORE_STATS_EV_BAD_MSG_HDR 8
+#define CORE_STATS_EV_REQ_ROUTE_LATENCY 100
+#define CORE_STATS_EV_RPL_ROUTE_LATENCY 101
+
+struct core_stats_latency_event
+{
+	int type;
+	unsigned int method;
+	unsigned int status_class;
+	unsigned int latency_us;
+};
+
 /** called each time a received request is dropped.
  * The request might be dropped explicitly (e.g. pre script callback)
  * or there might be an error while trying to forward it (e.g. send).
  */
-#define STATS_REQ_FWD_DROP() sr_event_exec(SREV_CORE_STATS, (void *)3)
+#define STATS_REQ_FWD_DROP() \
+	sr_event_exec(SREV_CORE_STATS, (void *)CORE_STATS_EV_DROP_REQ)
 
 
 /** called each time forwarding a request succeeds (send).*/
-#define STATS_REQ_FWD_OK() sr_event_exec(SREV_CORE_STATS, (void *)1)
+#define STATS_REQ_FWD_OK() \
+	sr_event_exec(SREV_CORE_STATS, (void *)CORE_STATS_EV_FWD_REQ_OK)
 
 
 /** called each time forwarding a reply fails.
@@ -62,31 +85,57 @@
  * pre script callbacks (module denying forwarding) or explicit script
  * drop (drop or module function returning 0).
  */
-#define STATS_RPL_FWD_DROP() sr_event_exec(SREV_CORE_STATS, (void *)4)
+#define STATS_RPL_FWD_DROP() \
+	sr_event_exec(SREV_CORE_STATS, (void *)CORE_STATS_EV_DROP_RPL)
 
 
 /* called each time forwarding a reply succeeds. */
-#define STATS_RPL_FWD_OK() sr_event_exec(SREV_CORE_STATS, (void *)2)
+#define STATS_RPL_FWD_OK() \
+	sr_event_exec(SREV_CORE_STATS, (void *)CORE_STATS_EV_FWD_RPL_OK)
 
 
 /** called each time a received request is too bad to process.
   * For now it's called in case the message does not have any via.
   */
-#define STATS_BAD_MSG() sr_event_exec(SREV_CORE_STATS, (void *)5)
+#define STATS_BAD_MSG() \
+	sr_event_exec(SREV_CORE_STATS, (void *)CORE_STATS_EV_ERR_REQ)
 
 
 /** called each time a received reply is too bad to process.
   * For now it's called in case the message does not have any via.
   */
-#define STATS_BAD_RPL() sr_event_exec(SREV_CORE_STATS, (void *)6)
+#define STATS_BAD_RPL() \
+	sr_event_exec(SREV_CORE_STATS, (void *)CORE_STATS_EV_ERR_RPL)
 
 
 /** called each time uri parsing fails. */
-#define STATS_BAD_URI() sr_event_exec(SREV_CORE_STATS, (void *)7)
+#define STATS_BAD_URI() \
+	sr_event_exec(SREV_CORE_STATS, (void *)CORE_STATS_EV_BAD_URI)
 
 
 /** called each time parsing some header fails. */
-#define STATS_BAD_MSG_HDR() sr_event_exec(SREV_CORE_STATS, (void *)8)
+#define STATS_BAD_MSG_HDR() \
+	sr_event_exec(SREV_CORE_STATS, (void *)CORE_STATS_EV_BAD_MSG_HDR)
+
+#define STATS_REQ_ROUTE_LATENCY(_method, _latency_us) \
+	do {                                              \
+		struct core_stats_latency_event _ev;          \
+		_ev.type = CORE_STATS_EV_REQ_ROUTE_LATENCY;   \
+		_ev.method = (_method);                       \
+		_ev.status_class = 0;                         \
+		_ev.latency_us = (_latency_us);               \
+		sr_event_exec(SREV_CORE_STATS, (void *)&_ev); \
+	} while(0)
+
+#define STATS_RPL_ROUTE_LATENCY(_method, _status_class, _latency_us) \
+	do {                                                             \
+		struct core_stats_latency_event _ev;                         \
+		_ev.type = CORE_STATS_EV_RPL_ROUTE_LATENCY;                  \
+		_ev.method = (_method);                                      \
+		_ev.status_class = (_status_class);                          \
+		_ev.latency_us = (_latency_us);                              \
+		sr_event_exec(SREV_CORE_STATS, (void *)&_ev);                \
+	} while(0)
 
 
 #endif /* USE_CORE_STATS */

--- a/src/core/receive.c
+++ b/src/core/receive.c
@@ -72,6 +72,21 @@ str default_via_port = {0, 0};
 
 int ksr_route_locks_size = 0;
 static rec_lock_set_t *ksr_route_locks_set = NULL;
+static unsigned int ksr_latency_sample_seq = 0;
+
+static inline int ksr_latency_sample_hit(unsigned int sample_n)
+{
+	if(sample_n <= 1) {
+		return 1;
+	}
+
+	ksr_latency_sample_seq++;
+	if((ksr_latency_sample_seq % sample_n) == 0) {
+		return 1;
+	}
+
+	return 0;
+}
 
 int ksr_route_locks_set_init(void)
 {
@@ -316,12 +331,16 @@ int receive_msg(char *buf, unsigned int len, receive_info_t *rcv_info)
 	int ret = -1;
 	struct timeval tvb = {0}, tve = {0};
 	unsigned int diff = 0;
+	unsigned int sample_n = 1;
 	str inb = STR_NULL;
 	sr_net_info_t netinfo = {0};
 	sr_kemi_eng_t *keng = NULL;
 	sr_event_param_t evp = {0};
 	unsigned int cidlockidx = 0;
 	unsigned int cidlockset = 0;
+	unsigned int rpl_method = METHOD_OTHER;
+	unsigned int rpl_status_class = 0;
+	struct cseq_body *cseqb = NULL;
 	int errsipmsg = 0;
 	int exectime = 0;
 
@@ -439,6 +458,7 @@ int receive_msg(char *buf, unsigned int len, receive_info_t *rcv_info)
 	if(is_printable(cfg_get(core, core_cfg, latency_cfg_log))) {
 		exectime = 1;
 	}
+	sample_n = cfg_get(core, core_cfg, latency_sample_n);
 
 	if(msg->first_line.type == SIP_REQUEST) {
 		ruri_mark_new(); /* ruri is usable for forking (not consumed yet) */
@@ -543,6 +563,10 @@ int receive_msg(char *buf, unsigned int len, receive_info_t *rcv_info)
 			gettimeofday(&tve, NULL);
 			diff = (tve.tv_sec - tvb.tv_sec) * 1000000
 				   + (tve.tv_usec - tvb.tv_usec);
+			if(ksr_latency_sample_hit(sample_n)) {
+				STATS_REQ_ROUTE_LATENCY(
+						msg->first_line.u.request.method_value, diff);
+			}
 			if(cfg_get(core, core_cfg, latency_limit_cfg) == 0
 					|| cfg_get(core, core_cfg, latency_limit_cfg) <= diff) {
 				LOG(cfg_get(core, core_cfg, latency_cfg_log),
@@ -571,6 +595,18 @@ int receive_msg(char *buf, unsigned int len, receive_info_t *rcv_info)
 
 		if(exectime) {
 			gettimeofday(&tvb, NULL);
+		}
+
+		rpl_method = METHOD_OTHER;
+		if(msg->cseq && msg->cseq->parsed) {
+			cseqb = get_cseq(msg);
+			if(cseqb != NULL) {
+				rpl_method = cseqb->method_id;
+			}
+		}
+		rpl_status_class = msg->first_line.u.reply.statuscode / 100;
+		if(rpl_status_class < 1 || rpl_status_class > 6) {
+			rpl_status_class = 0;
 		}
 
 		/* execute pre-script callbacks, if any; -jiri */
@@ -636,6 +672,9 @@ int receive_msg(char *buf, unsigned int len, receive_info_t *rcv_info)
 			gettimeofday(&tve, NULL);
 			diff = (tve.tv_sec - tvb.tv_sec) * 1000000
 				   + (tve.tv_usec - tvb.tv_usec);
+			if(ksr_latency_sample_hit(sample_n)) {
+				STATS_RPL_ROUTE_LATENCY(rpl_method, rpl_status_class, diff);
+			}
 			if(cfg_get(core, core_cfg, latency_limit_cfg) == 0
 					|| cfg_get(core, core_cfg, latency_limit_cfg) <= diff) {
 				LOG(cfg_get(core, core_cfg, latency_cfg_log),

--- a/src/core/receive.c
+++ b/src/core/receive.c
@@ -50,6 +50,7 @@
 #include "xavp.h"
 #include "select_buf.h"
 #include "locking.h"
+#include "atomic_ops.h"
 
 #include "tcp_server.h"	 /* for tcpconn_add_alias */
 #include "tcp_options.h" /* for access to tcp_accept_aliases*/
@@ -72,16 +73,18 @@ str default_via_port = {0, 0};
 
 int ksr_route_locks_size = 0;
 static rec_lock_set_t *ksr_route_locks_set = NULL;
-static unsigned int ksr_latency_sample_seq = 0;
+static volatile int ksr_latency_sample_seq = 0;
 
 static inline int ksr_latency_sample_hit(unsigned int sample_n)
 {
+	unsigned int seq;
+
 	if(sample_n <= 1) {
 		return 1;
 	}
 
-	ksr_latency_sample_seq++;
-	if((ksr_latency_sample_seq % sample_n) == 0) {
+	seq = (unsigned int)atomic_add_int(&ksr_latency_sample_seq, 1);
+	if((seq % sample_n) == 0) {
 		return 1;
 	}
 

--- a/src/modules/kex/core_stats.c
+++ b/src/modules/kex/core_stats.c
@@ -29,8 +29,11 @@
 
 
 #include <string.h>
+#include <stdint.h>
+#include <stdio.h>
 
 #include "../../core/counters.h"
+#include "../../core/core_stats.h"
 #include "../../core/events.h"
 #include "../../core/dprint.h"
 #include "../../core/timer.h"
@@ -134,6 +137,35 @@ DECLARE_STAT_VARS(update);
 DECLARE_STAT_VARS(refer);
 DECLARE_STAT_VARS(options);
 
+#define KSR_LAT_METHODS_NO 16
+#define KSR_LAT_STATUS_CLASS_NO 7
+#define KSR_LAT_BUCKETS_NO 9
+
+static const unsigned int ksr_lat_bucket_limits[KSR_LAT_BUCKETS_NO] = {
+		1000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, UINT32_MAX};
+
+static const char *ksr_lat_bucket_tokens[KSR_LAT_BUCKETS_NO] = {"1000", "5000",
+		"10000", "20000", "50000", "100000", "200000", "500000", "inf"};
+
+static const char *ksr_lat_method_tokens[KSR_LAT_METHODS_NO] = {"invite", "ack",
+		"bye", "cancel", "options", "register", "subscribe", "notify", "update",
+		"refer", "message", "info", "prack", "publish", "kdmq", "other"};
+
+static const char *ksr_lat_status_class_tokens[KSR_LAT_STATUS_CLASS_NO] = {
+		"1xx", "2xx", "3xx", "4xx", "5xx", "6xx", "other"};
+
+static counter_handle_t ksr_req_lat_bucket[KSR_LAT_METHODS_NO]
+										  [KSR_LAT_BUCKETS_NO];
+static counter_handle_t ksr_req_lat_sum[KSR_LAT_METHODS_NO];
+static counter_handle_t ksr_req_lat_count[KSR_LAT_METHODS_NO];
+static counter_handle_t ksr_rpl_lat_bucket[KSR_LAT_METHODS_NO]
+										  [KSR_LAT_STATUS_CLASS_NO]
+										  [KSR_LAT_BUCKETS_NO];
+static counter_handle_t ksr_rpl_lat_sum[KSR_LAT_METHODS_NO]
+									   [KSR_LAT_STATUS_CLASS_NO];
+static counter_handle_t ksr_rpl_lat_count[KSR_LAT_METHODS_NO]
+										 [KSR_LAT_STATUS_CLASS_NO];
+
 /* clang-format off */
 /*! exported core statistics */
 stat_export_t core_stats[] = {
@@ -231,6 +263,173 @@ stat_export_t shm_stats[] = {
 /* clang-format on */
 
 int stats_proc_stats_init_rpc(void);
+
+static int ksr_lat_method_idx(unsigned int method)
+{
+	switch(method) {
+		case METHOD_INVITE:
+			return 0;
+		case METHOD_ACK:
+			return 1;
+		case METHOD_BYE:
+			return 2;
+		case METHOD_CANCEL:
+			return 3;
+		case METHOD_OPTIONS:
+			return 4;
+		case METHOD_REGISTER:
+			return 5;
+		case METHOD_SUBSCRIBE:
+			return 6;
+		case METHOD_NOTIFY:
+			return 7;
+		case METHOD_UPDATE:
+			return 8;
+		case METHOD_REFER:
+			return 9;
+		case METHOD_MESSAGE:
+			return 10;
+		case METHOD_INFO:
+			return 11;
+		case METHOD_PRACK:
+			return 12;
+		case METHOD_PUBLISH:
+			return 13;
+		case METHOD_KDMQ:
+			return 14;
+		default:
+			return 15;
+	}
+}
+
+static int ksr_lat_status_class_idx(unsigned int status_class)
+{
+	if(status_class >= 1 && status_class <= 6) {
+		return (int)status_class - 1;
+	}
+
+	return 6;
+}
+
+static int ksr_lat_counter_register(
+		counter_handle_t *h, const char *name, const char *doc)
+{
+	if(counter_register(h, "core", name, 0, 0, 0, doc, 0) < 0) {
+		LM_ERR("failed to register counter core.%s\n", name);
+		return -1;
+	}
+
+	return 0;
+}
+
+static int ksr_register_latency_stats(void)
+{
+	char name[160];
+	int m, s, b;
+
+	for(m = 0; m < KSR_LAT_METHODS_NO; m++) {
+		for(b = 0; b < KSR_LAT_BUCKETS_NO; b++) {
+			snprintf(name, sizeof(name),
+					"request_route_latency_usec_bucket_method_%s_le_%s",
+					ksr_lat_method_tokens[m], ksr_lat_bucket_tokens[b]);
+			if(ksr_lat_counter_register(&ksr_req_lat_bucket[m][b], name,
+					   "request route latency bucket in usec")
+					< 0) {
+				return -1;
+			}
+		}
+		snprintf(name, sizeof(name), "request_route_latency_usec_sum_method_%s",
+				ksr_lat_method_tokens[m]);
+		if(ksr_lat_counter_register(&ksr_req_lat_sum[m], name,
+				   "request route latency sum in usec")
+				< 0) {
+			return -1;
+		}
+		snprintf(name, sizeof(name),
+				"request_route_latency_usec_count_method_%s",
+				ksr_lat_method_tokens[m]);
+		if(ksr_lat_counter_register(&ksr_req_lat_count[m], name,
+				   "request route latency sample count")
+				< 0) {
+			return -1;
+		}
+	}
+
+	for(m = 0; m < KSR_LAT_METHODS_NO; m++) {
+		for(s = 0; s < KSR_LAT_STATUS_CLASS_NO; s++) {
+			for(b = 0; b < KSR_LAT_BUCKETS_NO; b++) {
+				snprintf(name, sizeof(name),
+						"reply_route_latency_usec_bucket_method_%s_status_"
+						"class_%s_"
+						"le_%s",
+						ksr_lat_method_tokens[m],
+						ksr_lat_status_class_tokens[s],
+						ksr_lat_bucket_tokens[b]);
+				if(ksr_lat_counter_register(&ksr_rpl_lat_bucket[m][s][b], name,
+						   "reply route latency bucket in usec")
+						< 0) {
+					return -1;
+				}
+			}
+			snprintf(name, sizeof(name),
+					"reply_route_latency_usec_sum_method_%s_status_class_%s",
+					ksr_lat_method_tokens[m], ksr_lat_status_class_tokens[s]);
+			if(ksr_lat_counter_register(&ksr_rpl_lat_sum[m][s], name,
+					   "reply route latency sum in usec")
+					< 0) {
+				return -1;
+			}
+			snprintf(name, sizeof(name),
+					"reply_route_latency_usec_count_method_%s_status_class_%s",
+					ksr_lat_method_tokens[m], ksr_lat_status_class_tokens[s]);
+			if(ksr_lat_counter_register(&ksr_rpl_lat_count[m][s], name,
+					   "reply route latency sample count")
+					< 0) {
+				return -1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static void ksr_update_req_route_latency(unsigned int method, unsigned int usec)
+{
+	int m, b;
+
+	m = ksr_lat_method_idx(method);
+	counter_inc(ksr_req_lat_count[m]);
+	counter_add(ksr_req_lat_sum[m], usec);
+
+	for(b = 0; b < KSR_LAT_BUCKETS_NO; b++) {
+		if(usec <= ksr_lat_bucket_limits[b]) {
+			for(; b < KSR_LAT_BUCKETS_NO; b++) {
+				counter_inc(ksr_req_lat_bucket[m][b]);
+			}
+			return;
+		}
+	}
+}
+
+static void ksr_update_rpl_route_latency(
+		unsigned int method, unsigned int status_class, unsigned int usec)
+{
+	int m, s, b;
+
+	m = ksr_lat_method_idx(method);
+	s = ksr_lat_status_class_idx(status_class);
+	counter_inc(ksr_rpl_lat_count[m][s]);
+	counter_add(ksr_rpl_lat_sum[m][s], usec);
+
+	for(b = 0; b < KSR_LAT_BUCKETS_NO; b++) {
+		if(usec <= ksr_lat_bucket_limits[b]) {
+			for(; b < KSR_LAT_BUCKETS_NO; b++) {
+				counter_inc(ksr_rpl_lat_bucket[m][s][b]);
+			}
+			return;
+		}
+	}
+}
 
 
 static int km_cb_req_stats(struct sip_msg *msg, unsigned int flags, void *param)
@@ -460,40 +659,64 @@ static int km_cb_rpl_stats(struct sip_msg *msg, unsigned int flags, void *param)
 static int sts_update_core_stats(sr_event_param_t *evp)
 {
 	int type;
+	uintptr_t pev;
+	struct core_stats_latency_event *lev = NULL;
 
-	type = (int)(long)evp;
+	pev = (uintptr_t)evp;
+	if(pev > 16) {
+		lev = (struct core_stats_latency_event *)evp;
+		if(lev != NULL) {
+			type = lev->type;
+		} else {
+			return 0;
+		}
+	} else {
+		type = (int)(long)evp;
+	}
+
 	switch(type) {
-		case 1:
+		case CORE_STATS_EV_FWD_REQ_OK:
 			/* fwd_requests */
 			update_stat(fwd_reqs, 1);
 			break;
-		case 2:
+		case CORE_STATS_EV_FWD_RPL_OK:
 			/* fwd_replies */
 			update_stat(fwd_rpls, 1);
 			break;
-		case 3:
+		case CORE_STATS_EV_DROP_REQ:
 			/* drop_requests */
 			update_stat(drp_reqs, 1);
 			break;
-		case 4:
+		case CORE_STATS_EV_DROP_RPL:
 			/* drop_replies */
 			update_stat(drp_rpls, 1);
 			break;
-		case 5:
+		case CORE_STATS_EV_ERR_REQ:
 			/* err_requests */
 			update_stat(err_reqs, 1);
 			break;
-		case 6:
+		case CORE_STATS_EV_ERR_RPL:
 			/* err_replies */
 			update_stat(err_rpls, 1);
 			break;
-		case 7:
+		case CORE_STATS_EV_BAD_URI:
 			/* bad_URIs_rcvd */
 			update_stat(bad_URIs, 1);
 			break;
-		case 8:
+		case CORE_STATS_EV_BAD_MSG_HDR:
 			/* bad_msg_hdr */
 			update_stat(bad_msg_hdr, 1);
+			break;
+		case CORE_STATS_EV_REQ_ROUTE_LATENCY:
+			if(lev != NULL) {
+				ksr_update_req_route_latency(lev->method, lev->latency_us);
+			}
+			break;
+		case CORE_STATS_EV_RPL_ROUTE_LATENCY:
+			if(lev != NULL) {
+				ksr_update_rpl_route_latency(
+						lev->method, lev->status_class, lev->latency_us);
+			}
 			break;
 	}
 	return 0;
@@ -509,6 +732,10 @@ int register_core_stats(void)
 	/* register sh_mem statistics */
 	if(register_module_stats("shmem", shm_stats) != 0) {
 		LM_ERR("failed to register sh_mem statistics\n");
+		return -1;
+	}
+	if(ksr_register_latency_stats() < 0) {
+		LM_ERR("failed to register route latency statistics\n");
 		return -1;
 	}
 	if(register_script_cb(km_cb_req_stats, PRE_SCRIPT_CB | REQUEST_CB, 0) < 0) {

--- a/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
+++ b/src/modules/xhttp_prom/doc/xhttp_prom_admin.xml
@@ -163,6 +163,38 @@ modparam("xhttp_prom", "xhttp_prom_timeout", 600)
 		</emphasis>
 		User generated statistics and label names are not parsed.
 	  </para>
+	  <para>
+		When core route latency telemetry is enabled in &kamailio;, the exported
+		<emphasis>core</emphasis> statistics include histogram-style metric families
+		with labels:
+		<itemizedlist>
+		  <listitem>
+			<para><emphasis>request_route_latency_usec_bucket</emphasis> with labels
+			<emphasis>method</emphasis> and <emphasis>le</emphasis></para>
+		  </listitem>
+		  <listitem>
+			<para><emphasis>request_route_latency_usec_sum</emphasis> and
+			<emphasis>request_route_latency_usec_count</emphasis> with label
+			<emphasis>method</emphasis></para>
+		  </listitem>
+		  <listitem>
+			<para><emphasis>reply_route_latency_usec_bucket</emphasis> with labels
+			<emphasis>method</emphasis>, <emphasis>status_class</emphasis> and
+			<emphasis>le</emphasis></para>
+		  </listitem>
+		  <listitem>
+			<para><emphasis>reply_route_latency_usec_sum</emphasis> and
+			<emphasis>reply_route_latency_usec_count</emphasis> with labels
+			<emphasis>method</emphasis> and <emphasis>status_class</emphasis></para>
+		  </listitem>
+		</itemizedlist>
+	  </para>
+	  <para>
+		Global request or reply latency can be computed by aggregating these
+		metric series across their labels (for example, aggregate over
+		<emphasis>method</emphasis> and <emphasis>status_class</emphasis> as
+		needed).
+	  </para>
 	  <example>
 		<title>Set <varname>xhttp_prom_stats</varname> parameter</title>
 		<programlisting format="linespecific">

--- a/src/modules/xhttp_prom/prom.c
+++ b/src/modules/xhttp_prom/prom.c
@@ -34,6 +34,7 @@
 #include <time.h>
 #include <inttypes.h>
 #include <stdarg.h>
+#include <ctype.h>
 
 #include "../../core/globals.h"
 #include "../../core/counters.h"
@@ -201,6 +202,143 @@ int prom_body_timestamp_printf(prom_ctx_t *ctx, uint64_t ts)
 	}
 }
 
+static void ksr_prom_method_to_label(
+		const char *method_token, char *method_label, size_t method_label_size)
+{
+	if(method_token == NULL || method_label == NULL || method_label_size == 0) {
+		return;
+	}
+
+	if(strcmp(method_token, "invite") == 0) {
+		strncpy(method_label, "INVITE", method_label_size - 1);
+	} else if(strcmp(method_token, "ack") == 0) {
+		strncpy(method_label, "ACK", method_label_size - 1);
+	} else if(strcmp(method_token, "bye") == 0) {
+		strncpy(method_label, "BYE", method_label_size - 1);
+	} else if(strcmp(method_token, "cancel") == 0) {
+		strncpy(method_label, "CANCEL", method_label_size - 1);
+	} else if(strcmp(method_token, "options") == 0) {
+		strncpy(method_label, "OPTIONS", method_label_size - 1);
+	} else if(strcmp(method_token, "register") == 0) {
+		strncpy(method_label, "REGISTER", method_label_size - 1);
+	} else if(strcmp(method_token, "subscribe") == 0) {
+		strncpy(method_label, "SUBSCRIBE", method_label_size - 1);
+	} else if(strcmp(method_token, "notify") == 0) {
+		strncpy(method_label, "NOTIFY", method_label_size - 1);
+	} else if(strcmp(method_token, "update") == 0) {
+		strncpy(method_label, "UPDATE", method_label_size - 1);
+	} else if(strcmp(method_token, "refer") == 0) {
+		strncpy(method_label, "REFER", method_label_size - 1);
+	} else if(strcmp(method_token, "message") == 0) {
+		strncpy(method_label, "MESSAGE", method_label_size - 1);
+	} else if(strcmp(method_token, "info") == 0) {
+		strncpy(method_label, "INFO", method_label_size - 1);
+	} else if(strcmp(method_token, "prack") == 0) {
+		strncpy(method_label, "PRACK", method_label_size - 1);
+	} else if(strcmp(method_token, "publish") == 0) {
+		strncpy(method_label, "PUBLISH", method_label_size - 1);
+	} else if(strcmp(method_token, "kdmq") == 0) {
+		strncpy(method_label, "KDMQ", method_label_size - 1);
+	} else {
+		strncpy(method_label, "OTHER", method_label_size - 1);
+	}
+	method_label[method_label_size - 1] = '\0';
+}
+
+static int ksr_prom_emit_core_latency_metric(
+		prom_ctx_t *ctx, const char *name, long counter_val, uint64_t ts)
+{
+	char method_token[32];
+	char status_token[16];
+	char le_token[16];
+	char kind[16];
+	char method_label[32];
+
+	if(sscanf(name, "request_route_latency_usec_%15[^_]_method_%31[^_]_le_%15s",
+			   kind, method_token, le_token)
+			== 3) {
+		ksr_prom_method_to_label(
+				method_token, method_label, sizeof(method_label));
+		if(prom_body_name_printf(ctx, "%.*srequest_route_latency_usec_%s",
+				   xhttp_prom_beginning.len, xhttp_prom_beginning.s, kind)
+				== -1)
+			return -1;
+		if(prom_body_printf(ctx, "{method=\"%s\",le=\"%s\"%s} %ld",
+				   method_label,
+				   (strcmp(le_token, "inf") == 0) ? "+Inf" : le_token,
+				   xhttp_prom_tags_comma, counter_val)
+				== -1)
+			return -1;
+		if(prom_body_timestamp_printf(ctx, ts) == -1)
+			return -1;
+		return (prom_body_printf(ctx, "\n") == -1) ? -1 : 1;
+	}
+
+	if(sscanf(name, "request_route_latency_usec_%15[^_]_method_%31s", kind,
+			   method_token)
+			== 2) {
+		ksr_prom_method_to_label(
+				method_token, method_label, sizeof(method_label));
+		if(prom_body_name_printf(ctx, "%.*srequest_route_latency_usec_%s",
+				   xhttp_prom_beginning.len, xhttp_prom_beginning.s, kind)
+				== -1)
+			return -1;
+		if(prom_body_printf(ctx, "{method=\"%s\"%s} %ld", method_label,
+				   xhttp_prom_tags_comma, counter_val)
+				== -1)
+			return -1;
+		if(prom_body_timestamp_printf(ctx, ts) == -1)
+			return -1;
+		return (prom_body_printf(ctx, "\n") == -1) ? -1 : 1;
+	}
+
+	if(sscanf(name,
+			   "reply_route_latency_usec_%15[^_]_method_%31[^_]_status_class_"
+			   "%15[^_]_le_%15s",
+			   kind, method_token, status_token, le_token)
+			== 4) {
+		ksr_prom_method_to_label(
+				method_token, method_label, sizeof(method_label));
+		if(prom_body_name_printf(ctx, "%.*sreply_route_latency_usec_%s",
+				   xhttp_prom_beginning.len, xhttp_prom_beginning.s, kind)
+				== -1)
+			return -1;
+		if(prom_body_printf(ctx,
+				   "{method=\"%s\",status_class=\"%s\",le=\"%s\"%s} %ld",
+				   method_label, status_token,
+				   (strcmp(le_token, "inf") == 0) ? "+Inf" : le_token,
+				   xhttp_prom_tags_comma, counter_val)
+				== -1)
+			return -1;
+		if(prom_body_timestamp_printf(ctx, ts) == -1)
+			return -1;
+		return (prom_body_printf(ctx, "\n") == -1) ? -1 : 1;
+	}
+
+	if(sscanf(name,
+			   "reply_route_latency_usec_%15[^_]_method_%31[^_]_status_class_"
+			   "%15s",
+			   kind, method_token, status_token)
+			== 3) {
+		ksr_prom_method_to_label(
+				method_token, method_label, sizeof(method_label));
+		if(prom_body_name_printf(ctx, "%.*sreply_route_latency_usec_%s",
+				   xhttp_prom_beginning.len, xhttp_prom_beginning.s, kind)
+				== -1)
+			return -1;
+		if(prom_body_printf(ctx, "{method=\"%s\",status_class=\"%s\"%s} %ld",
+				   method_label, status_token, xhttp_prom_tags_comma,
+				   counter_val)
+				== -1)
+			return -1;
+		if(prom_body_timestamp_printf(ctx, ts) == -1)
+			return -1;
+		return (prom_body_printf(ctx, "\n") == -1) ? -1 : 1;
+	}
+
+	return 0;
+}
+
 /**
  * @brief Generate a string suitable for a Prometheus metric.
  *
@@ -221,6 +359,18 @@ static int metric_generate(
 	LM_DBG("metric -> group: %.*s  name: %.*s  value: %lu  TS: %" PRIu64 "\n",
 			group->len, group->s, name->len, name->s, counter_val,
 			(uint64_t)ts);
+
+	if(group->len == 4 && strncmp(group->s, "core", 4) == 0) {
+		int lret;
+		lret = ksr_prom_emit_core_latency_metric(ctx, name->s, counter_val, ts);
+		if(lret < 0) {
+			LM_ERR("failed to print core latency metric\n");
+			return -1;
+		}
+		if(lret > 0) {
+			return 0;
+		}
+	}
 
 	/* Print metric name. */
 	if(prom_body_name_printf(ctx, "%.*s%.*s_%.*s", xhttp_prom_beginning.len,


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

This PR adds sampled core route latency telemetry and exposes it via existing
internal statistics, scrapeable through `xhttp_prom`.

### Commit split

1. `core: add sampled route latency telemetry and cfg knob`
   - adds route latency event payload and event IDs in core stats path
   - emits sampled request/reply route latency observations in receive path
   - derives reply method from CSeq and classifies reply status (1xx..6xx/other)
   - adds core config parameter `latency_sample_n` (default 1, min 1)
   - wires parameter through `cfg_core.{c,h}`, `cfg.y`, `cfg.lex`
   - documents core settings in `doc/tutorials/cfg_list/docbook/cfg_core.xml`

2. `kex: register and update route latency histogram stats`
   - registers bounded latency counters in `core` stats group as histogram-style
     bucket/sum/count series
   - request dimensions: `method`
   - reply dimensions: `method`, `status_class`

3. `xhttp_prom: export core route latency stats as labeled histogram series`
   - maps new core latency counters to Prometheus output with labels
   - exports `_bucket`, `_sum`, `_count` families
   - maps internal `inf` token to Prometheus `+Inf`
   - documents metric families and aggregation guidance in
     `src/modules/xhttp_prom/doc/xhttp_prom_admin.xml`

4. `devcontainer: add libxml2-utils for xmllint availability`
   - adds `libxml2-utils` for XML validation tooling in the Debian devcontainer

### Runtime behavior and compatibility

- No route-script instrumentation is required.
- No additional hot-path network sends are introduced.
- Latency telemetry generation is tied to `core.latency_cfg_log` printable level.
- `core.latency_sample_n` affects metric sampling only; it does not change
  existing latency log messages or thresholds.
- Global request/reply latency views are available by aggregating labeled series
  in PromQL; detailed method/status breakdowns remain available.

### Validation performed

- Formatted with repository `.clang-format`.
- Built successfully in Debian devcontainer:
  - `make -C src -j4`

### Backport plan

This change is intended for backport to `6.1` and `5.8` after master merge,
using `git cherry-pick -x` per CONTRIBUTING guide.

### AI Disclosure

Parts of this contribution were developed with assistance from an AI coding
assistant. The assistant was used for implementation and documentation 
drafting.

All generated content was reviewed, edited, and validated by me before
submission, including:
- code and commit structure review
- formatting checks (`clang-format`)
- local build validation (`make -C src -j4` in Debian devcontainer)
