### PR TITLE
cplc: trace level and crash

### DIFF
--- a/src/modules/cplc/cpl_proxy.h
+++ b/src/modules/cplc/cpl_proxy.h
@@ -149,7 +149,12 @@ static void reply_callback(struct cell *t, int type, struct tmcb_params *ps)
 	int rez;
 
 	if(intr == 0) {
-		LM_WARN("param=0 for callback %d, transaction=%p \n", type, t);
+		if ((1 == cpl_env.ignore3xx) && (type&TMCB_RESPONSE_OUT)) {
+			LM_DBG("param=0 for callback %d, transaction=%p, due to a 3XX ignored \n", type, t);
+		}
+		else {
+			LM_WARN("param=0 for callback %d, transaction=%p \n", type, t);
+		}
 		return;
 	}
 

--- a/src/modules/cplc/cpl_run.c
+++ b/src/modules/cplc/cpl_run.c
@@ -745,12 +745,6 @@ static inline char *run_redirect(struct cpl_interpreter *intr)
 	else
 		i = cpl_fct.slb.freply(intr->msg, 302, &cpl_302_reason);
 
-	/* msg which I'm working on can be in private memory or is a clone into
-	 * shared memory (if I'm after a failed proxy); So, it's better to removed
-	 * by myself the lump that I added previously */
-	unlink_lump_rpl(intr->msg, lump);
-	free_lump_rpl(lump);
-
 	if(i != 1) {
 		LM_ERR("unable to send redirect reply!\n");
 		goto runtime_error;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
cplc:
- modify trace level when a 3XX response is managed and ignore3xx is activated
- crash: Sometimes cplc module wants to unlink lump on current sip message but the pointer is no more valid and a crash occurs. Moreover the lump created is also destroyed when freply is called like sip message (it was the root cause of this crash). So this patch does not introduce any memory leak as freply already have done the stuff by deleting lump.