### PR TITLE
ims_pcscf: fix sec-agree shared memory leaks on (re-)registration

### DIFF
--- a/src/modules/ims_ipsec_pcscf/cmd.c
+++ b/src/modules/ims_ipsec_pcscf/cmd.c
@@ -823,6 +823,34 @@ int add_security_server_header(struct sip_msg *m, ipsec_t *s)
 	return 0;
 }
 
+// Free an ipsec_t (the struct and its sec-agree string fields). Used to release
+// the old data.ipsec that gets replaced on the contact at registration, and the
+// request ipsec_t that is not stored on re-registration - both were previously
+// orphaned and leaked.
+static void free_ipsec_data(ipsec_t *p)
+{
+	if(!p) {
+		return;
+	}
+	if(p->ealg.s)
+		shm_free(p->ealg.s);
+	if(p->r_ealg.s)
+		shm_free(p->r_ealg.s);
+	if(p->ck.s)
+		shm_free(p->ck.s);
+	if(p->alg.s)
+		shm_free(p->alg.s);
+	if(p->r_alg.s)
+		shm_free(p->r_alg.s);
+	if(p->ik.s)
+		shm_free(p->ik.s);
+	if(p->prot.s)
+		shm_free(p->prot.s);
+	if(p->mod.s)
+		shm_free(p->mod.s);
+	shm_free(p);
+}
+
 int ipsec_create(struct sip_msg *m, udomain_t *d, int _cflags)
 {
 	pcontact_t *pcontact = NULL;
@@ -834,6 +862,10 @@ int ipsec_create(struct sip_msg *m, udomain_t *d, int _cflags)
 	security_t *req_sec_params = NULL;
 	ipsec_t *s = NULL;
 	ipsec_t *old_s = NULL;
+	// set to 1 once req_sec_params->data.ipsec is handed to the contact (initial
+	// registration); if it stays 0 that ipsec_t was only used to build the
+	// tunnel and must be freed before returning, otherwise it leaks
+	int ipsec_swapped = 0;
 
 	if(m->first_line.type == SIP_REPLY) {
 		t = tmb.t_gett();
@@ -925,7 +957,17 @@ int ipsec_create(struct sip_msg *m, udomain_t *d, int _cflags)
 
 	if(ci.via_port == SIP_PORT) {
 		if(req_sec_params != NULL) {
+			ipsec_t *old_ipsec = pcontact->security_temp->data.ipsec;
 			pcontact->security_temp->data.ipsec = s;
+			// s is now owned by the contact (freed at contact expiry by
+			// free_security()); do not free it on the cleanup path
+			ipsec_swapped = 1;
+			// free the ipsec_t we just replaced on the contact - it was
+			// stored by save_pending() (or a prior ipsec_create()) and was
+			// previously orphaned on every registration
+			if(old_ipsec && old_ipsec != s) {
+				free_ipsec_data(old_ipsec);
+			}
 		}
 		// Update temp security parameters
 		if(ul.update_temp_security(d, pcontact->security_temp->type,
@@ -966,6 +1008,16 @@ int ipsec_create(struct sip_msg *m, udomain_t *d, int _cflags)
 	ret = IPSEC_CMD_SUCCESS; // all good, set ret to SUCCESS, and exit
 
 cleanup:
+	// On the re-registration path the swap did not happen, so
+	// req_sec_params->data.ipsec was only used to build the tunnel and is never
+	// stored on the contact. Free it here, otherwise it leaks on every
+	// re-registration. On the initial path ipsec_swapped==1 and data.ipsec is
+	// now owned by the contact - do NOT free it.
+	// sec_header is intentionally left alone (freed via the data_lump path).
+	if(req_sec_params && !ipsec_swapped && req_sec_params->data.ipsec) {
+		free_ipsec_data(req_sec_params->data.ipsec);
+		req_sec_params->data.ipsec = NULL;
+	}
 	// Do not free str* sec_header! It will be freed in data_lump.c -> free_lump()
 	ul.unlock_udomain(d, &ci.via_host, ci.via_port, ci.via_prot);
 	pkg_free(ci.received_host.s);

--- a/src/modules/ims_registrar_pcscf/save.c
+++ b/src/modules/ims_registrar_pcscf/save.c
@@ -442,6 +442,9 @@ int save_pending(struct sip_msg *_m, udomain_t *_d)
 
 	// Parse security parameters
 	security_t *sec_params = NULL;
+	// set to 1 once sec_params ownership is handed to the contact; if it stays 0
+	// sec_params must be freed before returning, otherwise it leaks
+	int sec_params_stored = 0;
 	if((sec_params = cscf_get_security(_m)) == NULL) {
 		LM_DBG("Will save pending contact without security parameters\n");
 	}
@@ -474,6 +477,14 @@ int save_pending(struct sip_msg *_m, udomain_t *_d)
 		}
 	}
 
+	// sec_verify_params is only used to copy the SPI/port values into sec_params
+	// above; it is never stored on the contact, so free it here - otherwise it
+	// leaks a security_t on every REGISTER that carries a Security-Verify header
+	if(sec_verify_params) {
+		free_security_t(sec_verify_params);
+		sec_verify_params = NULL;
+	}
+
 	ul.lock_udomain(_d, &ci.via_host, ci.via_port, ci.via_prot);
 	if(ul.get_pcontact(_d, &ci, &pcontact, 0)
 			!= 0) { //need to insert new contact
@@ -498,6 +509,10 @@ int save_pending(struct sip_msg *_m, udomain_t *_d)
 						   _d, sec_params->type, sec_params, pcontact)
 						!= 0) {
 					LM_ERR("Error updating temp security\n");
+				} else {
+					// ownership handed to contact->security_temp; it is freed
+					// later by free_pcontact() when the contact expires
+					sec_params_stored = 1;
 				}
 			}
 		}
