### PR TITLE
sipcapture: validate HEPv3 chunk boundaries against packet length

### DIFF
--- a/misc/fuzz/fuzz_hep.c
+++ b/misc/fuzz/fuzz_hep.c
@@ -1,0 +1,193 @@
+/*
+ * libFuzzer / OSS-Fuzz target for the HEPv3 capture-packet chunk parser in
+ * src/modules/sipcapture/hep.c.
+ *
+ * The HEPv3 parsers (parsing_hepv3_message, hepv3_message_parse,
+ * hepv3_get_chunk) are sipcapture module functions that pull in the whole
+ * module and the SIP receive path, so they cannot be linked into the core
+ * OSS-Fuzz harness the way the parse_* targets are. This target is therefore
+ * self-contained: it walks the chunk list of a fuzzed HEP datagram using the
+ * same control-header and per-chunk bounds checks the module uses
+ * (hepv3_total_length / hepv3_chunk_ok) and dereferences each chunk the way
+ * the parser does, so AddressSanitizer flags any read past the datagram. Keep
+ * the three helpers below in sync with src/modules/sipcapture/hep.c.
+ *
+ * Standalone build:
+ *   clang -fsanitize=address,fuzzer misc/fuzz/fuzz_hep.c -o fuzz_hep
+ */
+#include <stdint.h>
+#include <string.h>
+#include <arpa/inet.h>
+
+typedef struct
+{
+	uint16_t vendor_id;
+	uint16_t type_id;
+	uint16_t length;
+} __attribute__((packed)) hep_chunk_t;
+
+typedef struct
+{
+	hep_chunk_t chunk;
+	uint8_t data;
+} __attribute__((packed)) hep_chunk_uint8_t;
+
+typedef struct
+{
+	hep_chunk_t chunk;
+	uint16_t data;
+} __attribute__((packed)) hep_chunk_uint16_t;
+
+typedef struct
+{
+	hep_chunk_t chunk;
+	uint32_t data;
+} __attribute__((packed)) hep_chunk_uint32_t;
+
+typedef struct
+{
+	hep_chunk_t chunk;
+	struct in_addr data;
+} __attribute__((packed)) hep_chunk_ip4_t;
+
+typedef struct
+{
+	hep_chunk_t chunk;
+	struct in6_addr data;
+} __attribute__((packed)) hep_chunk_ip6_t;
+
+typedef struct
+{
+	char id[4];
+	uint16_t length;
+} __attribute__((packed)) hep_ctrl_t;
+
+/* --- mirror of the helpers in src/modules/sipcapture/hep.c --- */
+static unsigned int hepv3_chunk_minlen(int chunk_type)
+{
+	switch(chunk_type) {
+		case 1:
+		case 2:
+		case 11:
+			return sizeof(hep_chunk_uint8_t);
+		case 3:
+		case 4:
+			return sizeof(hep_chunk_ip4_t);
+		case 5:
+		case 6:
+			return sizeof(hep_chunk_ip6_t);
+		case 7:
+		case 8:
+		case 13:
+			return sizeof(hep_chunk_uint16_t);
+		case 9:
+		case 10:
+		case 12:
+			return sizeof(hep_chunk_uint32_t);
+		default:
+			return sizeof(hep_chunk_t);
+	}
+}
+
+static int hepv3_chunk_ok(const char *buf, unsigned int blen, unsigned int off)
+{
+	const hep_chunk_t *chunk;
+	unsigned int minlen;
+	int chunk_vendor, chunk_length;
+
+	if(off + sizeof(hep_chunk_t) > blen)
+		return -1;
+	chunk = (const hep_chunk_t *)(buf + off);
+	chunk_vendor = ntohs(chunk->vendor_id);
+	chunk_length = ntohs(chunk->length);
+	minlen = sizeof(hep_chunk_t);
+	if(chunk_vendor == 0)
+		minlen = hepv3_chunk_minlen(ntohs(chunk->type_id));
+	if(chunk_length < (int)minlen)
+		return -1;
+	if(off + (unsigned int)chunk_length > blen)
+		return -1;
+	return 0;
+}
+
+static int hepv3_total_length(const char *buf, unsigned int len)
+{
+	int total_length;
+
+	if(len < sizeof(hep_ctrl_t))
+		return -1;
+	total_length = ntohs(((const hep_ctrl_t *)buf)->length);
+	if((unsigned int)total_length > len)
+		return -1;
+	return total_length;
+}
+
+/* volatile sinks so the typed dereferences are not optimized away */
+static volatile unsigned int g_u;
+static volatile unsigned char g_addr[16];
+
+/* Walk the chunks the way parsing_hepv3_message() does, dereferencing the
+ * fixed-width value of each known chunk type. With the bounds checks in place
+ * every dereference must stay inside the datagram. */
+static void hepv3_walk(const char *buf, unsigned int len)
+{
+	int i, total_length, chunk_vendor, chunk_type, chunk_length;
+	const char *tmp;
+
+	total_length = hepv3_total_length(buf, len);
+	if(total_length < 0)
+		return;
+
+	i = sizeof(hep_ctrl_t);
+	while(i < total_length) {
+		if(hepv3_chunk_ok(buf, (unsigned int)total_length, (unsigned int)i) < 0)
+			return;
+
+		tmp = buf + i;
+		chunk_vendor = ntohs(((const hep_chunk_t *)tmp)->vendor_id);
+		chunk_type = ntohs(((const hep_chunk_t *)tmp)->type_id);
+		chunk_length = ntohs(((const hep_chunk_t *)tmp)->length);
+
+		if(chunk_vendor == 0) {
+			switch(chunk_type) {
+				case 1:
+				case 2:
+				case 11:
+					g_u += ((const hep_chunk_uint8_t *)tmp)->data;
+					break;
+				case 3:
+				case 4:
+					g_u += ((const hep_chunk_ip4_t *)tmp)->data.s_addr;
+					break;
+				case 5:
+				case 6:
+					memcpy((void *)g_addr,
+							&((const hep_chunk_ip6_t *)tmp)->data, 16);
+					break;
+				case 7:
+				case 8:
+				case 13:
+					g_u += ntohs(((const hep_chunk_uint16_t *)tmp)->data);
+					break;
+				case 9:
+				case 10:
+				case 12:
+					g_u += ntohl(((const hep_chunk_uint32_t *)tmp)->data);
+					break;
+				default:
+					break;
+			}
+		}
+		i += chunk_length;
+	}
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	if(size < sizeof(hep_ctrl_t) || size > 65535) {
+		/* HEP datagrams are bounded by a 16-bit length field */
+		return 0;
+	}
+	hepv3_walk((const char *)data, (unsigned int)size);
+	return 0;
+}

