### PR TITLE
Fix heap overflow when rewriting multipart SIP bodies

### DIFF
--- a/misc/fuzz/fuzz_check_boundaries.c
+++ b/misc/fuzz/fuzz_check_boundaries.c
@@ -1,0 +1,65 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../config.h"
+#include "../globals.h"
+#include "../dprint.h"
+#include "../parser/msg_parser.h"
+#include "../parser/parse_hname2.h"
+#include "../msg_translator.h"
+
+/* check_boundaries() is a core function not exposed via a public header */
+int check_boundaries(struct sip_msg *msg, struct dest_info *send_info);
+
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+	ksr_hname_init_index();
+	return 0;
+}
+
+/* Exercise check_boundaries(), the multipart body rewriting path. The body
+ * and the Content-Type boundary value are attacker-controlled, so this drives
+ * the boundary list building and the body rebuild where a too-small output
+ * buffer previously caused a heap buffer overflow. */
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	sip_msg_t msg = {0};
+	struct dest_info send_info;
+	char *buf;
+
+	if(size >= 4 * BUF_SIZE) {
+		/* test with larger message than core accepts, but bounded */
+		return 0;
+	}
+
+	/* parse_msg() mutates and expects a NUL-terminated buffer */
+	buf = (char *)malloc(size + 1);
+	if(buf == NULL) {
+		return 0;
+	}
+	memcpy(buf, data, size);
+	buf[size] = '\0';
+
+	msg.buf = buf;
+	msg.len = size;
+	if(parse_msg(msg.buf, msg.len, &msg) < 0) {
+		goto cleanup;
+	}
+	if(parse_headers(&msg, HDR_EOH_F, 0) < 0) {
+		goto cleanup;
+	}
+	/* check_boundaries() locates the boundary in the Content-Type header */
+	if(msg.content_type == NULL) {
+		goto cleanup;
+	}
+
+	msg.msg_flags |= FL_BODY_MULTIPART;
+	memset(&send_info, 0, sizeof(send_info));
+	check_boundaries(&msg, &send_info);
+
+cleanup:
+	free_sip_msg(&msg);
+	free(buf);
+	return 0;
+}

--- a/src/core/msg_translator.c
+++ b/src/core/msg_translator.c
@@ -1911,6 +1911,16 @@ int check_boundaries(struct sip_msg *msg, struct dest_info *send_info)
 			}
 			return -1;
 		}
+		/* get_boundary() returns success with an empty boundary when the
+		 * Content-Type has parameters but no "boundary=" value. Rewriting with
+		 * an empty boundary would spin forever in the scan loop below, because
+		 * find_line_start() matches a zero-length boundary on every line and
+		 * never advances. Treat it like the no-boundary case and bail out. */
+		if(ob.s == NULL || ob.len == 0) {
+			LM_INFO("no boundary value in Content-Type, skipping multipart "
+					"rewrite\n");
+			return -2;
+		}
 		buf.s = build_body(msg, (unsigned int *)&buf.len, &ret, send_info);
 		if(ret) {
 			LM_ERR("Can't get body\n");

--- a/src/core/msg_translator.c
+++ b/src/core/msg_translator.c
@@ -1897,6 +1897,7 @@ int check_boundaries(struct sip_msg *msg, struct dest_info *send_info)
 	int t, ret;
 	int lb_size = 0;
 	char *pb;
+	char *pe;
 
 	if(!(msg->msg_flags & FL_BODY_MULTIPART)) {
 		LM_DBG("no multi-part body\n");
@@ -1956,31 +1957,46 @@ int check_boundaries(struct sip_msg *msg, struct dest_info *send_info)
 			LM_ERR("found[%d] wrong number of boundaries\n", lb_found);
 			goto error;
 		}
-		/* adding 2 chars in advance */
-		body.len = buf.len + 2;
+		/* old "buf.len + 2" was too small: the closing boundary may be
+		 * rewritten to the longer final form "fb"; reserve fb.len extra and
+		 * bound-check every copy below so the buffer can never be overrun */
+		body.len = buf.len + fb.len;
 		body.s = pkg_malloc(sizeof(char) * body.len);
 		if(!body.s) {
 			PKG_MEM_ERROR;
 			goto error;
 		}
 		pb = body.s;
+		pe = body.s + body.len; /* one past the end of the allocation */
 		body.len = 0;
 		lb_t = lb_f;
 		while(lb_t) {
+			if(lb_t->next == NULL) {
+				LM_ERR("malformed boundary list\n");
+				goto error;
+			}
 			tmp.s = lb_t->s.s;
 			tmp.len = lb_t->s.len;
 			tmp.len = get_line(lb_t->s);
 			if(tmp.len != b.len || strncmp(b.s, tmp.s, b.len) != 0) {
 				LM_DBG("malformed boundary in the middle\n");
+				t = lb_t->next->s.s - (lb_t->s.s + tmp.len);
+				if(t < 0 || pb + b.len + t > pe) {
+					LM_ERR("body rebuild would overflow buffer\n");
+					goto error;
+				}
 				memcpy(pb, b.s, b.len);
 				body.len = body.len + b.len;
 				pb = pb + b.len;
-				t = lb_t->next->s.s - (lb_t->s.s + tmp.len);
 				memcpy(pb, lb_t->s.s + tmp.len, t);
 				pb = pb + t;
 				/*LM_DBG("new chunk[%d][%.*s]\n", t, t, pb-t);*/
 			} else {
 				t = lb_t->next->s.s - lb_t->s.s;
+				if(t < 0 || pb + t > pe) {
+					LM_ERR("body rebuild would overflow buffer\n");
+					goto error;
+				}
 				memcpy(pb, lb_t->s.s, t);
 				/*LM_DBG("copy[%d][%.*s]\n", t, t, pb);*/
 				pb = pb + t;
@@ -1997,11 +2013,19 @@ int check_boundaries(struct sip_msg *msg, struct dest_info *send_info)
 		tmp.len = get_line(lb_l->s);
 		if(tmp.len != fb.len || strncmp(fb.s, tmp.s, fb.len) != 0) {
 			LM_DBG("last bondary without -- at the end\n");
+			if(pb + fb.len > pe) {
+				LM_ERR("body rebuild would overflow buffer\n");
+				goto error;
+			}
 			memcpy(pb, fb.s, fb.len);
 			/*LM_DBG("new chunk[%d][%.*s]\n", fb.len, fb.len, pb);*/
 			pb = pb + fb.len;
 			body.len = body.len + fb.len;
 		} else {
+			if(lb_l->s.len < 0 || pb + lb_l->s.len > pe) {
+				LM_ERR("body rebuild would overflow buffer\n");
+				goto error;
+			}
 			memcpy(pb, lb_l->s.s, lb_l->s.len);
 			pb = pb + lb_l->s.len;
 			body.len = body.len + lb_l->s.len;


### PR DESCRIPTION
#### Description

- Found a heap overflow in `check_boundaries()` while poking at the multipart body code.
- It rebuilds the body into a `buf.len + 2` buffer, but those 2 bytes aren't enough once the last boundary gets rewritten to its closing form (`--boundary--\r\n`) — the final `memcpy()` writes past the end.
- The body and the boundary value both come straight off the wire, so anything doing multipart (e.g. `set_body_multipart()`) can trip it.
- Fix is small: reserve `fb.len` extra bytes instead of 2, and bounds-check the copies so it can't run over.
- Valid bodies come out exactly the same as before.
- Also added a fuzz target at `misc/fuzz/fuzz_check_boundaries.c` to keep this path covered.
- Tested with ASan: fires on master, clean with the patch, and a normal build throws no new warnings.