@@ -509,6 +524,8 @@ int save_pending(struct sip_msg *_m, udomain_t *_d)
 							&& (pcontact->expires + window_for_notify
 									> local_time_now))) {
 				ul.unlock_udomain(_d, &ci.via_host, ci.via_port, ci.via_prot);
+				if(sec_params && !sec_params_stored)
+					free_security_t(sec_params);
 				return -2;
 			}
 			if((pcontact->expires + window_for_notify) <= local_time_now) {
@@ -517,6 +534,8 @@ int save_pending(struct sip_msg *_m, udomain_t *_d)
 				ci_.num_service_routes = 0;
 				ul.update_pcontact(_d, &ci_, pcontact);
 				ul.unlock_udomain(_d, &ci.via_host, ci.via_port, ci.via_prot);
+				if(sec_params && !sec_params_stored)
+					free_security_t(sec_params);
 				return -2;
 			}
 		} else if(pcontact->reg_state == PCONTACT_DEREG_PENDING_PUBLISH) {
@@ -533,6 +552,11 @@ int save_pending(struct sip_msg *_m, udomain_t *_d)
 
 	ul.unlock_udomain(_d, &ci.via_host, ci.via_port, ci.via_prot);
 
+	// free sec_params if it was not handed to the contact (re-registration,
+	// failed insert, ...) - otherwise it leaks a security_t on every such
+	// REGISTER. This is the path that previously leaked on each re-REGISTER.
+	if(sec_params && !sec_params_stored)
+		free_security_t(sec_params);
 
 	return 1;
 

--- a/src/modules/ims_registrar_pcscf/sec_agree.c
+++ b/src/modules/ims_registrar_pcscf/sec_agree.c
@@ -105,6 +105,53 @@ static int process_sec_agree_param(str name, str value, ipsec_t *ret)
 	return 0;
 }
 
