### PR TITLE
carrierroute: fix for get_rpc_opts corrupts memory

### DIFF
--- a/src/modules/carrierroute/cr_rpc_helper.c
+++ b/src/modules/carrierroute/cr_rpc_helper.c
@@ -35,7 +35,7 @@ static int str_toklen(str *str, const char *delims)
 {
 	int len;
 
-	if((str == NULL) || (str->s == NULL)) {
+	if((str == NULL) || (str->s == NULL) || (str->len <= 0)) {
 		/* No more tokens */
 		return -1;
 	}
@@ -376,14 +376,13 @@ int get_rpc_opts(str *buf, rpc_opt_t *opts, unsigned int opt_set[])
 	int i, op = -1;
 	unsigned int used_opts = 0;
 	int toklen;
+	char prob_buf[256];
 
 	memset(opt_argv, 0, sizeof(opt_argv));
 	memset(opts, 0, sizeof(rpc_opt_t));
 	opts->prob = -1;
 
 	while((toklen = str_toklen(buf, " \t\r\n")) >= 0 && opt_argc < 20) {
-		buf->s[toklen] =
-				'\0'; /* insert zero termination, since strtod might be used later on it */
 		opt_argv[opt_argc].len = toklen;
 		opt_argv[opt_argc].s = buf->s;
 		buf->s += toklen + 1;
@@ -475,8 +474,16 @@ int get_rpc_opts(str *buf, rpc_opt_t *opts, unsigned int opt_set[])
 							op = -1;
 							break;
 						case OPT_PROB:
-							opts->prob = strtod(opt_argv[i].s,
-									NULL); /* we can use str.s since we zero terminated it earlier */
+							// copy the opt[i] string to a zero-terminated buffer since strtod needs that
+							if(opt_argv[i].len >= (int)sizeof(prob_buf)) {
+								FIFO_ERR(E_WRONGOPT);
+								LM_ERR("probability value too long: %.*s\n",
+										opt_argv[i].len, opt_argv[i].s);
+								return -1;
+							}
+							memcpy(prob_buf, opt_argv[i].s, opt_argv[i].len);
+							prob_buf[opt_argv[i].len] = '\0';
+							opts->prob = strtod(prob_buf, NULL);
 							op = -1;
 							break;
 						case OPT_R_PREFIX:


### PR DESCRIPTION
This fixes a bug in get_rpc_opts function which would write a null character past the end of received buf parameter. This could eventually result in a coredump.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [ ] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
