### PR TITLE
path: add advertised_address functions

### DIFF
--- a/src/core/lump_struct.h
+++ b/src/core/lump_struct.h
@@ -57,7 +57,9 @@ enum lump_subst
 	SUBST_RCV_ALL,
 	SUBST_SND_ALL, /* ip:port;transport=proto */
 	SUBST_RCV_ALL_EX,
-	SUBST_SND_ALL_EX /* ip:port;transport=proto;sn=xyz */
+	SUBST_SND_ALL_EX, /* ip:port;transport=proto;sn=xyz */
+	SUBST_RCV_SOCKNAME,
+	SUBST_SND_SOCKNAME /* ;sn=xyz (socket name parameter only) */
 };
 /* Where:
 				 * SND = sending, e.g the src ip of the outgoing message

--- a/src/core/msg_translator.c
+++ b/src/core/msg_translator.c
@@ -725,6 +725,13 @@ static inline int lumps_len(
 				LM_CRIT("null bind_address (SUBST_RCV_ALL)\n");              \
 			};                                                               \
 			break;                                                           \
+		case SUBST_RCV_SOCKNAME:                                             \
+			if(msg->rcv.bind_address                                         \
+					&& msg->rcv.bind_address->sockname.len > 0) {            \
+				new_len += SOCKNAME_PARAM_LEN                                \
+						   + msg->rcv.bind_address->sockname.len;            \
+			}                                                                \
+			break;                                                           \
 		case SUBST_SND_IP:                                                   \
 			if(send_sock) {                                                  \
 				new_len += send_address_str->len;                            \
@@ -820,6 +827,11 @@ static inline int lumps_len(
 			} else {                                                         \
 				LM_CRIT("null send_sock (SUBST_SND_ALL)\n");                 \
 			};                                                               \
+			break;                                                           \
+		case SUBST_SND_SOCKNAME:                                             \
+			if(send_sock && send_sock->sockname.len > 0) {                   \
+				new_len += SOCKNAME_PARAM_LEN + send_sock->sockname.len;     \
+			}                                                                \
 			break;                                                           \
 		case SUBST_NOP: /* do nothing */                                     \
 			break;                                                           \
@@ -1172,6 +1184,16 @@ void process_lumps(struct sip_msg *msg, struct lump *lumps, char *new_buf,
 						msg->rcv.bind_address, recv_address_str);              \
 			};                                                                 \
 			break;                                                             \