+void free_security_t(security_t *params)
+{
+	if(!params) {
+		return;
+	}
+
+	if(params->sec_header.s) {
+		shm_free(params->sec_header.s);
+	}
+
+	switch(params->type) {
+		case SECURITY_IPSEC:
+			if(params->data.ipsec) {
+				if(params->data.ipsec->ealg.s)
+					shm_free(params->data.ipsec->ealg.s);
+				if(params->data.ipsec->r_ealg.s)
+					shm_free(params->data.ipsec->r_ealg.s);
+				if(params->data.ipsec->ck.s)
+					shm_free(params->data.ipsec->ck.s);
+				if(params->data.ipsec->alg.s)
+					shm_free(params->data.ipsec->alg.s);
+				if(params->data.ipsec->r_alg.s)
+					shm_free(params->data.ipsec->r_alg.s);
+				if(params->data.ipsec->ik.s)
+					shm_free(params->data.ipsec->ik.s);
+				if(params->data.ipsec->prot.s)
+					shm_free(params->data.ipsec->prot.s);
+				if(params->data.ipsec->mod.s)
+					shm_free(params->data.ipsec->mod.s);
+
+				shm_free(params->data.ipsec);
+			}
+			break;
+
+		case SECURITY_TLS:
+			if(params->data.tls) {
+				shm_free(params->data.tls);
+			}
+			break;
+
+		case SECURITY_NONE:
+			break;
+	}
+
+	shm_free(params);
+}
+
 static security_t *parse_sec_agree(struct hdr_field *h)
 {
 	int i = 0;
@@ -213,33 +260,7 @@ cleanup:
 	// The same piece of code also lives in modules/ims_usrloc_pcscf/pcontact.c
 	// Function - free_security()
 	// Keep them in sync!
-	if(params) {
-		if(params->sec_header.s)
-			shm_free(params->sec_header.s);
-		if(params->type == SECURITY_IPSEC && params->data.ipsec) {
-			if(params->data.ipsec->ealg.s)
-				shm_free(params->data.ipsec->ealg.s);
-			if(params->data.ipsec->r_ealg.s)
-				shm_free(params->data.ipsec->r_ealg.s);
-			if(params->data.ipsec->ck.s)
-				shm_free(params->data.ipsec->ck.s);
-			if(params->data.ipsec->alg.s)
-				shm_free(params->data.ipsec->alg.s);
-			if(params->data.ipsec->r_alg.s)
-				shm_free(params->data.ipsec->r_alg.s);
-			if(params->data.ipsec->ik.s)
-				shm_free(params->data.ipsec->ik.s);
-			if(params->data.ipsec->prot.s)
-				shm_free(params->data.ipsec->prot.s);
-			if(params->data.ipsec->mod.s)
-				shm_free(params->data.ipsec->mod.s);
-			shm_free(params->data.ipsec);
-		} else {
-			shm_free(params->data.ipsec);
-		}
-
-		shm_free(params);
-	}
+	free_security_t(params);
 
 	return NULL;
 }

--- a/src/modules/ims_registrar_pcscf/sec_agree.h
+++ b/src/modules/ims_registrar_pcscf/sec_agree.h
@@ -42,4 +42,13 @@ security_t *cscf_get_security(struct sip_msg *msg);
  */
 security_t *cscf_get_security_verify(struct sip_msg *msg);
 
+/**
+ * Free a security_t allocated by parse_sec_agree() / cscf_get_security[_verify]().
+ * Safe to call with NULL. Frees the struct, its sec_header, the ipsec_t and all
+ * of its parsed string fields. Mirrors free_security() in
+ * ims_usrloc_pcscf/pcontact.c - keep the two in sync.
+ * @param params - the security_t to free (may be NULL)
+ */
+void free_security_t(security_t *params);
+
 #endif // SEC_AGREE_H

--- a/src/modules/ims_usrloc_pcscf/pcontact.c
+++ b/src/modules/ims_usrloc_pcscf/pcontact.c
@@ -114,8 +114,7 @@ void free_ppublic(ppublic_t *_p)
 
 
 // The same piece of code also lives in modules/ims_registrar_pcscf/sec_agree.c
-// Function - parse_sec_agree()
-// goto label - cleanup
+// Function - free_security_t()
 // Keep them in sync!
 void free_security(security_t *_p)
 {


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4670 and #4671

#### Description
Follow-up to the double-free fixes in #4670 / #4671. Those fixed the crash in
`parse_sec_agree()`'s error path, but the P-CSCF sec-agree code still leaks
shared memory on the normal (re-)registration paths:

**ims_registrar_pcscf — `save_pending()`**
- `sec_verify_params` (Security-Verify) is only used to copy SPI/port values
  into `sec_params` and is never stored on the contact → leaked on every
  REGISTER carrying a Security-Verify header.
- `sec_params` (Security-Client) is only handed to the contact on the initial
  registration; on re-REGISTER and on the DB_ONLY de-registration early returns
  it is never stored → leaked on every re-REGISTER.

**ims_ipsec_pcscf — `ipsec_create()`**
- Initial registration overwrites `pcontact->security_temp->data.ipsec` with the
  new `ipsec_t` without freeing the previous one (stored by `save_pending()`) →
  orphaned on every registration.
- On re-registration `req_sec_params->data.ipsec` is only used to build the
  tunnel and is never stored → leaked on every re-REGISTER.

Ownership is tracked (`sec_params_stored`, `ipsec_swapped`) so structures are
freed only on the paths where they are not handed to the contact; no double-free.

Verified with `kamcmd mod.stats all shm`: on a fresh start `ims_registrar_pcscf`
is 0 and `ims_ipsec_pcscf` is just the fixed SPI pool. Before the fix both grew
on every re-registration cycle and never returned to baseline after UEs
de-registered; with the fix the totals plateau under load and return to baseline.
