### PR TITLE
core: update max length of path header

### DIFF
--- a/src/core/config.h
+++ b/src/core/config.h
@@ -61,7 +61,7 @@
 
 #define MAX_URI_SIZE 1024 /*!< Max URI size used when rewriting URIs */
 
-#define MAX_PATH_SIZE 256 /*!< Maximum length of path header buffer */
+#define MAX_PATH_SIZE 512 /*!< Maximum length of path header buffer */
 
 #define MAX_INSTANCE_SIZE \
 	256 /*!< Maximum length of +sip.instance contact header param value buffer */


### PR DESCRIPTION
#### Description

Small update on the maximum length of `Path` header. Update from `256` hard limit to `512`.

For some possible cases, `256` is not enough.
Enabling `r2` + `socket names` + `received` + `parameters`, we can easily surpass that value.

With this, we are more safe.

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)


