### PR TITLE
tls: warn when tls_threads_mode is unsafe with OpenSSL 3.x

### DIFF
--- a/src/modules/tls/tls_mod.c
+++ b/src/modules/tls/tls_mod.c
@@ -438,6 +438,25 @@ static int mod_init(void)
 	}
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+	/* Detect the OpenSSL version DYNAMICALLY (the linked libssl at runtime, not the
+	 * build-time header): with OpenSSL >= 3.x the per-thread OpenSSL state inherited
+	 * by forked workers is not fork-safe and can corrupt/SIGSEGV (e.g. when
+	 * http_client/libcurl also uses OpenSSL) unless it is cleaned up at fork. That
+	 * cleanup is enabled by the core parameter tls_threads_mode; the default (0,
+	 * KSR_TLS_THREADS_MNONE) leaves it off. Warn so the operator sets a safe value. */
+	if(OpenSSL_version_num() >= 0x30000000L
+			&& ksr_tls_threads_mode == KSR_TLS_THREADS_MNONE) {
+		LM_WARN("OpenSSL runtime version '%s' (>= 3.0) with tls_threads_mode=0 "
+				"is"
+				" unsafe and can crash worker processes - set "
+				"'tls_threads_mode=2'"
+				" in the global section of kamailio.cfg for production (or"
+				" 'tls_threads_mode=1' for development/troubleshooting)\n",
+				OpenSSL_version(OPENSSL_VERSION));
+	}
+#endif
+
 	if(tls_disable) {
 		LM_WARN("tls support is disabled "
 				"(set enable_tls=1 in the config to enable it)\n");


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Added a warning message to help people adapt their legacy kamailio.cfg script and avoid TLS related crashes.