### PR TITLE
[5.1] backport CVE-2020-27507: duplicate headers in tm local requests

### DIFF
--- a/src/modules/tm/t_msgbuilder.c
+++ b/src/modules/tm/t_msgbuilder.c
@@ -281,6 +281,7 @@ char *build_local_reparse(struct cell *Trans,unsigned int branch,
 #endif /* CANCEL_REASON_SUPPORT */
 	int hadded = 0;
 	sr_cfgenv_t *cenv = NULL;
+	hdr_flags_t hdr_flags = 0;
 
 	invite_buf = Trans->uac[branch].request.buffer;
 	invite_len = Trans->uac[branch].request.buffer_len;
@@ -379,6 +380,11 @@ char *build_local_reparse(struct cell *Trans,unsigned int branch,
 		switch(hf_type) {
 			case HDR_CSEQ_T:
 				/* find the method name and replace it */
+				if(hdr_flags &  HDR_CSEQ_F) {
+					LM_DBG("duplicate CSeq header\n");
+					goto errorhdr;
+				}
+				hdr_flags |=  HDR_CSEQ_F;
 				while ((s < invite_buf_end)
 					&& ((*s == ':') || (*s == ' ') || (*s == '\t') ||
 						((*s >= '0') && (*s <= '9')))
@@ -399,6 +405,12 @@ char *build_local_reparse(struct cell *Trans,unsigned int branch,
 				break;
 
 			case HDR_TO_T:
+				if(hdr_flags &  HDR_TO_F) {
+					LM_DBG("duplicate To header\n");
+					goto errorhdr;
+				}
+				hdr_flags |=  HDR_TO_F;
+
 				if (to_len == 0) {
 					/* there is no To tag required, just copy paste
 					 * the header */
@@ -413,7 +425,25 @@ char *build_local_reparse(struct cell *Trans,unsigned int branch,
 				break;
 
 			case HDR_FROM_T:
+				/* copy hf */
+				if(hdr_flags &  HDR_FROM_F) {
+					LM_DBG("duplicate From header\n");
+					goto errorhdr;
+				}
+				hdr_flags |=  HDR_FROM_F;
+				s = lw_next_line(s, invite_buf_end);
+				append_str(d, s1, s - s1);
+				break;
 			case HDR_CALLID_T:
+				/* copy hf */
+				if(hdr_flags &  HDR_CALLID_F) {
+					LM_DBG("duplicate Call-Id header\n");
+					goto errorhdr;
+				}
+				hdr_flags |=  HDR_CALLID_F;
+				s = lw_next_line(s, invite_buf_end);
+				append_str(d, s1, s - s1);
+				break;
 			case HDR_ROUTE_T:
 			case HDR_MAXFORWARDS_T:
 				/* copy hf */
@@ -515,6 +545,7 @@ char *build_local_reparse(struct cell *Trans,unsigned int branch,
 	/* HDR_EOH_T was not found in the buffer, the message is corrupt */
 	LM_ERR("HDR_EOH_T was not found\n");
 
+errorhdr:
 	shm_free(cancel_buf);
 error:
 	LM_ERR("cannot build %.*s request\n", method_len, method);


### PR DESCRIPTION
same issue as the 5.0 PR, for the 5.1 branch. `ada3701d22b1` teaches `build_local_reparse` to track which of CSeq/To/From/Call-ID it has already emitted and skip duplicates; without it a crafted request with duplicate headers gets rebuilt with the duplicates intact (header injection / smuggling). missing on 5.1.

checked the header-copy path with an INVITE carrying two From headers: pre-fix both copy through, post-fix the second is dropped and the request rejected. clean cherry-pick.

upstream: https://github.com/kamailio/kamailio/commit/ada3701d22b1
CVE: https://nvd.nist.gov/vuln/detail/CVE-2020-27507