### PR TITLE
dialog: on received ACK, bump dmq replicated dlg to CONFIRMED state

### DIFF
--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -324,16 +324,24 @@ int dlg_dmq_handle_msg(
 				case DLG_STATE_EARLY:
 					dlg->start_ts = start_ts;
 					dlg->lifetime = lifetime;
-					dlg_set_leg_info(
-							dlg, &tag1, &route_set1, &contact1, &cseq1, 0);
+					/* apply leg info if it carries data */
+					if(tag1.len > 0) {
+						dlg_set_leg_info(
+								dlg, &tag1, &route_set1, &contact1, &cseq1, 0);
+					}
 					break;
 				case DLG_STATE_CONFIRMED:
 					dlg->start_ts = start_ts;
 					dlg->lifetime = lifetime;
-					dlg_set_leg_info(
-							dlg, &tag1, &route_set1, &contact1, &cseq1, 0);
-					dlg_set_leg_info(
-							dlg, &tag2, &route_set2, &contact2, &cseq2, 1);
+					/* apply leg info if it carries data */
+					if(tag1.len > 0) {
+						dlg_set_leg_info(
+								dlg, &tag1, &route_set1, &contact1, &cseq1, 0);
+					}
+					if(tag2.len > 0) {
+						dlg_set_leg_info(
+								dlg, &tag2, &route_set2, &contact2, &cseq2, 1);
+					}
 					if(insert_dlg_timer(&dlg->tl, dlg->lifetime) != 0) {
 						LM_CRIT("Unable to insert dlg timer %p [%u:%u]\n", dlg,
 								dlg->h_entry, dlg->h_id);

--- a/src/modules/dialog/dlg_hash.c
+++ b/src/modules/dialog/dlg_hash.c
@@ -1277,6 +1277,12 @@ void next_state_dlg(
 				case DLG_STATE_DELETED:
 					break;
 				default:
+					/* if dmq replicated dialog received ACK */
+					if((dlg->iflags & DLG_IFLAG_DMQ_SYNC)
+							&& !(dlg->dflags & DLG_FLAG_TM)) {
+						dlg->state = DLG_STATE_CONFIRMED;
+						break;
+					}
 					log_next_state_dlg(event, dlg);
 			}
 			break;


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This commit fixes the "bogus event 6 in state 2" CRITICAL log event spotted on the node that received replicated dialog.

This happens because:
1. use dialog module with "enable_dmq=1"
2. in an active-active setup, due to DNS balancing, ACK can reach a different kamailio node, where dialog was only replicated via DMQ. Note that dialog state 3 (CONFIRMED_NA)  is not currently replicated via dialog DMQ, and even if it would, this log could still happen sometimes (race between the KDMQ for state 3 and SIP ACK)