+		case SUBST_RCV_SOCKNAME:                                               \
+			if(msg->rcv.bind_address                                           \
+					&& msg->rcv.bind_address->sockname.len > 0) {              \
+				memcpy(new_buf + offset, SOCKNAME_PARAM, SOCKNAME_PARAM_LEN);  \
+				offset += SOCKNAME_PARAM_LEN;                                  \
+				memcpy(new_buf + offset, msg->rcv.bind_address->sockname.s,    \
+						msg->rcv.bind_address->sockname.len);                  \
+				offset += msg->rcv.bind_address->sockname.len;                 \
+			}                                                                  \
+			break;                                                             \
 		case SUBST_SND_IP:                                                     \
 			if(send_sock) {                                                    \
 				if((send_af == AF_INET6) && (send_address_str->s[0] != '[')) { \
@@ -1287,6 +1309,15 @@ void process_lumps(struct sip_msg *msg, struct lump *lumps, char *new_buf,
 			} else {                                                           \
 				LM_CRIT("null send_sock (SUBST_SND_ALL)\n");                   \
 			};                                                                 \
+			break;                                                             \
+		case SUBST_SND_SOCKNAME:                                               \
+			if(send_sock && send_sock->sockname.len > 0) {                     \
+				memcpy(new_buf + offset, SOCKNAME_PARAM, SOCKNAME_PARAM_LEN);  \
+				offset += SOCKNAME_PARAM_LEN;                                  \
+				memcpy(new_buf + offset, send_sock->sockname.s,                \
+						send_sock->sockname.len);                              \
+				offset += send_sock->sockname.len;                             \
+			}                                                                  \
 			break;                                                             \
 		case SUBST_RCV_PROTO:                                                  \
 			if(msg->rcv.bind_address) {                                        \

--- a/src/modules/path/doc/path_admin.xml
+++ b/src/modules/path/doc/path_admin.xml
@@ -239,33 +239,6 @@ modparam("path", "sockname_mode", 1)
 </programlisting>
 		</example>
 	</section>
-	<section id="path.p.advertised_address">
-		<title><varname>advertised_address</varname> (str)</title>
-		<para>
-		If set to a valid IP address or hostname, optionally followed by a port
-		(e.g. <quote>proxy.example.com</quote> or <quote>1.2.3.4:5080</quote>),
-		the Path URI host part is built from this value instead of the outgoing
-		socket address.
-		</para>
-		<para>
-		When not set or empty, <function>add_path()</function> and
-		<function>add_path_received()</function> keep the default behaviour of
-		using the outgoing interface address.
-		</para>
-		<para>
-		<emphasis>
-			Default value is empty (not set).
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>advertised_address</varname> parameter</title>
-		<programlisting format="linespecific">
-...
-modparam("path", "advertised_address", "proxy.example.com")
-...
-</programlisting>
-		</example>
-	</section>
 	</section>
 
 	<section>
@@ -461,6 +434,114 @@ if (!add_path_received("inbound", "ob")) {
 	sl_send_reply("503", "Internal Path Error");
 	...
 };
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="path.f.add_path_advertised_address">
+		<title>
+		<function moreinfo="none">add_path_advertised_address(address [, user [, parameters]])</function>
+		</title>
+		<para>
+		This function behaves like <function>add_path()</function>,
+		<function>add_path(user)</function> or
+		<function>add_path(user, parameters)</function> depending on the number
+		of arguments given, with one difference: the host part of the Path URI
+		is built from the given <emphasis>address</emphasis> instead of the
+		outgoing socket address (no socket/lump substitution is applied).
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para>
+			<emphasis>address</emphasis> - The host (and optional port) used as
+			domain part of the Path URI, e.g.
+			<quote>proxy.example.com</quote> or <quote>1.2.3.4:5080</quote>.
+			SPVE is supported.
+			</para>
+		</listitem>
+		<listitem>
+			<para>
+			<emphasis>user</emphasis> - The username to be inserted as user part.
+			SPVE is supported. Optional.
+			</para>
+		</listitem>
+		<listitem>
+			<para>
+			<emphasis>parameters</emphasis> - Additional parameters appended to
+			the Path URI. SPVE is supported. Optional.
+			</para>
+		</listitem>
+		</itemizedlist>
+		<para>
+		This function can be used from REQUEST_ROUTE.
+		</para>
+		<example>
+		<title><function>add_path_advertised_address</function> usage</title>
+		<programlisting format="linespecific">
+...
+if (!add_path_advertised_address("proxy.example.com")) {
+	sl_send_reply("503", "Internal Path Error");
+	...
+};
+# with user and parameters
+add_path_advertised_address("1.2.3.4:5080", "inbound", "ob");
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="path.f.add_path_received_advertised_address">
+		<title>
+		<function moreinfo="none">add_path_received_advertised_address(address [, user [, parameters]])</function>
+		</title>
+		<para>
+		This function behaves like <function>add_path_received()</function>,
+		<function>add_path_received(user)</function> or
+		<function>add_path_received(user, parameters)</function> depending on the
+		number of arguments given, with one difference: the host part of the
+		Path URI is built from the given <emphasis>address</emphasis> instead of
+		the outgoing socket address (no socket/lump substitution is applied). The
+		address the request was received from is still appended as
+		received-parameter.
+		</para>
+		<para>Meaning of the parameters is as follows:</para>
+		<itemizedlist>
+		<listitem>
+			<para>
+			<emphasis>address</emphasis> - The host (and optional port) used as
+			domain part of the Path URI, e.g.
+			<quote>proxy.example.com</quote> or <quote>1.2.3.4:5080</quote>.
+			SPVE is supported.
+			</para>
+		</listitem>
+		<listitem>
+			<para>
+			<emphasis>user</emphasis> - The username to be inserted as user part.
+			SPVE is supported. Optional.
+			</para>
+		</listitem>
+		<listitem>
+			<para>
+			<emphasis>parameters</emphasis> - Additional parameters appended to
+			the Path URI. SPVE is supported. Optional.
+			</para>
+		</listitem>
+		</itemizedlist>
+		<para>
+		This function can be used from REQUEST_ROUTE.
+		</para>
+		<example>
+		<title><function>add_path_received_advertised_address</function> usage</title>
+		<programlisting format="linespecific">
+...
+if (!add_path_received_advertised_address("proxy.example.com")) {
+	sl_send_reply("503", "Internal Path Error");
+	...
+};
+# with user and parameters
+add_path_received_advertised_address("1.2.3.4:5080", "inbound", "ob");
 ...
 </programlisting>
 		</example>

--- a/src/modules/path/doc/path_admin.xml
+++ b/src/modules/path/doc/path_admin.xml
@@ -239,6 +239,33 @@ modparam("path", "sockname_mode", 1)
 </programlisting>
 		</example>
 	</section>
+	<section id="path.p.advertised_address">
+		<title><varname>advertised_address</varname> (str)</title>
+		<para>
+		If set to a valid IP address or hostname, optionally followed by a port
+		(e.g. <quote>proxy.example.com</quote> or <quote>1.2.3.4:5080</quote>),
+		the Path URI host part is built from this value instead of the outgoing
+		socket address.
+		</para>
+		<para>
+		When not set or empty, <function>add_path()</function> and
+		<function>add_path_received()</function> keep the default behaviour of
+		using the outgoing interface address.
+		</para>
+		<para>
+		<emphasis>
+			Default value is empty (not set).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>advertised_address</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("path", "advertised_address", "proxy.example.com")
+...
+</programlisting>
+		</example>
+	</section>
 	</section>
 
 	<section>

--- a/src/modules/path/path.c
+++ b/src/modules/path/path.c
@@ -63,8 +63,6 @@ const static char *proto_strings[] = {
 };
 
 extern int path_sockname_mode;
-extern int path_advertised_address_ok;
-extern str path_advertised_address;
 extern str path_received_name;
 
 static char *path_strzdup(char *src, int len)
@@ -106,19 +104,24 @@ static int handleOutbound(sip_msg_t *_m, str *user, path_param_t *param)
 	return 1;
 }
 
-int path_advertised_address_init(str *addr)
+/*! \brief
+ * Validate the advertised address value given to the add_path_*_advertised_*
+ * functions. The value is expected to be a valid host part, optionally
+ * followed by a port (e.g. "proxy.example.com" or "1.2.3.4:5080").
+ */
+static int path_check_advertised_address(str *addr)
 {
 	char buf[MAX_URI_SIZE];
 	struct sip_uri uri;
 	int len;
 
 	if(addr == NULL || addr->len <= 0 || addr->s == NULL) {
-		path_advertised_address_ok = 0;
-		return 0;
+		LM_ERR("empty advertised address value\n");
+		return -1;
 	}
 
 	if(addr->len > MAX_URI_SIZE - 7) {
-		LM_ERR("advertised_address is too long (%d)\n", addr->len);
+		LM_ERR("advertised address is too long (%d)\n", addr->len);
 		return -1;
 	}
 
@@ -129,18 +132,15 @@ int path_advertised_address_init(str *addr)
 
 	memset(&uri, 0, sizeof(uri));
 	if(parse_uri(buf, len, &uri) < 0 || uri.host.len <= 0) {
-		LM_ERR("invalid advertised_address: %.*s\n", addr->len, addr->s);
+		LM_ERR("invalid advertised address: %.*s\n", addr->len, addr->s);
 		return -1;
 	}
 
-	path_advertised_address_ok = 1;
-	LM_DBG("using advertised_address %.*s for Path headers\n", addr->len,
-			addr->s);
 	return 0;
 }
 
-static int prepend_path(
-		sip_msg_t *_m, str *user, path_param_t param, str *add_params)
+static int prepend_path(sip_msg_t *_m, str *user, path_param_t param,
+		str *add_params, str *adv_addr)
 {
 	struct lump *l;
 	char *prefix, *suffix, *dp;
@@ -242,11 +242,11 @@ static int prepend_path(
 	l = insert_new_lump_before(l, prefix, prefix_len, 0);
 	if(!l)
 		goto out3;
-	if(path_advertised_address_ok) {
-		dp = path_strzdup(path_advertised_address.s, path_advertised_address.len);
+	if(adv_addr && adv_addr->len > 0) {
+		dp = path_strzdup(adv_addr->s, adv_addr->len);
 		if(dp == NULL)
 			goto out2;
-		l = insert_new_lump_before(l, dp, path_advertised_address.len, 0);
+		l = insert_new_lump_before(l, dp, adv_addr->len, 0);
 		if(!l)
 			goto out2;
 	} else {
@@ -266,12 +266,11 @@ static int prepend_path(
 		l = insert_new_lump_before(l, dp, prefix_len, 0);
 		if(!l)
 			goto out1;
-		if(path_advertised_address_ok) {
-			dp = path_strzdup(
-					path_advertised_address.s, path_advertised_address.len);
+		if(adv_addr && adv_addr->len > 0) {
+			dp = path_strzdup(adv_addr->s, adv_addr->len);
 			if(dp == NULL)
 				goto out1;
-			l = insert_new_lump_before(l, dp, path_advertised_address.len, 0);
+			l = insert_new_lump_before(l, dp, adv_addr->len, 0);
 			if(!l)
 				goto out1;
 		} else {
@@ -312,7 +311,7 @@ int ki_add_path(struct sip_msg *_msg)
 	ret = handleOutbound(_msg, &user, &param);
 
 	if(ret > 0) {
-		ret = prepend_path(_msg, &user, param, NULL);
+		ret = prepend_path(_msg, &user, param, NULL, NULL);
 	}
 
 	if(user.s != NULL) {
@@ -349,7 +348,7 @@ int add_path_usr(struct sip_msg *_msg, char *_usr, char *_parms)
 		}
 	}
 
-	return prepend_path(_msg, &user, PATH_PARAM_NONE, &parms);
+	return prepend_path(_msg, &user, PATH_PARAM_NONE, &parms, NULL);
 }
 
 /*! \brief
@@ -359,7 +358,7 @@ int add_path_usr(struct sip_msg *_msg, char *_usr, char *_parms)
 int ki_add_path_user(sip_msg_t *_msg, str *_user)
 {
 	str parms = {0, 0};
-	return prepend_path(_msg, _user, PATH_PARAM_NONE, &parms);
+	return prepend_path(_msg, _user, PATH_PARAM_NONE, &parms, NULL);
 }
 
 /*! \brief
@@ -368,7 +367,7 @@ int ki_add_path_user(sip_msg_t *_msg, str *_user)
  */
 int ki_add_path_user_params(sip_msg_t *_msg, str *_user, str *_params)
 {
-	return prepend_path(_msg, _user, PATH_PARAM_NONE, _params);
+	return prepend_path(_msg, _user, PATH_PARAM_NONE, _params, NULL);
 }
 
 /*! \brief
@@ -384,7 +383,7 @@ int ki_add_path_received(sip_msg_t *_msg)
 	ret = handleOutbound(_msg, &user, &param);
 
 	if(ret > 0) {
-		ret = prepend_path(_msg, &user, param, NULL);
+		ret = prepend_path(_msg, &user, param, NULL, NULL);
 	}
 
 	if(user.s != NULL) {
@@ -425,7 +424,7 @@ int add_path_received_usr(struct sip_msg *_msg, char *_usr, char *_parms)
 		}
 	}
 
-	return prepend_path(_msg, &user, PATH_PARAM_RECEIVED, &parms);
+	return prepend_path(_msg, &user, PATH_PARAM_RECEIVED, &parms, NULL);
 }
 
 /*! \brief
@@ -435,7 +434,7 @@ int add_path_received_usr(struct sip_msg *_msg, char *_usr, char *_parms)
 int ki_add_path_received_user(sip_msg_t *_msg, str *_user)
 {
 	str parms = {0, 0};
-	return prepend_path(_msg, _user, PATH_PARAM_RECEIVED, &parms);
+	return prepend_path(_msg, _user, PATH_PARAM_RECEIVED, &parms, NULL);
 }
 
 /*! \brief
@@ -444,7 +443,157 @@ int ki_add_path_received_user(sip_msg_t *_msg, str *_user)
  */
 int ki_add_path_received_user_params(sip_msg_t *_msg, str *_user, str *_params)
 {
-	return prepend_path(_msg, _user, PATH_PARAM_RECEIVED, _params);
+	return prepend_path(_msg, _user, PATH_PARAM_RECEIVED, _params, NULL);
+}
+
+/*! \brief
+ * Prepend own uri to Path header building the host part from the given
+ * advertised address instead of the outgoing socket address. Mirrors the
+ * behaviour of add_path()/add_path_received() (including outbound handling).
+ */
+static int prepend_path_advertised_address(
+		sip_msg_t *_msg, str *_addr, path_param_t param)
+{
+	str user = {0, 0};
+	int ret;
+
+	if(path_check_advertised_address(_addr) < 0)
+		return -1;
+
+	ret = handleOutbound(_msg, &user, &param);
+
+	if(ret > 0) {
+		ret = prepend_path(_msg, &user, param, NULL, _addr);
+	}
+
+	if(user.s != NULL) {
+		pkg_free(user.s);
+	}
+
+	return ret;
+}
+
+/*! \brief
+ * Prepend own uri to Path header building the host part from the given
+ * advertised address instead of the outgoing socket address and take care of
+ * the given user (and parameters). Mirrors add_path(user[, params]) /
+ * add_path_received(user[, params]).
+ */
+static int prepend_path_advertised_address_usr(sip_msg_t *_msg, str *_addr,
+		str *_user, str *_params, path_param_t param)
+{
+	if(path_check_advertised_address(_addr) < 0)
+		return -1;
+
+	return prepend_path(_msg, _user, param, _params, _addr);
+}
+
+/*! \brief
+ * Resolve the config function parameters and prepend a Path header using the
+ * given advertised address. When no user is given the behaviour matches
+ * add_path()/add_path_received(), otherwise add_path(user[, params]) /
+ * add_path_received(user[, params]).
+ */
+static int add_path_advertised_address_f(sip_msg_t *_msg, char *_addr,
+		char *_usr, char *_parms, path_param_t param)
+{
+	str addr = {0, 0};
+	str user = {0, 0};
+	str parms = {0, 0};
+
+	if(_addr == NULL) {
+		LM_ERR("advertised address parameter is required\n");
+		return -1;
+	}
+	if(get_str_fparam(&addr, _msg, (fparam_t *)_addr) < 0) {
+		LM_ERR("failed to get advertised address value\n");
+		return -1;
+	}
+
+	if(_usr == NULL) {
+		return prepend_path_advertised_address(_msg, &addr, param);
+	}
+
+	if(get_str_fparam(&user, _msg, (fparam_t *)_usr) < 0) {
+		LM_ERR("failed to get user value\n");
+		return -1;
+	}
+	if(_parms) {
+		if(get_str_fparam(&parms, _msg, (fparam_t *)_parms) < 0) {
+			LM_ERR("failed to get params value\n");
+			return -1;
+		}
+	}
+
+	return prepend_path_advertised_address_usr(
+			_msg, &addr, &user, &parms, param);
+}
+
+/*! \brief
+ * Prepend own uri to Path header using the given advertised address.
+ */
+int add_path_advertised_address(
+		sip_msg_t *_msg, char *_addr, char *_usr, char *_parms)
+{
+	return add_path_advertised_address_f(
+			_msg, _addr, _usr, _parms, PATH_PARAM_NONE);
+}
+
+/*! \brief
+ * Prepend own uri to Path header using the given advertised address and append
+ * the received address as "received"-param.
+ */
+int add_path_received_advertised_address(
+		sip_msg_t *_msg, char *_addr, char *_usr, char *_parms)
+{
+	return add_path_advertised_address_f(
+			_msg, _addr, _usr, _parms, PATH_PARAM_RECEIVED);
+}
+
+/*! \brief
+ * KEMI: prepend own uri to Path header using the given advertised address.
+ */
+int ki_add_path_advertised_address(sip_msg_t *_msg, str *_addr)
+{
+	return prepend_path_advertised_address(_msg, _addr, PATH_PARAM_NONE);
+}
+
+int ki_add_path_advertised_address_user(sip_msg_t *_msg, str *_addr, str *_user)
+{
+	str parms = {0, 0};
+	return prepend_path_advertised_address_usr(
+			_msg, _addr, _user, &parms, PATH_PARAM_NONE);
+}
+
+int ki_add_path_advertised_address_user_params(
+		sip_msg_t *_msg, str *_addr, str *_user, str *_params)
+{
+	return prepend_path_advertised_address_usr(
+			_msg, _addr, _user, _params, PATH_PARAM_NONE);
+}
+
+/*! \brief
+ * KEMI: prepend own uri to Path header using the given advertised address and
+ * append the received address as "received"-param.
+ */
+int ki_add_path_received_advertised_address(sip_msg_t *_msg, str *_addr)
+{
+	return prepend_path_advertised_address(_msg, _addr, PATH_PARAM_RECEIVED);
+}
+
+int ki_add_path_received_advertised_address_user(
+		sip_msg_t *_msg, str *_addr, str *_user)
+{
+	str parms = {0, 0};
+	return prepend_path_advertised_address_usr(
+			_msg, _addr, _user, &parms, PATH_PARAM_RECEIVED);
+}
+
+int ki_add_path_received_advertised_address_user_params(
+		sip_msg_t *_msg, str *_addr, str *_user, str *_params)
+{
+	return prepend_path_advertised_address_usr(
+			_msg, _addr, _user, _params, PATH_PARAM_RECEIVED);
 }
 
 /*! \brief

--- a/src/modules/path/path.c
+++ b/src/modules/path/path.c
@@ -37,6 +37,7 @@
 #include "../../core/data_lump.h"
 #include "../../core/parser/parse_param.h"
 #include "../../core/parser/parse_uri.h"
+#include "../../core/config.h"
 #include "../../core/strutils.h"
 #include "../../core/dset.h"
 
@@ -62,6 +63,8 @@ const static char *proto_strings[] = {
 };
 
 extern int path_sockname_mode;
+extern int path_advertised_address_ok;
+extern str path_advertised_address;
 extern str path_received_name;
 
 static char *path_strzdup(char *src, int len)
@@ -101,6 +104,39 @@ static int handleOutbound(sip_msg_t *_m, str *user, path_param_t *param)
 	}
 
 	return 1;
+}
+
+int path_advertised_address_init(str *addr)
+{
+	char buf[MAX_URI_SIZE];
+	struct sip_uri uri;
+	int len;
+
+	if(addr == NULL || addr->len <= 0 || addr->s == NULL) {
+		path_advertised_address_ok = 0;
+		return 0;
+	}
+
+	if(addr->len > MAX_URI_SIZE - 7) {
+		LM_ERR("advertised_address is too long (%d)\n", addr->len);
+		return -1;
+	}
+
+	memcpy(buf, "sip:", 4);
+	memcpy(buf + 4, addr->s, addr->len);
+	memcpy(buf + 4 + addr->len, ";lr", 3);
+	len = 4 + addr->len + 3;
+
+	memset(&uri, 0, sizeof(uri));
+	if(parse_uri(buf, len, &uri) < 0 || uri.host.len <= 0) {
+		LM_ERR("invalid advertised_address: %.*s\n", addr->len, addr->s);
+		return -1;
+	}
+
+	path_advertised_address_ok = 1;
+	LM_DBG("using advertised_address %.*s for Path headers\n", addr->len,
+			addr->s);
+	return 0;
 }
 
 static int prepend_path(
@@ -206,10 +242,19 @@ static int prepend_path(
 	l = insert_new_lump_before(l, prefix, prefix_len, 0);
 	if(!l)
 		goto out3;
-	l = insert_subst_lump_before(
-			l, (path_sockname_mode) ? SUBST_SND_ALL_EX : SUBST_SND_ALL, 0);
-	if(!l)
-		goto out2;
+	if(path_advertised_address_ok) {
+		dp = path_strzdup(path_advertised_address.s, path_advertised_address.len);
+		if(dp == NULL)
+			goto out2;
+		l = insert_new_lump_before(l, dp, path_advertised_address.len, 0);
+		if(!l)
+			goto out2;
+	} else {
+		l = insert_subst_lump_before(
+				l, (path_sockname_mode) ? SUBST_SND_ALL_EX : SUBST_SND_ALL, 0);
+		if(!l)
+			goto out2;
+	}
 	l = insert_new_lump_before(l, suffix, cp.len, 0);
 	if(!l)
 		goto out2;
@@ -221,10 +266,20 @@ static int prepend_path(
 		l = insert_new_lump_before(l, dp, prefix_len, 0);
 		if(!l)
 			goto out1;
-		l = insert_subst_lump_before(
-				l, (path_sockname_mode) ? SUBST_RCV_ALL_EX : SUBST_RCV_ALL, 0);
-		if(!l)
-			goto out1;
+		if(path_advertised_address_ok) {
+			dp = path_strzdup(
+					path_advertised_address.s, path_advertised_address.len);
+			if(dp == NULL)
+				goto out1;
+			l = insert_new_lump_before(l, dp, path_advertised_address.len, 0);
+			if(!l)
+				goto out1;
+		} else {
+			l = insert_subst_lump_before(
+					l, (path_sockname_mode) ? SUBST_RCV_ALL_EX : SUBST_RCV_ALL, 0);
+			if(!l)
+				goto out1;
+		}
 		dp = path_strzdup(suffix, cp.len);
 		if(dp == NULL)
 			goto out1;

--- a/src/modules/path/path.c
+++ b/src/modules/path/path.c
@@ -249,6 +249,13 @@ static int prepend_path(sip_msg_t *_m, str *user, path_param_t param,
 		l = insert_new_lump_before(l, dp, adv_addr->len, 0);
 		if(!l)
 			goto out2;
+		/* the advertised address replaces the host part only, so the socket
+		 * name still has to be appended at send time if sockname_mode is on */
+		if(path_sockname_mode) {
+			l = insert_subst_lump_before(l, SUBST_SND_SOCKNAME, 0);
+			if(!l)
+				goto out2;
+		}
 	} else {
 		l = insert_subst_lump_before(
 				l, (path_sockname_mode) ? SUBST_SND_ALL_EX : SUBST_SND_ALL, 0);
@@ -273,9 +280,14 @@ static int prepend_path(sip_msg_t *_m, str *user, path_param_t param,
 			l = insert_new_lump_before(l, dp, adv_addr->len, 0);
 			if(!l)
 				goto out1;
+			if(path_sockname_mode) {
+				l = insert_subst_lump_before(l, SUBST_RCV_SOCKNAME, 0);
+				if(!l)
+					goto out1;
+			}
 		} else {
-			l = insert_subst_lump_before(
-					l, (path_sockname_mode) ? SUBST_RCV_ALL_EX : SUBST_RCV_ALL, 0);
+			l = insert_subst_lump_before(l,
+					(path_sockname_mode) ? SUBST_RCV_ALL_EX : SUBST_RCV_ALL, 0);
 			if(!l)
 				goto out1;
 		}

--- a/src/modules/path/path.c
+++ b/src/modules/path/path.c
@@ -249,8 +249,15 @@ static int prepend_path(sip_msg_t *_m, str *user, path_param_t param,
 		l = insert_new_lump_before(l, dp, adv_addr->len, 0);
 		if(!l)
 			goto out2;
-		/* the advertised address replaces the host part only, so the socket
-		 * name still has to be appended at send time if sockname_mode is on */
+		dp = path_strzdup(TRANSPORT_PARAM, TRANSPORT_PARAM_LEN);
+		if(dp == NULL)
+			goto out2;
+		l = insert_new_lump_before(l, dp, TRANSPORT_PARAM_LEN, 0);
+		if(!l)
+			goto out2;
+		l = insert_subst_lump_before(l, SUBST_SND_PROTO, 0);
+		if(!l)
+			goto out2;
 		if(path_sockname_mode) {
 			l = insert_subst_lump_before(l, SUBST_SND_SOCKNAME, 0);
 			if(!l)
@@ -278,6 +285,15 @@ static int prepend_path(sip_msg_t *_m, str *user, path_param_t param,
 			if(dp == NULL)
 				goto out1;
 			l = insert_new_lump_before(l, dp, adv_addr->len, 0);
+			if(!l)
+				goto out1;
+			dp = path_strzdup(TRANSPORT_PARAM, TRANSPORT_PARAM_LEN);
+			if(dp == NULL)
+				goto out1;
+			l = insert_new_lump_before(l, dp, TRANSPORT_PARAM_LEN, 0);
+			if(!l)
+				goto out1;
+			l = insert_subst_lump_before(l, SUBST_RCV_PROTO, 0);
 			if(!l)
 				goto out1;
 			if(path_sockname_mode) {

--- a/src/modules/path/path.h
+++ b/src/modules/path/path.h
@@ -70,6 +70,11 @@ int ki_add_path_received_user(sip_msg_t *_msg, str *_user);
 int ki_add_path_received_user_params(sip_msg_t *_msg, str *_user, str *_params);
 
 /*
+ * Validate and enable the advertised_address module parameter.
+ */
+int path_advertised_address_init(str *addr);
+
+/*
  * rr callback for setting dst-uri
  */
 void path_rr_callback(struct sip_msg *_m, str *r_param, void *cb_param);

--- a/src/modules/path/path.h
+++ b/src/modules/path/path.h
@@ -70,9 +70,30 @@ int ki_add_path_received_user(sip_msg_t *_msg, str *_user);
 int ki_add_path_received_user_params(sip_msg_t *_msg, str *_user, str *_params);
 
 /*
- * Validate and enable the advertised_address module parameter.
+ * Prepend own uri to Path header using the given advertised address as the
+ * host part instead of the outgoing socket address.
  */
-int path_advertised_address_init(str *addr);
+int add_path_advertised_address(
+		struct sip_msg *_msg, char *_addr, char *_usr, char *_parms);
+
+int ki_add_path_advertised_address(sip_msg_t *_msg, str *_addr);
+int ki_add_path_advertised_address_user(
+		sip_msg_t *_msg, str *_addr, str *_user);
+int ki_add_path_advertised_address_user_params(
+		sip_msg_t *_msg, str *_addr, str *_user, str *_params);
+
+/*
+ * Prepend own uri to Path header using the given advertised address as the
+ * host part and append the received address as "received"-param.
+ */
+int add_path_received_advertised_address(
+		struct sip_msg *_msg, char *_addr, char *_usr, char *_parms);
+
+int ki_add_path_received_advertised_address(sip_msg_t *_msg, str *_addr);
+int ki_add_path_received_advertised_address_user(
+		sip_msg_t *_msg, str *_addr, str *_user);
+int ki_add_path_received_advertised_address_user_params(
+		sip_msg_t *_msg, str *_addr, str *_user, str *_params);
 
 /*
  * rr callback for setting dst-uri

--- a/src/modules/path/path_mod.c
+++ b/src/modules/path/path_mod.c
@@ -69,6 +69,8 @@ int path_received_format = 0;
 int path_enable_r2 = 0;
 int path_sockname_mode = 0;
 str path_received_name = str_init("received");
+str path_advertised_address = STR_NULL;
+int path_advertised_address_ok = 0;
 
 /*! \brief
  * Module initialization function prototype
@@ -114,6 +116,7 @@ static param_export_t params[] = {
 	{"enable_r2", PARAM_INT, &path_enable_r2},
 	{"sockname_mode", PARAM_INT, &path_sockname_mode},
 	{"received_name", PARAM_STR, &path_received_name},
+	{"advertised_address", PARAM_STR, &path_advertised_address},
 	{0, 0, 0}
 };
 
@@ -153,6 +156,9 @@ static int mod_init(void)
 		LM_INFO("outbound module not available\n");
 		memset(&path_obb, 0, sizeof(ob_api_t));
 	}
+
+	if(path_advertised_address_init(&path_advertised_address) < 0)
+		return -1;
 
 	return 0;
 }

--- a/src/modules/path/path_mod.c
+++ b/src/modules/path/path_mod.c
@@ -69,8 +69,6 @@ int path_received_format = 0;
 int path_enable_r2 = 0;
 int path_sockname_mode = 0;
 str path_received_name = str_init("received");
-str path_advertised_address = STR_NULL;
-int path_advertised_address_ok = 0;
 
 /*! \brief
  * Module initialization function prototype
@@ -104,6 +102,21 @@ static cmd_export_t cmds[] = {
 		fixup_spve_null, fixup_free_spve_null, REQUEST_ROUTE},
 	{"add_path_received", (cmd_function)add_path_received_usr, 2,
 		fixup_spve_spve, fixup_free_spve_spve, REQUEST_ROUTE},
+	{"add_path_advertised_address", (cmd_function)add_path_advertised_address, 1,
+		fixup_spve_all, fixup_free_spve_all, REQUEST_ROUTE},
+	{"add_path_advertised_address", (cmd_function)add_path_advertised_address, 2,
+		fixup_spve_all, fixup_free_spve_all, REQUEST_ROUTE},
+	{"add_path_advertised_address", (cmd_function)add_path_advertised_address, 3,
+		fixup_spve_all, fixup_free_spve_all, REQUEST_ROUTE},
+	{"add_path_received_advertised_address",
+		(cmd_function)add_path_received_advertised_address, 1,
+		fixup_spve_all, fixup_free_spve_all, REQUEST_ROUTE},
+	{"add_path_received_advertised_address",
+		(cmd_function)add_path_received_advertised_address, 2,
+		fixup_spve_all, fixup_free_spve_all, REQUEST_ROUTE},
+	{"add_path_received_advertised_address",
+		(cmd_function)add_path_received_advertised_address, 3,
+		fixup_spve_all, fixup_free_spve_all, REQUEST_ROUTE},
 	{0, 0, 0, 0, 0, 0}
 };
 
@@ -116,7 +129,6 @@ static param_export_t params[] = {
 	{"enable_r2", PARAM_INT, &path_enable_r2},
 	{"sockname_mode", PARAM_INT, &path_sockname_mode},
 	{"received_name", PARAM_STR, &path_received_name},
-	{"advertised_address", PARAM_STR, &path_advertised_address},
 	{0, 0, 0}
 };
 
@@ -157,9 +169,6 @@ static int mod_init(void)
 		memset(&path_obb, 0, sizeof(ob_api_t));
 	}
 
-	if(path_advertised_address_init(&path_advertised_address) < 0)
-		return -1;
-
 	return 0;
 }
 
@@ -196,6 +205,36 @@ static sr_kemi_t sr_kemi_path_exports[] = {
 	{ str_init("path"), str_init("add_path_received_user_params"),
 		SR_KEMIP_INT, ki_add_path_received_user_params,
 		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("path"), str_init("add_path_advertised_address"),
+		SR_KEMIP_INT, ki_add_path_advertised_address,
+		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("path"), str_init("add_path_advertised_address_user"),
+		SR_KEMIP_INT, ki_add_path_advertised_address_user,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("path"), str_init("add_path_advertised_address_user_params"),
+		SR_KEMIP_INT, ki_add_path_advertised_address_user_params,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("path"), str_init("add_path_received_advertised_address"),
+		SR_KEMIP_INT, ki_add_path_received_advertised_address,
+		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("path"), str_init("add_path_received_advertised_address_user"),
+		SR_KEMIP_INT, ki_add_path_received_advertised_address_user,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("path"), str_init("add_path_received_advertised_address_user_params"),
+		SR_KEMIP_INT, ki_add_path_received_advertised_address_user_params,
+		{ SR_KEMIP_STR, SR_KEMIP_STR, SR_KEMIP_STR,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
 	{ {0, 0}, {0, 0}, 0, NULL, { 0, 0, 0, 0, 0, 0 } }


### PR DESCRIPTION
#### Description

Support to declare an `advertised_address` in the `Path` header(s).
The approach is similar to `rr` module.

`socket name (sn)` support is also included, when `advertised_address` is used. And in a lot of scenarios, makes sense to use both at same time.

`transport` mapping also applied.

Quiet useful, allowing the preload of `lr` in a pool of instances, instead of pointing to static IP's.

Support for `received`, `r2` tested.

Example of usage:

```sh
add_path_received_advertised_address("$env(INST_FQDN)", "", "ob");
```

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)