--- a/src/modules/sipcapture/hep.c
+++ b/src/modules/sipcapture/hep.c
@@ -251,6 +251,104 @@ int hepv3_received(char *buf, unsigned int len, struct receive_info *ri)
 	return -1;
 }
 
+/*
+ * Smallest valid on-wire size of a HEPv3 chunk of the given vendor-0 type.
+ * It is the 6-byte generic chunk header (hep_chunk_t) plus the fixed-width
+ * value the parser later dereferences for that type. The sizes are taken
+ * from the on-wire structures in hep.h, so they stay in sync if those change.
+ * The chunk type ids follow the HEP3 specification and match the switch
+ * statements in the parsers below:
+ *   1  IP protocol family    2  IP protocol id      11 protocol type   (u8)
+ *   3  IPv4 source address   4  IPv4 dest address                      (ip4)
+ *   5  IPv6 source address   6  IPv6 dest address                      (ip6)
+ *   7  source port           8  destination port    13 keep-alive tmr  (u16)
+ *   9  timestamp seconds     10 timestamp usec       12 capture agent  (u32)
+ * Types carrying a variable-length payload (14 auth key, 15 captured
+ * payload, 17 correlation id) and unknown types only require the generic
+ * header. Used to reject truncated chunks before they are cast to a typed
+ * struct and dereferenced.
+ */
+static unsigned int hepv3_chunk_minlen(int chunk_type)
+{
+	switch(chunk_type) {
+		case 1:
+		case 2:
+		case 11:
+			return sizeof(hep_chunk_uint8_t);
+		case 3:
+		case 4:
+			return sizeof(hep_chunk_ip4_t);
+		case 5:
+		case 6:
+			return sizeof(hep_chunk_ip6_t);
+		case 7:
+		case 8:
+		case 13:
+			return sizeof(hep_chunk_uint16_t);
+		case 9:
+		case 10:
+		case 12:
+			return sizeof(hep_chunk_uint32_t);
+		default:
+			return sizeof(hep_chunk_t);
+	}
+}
+
+/*
+ * Verify the HEPv3 chunk at byte offset off of a blen-byte buffer is safe to
+ * dereference: the generic chunk header must be present, the advertised
+ * length must cover the header and (for a known vendor-0 chunk) the fixed-
+ * width value the parser reads for that type, and the whole chunk must lie
+ * within the buffer. Returns 0 if the chunk is safe, -1 otherwise.
+ */
+static int hepv3_chunk_ok(const char *buf, unsigned int blen, unsigned int off)
+{
+	const hep_chunk_t *chunk;
+	unsigned int minlen;
+	int chunk_vendor, chunk_length;
+
+	/* the generic chunk header must lie within the buffer */
+	if(off + sizeof(hep_chunk_t) > blen)
+		return -1;
+
+	chunk = (const hep_chunk_t *)(buf + off);
+	chunk_vendor = ntohs(chunk->vendor_id);
+	chunk_length = ntohs(chunk->length);
+
+	/* a chunk must advertise at least its header and, for a known vendor-0
+	 * chunk, the fixed-width value its type is later read as */
+	minlen = sizeof(hep_chunk_t);
+	if(chunk_vendor == 0)
+		minlen = hepv3_chunk_minlen(ntohs(chunk->type_id));
+	if(chunk_length < (int)minlen)
+		return -1;
+
+	/* the whole chunk must lie within the buffer */
+	if(off + (unsigned int)chunk_length > blen)
+		return -1;
+
+	return 0;
+}
+
+/*
+ * Validate the HEPv3 control header of a len-byte datagram and return the
+ * advertised total length, which must not exceed the bytes actually received
+ * so the chunk loop can never read past the datagram. Returns -1 if the
+ * header is missing or the advertised length is larger than the datagram.
+ */
+static int hepv3_total_length(const char *buf, unsigned int len)
+{
+	int total_length;
+
+	if(len < sizeof(hep_ctrl_t))
+		return -1;
+	total_length = ntohs(((const hep_ctrl_t *)buf)->length);
+	/* compare in unsigned space; total_length fits 16 bits */
+	if((unsigned int)total_length > len)
+		return -1;
+	return total_length;
+}
+
 int parsing_hepv3_message(char *buf, unsigned int len)
 {
 
@@ -287,8 +385,12 @@ int parsing_hepv3_message(char *buf, unsigned int len)
 	/* HEADER */
 	hg->header = (hep_ctrl_t *)(buf);
 
-	/*Packet size */
-	total_length = ntohs(hg->header->length);
+	/* validate header and bound parsing by the received datagram size */
+	total_length = hepv3_total_length(buf, len);
+	if(total_length < 0) {
+		LM_ERR("invalid HEPv3 header, received %u bytes\n", len);
+		goto error;
+	}
 
 	ri.src_port = 0;
 	ri.dst_port = 0;
@@ -306,18 +408,17 @@ int parsing_hepv3_message(char *buf, unsigned int len)
 		/*OUR TMP DATA */
 		tmp = buf + i;
 
+		/* bounds-check the chunk before any field is dereferenced */
+		if(hepv3_chunk_ok(buf, total_length, i) < 0) {
+			LM_ERR("malformed HEPv3 chunk at offset %d\n", i);
+			goto error;
+		}
+
 		chunk = (struct hep_chunk *)tmp;
 
 		chunk_vendor = ntohs(chunk->vendor_id);
 		chunk_type = ntohs(chunk->type_id);
 		chunk_length = ntohs(chunk->length);
-
-
-		/* if chunk_length */
-		if(chunk_length == 0) {
-			/* BAD LEN we drop this packet */
-			goto error;
-		}
 
 		/* SKIP not general Chunks */
 		if(chunk_vendor != 0) {
@@ -571,8 +672,12 @@ int hepv3_message_parse(char *buf, unsigned int len, sip_msg_t *msg)
 	/* HEADER */
 	hg->header = (hep_ctrl_t *)(buf);
 
-	/*Packet size */
-	total_length = ntohs(hg->header->length);
+	/* validate header and bound parsing by the received datagram size */
+	total_length = hepv3_total_length(buf, len);
+	if(total_length < 0) {
+		LM_ERR("invalid HEPv3 header, received %u bytes\n", len);
+		goto error;
+	}
 
 	dst_ip.af = 0;
 	src_ip.af = 0;
@@ -588,17 +693,17 @@ int hepv3_message_parse(char *buf, unsigned int len, sip_msg_t *msg)
 		/*OUR TMP DATA */
 		tmp = buf + i;
 
+		/* bounds-check the chunk before any field is dereferenced */
+		if(hepv3_chunk_ok(buf, total_length, i) < 0) {
+			LM_ERR("malformed HEPv3 chunk at offset %d\n", i);
+			goto error;
+		}
+
 		chunk = (struct hep_chunk *)tmp;
 
 		chunk_vendor = ntohs(chunk->vendor_id);
 		chunk_type = ntohs(chunk->type_id);
 		chunk_length = ntohs(chunk->length);
-
-		/* if chunk_length */
-		if(chunk_length == 0) {
-			/* BAD LEN we drop this packet */
-			goto error;
-		}
 
 		/* SKIP not general Chunks */
 		if(chunk_vendor != 0) {
@@ -939,8 +1044,12 @@ int hepv3_get_chunk(struct sip_msg *msg, char *buf, unsigned int len,
 	/* HEADER */
 	hg->header = (hep_ctrl_t *)(buf);
 
-	/*Packet size */
-	total_length = ntohs(hg->header->length);
+	/* validate header and bound parsing by the received datagram size */
+	total_length = hepv3_total_length(buf, len);
+	if(total_length < 0) {
+		LM_ERR("invalid HEPv3 header, received %u bytes\n", len);
+		goto error;
+	}
 
 	i = sizeof(hep_ctrl_t);
 
@@ -949,17 +1058,17 @@ int hepv3_get_chunk(struct sip_msg *msg, char *buf, unsigned int len,
 		/*OUR TMP DATA */
 		tmp = buf + i;
 
+		/* bounds-check the chunk before any field is dereferenced */
+		if(hepv3_chunk_ok(buf, total_length, i) < 0) {
+			LM_ERR("malformed HEPv3 chunk at offset %d\n", i);
+			goto error;
+		}
+
 		chunk = (struct hep_chunk *)tmp;
 
 		chunk_vendor = ntohs(chunk->vendor_id);
 		chunk_type = ntohs(chunk->type_id);
 		chunk_length = ntohs(chunk->length);
-
-		/* if chunk_length */
-		if(chunk_length == 0) {
-			/* BAD LEN we drop this packet */
-			goto error;
-		}
 
 		/* SKIP not general Chunks */
 		if(chunk_vendor != 0) {


### PR DESCRIPTION
### Description
Noticed the HEPv3 parser in `sipcapture` takes `total_length` from the packet header and walks chunks up to that value without verifying it against the number of bytes actually received. The HEPv2 path right above already performs this validation, making HEPv3 the exception. As a result, a malformed HEP packet can cause out-of-bounds reads while parsing chunks, including a small underflow in type-15 chunk handling. Since HEP is received over UDP, the issue is remotely reachable.

### Changes
Added two helper functions, `hepv3_total_length()` and `hepv3_chunk_ok()`, and reused them across the three HEPv3 parsers that iterate over chunks. The helpers ensure the advertised packet length and chunk boundaries stay within the received buffer. Also added `misc/fuzz/fuzz_hep.c` to exercise malformed HEP inputs.

### Result
Valid HEP packets continue to parse exactly as before, while malformed packets are safely rejected. ASan reproduces the issue on master and runs clean with this patch applied.
