### PR TITLE
dialog: run terminated callbacks when dialog ended and synced via dmq

### DIFF
--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -366,6 +366,12 @@ int dlg_dmq_handle_msg(
 					/* keep dialog around for a bit, to prevent out-of-order
 					 * syncs to reestablish the dlg */
 					dlg->init_ts = ksr_time_uint(NULL, NULL);
+
+					if(dlg->state != DLG_STATE_DELETED) {
+						run_dlg_callbacks(DLGCB_TERMINATED, dlg, NULL, NULL,
+								DLG_DIR_NONE, 0);
+					}
+
 					break;
 				default:
 					LM_ERR("unhandled state update to state %u\n", state);


### PR DESCRIPTION
Skip if already in DLG_STATE_DELETED

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
1. Due to DNS load-balancing, in an active-active DMQ scenario, BYE can reach any other kamailio node (that did NOT dlg_managed the original dialog and bound it to underlying TM).
2. The KDMQ with DLG_STATE_DELETED will reach from the other node to all nodes, but the SIP itself will reach *only* the other node
3. Thus, the terminated callbacks will never run (e.g. on the node that originally created the dialog) [a][b]
4. Thus, pua_dialoginfo PUBLISH with "terminated" state will be never sent out [c] [d]

[a] https://github.com/net2phone/n2p-kamailio/blob/ae9bec6be1f8e42aca0eea5c1354f83b922dba2e/src/modules/dialog/dlg_handlers.c#L1502
[b] https://github.com/net2phone/n2p-kamailio/blob/ae9bec6be1f8e42aca0eea5c1354f83b922dba2e/src/modules/dialog/dlg_handlers.c#L404
[c] https://github.com/net2phone/n2p-kamailio/blob/ae9bec6be1f8e42aca0eea5c1354f83b922dba2e/src/modules/pua_dialoginfo/pua_dialoginfo.c#L109 
[d] https://github.com/net2phone/n2p-kamailio/blob/ae9bec6be1f8e42aca0eea5c1354f83b922dba2e/src/modules/pua_dialoginfo/pua_dialoginfo.c#L867

Also, in any other hop-by-hop flows: core -> kamailio1(dlg_manage) -> kamailio2(receive replicated dialog) -> client, if client sends BYE and KDMQ with DLG_STATE_DELETED reaches kamailio1 faster than the SIP BYE itself, the terminated callbacks will not run => same pua_dialoginfo issue