### PR TITLE
core: strutils - fix out of bounds read in replace()

### DIFF
--- a/src/core/strutils.c
+++ b/src/core/strutils.c
@@ -768,6 +768,8 @@ int cmp_aor_str(str *s1, str *s2)
 	return cmp_aor(&uri1, &uri2);
 }
 
+#define SR_RE_MAX_MATCH 6
+
 /*! \brief Replace in replacement tokens \\d with substrings of string pointed by
  * pmatch.
  */
@@ -783,9 +785,9 @@ int replace(regmatch_t *pmatch, char *string, char *replacement, str *result)
 			if(i < len - 1) {
 				if(isdigit((unsigned char)replacement[i + 1])) {
 					digit = replacement[i + 1] - '0';
-					if(pmatch[digit].rm_so != -1) {
+					if(digit < SR_RE_MAX_MATCH && pmatch[digit].rm_so != -1) {
 						size = pmatch[digit].rm_eo - pmatch[digit].rm_so;
-						if(j + size < result->len) {
+						if(size >= 0 && j + size < result->len) {
 							memcpy(&(result->s[j]),
 									string + pmatch[digit].rm_so, size);
 							j = j + size;
@@ -815,8 +817,6 @@ int replace(regmatch_t *pmatch, char *string, char *replacement, str *result)
 	return 1;
 }
 
-
-#define SR_RE_MAX_MATCH 6
 
 /*! \brief Match pattern against string and store result in pmatch */
 int reg_match(char *pattern, char *string, regmatch_t *pmatch)


### PR DESCRIPTION
### what i changed 
`replace()` in `src/core/strutils.c` uses a `\d` backreference digit straight
as an index into `pmatch[]`, but the array only has 6 entries (indices 0–5,
`SR_RE_MAX_MATCH`). A `\6`–`\9` token reads past the end of it.

The garbage `regmatch_t` that comes back gives a bad source offset and a
`size = rm_eo - rm_so` that can be negative — and a negative `size` slips
through the `j + size < result->len` check straight into `memcpy()`, where it
turns into a huge length and overflows `result->s`.

Fix just bounds the index (`digit < 6`) and rejects a negative size before the
copy. Valid backreferences behave exactly as before.

Tested with an ASan build — a `\6` replacement trips stack-buffer-overflow
before the patch, clean after. Builds fine with gcc `-Wall`, clang-format clean.
