### PR TITLE
dialog: add a new function to allow the removal of dialogs shared from dmq peers

### DIFF
--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -203,6 +203,8 @@ static int fixup_dlg_refer(void **param, int param_no);
 static int fixup_dlg_bridge(void **param, int param_no);
 static int w_dlg_get(struct sip_msg *, char *, char *, char *);
 static int w_is_known_dlg(struct sip_msg *);
+static int w_dlg_remove_dialogs_from_node(
+		struct sip_msg *msg, char *uri, char *s2);
 static int w_dlg_set_ruri(sip_msg_t *, char *, char *);
 static int w_dlg_db_load_callid(sip_msg_t *msg, char *ci, char *p2);
 static int w_dlg_db_load_extra(sip_msg_t *msg, char *p1, char *p2);
@@ -277,6 +279,8 @@ static cmd_export_t cmds[]={
 	{"dlg_get",(cmd_function)w_dlg_get,                   3,fixup_dlg_bridge,
 			0, ANY_ROUTE },
 	{"is_known_dlg", (cmd_function)w_is_known_dlg,        0, NULL,
+			0, ANY_ROUTE },
+	{"dlg_remove_dialogs_from_node", (cmd_function)w_dlg_remove_dialogs_from_node, 1, fixup_spve_null,
 			0, ANY_ROUTE },
 	{"dlg_set_timeout", (cmd_function)w_dlg_set_timeout,  1,fixup_igp_null,
 			0, ANY_ROUTE },
@@ -2858,6 +2862,11 @@ static sr_kemi_t sr_kemi_dialog_exports[] = {
 		{ SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
+	{ str_init("dialog"), str_init("dlg_remove_dialogs_from_node"),
+		SR_KEMIP_INT, ki_dlg_remove_dialogs_from_node,
+		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
 	{ str_init("dialog"), str_init("dlg_set_timeout"),
 		SR_KEMIP_INT, ki_dlg_set_timeout,
 		{ SR_KEMIP_INT, SR_KEMIP_NONE, SR_KEMIP_NONE,
@@ -3420,6 +3429,19 @@ static void internal_rpc_profile_print_dlgs(
 static int w_is_known_dlg(sip_msg_t *msg)
 {
 	return is_known_dlg(msg);
+}
+
+static int w_dlg_remove_dialogs_from_node(
+		struct sip_msg *msg, char *uri, char *s2)
+{
+	str val;
+
+	if(fixup_get_svalue(msg, (gparam_t *)uri, &val) != 0) {
+		LM_ERR("no node_uri value\n");
+		return -1;
+	}
+
+	return ki_dlg_remove_dialogs_from_node(msg, &val);
 }
 
 static int w_dlg_set_ruri(sip_msg_t *msg, char *p1, char *p2)

--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -267,6 +267,19 @@ int dlg_dmq_handle_msg(
 				/* prevent DB sync */
 				dlg->dflags &= ~(DLG_FLAG_NEW | DLG_FLAG_CHANGED);
 				dlg->iflags |= DLG_IFLAG_DMQ_SYNC;
+				if(node && node->orig_uri.s && node->orig_uri.len > 0) {
+					dlg->dmq_node_uri.s =
+							(char *)shm_malloc(node->orig_uri.len + 1);
+					if(dlg->dmq_node_uri.s) {
+						memcpy(dlg->dmq_node_uri.s, node->orig_uri.s,
+								node->orig_uri.len);
+						dlg->dmq_node_uri.s[node->orig_uri.len] = '\0';
+						dlg->dmq_node_uri.len = node->orig_uri.len;
+					} else {
+						LM_ERR("no shm memory for dmq_node_uri\n");
+						dlg->dmq_node_uri.len = 0;
+					}
+				}
 				if(lm > 0) {
 					dlg->last_modified = lm;
 				}
@@ -702,4 +715,73 @@ int dmq_send_all_dlgs(dmq_node_t *dmq_node)
 	}
 
 	return 0;
+}
+
+
+int ki_dlg_remove_dialogs_from_node(sip_msg_t *msg, str *node_uri)
+{
+	unsigned int i;
+	dlg_cell_t *dlg;
+	dlg_cell_t *tdlg;
+	int ret;
+	int count = 0;
+
+	if(node_uri == NULL || node_uri->s == NULL || node_uri->len <= 0) {
+		LM_ERR("invalid node_uri parameter\n");
+		return -1;
+	}
+
+	if(d_table == NULL) {
+		LM_ERR("dialog table not initialized\n");
+		return -1;
+	}
+
+	LM_DBG("removing DMQ-synced dialogs from node [%.*s]\n", node_uri->len,
+			node_uri->s);
+
+	for(i = 0; i < d_table->size; i++) {
+		dlg_lock(d_table, &d_table->entries[i]);
+		dlg = d_table->entries[i].first;
+		while(dlg) {
+			tdlg = dlg;
+			dlg = dlg->next;
+			if(!(tdlg->iflags & DLG_IFLAG_DMQ_SYNC)) {
+				continue;
+			}
+			if(tdlg->dmq_node_uri.len != node_uri->len
+					|| strncmp(tdlg->dmq_node_uri.s, node_uri->s, node_uri->len)
+							   != 0) {
+				continue;
+			}
+			LM_DBG("removing dlg [%u:%u] callid [%.*s] state [%u] "
+				   "from node [%.*s]\n",
+					tdlg->h_entry, tdlg->h_id, tdlg->callid.len, tdlg->callid.s,
+					tdlg->state, node_uri->len, node_uri->s);
+			if(tdlg->state == DLG_STATE_CONFIRMED
+					|| tdlg->state == DLG_STATE_EARLY) {
+				ret = remove_dialog_timer(&tdlg->tl);
+				if(ret < 0) {
+					LM_CRIT("unable to unlink timer on dlg %p [%u:%u]\n", tdlg,
+							tdlg->h_entry, tdlg->h_id);
+				}
+			}
+			if(tdlg->state == DLG_STATE_CONFIRMED
+					|| tdlg->state == DLG_STATE_CONFIRMED_NA) {
+				if_update_stat(dlg_enable_stats, active_dlgs, -1);
+			} else if(tdlg->state == DLG_STATE_EARLY) {
+				if_update_stat(dlg_enable_stats, early_dlgs, -1);
+			}
+			/* prevent DB sync and DMQ re-broadcast */
+			tdlg->dflags |= DLG_FLAG_NEW;
+			tdlg->iflags &= ~DLG_IFLAG_DMQ_SYNC;
+			unlink_unsafe_dlg(&d_table->entries[i], tdlg);
+			destroy_dlg(tdlg);
+			count++;
+		}
+		dlg_unlock(d_table, &d_table->entries[i]);
+	}
+
+	LM_INFO("removed %d DMQ-synced dialogs from node [%.*s]\n", count,
+			node_uri->len, node_uri->s);
+	return count > 0 ? 1 : -1;
 }

--- a/src/modules/dialog/dlg_dmq.h
+++ b/src/modules/dialog/dlg_dmq.h
@@ -48,4 +48,5 @@ int dlg_dmq_handle_msg(
 		struct sip_msg *msg, peer_reponse_t *resp, dmq_node_t *node);
 int dlg_dmq_replicate_action(dlg_dmq_action_t action, dlg_cell_t *dlg,
 		int needlock, dmq_node_t *node);
+int ki_dlg_remove_dialogs_from_node(sip_msg_t *msg, str *node_uri);
 #endif

--- a/src/modules/dialog/dlg_hash.c
+++ b/src/modules/dialog/dlg_hash.c
@@ -406,6 +406,8 @@ void destroy_dlg(struct dlg_cell *dlg)
 	if(dlg->toroute_name.s)
 		shm_free(dlg->toroute_name.s);
 
+	if(dlg->dmq_node_uri.s)
+		shm_free(dlg->dmq_node_uri.s);
 
 	while(dlg->vars) {
 		var = dlg->vars;

--- a/src/modules/dialog/dlg_hash.h
+++ b/src/modules/dialog/dlg_hash.h
@@ -144,6 +144,7 @@ typedef struct dlg_cell
 	unsigned int ka_src_counter; /*!< keepalive src (caller) counter */
 	unsigned int ka_dst_counter; /*!< keepalive dst (callee) counter */
 	unsigned int last_modified;	 /*!< LWW timestamp for DMQ sync */
+	str dmq_node_uri;			 /*!< URI of DMQ node that synced this dialog */
 } dlg_cell_t;
 
 

--- a/src/modules/dialog/doc/dialog_admin.xml
+++ b/src/modules/dialog/doc/dialog_admin.xml
@@ -2694,6 +2694,46 @@ if(has_totag()) {
 		</example>
 	</section>
 
+	<section id="dialog.f.dlg_remove_dialogs_from_node">
+		<title>
+		<function moreinfo="none">dlg_remove_dialogs_from_node(node_uri)</function>
+		</title>
+		<para>
+			Remove all dialogs that were synced via DMQ from a specific
+			node, identified by its DMQ node URI. This is useful for
+			cleaning up stale dialogs when a DMQ peer node goes down
+			permanently and its synced dialogs are no longer needed
+			on the local node.
+		</para>
+		<para>
+			Only dialogs that have the DMQ sync flag set and whose
+			originating node URI matches the provided argument will
+			be removed. Locally created dialogs and dialogs synced
+			from other nodes are not affected.
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para><emphasis>node_uri</emphasis> - the DMQ node URI of
+			the peer whose dialogs should be removed (e.g.,
+			"sip:10.0.0.2:5060"). The parameter can contain
+			pseudo-variables.
+			</para>
+		</listitem>
+		</itemizedlist>
+		<para>
+			This function can be used from ANY_ROUTE.
+		</para>
+		<example>
+		<title><function>dlg_remove_dialogs_from_node()</function> usage</title>
+		<programlisting format="linespecific">
+...
+dlg_remove_dialogs_from_node("sip:10.0.0.2:5060");
+...
+</programlisting>
+		</example>
+	</section>
+
 	<section id="dialog.f.dlg_reset_property">
 		<title>
 		<function moreinfo="none">dlg_reset_property(attr)</function>


### PR DESCRIPTION
#### Description

In a scalable `Kamailio` architecture that uses `DMQ` to share dialogs (profiles, essentialy) between the peers, in some cases could make sense to remove dialogs that were created and synced from other peers. Example: If a peer goes down and didn't go up again (or in a feasible time), could make sense to remove its synced dialogs (example: `dmq` used to implement a shared dialog counter per provider).

To allow it, a new function was introduced in `dialog` module: `dlg_remove_dialogs_from_node`.

With the new `event_routes`: `peer-up` and `peer-up`, we can easily use this new function to clean the dialogs based on the peer state. 

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue

**Note:** `clang` errors are not related to my PR;