### PR TITLE
presence: LWW tighter checks

### DIFF
--- a/src/modules/presence/hash.c
+++ b/src/modules/presence/hash.c
@@ -304,8 +304,16 @@ int insert_and_replace_shtable(
 						new_rec->from_tag.len, new_rec->from_tag.s,
 						new_rec->to_tag.len, new_rec->to_tag.s);
 
-				/* LWW: skip replace if local record is newer */
-				if(rec->received_time > new_rec->received_time) {
+				/* LWW: skip replace if local record is newer, for same dialog */
+				if(rec->received_time > new_rec->received_time
+						&& rec->from_tag.len == new_rec->from_tag.len
+						&& rec->to_tag.len == new_rec->to_tag.len
+						&& memcmp(rec->from_tag.s, new_rec->from_tag.s,
+								   new_rec->from_tag.len)
+								   == 0
+						&& memcmp(rec->to_tag.s, new_rec->to_tag.s,
+								   new_rec->to_tag.len)
+								   == 0) {
 					LM_DBG("LWW: skipping stale subscription replace "
 						   "for contact=[%.*s] pres_uri="
 						   "[%.*s] local_recv=%u incoming_recv=%u\n",
@@ -502,11 +510,11 @@ int update_shtable(
 	if(type & REMOTE_TYPE) {
 		s->expires = subs->expires + ksr_time_sint(NULL, NULL);
 		s->remote_cseq = subs->remote_cseq;
+		s->received_time = subs->received_time;
 	} else {
 		subs->local_cseq = ++s->local_cseq;
 		subs->version = ++s->version;
 	}
-	s->received_time = subs->received_time;
 
 	if(presence_sip_uri_match(&s->contact, &subs->contact)) {
 		shm_free(s->contact.s);
@@ -1141,7 +1149,8 @@ int ps_ptable_replace(ps_presentity_t *ptm, ps_presentity_t *pt)
 	while(ptn != NULL) {
 		if(ps_presentity_match(ptn, &ptc, 2) == 1) {
 			/* LWW: skip replace if local record is newer */
-			if(ptn->received_time > ptv.received_time) {
+			if(ptv.received_time > 0
+					&& ptn->received_time > ptv.received_time) {
 				LM_DBG("LWW: skipping stale presentity replace for "
 					   "%.*s@%.*s local_recv=%d incoming_recv=%d\n",
 						ptn->user.len, ptn->user.s, ptn->domain.len,
@@ -1214,7 +1223,8 @@ int ps_ptable_update(ps_presentity_t *ptm, ps_presentity_t *pt)
 	while(ptn != NULL) {
 		if(ps_presentity_match(ptn, &ptc, 2) == 1) {
 			/* LWW: skip update if local record is newer */
-			if(ptn->received_time > ptv.received_time) {
+			if(ptv.received_time > 0
+					&& ptn->received_time > ptv.received_time) {
 				LM_DBG("LWW: skipping stale presentity update for "
 					   "%.*s@%.*s local_recv=%d incoming_recv=%d\n",
 						ptn->user.len, ptn->user.s, ptn->domain.len,
@@ -1279,7 +1289,8 @@ int ps_ptable_remove(ps_presentity_t *pt)
 	while(ptn != NULL) {
 		if(ps_presentity_match(ptn, &ptc, 2) == 1) {
 			/* LWW: skip delete if local record is newer */
-			if(ptn->received_time > ptc.received_time) {
+			if(ptc.received_time > 0
+					&& ptn->received_time > ptc.received_time) {
 				LM_DBG("LWW: skipping stale presentity delete for "
 					   "%.*s@%.*s local_recv=%d incoming_recv=%d\n",
 						ptn->user.len, ptn->user.s, ptn->domain.len,

--- a/src/modules/presence/presentity.c
+++ b/src/modules/presence/presentity.c
@@ -482,10 +482,12 @@ int ps_cache_delete_presentity_if_dialog_id_exists(
 		if(check_if_dialog(ptx->body, &db_is_dialog, &db_dialog_id) == 0) {
 			// If ID from DB matches the one we supplied
 			if(db_dialog_id && !strcmp(db_dialog_id, dialog_id)) {
+				memset(&old_presentity, 0, sizeof(presentity_t));
 				old_presentity.domain = presentity->domain;
 				old_presentity.user = presentity->user;
 				old_presentity.event = presentity->event;
 				old_presentity.etag = ptx->etag;
+				old_presentity.received_time = ptx->received_time;
 
 				LM_DBG("Presentity found - deleting it\n");
 


### PR DESCRIPTION
Also zero-out old presentity before assigning the values, received_time value included.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
We have noticed issues with presentities deletion due to LWW checks.
Assign "received_time" for the old presentity when deleted.
Also added tighter LWW checks for both subs and presentities.