### PR TITLE
[5.0] backport CVE-2020-27507: duplicate headers in tm local requests

### DIFF
--- a/src/modules/tm/t_msgbuilder.c
+++ b/src/modules/tm/t_msgbuilder.c
@@ -279,6 +279,7 @@ char *build_local_reparse(struct cell *Trans,unsigned int branch,
 #endif /* CANCEL_REASON_SUPPORT */
 	int hadded = 0;
 	sr_cfgenv_t *cenv = NULL;
+	hdr_flags_t hdr_flags = 0;
 
 	invite_buf = Trans->uac[branch].request.buffer;
 	invite_len = Trans->uac[branch].request.buffer_len;
@@ -375,6 +376,11 @@ char *build_local_reparse(struct cell *Trans,unsigned int branch,
 		switch(hf_type) {
 			case HDR_CSEQ_T:
 				/* find the method name and replace it */
+				if(hdr_flags &  HDR_CSEQ_F) {
+					LM_DBG("duplicate CSeq header\n");
+					goto errorhdr;
+				}
+				hdr_flags |=  HDR_CSEQ_F;
 				while ((s < invite_buf_end)
 					&& ((*s == ':') || (*s == ' ') || (*s == '\t') ||
 						((*s >= '0') && (*s <= '9')))
@@ -395,6 +401,12 @@ char *build_local_reparse(struct cell *Trans,unsigned int branch,
 				break;
 
 			case HDR_TO_T:
+				if(hdr_flags &  HDR_TO_F) {
+					LM_DBG("duplicate To header\n");
+					goto errorhdr;
+				}
+				hdr_flags |=  HDR_TO_F;
+
 				if (to_len == 0) {
 					/* there is no To tag required, just copy paste
 					 * the header */
@@ -409,7 +421,25 @@ char *build_local_reparse(struct cell *Trans,unsigned int branch,
 				break;
 
 			case HDR_FROM_T:
+				/* copy hf */
+				if(hdr_flags &  HDR_FROM_F) {
+					LM_DBG("duplicate From header\n");
+					goto errorhdr;
+				}
+				hdr_flags |=  HDR_FROM_F;
+				s = lw_next_line(s, invite_buf_end);
+				append_str(d, s1, s - s1);
+				break;
 			case HDR_CALLID_T:
+				/* copy hf */
+				if(hdr_flags &  HDR_CALLID_F) {
+					LM_DBG("duplicate Call-Id header\n");
+					goto errorhdr;
+				}
+				hdr_flags |=  HDR_CALLID_F;
+				s = lw_next_line(s, invite_buf_end);
+				append_str(d, s1, s - s1);
+				break;
 			case HDR_ROUTE_T:
 			case HDR_MAXFORWARDS_T:
 				/* copy hf */
@@ -511,6 +541,7 @@ char *build_local_reparse(struct cell *Trans,unsigned int branch,
 	/* HDR_EOH_T was not found in the buffer, the message is corrupt */
 	LM_ERR("HDR_EOH_T was not found\n");
 
+errorhdr:
 	shm_free(cancel_buf);
 error:
 	LM_ERR("cannot build %.*s request\n", method_len, method);


### PR DESCRIPTION
`ada3701d22b1` makes `build_local_reparse` track which of CSeq/To/From/Call-ID it's already emitted and bail on a duplicate. without it a crafted request with duplicate headers is rebuilt with the duplicates intact — header injection / smuggling. missing on 5.0.

modeled the header-copy loop with an INVITE carrying two From headers: pre-fix both copy through, post-fix the duplicate is detected and the request rejected. (modeled the control flow rather than a full daemon build.) clean cherry-pick.

upstream: https://github.com/kamailio/kamailio/commit/ada3701d22b1
CVE: https://nvd.nist.gov/vuln/detail/CVE-2020-27507

old CVE; companion PR for 5.1 alongside this.