### PR TITLE
RFC: TCP Reactor: own all TCP network I/O in `PROC_TCP_MAIN`

### DIFF
--- a/src/core/tcp_cond.c
+++ b/src/core/tcp_cond.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2025 S-P Chan
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/* pthread_mutexattr_setrobust()/pthread_mutex_consistent() need _GNU_SOURCE
+ * (or _POSIX_C_SOURCE >= 200809) on glibc; must be set before any include. */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <errno.h>
+#include <pthread.h>
+#include <string.h>
+
+#include "dprint.h"
+#include "tcp_cond.h"
+
+int tcp_cond_init(tcp_cond_t *cond)
+{
+	pthread_mutexattr_t mattr;
+	pthread_condattr_t cattr;
+
+	/* process-shared + robust mutex */
+	if(pthread_mutexattr_init(&mattr) != 0) {
+		LM_ERR("failed to init mutex attributes\n");
+		return -1;
+	}
+	if(pthread_mutexattr_setpshared(&mattr, PTHREAD_PROCESS_SHARED) != 0
+			|| pthread_mutexattr_setrobust(&mattr, PTHREAD_MUTEX_ROBUST) != 0
+			|| pthread_mutex_init(&cond->m, &mattr) != 0) {
+		LM_ERR("failed to set up process-shared robust mutex\n");
+		pthread_mutexattr_destroy(&mattr);
+		return -1;
+	}
+	pthread_mutexattr_destroy(&mattr);
+
+	/* process-shared condition variable */
+	if(pthread_condattr_init(&cattr) != 0) {
+		LM_ERR("failed to init cond attributes\n");
+		pthread_mutex_destroy(&cond->m);
+		return -1;
+	}
+	if(pthread_condattr_setpshared(&cattr, PTHREAD_PROCESS_SHARED) != 0
+			|| pthread_cond_init(&cond->c, &cattr) != 0) {
+		LM_ERR("failed to set up process-shared cond\n");
+		pthread_condattr_destroy(&cattr);
+		pthread_mutex_destroy(&cond->m);
+		return -1;
+	}
+	pthread_condattr_destroy(&cattr);
+
+	return 0;
+}
+
+void tcp_cond_destroy(tcp_cond_t *cond)
+{
+	pthread_cond_destroy(&cond->c);
+	pthread_mutex_destroy(&cond->m);
+}
+
+/* Recover a robust mutex whose previous owner died while holding it: we now own
+ * the lock, but the data it protects may be inconsistent. Marking it consistent
+ * keeps the mutex usable; without this it would become ENOTRECOVERABLE and every
+ * future lock attempt would fail. */
+static void tcp_cond_recover_owner_dead(tcp_cond_t *cond)
+{
+	LM_WARN("robust mutex %p owner died; recovering (state may be partial)\n",
+			(void *)cond);
+	if(pthread_mutex_consistent(&cond->m) != 0)
+		LM_ERR("failed to make robust mutex %p consistent\n", (void *)cond);
+}
+
+void tcp_cond_lock(tcp_cond_t *cond)
+{
+	int ret;
+
+	ret = pthread_mutex_lock(&cond->m);
+	if(ret == EOWNERDEAD) {
+		tcp_cond_recover_owner_dead(cond);
+	} else if(ret != 0) {
+		LM_ERR("pthread_mutex_lock failed: %s (%d)\n", strerror(ret), ret);
+	}
+}
+
+void tcp_cond_unlock(tcp_cond_t *cond)
+{
+	int ret;
+
+	ret = pthread_mutex_unlock(&cond->m);
+	if(ret != 0)
+		LM_ERR("pthread_mutex_unlock failed: %s (%d)\n", strerror(ret), ret);
+}
+
+void tcp_cond_wait(tcp_cond_t *cond)
+{
+	int ret;
+
+	/* re-acquires the mutex on wakeup; that re-acquire can also report a dead
+	 * previous owner on a robust mutex */
+	ret = pthread_cond_wait(&cond->c, &cond->m);
+	if(ret == EOWNERDEAD) {
+		tcp_cond_recover_owner_dead(cond);
+	} else if(ret != 0) {
+		LM_ERR("pthread_cond_wait failed: %s (%d)\n", strerror(ret), ret);
+	}
+}
+
+void tcp_cond_signal(tcp_cond_t *cond)
+{
+	int ret;
+
+	ret = pthread_cond_signal(&cond->c);
+	if(ret != 0)
+		LM_ERR("pthread_cond_signal failed: %s (%d)\n", strerror(ret), ret);
+}
+
+void tcp_cond_broadcast(tcp_cond_t *cond)
+{
+	int ret;
+
+	ret = pthread_cond_broadcast(&cond->c);
+	if(ret != 0)
+		LM_ERR("pthread_cond_broadcast failed: %s (%d)\n", strerror(ret), ret);
+}

--- a/src/core/tcp_cond.h
+++ b/src/core/tcp_cond.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 S-P Chan
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _TCP_COND_H_
+#define _TCP_COND_H_
+
+#include <pthread.h>
+
+/*
+ * Cross-process condition variable for the TCP reactor thread pool
+ * (tcp_main_threads == 2).
+ *
+ * The struct is meant to live in shared memory: TCP worker processes signal it
+ * to submit write jobs, while the pool threads inside PROC_TCP_MAIN wait on it.
+ * Because waiters and signalers are different PIDs sharing one shm page, both
+ * the mutex and the condvar are PTHREAD_PROCESS_SHARED.
+ *
+ * The mutex is additionally PTHREAD_MUTEX_ROBUST: if a process dies while
+ * holding the lock, the next tcp_cond_lock()/tcp_cond_wait() recovers it
+ * (EOWNERDEAD -> pthread_mutex_consistent) instead of leaving every future
+ * locker stuck at ENOTRECOVERABLE.
+ */
+typedef struct tcp_cond
+{
+	pthread_mutex_t m;
+	pthread_cond_t c;
+} tcp_cond_t;
+
+/* Initialize a tcp_cond_t (typically allocated in shared memory).
+ * Returns 0 on success, -1 on error. */
+int tcp_cond_init(tcp_cond_t *cond);
+
+/* Destroy a tcp_cond_t. Does not free the memory holding it. */
+void tcp_cond_destroy(tcp_cond_t *cond);
+
+/* Lock / unlock the embedded mutex. tcp_cond_lock() transparently recovers a
+ * robust mutex abandoned by a crashed owner. */
+void tcp_cond_lock(tcp_cond_t *cond);
+void tcp_cond_unlock(tcp_cond_t *cond);
+
+/* Wait on the condition. Must be called with the mutex held (via
+ * tcp_cond_lock()). Recovers the robust mutex if it was abandoned while being
+ * re-acquired on wakeup. */
+void tcp_cond_wait(tcp_cond_t *cond);
+
+/* Wake one / all waiters. */
+void tcp_cond_signal(tcp_cond_t *cond);
+void tcp_cond_broadcast(tcp_cond_t *cond);
+
+#endif /* _TCP_COND_H_ */

--- a/src/core/tcp_conn.h
+++ b/src/core/tcp_conn.h
@@ -186,6 +186,10 @@ typedef enum conn_cmds
 	CONN_WRITE_REQ /* mode 2: worker asks tcp_main to queue a write on an
 						* existing connection; response[0] is a
 						* tcp_reactor_write_req_t*, not a tcp_connection* */
+	,
+	CONN_CONNECT_REQ /* mode 2: worker asks tcp_main to open a new outbound
+						* connection and send on it; response[0] is a
+						* tcp_reactor_connect_req_t*, not a tcp_connection* */
 } conn_cmds_t;
 /* CONN_RELEASE, EOF, ERROR, DESTROY can be used by "reader" processes
  * CONN_GET_FD, CONN_NEW*, CONN_QUEUED_WRITE only by writers */

--- a/src/core/tcp_conn.h
+++ b/src/core/tcp_conn.h
@@ -73,6 +73,9 @@
 	(1 << 19) /* write interest shielded: handed to a pool thread */
 #define F_CONN_WRITE_QUEUED \
 	(1 << 20) /* conn is linked in the shm write queue (dedup) */
+#define F_CONN_POOL_BUSY \
+	(1 << 21) /* owned by a pool job: shielded out of io_h + local timer.
+			   * Serializes read/write jobs per conn (one owner at a time). */
 
 #ifndef NO_READ_HTTP11
 #define READ_HTTP11

--- a/src/core/tcp_conn.h
+++ b/src/core/tcp_conn.h
@@ -66,6 +66,13 @@
 #define F_CONN_CLOSE_EV 32768 /* explicitely call tcpops ev route when closed */
 #define F_CONN_NOSEND 65536	  /* do not send data on this connection */
 #define F_CONN_NORECV (1 << 17) /* do not receive data on this connection */
+/* mode 2 (tcp reactor thread pool) flags */
+#define F_CONN_REMOVED_READ \
+	(1 << 18) /* read interest shielded: handed to a pool thread */
+#define F_CONN_REMOVED_WRITE \
+	(1 << 19) /* write interest shielded: handed to a pool thread */
+#define F_CONN_WRITE_QUEUED \
+	(1 << 20) /* conn is linked in the shm write queue (dedup) */
 
 #ifndef NO_READ_HTTP11
 #define READ_HTTP11
@@ -298,6 +305,19 @@ typedef struct ksr_coninfo
 } ksr_coninfo_t;
 
 
+/* mode 2 (tcp reactor thread pool): per-connection plaintext write staging
+ * chunk. A TCP worker process appends plaintext here (under write_lock) instead
+ * of touching wbuf_q; a pool thread in PROC_TCP_MAIN later encodes it (TLS) or
+ * copies it (plain) into wbuf_q and writes it out. shm-allocated. */
+struct tcp_wchunk
+{
+	char *buf;
+	unsigned int len;
+	snd_flags_t send_flags;
+	struct tcp_wchunk *next;
+};
+
+
 typedef struct tcp_connection
 {
 	int s;	/*socket, used by "tcp main" */
@@ -330,6 +350,12 @@ typedef struct tcp_connection
 	int aliases; /* aliases number, at least 1 */
 #ifdef TCP_ASYNC
 	struct tcp_wbuffer_queue wbuf_q;
+	/* mode 2 (tcp reactor) write path: linkage in the shared write queue, and
+	 * the per-connection plaintext staging list. All guarded by write_lock /
+	 * the write-queue condvar; unused (NULL) in modes 0/1. */
+	struct tcp_connection *wq_next;
+	struct tcp_wchunk *wsq_head;
+	struct tcp_wchunk *wsq_tail;
 #endif
 } tcp_connection_t;
 

--- a/src/core/tcp_conn.h
+++ b/src/core/tcp_conn.h
@@ -182,6 +182,10 @@ typedef enum conn_cmds
 	,
 	CONN_NEW_COMPLETE /* like CONN_NEW_PENDING_WRITE, but there is no
 						* pending write (the write queue might be empty) */
+	,
+	CONN_WRITE_REQ /* mode 2: worker asks tcp_main to queue a write on an
+						* existing connection; response[0] is a
+						* tcp_reactor_write_req_t*, not a tcp_connection* */
 } conn_cmds_t;
 /* CONN_RELEASE, EOF, ERROR, DESTROY can be used by "reader" processes
  * CONN_GET_FD, CONN_NEW*, CONN_QUEUED_WRITE only by writers */

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -197,6 +197,16 @@ static int *connection_id = 0; /*  unique for each connection, used for
 								for a reply */
 int unix_tcp_sock;
 
+/* mode 2 reactor: shared AF_UNIX SOCK_DGRAM socketpair.
+ * [0] = read end (all workers recvfrom this fd after fork)
+ * [1] = write end (tcp_main sends task pointers here) */
+static int ksr_tcp_reactor_dsock[2] = {-1, -1};
+
+int ksr_tcp_reactor_get_dispatch_rfd(void)
+{
+	return ksr_tcp_reactor_dsock[0];
+}
+
 static int tcp_proto_no = -1; /* tcp protocol number as returned by
 							   getprotobyname */
 
@@ -517,7 +527,7 @@ again:
 	} else
 		goto end;
 
-		/* poll/select loop */
+	/* poll/select loop */
 #if defined(HAVE_SELECT) && defined(BLOCKING_USE_SELECT)
 	FD_ZERO(&orig_set);
 	FD_SET(fd, &orig_set);
@@ -2105,7 +2115,7 @@ inline static int _tcpconn_add_alias_unsafe(struct tcp_connection *c, int port,
 						for(r = i; r < p->aliases; r++) {
 							tcpconn_listrm(
 									tcpconn_aliases_hash[p->con_aliases[r]
-																 .hash],
+													.hash],
 									&p->con_aliases[r], next, prev);
 						}
 						if(likely((i + 1) < p->aliases)) {
@@ -2118,7 +2128,7 @@ inline static int _tcpconn_add_alias_unsafe(struct tcp_connection *c, int port,
 						for(r = i; r < p->aliases; r++) {
 							tcpconn_listadd(
 									tcpconn_aliases_hash[p->con_aliases[r]
-																 .hash],
+													.hash],
 									&p->con_aliases[r], next, prev);
 						}
 					} else
@@ -5235,6 +5245,30 @@ void tcp_main_loop()
 			goto error;
 		}
 		LM_INFO("tcp main processing threads prepared\n");
+		if(ksr_tcp_main_threads == 2) {
+			if(socketpair(AF_UNIX, SOCK_DGRAM, 0, ksr_tcp_reactor_dsock) < 0) {
+				LM_ERR("failed to create reactor dispatch socketpair: %s\n",
+						strerror(errno));
+				goto error;
+			}
+			if(fcntl(ksr_tcp_reactor_dsock[0], F_SETFL,
+					   fcntl(ksr_tcp_reactor_dsock[0], F_GETFL) | O_NONBLOCK)
+					< 0) {
+				LM_ERR("failed to set O_NONBLOCK on reactor dsock[0]: %s\n",
+						strerror(errno));
+				goto error;
+			}
+			if(fcntl(ksr_tcp_reactor_dsock[1], F_SETFL,
+					   fcntl(ksr_tcp_reactor_dsock[1], F_GETFL) | O_NONBLOCK)
+					< 0) {
+				LM_ERR("failed to set O_NONBLOCK on reactor dsock[1]: %s\n",
+						strerror(errno));
+				goto error;
+			}
+			LM_INFO("tcp reactor dispatch socketpair created"
+					" (rfd=%d wfd=%d)\n",
+					ksr_tcp_reactor_dsock[0], ksr_tcp_reactor_dsock[1]);
+		}
 	} else {
 		LM_INFO("tcp main processing threads not enabled\n");
 	}

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -4472,15 +4472,14 @@ static int tcp_reactor_enable_write_watch(struct tcp_connection *c)
 {
 	ticks_t t;
 
-	/* mode 2 (Phase 2): if the conn is currently shielded for an in-flight pool
-	 * read job it is owned exclusively by that pool thread - it is in neither
-	 * io_h nor the local timer. Return immediately WITHOUT touching c->flags or
-	 * io_h: a pool thread (this may be called from its TLS / CRLF-pong
-	 * write-back) must not race the io_wait thread on c->flags. The data is
-	 * already staged in wbuf_q and tcp_reactor_read_rearm() re-arms POLLOUT
-	 * from wbuf_q at completion. This check MUST come before any c->flags
-	 * write below. */
-	if(c->flags & F_CONN_REMOVED_READ)
+	/* mode 2 (Phase 2): if the conn is currently owned by a pool job
+	 * (F_CONN_POOL_BUSY) it is in neither io_h nor the local timer, and is
+	 * being touched by a pool thread. Return immediately WITHOUT touching
+	 * c->flags or io_h - a pool thread (this may be called from its TLS /
+	 * CRLF-pong write-back) must not race the io_wait thread on c->flags. The
+	 * data is already in wbuf_q and the job completion re-arms POLLOUT from it.
+	 * This check MUST come before any c->flags write below. */
+	if(c->flags & F_CONN_POOL_BUSY)
 		return 0;
 	if(c->flags & F_CONN_WANTS_WR)
 		return 0;
@@ -4566,9 +4565,10 @@ static void tcp_reactor_arm_read_timeout(struct tcp_connection *c, ticks_t t)
 	}
 }
 
-/* mode 2 (Phase 2): enqueue a TCP_R_READ job for c onto the pool task queue.
- * Caller (io_wait thread) has already shielded the fd. Returns 0/-1. */
-static int tcp_reactor_enqueue_read(struct tcp_connection *c)
+/* mode 2 (Phase 2): enqueue a read/write/run job for c onto the pool task
+ * queue. Caller (io_wait thread) has already shielded the conn. Returns 0/-1. */
+static int tcp_reactor_enqueue_job(
+		struct tcp_connection *c, enum tcp_reactor_op op)
 {
 	struct tcp_reactor_job *job;
 
@@ -4579,7 +4579,7 @@ static int tcp_reactor_enqueue_read(struct tcp_connection *c)
 	}
 	memset(job, 0, sizeof(*job));
 	job->conn = c;
-	job->op = TCP_R_READ;
+	job->op = op;
 	tcp_cond_lock(&tcp_reactor_wq->cond);
 	job->next = NULL;
 	if(tcp_rpool.task_tail != NULL)
@@ -4592,17 +4592,78 @@ static int tcp_reactor_enqueue_read(struct tcp_connection *c)
 	return 0;
 }
 
-/* mode 2 (Phase 2): re-arm a connection in the reactor after a pool read job
- * completed successfully (unshield). Runs in the io_wait thread. Adds POLLIN,
- * plus POLLOUT if a write accumulated while the read was in flight. Refreshes
- * the idle / partial-read timeout. Returns 0 on success, -1 on io_watch error
- * (caller should then close the connection). */
+/* mode 2 (Phase 2): take exclusive pool ownership of a connection. Runs in the
+ * io_wait thread. Removes the conn from io_h and the local timer, clears its
+ * watch flags, sets F_CONN_POOL_BUSY, and takes the single "in-pool" refcount
+ * that is held until the conn is unshielded or closed (it spans chained jobs).
+ * No-op (returns 0) if already busy. Returns -1 on io_watch error. */
+static int tcp_reactor_shield(struct tcp_connection *c, int fd_i)
+{
+	if(c->flags & F_CONN_POOL_BUSY)
+		return 0;
+	if((c->flags & (F_CONN_READ_W | F_CONN_WRITE_W)) && (c->s != -1)) {
+		if(unlikely(io_watch_del(&io_h, c->s, fd_i, 0) < 0)) {
+			LM_ERR("reactor: io_watch_del (shield) failed for %p fd %d\n", c,
+					c->s);
+			return -1;
+		}
+	}
+	if(c->flags & F_CONN_MAIN_TIMER) {
+		local_timer_del(&tcp_main_ltimer, &c->timer);
+		c->flags &= ~F_CONN_MAIN_TIMER;
+	}
+	c->flags &= ~(
+			F_CONN_READ_W | F_CONN_WRITE_W | F_CONN_WANTS_RD | F_CONN_WANTS_WR);
+	c->flags |= F_CONN_POOL_BUSY;
+	tcpconn_ref(c); /* in-pool ref: released at unshield/close */
+	return 0;
+}
+
+/* mode 2 (Phase 2): stage a plaintext write chunk onto c's per-connection
+ * write staging list (shm). Taken by a pool TCP_R_WRITE job. Safe to call from
+ * the io_wait thread (CONN_WRITE_REQ handler). Returns 0/-1. */
+static int tcp_reactor_wsq_add(struct tcp_connection *c, const char *buf,
+		unsigned len, snd_flags_t send_flags)
+{
+	struct tcp_wchunk *ch;
+
+	ch = shm_malloc(sizeof(*ch));
+	if(unlikely(ch == NULL)) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+	ch->buf = shm_malloc(len ? len : 1);
+	if(unlikely(ch->buf == NULL)) {
+		SHM_MEM_ERROR;
+		shm_free(ch);
+		return -1;
+	}
+	if(len)
+		memcpy(ch->buf, buf, len);
+	ch->len = len;
+	ch->send_flags = send_flags;
+	ch->next = NULL;
+	lock_get(&c->write_lock);
+	if(c->wsq_tail != NULL)
+		c->wsq_tail->next = ch;
+	else
+		c->wsq_head = ch;
+	c->wsq_tail = ch;
+	lock_release(&c->write_lock);
+	return 0;
+}
+
+/* mode 2 (Phase 2): re-arm a connection in the reactor after its pool job(s)
+ * finished (unshield). Runs in the io_wait thread. Clears F_CONN_POOL_BUSY,
+ * adds POLLIN plus POLLOUT if a write accumulated, and re-arms the local timer
+ * the shield removed. Returns 0 on success, -1 on io_watch error (caller
+ * should then close the connection). */
 static int tcp_reactor_read_rearm(struct tcp_connection *c)
 {
 	short events = POLLIN;
 	ticks_t t;
 
-	c->flags &= ~F_CONN_REMOVED_READ;
+	c->flags &= ~(F_CONN_POOL_BUSY | F_CONN_REMOVED_READ);
 	c->flags |= F_CONN_READ_W | F_CONN_WANTS_RD;
 	if(_wbufq_non_empty(c)) {
 		events |= POLLOUT;
@@ -4627,16 +4688,41 @@ static int tcp_reactor_read_rearm(struct tcp_connection *c)
 	return 0;
 }
 
-/* mode 2 (Phase 2): tear down a connection after a pool read job reported
- * EOF/error. The conn is already shielded (removed from io_h, READ_W/WRITE_W
- * cleared) so there is no io_watch_del here. Runs in the io_wait thread.
- * Mirrors the reactor_close teardown. */
+/* mode 2 (Phase 2): tear down a connection owned by a pool job (EOF/error). The
+ * conn is shielded (already out of io_h + timer); releases both the hash and
+ * the in-pool refcounts. Runs in the io_wait thread. */
 static void tcp_reactor_read_close(struct tcp_connection *c)
 {
 	if(tcpconn_try_unhash(c))
 		tcpconn_put(c);
-	c->flags &= ~(F_CONN_REMOVED_READ | F_CONN_WANTS_RD | F_CONN_WANTS_WR);
+	c->flags &= ~(F_CONN_POOL_BUSY | F_CONN_REMOVED_READ | F_CONN_WANTS_RD
+				  | F_CONN_WANTS_WR);
 	tcpconn_put_destroy(c);
+}
+
+/* mode 2 (Phase 2): pool job completion on a healthy conn (io_wait thread).
+ * If a write was staged during the job, chain a TCP_R_WRITE job and keep
+ * ownership (POOL_BUSY + in-pool ref stay). Otherwise release the in-pool ref
+ * and hand the conn back to the reactor (un-shield: re-arm io_h + timer). */
+static void tcp_reactor_unshield_or_chain(struct tcp_connection *c)
+{
+	if(c->wsq_head != NULL && (c->flags & F_CONN_HASHED)
+			&& c->state != S_CONN_BAD) {
+		if(likely(tcp_reactor_enqueue_job(c, TCP_R_WRITE) == 0))
+			return; /* keep POOL_BUSY + in-pool ref; the write job completes */
+		/* enqueue failed: fall through to un-shield; the staged data waits in
+		 * wsq until the next write trigger */
+	}
+	if(unlikely(tcpconn_put(c))) { /* release the in-pool ref */
+		tcpconn_destroy(c);
+		return;
+	}
+	if(unlikely(!(c->flags & F_CONN_HASHED) || (c->state == S_CONN_BAD))) {
+		tcp_reactor_read_close(c);
+		return;
+	}
+	if(unlikely(tcp_reactor_read_rearm(c) < 0))
+		tcp_reactor_read_close(c);
 }
 #endif /* TCP_ASYNC */
 
@@ -4919,6 +5005,39 @@ inline static int handle_ser_child(struct process_table *p, int fd_i)
 				shm_free(wreq);
 				break;
 			}
+#ifdef TCP_ASYNC
+			/* Step 4: plain TCP writes are offloaded to a pool thread. Stage the
+			 * plaintext, then - if the conn is not already owned by a pool job -
+			 * shield it and enqueue a write job. If it is busy, the data waits in
+			 * wsq and the running job's completion chains a write job. TLS keeps
+			 * the inline encode+watch path below. */
+			if(likely(tcpconn->type == PROTO_TCP)) {
+				if(unlikely(tcp_reactor_wsq_add(tcpconn, wreq->buf, wreq->len,
+									wreq->send_flags)
+							< 0)) {
+					tcpconn->state = S_CONN_BAD;
+					tcpconn->timeout = get_ticks_raw(); /* force reaper */
+					shm_free(wreq->buf);
+					shm_free(wreq);
+					break;
+				}
+				shm_free(wreq->buf);
+				shm_free(wreq);
+				if(!(tcpconn->flags & F_CONN_POOL_BUSY)) {
+					if(unlikely(tcp_reactor_shield(tcpconn, -1) < 0)) {
+						tcpconn->state = S_CONN_BAD;
+						tcpconn->timeout = get_ticks_raw();
+						break;
+					}
+					if(unlikely(tcp_reactor_enqueue_job(tcpconn, TCP_R_WRITE)
+								< 0)) {
+						/* release the in-pool ref + un-shield; data waits in wsq */
+						tcp_reactor_unshield_or_chain(tcpconn);
+					}
+				}
+				break;
+			}
+#endif /* TCP_ASYNC */
 			if(unlikely(tcp_reactor_wbuf_enqueue(
 								tcpconn, wreq->buf, wreq->len, wreq->send_flags)
 						< 0)) {
@@ -5469,8 +5588,8 @@ inline static int handle_tcpconn_ev(
 			 * scratch buffer with the io_wait thread's TLS encode and/or run
 			 * sr_event callbacks not yet made thread-safe. */
 			if(likely(tcpconn->type == PROTO_TCP)) {
-				/* shield the fd from the (level-triggered) reactor so it is not
-				 * re-fired while the pool thread owns it, then enqueue the job */
+				/* shield the conn from the (level-triggered) reactor + timer so
+				 * a pool thread can own it exclusively, then enqueue the read */
 				if(ev
 						& (POLLHUP | POLLERR
 #ifdef POLLRDHUP
@@ -5478,29 +5597,12 @@ inline static int handle_tcpconn_ev(
 #endif /* POLLRDHUP */
 								))
 					tcpconn->flags |= F_CONN_FORCE_EOF;
-				if(unlikely(io_watch_del(&io_h, tcpconn->s, fd_i, 0) < 0)) {
-					LM_ERR("reactor: io_watch_del (read shield) failed for %p "
-						   "fd %d\n",
-							tcpconn, tcpconn->s);
+				if(unlikely(tcp_reactor_shield(tcpconn, fd_i) < 0))
 					goto reactor_close;
-				}
-				/* disarm the local timer too: while the pool thread owns the
-				 * conn, the io_wait thread must not run tcpconn_main_timeout()
-				 * on it (that would race c->flags / unhash under the reader).
-				 * The completion re-arms it. */
-				if(tcpconn->flags & F_CONN_MAIN_TIMER) {
-					local_timer_del(&tcp_main_ltimer, &tcpconn->timer);
-					tcpconn->flags &= ~F_CONN_MAIN_TIMER;
-				}
-				tcpconn->flags &= ~(F_CONN_READ_W | F_CONN_WRITE_W
-									| F_CONN_WANTS_RD | F_CONN_WANTS_WR);
 				tcpconn->flags |= F_CONN_REMOVED_READ;
-				tcpconn_ref(tcpconn); /* held by the job until completion */
-				if(unlikely(tcp_reactor_enqueue_read(tcpconn) < 0)) {
-					/* could not enqueue: undo the shield and keep the conn */
-					tcpconn_put(tcpconn);
-					if(tcp_reactor_read_rearm(tcpconn) < 0)
-						goto reactor_close;
+				if(unlikely(tcp_reactor_enqueue_job(tcpconn, TCP_R_READ) < 0)) {
+					/* could not enqueue: release the in-pool ref and un-shield */
+					tcp_reactor_unshield_or_chain(tcpconn);
 				}
 				return 0;
 			}
@@ -5778,22 +5880,19 @@ static void tcp_reactor_handle_done(void)
 		switch(op) {
 #ifdef TCP_ASYNC
 			case TCP_R_READ:
-				/* release the job's connection refcount; if it was the last
-				 * (conn unhashed under us) the conn is already gone */
-				if(unlikely(tcpconn_put(conn))) {
-					tcpconn_destroy(conn);
-					break;
-				}
-				if(likely(resp >= 0 && (conn->flags & F_CONN_HASHED))) {
-					if(unlikely(tcp_reactor_read_rearm(conn) < 0))
-						tcp_reactor_read_close(conn);
-				} else {
+			case TCP_R_WRITE:
+				/* The conn carries the single in-pool refcount (taken at
+				 * shield, released by close / unshield - not per job).
+				 * resp < 0 => EOF/error/write-error => tear down; else either
+				 * chain a staged write or hand the conn back to the reactor. */
+				if(unlikely(resp < 0)) {
 					tcp_reactor_read_close(conn);
+				} else {
+					tcp_reactor_unshield_or_chain(conn);
 				}
 				break;
 #endif /* TCP_ASYNC */
 			default:
-				/* TCP_R_WRITE completion lands here in Step 4 */
 				break;
 		}
 		job = next;
@@ -5826,25 +5925,22 @@ static void *tcp_reactor_thread_routine(void *arg)
 			tcp_cond_unlock(&tcp_reactor_wq->cond);
 			break;
 		}
-		/* read/run jobs (reactor-enqueued, pkg) take priority over write jobs */
+		/* All jobs (read/write/run) are enqueued onto task_head by the io_wait
+		 * thread, which has already shielded the conn (F_CONN_POOL_BUSY) and
+		 * taken the in-pool refcount. The shm write queue (tcp_reactor_wq->head)
+		 * is NOT used in the POOL_BUSY design - writes route via CONN_WRITE_REQ
+		 * -> io_wait -> task_head so the conn is shielded before any pool thread
+		 * touches it. Popping a conn directly from the shm wq here would bypass
+		 * the shield/refcount, so it is intentionally disabled (see
+		 * tcp_reactor_wq_pop(), which always returns NULL). */
 		job = tcp_rpool.task_head;
 		if(job != NULL) {
 			tcp_rpool.task_head = job->next;
 			if(tcp_rpool.task_head == NULL)
 				tcp_rpool.task_tail = NULL;
-		} else if((conn = tcp_reactor_wq_pop()) != NULL) {
-			job = pkg_malloc(sizeof(*job));
-			if(unlikely(job == NULL)) {
-				PKG_MEM_ERROR;
-				/* drop: clear the queued flag so a later send re-queues it
-				 * (refcount handling finalized in Step 4) */
-				conn->flags &= ~F_CONN_WRITE_QUEUED;
-				tcp_cond_unlock(&tcp_reactor_wq->cond);
-				continue;
-			}
-			memset(job, 0, sizeof(*job));
-			job->conn = conn;
-			job->op = TCP_R_WRITE;
+		} else if(unlikely((conn = tcp_reactor_wq_pop()) != NULL)) {
+			LM_CRIT("reactor: conn %p in the unused shm write queue\n", conn);
+			conn->flags &= ~F_CONN_WRITE_QUEUED;
 		}
 		tcp_cond_unlock(&tcp_reactor_wq->cond);
 
@@ -5877,10 +5973,33 @@ static void *tcp_reactor_thread_routine(void *arg)
 				job->ret = (resp < 0) ? -1 : 0;
 				break;
 			}
-			case TCP_R_WRITE:
-				/* TODO(step 4): drain conn->wsq -> tls_encode/copy -> wbuf_q */
-				job->ret = 0;
+			case TCP_R_WRITE: {
+				/* drain the connection's plaintext staging list into wbuf_q
+				 * (PROTO_TCP: plain copy; no TLS at this step) and flush wbuf_q
+				 * to the socket. No c->flags writes here (the io_wait completion
+				 * owns those); only buffers/state under write_lock. */
+				struct tcp_wchunk *ch;
+				int werr = 0, wempty = 0;
+				conn = job->conn;
+				lock_get(&conn->write_lock);
+				while((ch = conn->wsq_head) != NULL) {
+					conn->wsq_head = ch->next;
+					if(ch->len && _wbufq_add(conn, ch->buf, ch->len) < 0)
+						werr = 1;
+					tcpconn_set_send_flags(conn, ch->send_flags);
+					shm_free(ch->buf);
+					shm_free(ch);
+				}
+				conn->wsq_tail = NULL;
+				lock_release(&conn->write_lock);
+				if(!werr && wbufq_run(conn->s, conn, &wempty) < 0)
+					werr = 1;
+				/* resp: <0 error; 1 = wbuf_q still has data (needs POLLOUT,
+				 * handled inline after un-shield); 0 = fully drained */
+				job->resp = werr ? -1 : (wempty ? 0 : 1);
+				job->ret = (job->resp < 0) ? -1 : 0;
 				break;
+			}
 			default:
 				LM_ERR("unknown reactor job op %d\n", job->op);
 				job->ret = -1;

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -55,6 +55,8 @@
 #include <stdint.h> /* UINT32_MAX */
 
 #include <unistd.h>
+#include <signal.h>	 /* sigfillset/pthread_sigmask - mode 2 pool threads */
+#include <pthread.h> /* mode 2 reactor thread pool */
 
 #include <errno.h>
 #include <string.h>
@@ -5596,6 +5598,216 @@ error:
  *         >0 on successfull read from the fd (when there might be more io
  *            queued -- the receive buffer might still be non-empty)
  */
+/* ========================================================================
+ * mode 2 (Phase 2): reactor thread pool living inside PROC_TCP_MAIN.
+ * The io_wait thread (this process's main thread) owns epoll exclusively;
+ * pool threads only run read/write callbacks and signal completion back over
+ * notify_pipe. At this step the job-execution bodies are stubs - reads are
+ * still done inline (Phase 1) and writes still go via CONN_WRITE_REQ - so the
+ * threads simply spawn and block in tcp_cond_wait until Steps 3-4 wire up the
+ * enqueue paths.
+ * ======================================================================== */
+
+/* hardcoded for now (Phase2v2 §7.4); not a cfg param yet */
+static int tcp_reactor_threads = 8;
+
+/* per-pool-thread index (0..N-1); -1 in the reactor/main thread and any other
+ * thread. Set at thread start; used by Step 3's per-thread TLS scratch buffers. */
+static _Thread_local int tcp_reactor_thread_idx = -1;
+
+/* pop the head connection off the shm write queue. Caller must hold the
+ * write-queue cond lock. F_CONN_WRITE_QUEUED stays set until completion. */
+static struct tcp_connection *tcp_reactor_wq_pop(void)
+{
+	struct tcp_connection *conn = tcp_reactor_wq->head;
+	if(conn != NULL) {
+		tcp_reactor_wq->head = conn->wq_next;
+		if(tcp_reactor_wq->head == NULL)
+			tcp_reactor_wq->tail = NULL;
+		conn->wq_next = NULL;
+	}
+	return conn;
+}
+
+/* runs in the io_wait thread on notify_pipe readiness. Steps 3-5 fill in the
+ * re-arm / close logic; for now just drain and free any completed jobs so a
+ * stray job (none are produced yet) cannot leak. */
+static void tcp_reactor_handle_done(void)
+{
+	struct tcp_reactor_job *job, *next;
+
+	pthread_mutex_lock(&tcp_rpool.done_lock);
+	job = tcp_rpool.done_head;
+	tcp_rpool.done_head = tcp_rpool.done_tail = NULL;
+	pthread_mutex_unlock(&tcp_rpool.done_lock);
+
+	while(job != NULL) {
+		next = job->next;
+		/* TODO(step 3-5): re-arm job->conn in io_h or close on error, and
+		 * release the job's connection refcount before freeing */
+		pkg_free(job);
+		job = next;
+	}
+}
+
+/* pool thread body. arg = thread index. */
+static void *tcp_reactor_thread_routine(void *arg)
+{
+	struct tcp_reactor_job *job;
+	struct tcp_connection *conn;
+	sigset_t set;
+	char wake = 'x';
+
+	tcp_reactor_thread_idx = (int)(long)arg;
+
+	/* block signals - PROC_TCP_MAIN's main thread is the signal handler */
+	sigfillset(&set);
+	pthread_sigmask(SIG_BLOCK, &set, NULL);
+
+	while(1) {
+		job = NULL;
+		tcp_cond_lock(&tcp_reactor_wq->cond);
+		while(!tcp_rpool.stop && tcp_rpool.task_head == NULL
+				&& tcp_reactor_wq->head == NULL) {
+			tcp_cond_wait(&tcp_reactor_wq->cond);
+		}
+		if(tcp_rpool.stop && tcp_rpool.task_head == NULL
+				&& tcp_reactor_wq->head == NULL) {
+			tcp_cond_unlock(&tcp_reactor_wq->cond);
+			break;
+		}
+		/* read/run jobs (reactor-enqueued, pkg) take priority over write jobs */
+		job = tcp_rpool.task_head;
+		if(job != NULL) {
+			tcp_rpool.task_head = job->next;
+			if(tcp_rpool.task_head == NULL)
+				tcp_rpool.task_tail = NULL;
+		} else if((conn = tcp_reactor_wq_pop()) != NULL) {
+			job = pkg_malloc(sizeof(*job));
+			if(unlikely(job == NULL)) {
+				PKG_MEM_ERROR;
+				/* drop: clear the queued flag so a later send re-queues it
+				 * (refcount handling finalized in Step 4) */
+				conn->flags &= ~F_CONN_WRITE_QUEUED;
+				tcp_cond_unlock(&tcp_reactor_wq->cond);
+				continue;
+			}
+			memset(job, 0, sizeof(*job));
+			job->conn = conn;
+			job->op = TCP_R_WRITE;
+		}
+		tcp_cond_unlock(&tcp_reactor_wq->cond);
+
+		if(job == NULL)
+			continue; /* spurious wakeup */
+
+		switch(job->op) {
+			case TCP_R_RUN:
+				job->ret = (job->run != NULL) ? job->run(job->data) : -1;
+				pkg_free(job); /* RUN frees in-thread, no completion needed */
+				continue;
+			case TCP_R_READ:
+				/* TODO(step 3): tcp_read_req(job->conn) on conn->s */
+				job->ret = 0;
+				break;
+			case TCP_R_WRITE:
+				/* TODO(step 4): drain conn->wsq -> tls_encode/copy -> wbuf_q */
+				job->ret = 0;
+				break;
+			default:
+				LM_ERR("unknown reactor job op %d\n", job->op);
+				job->ret = -1;
+				break;
+		}
+
+		/* hand the completed job back to the reactor thread */
+		pthread_mutex_lock(&tcp_rpool.done_lock);
+		job->next = NULL;
+		if(tcp_rpool.done_tail != NULL)
+			tcp_rpool.done_tail->next = job;
+		else
+			tcp_rpool.done_head = job;
+		tcp_rpool.done_tail = job;
+		pthread_mutex_unlock(&tcp_rpool.done_lock);
+
+		if(write(tcp_rpool.notify_pipe[1], &wake, 1) < 0) {
+			if(errno != EAGAIN && errno != EWOULDBLOCK)
+				LM_ERR("failed to notify reactor of completion: %s\n",
+						strerror(errno));
+		}
+	}
+	return NULL;
+}
+
+/* create the notify pipe + spawn the pool. Runs in PROC_TCP_MAIN after io_h is
+ * initialized. Returns 0 on success, -1 on error. */
+static int tcp_reactor_pool_init(void)
+{
+	int i;
+
+	if(pipe(tcp_rpool.notify_pipe) < 0) {
+		LM_ERR("reactor notify pipe: %s\n", strerror(errno));
+		return -1;
+	}
+	if(fcntl(tcp_rpool.notify_pipe[0], F_SETFL,
+			   fcntl(tcp_rpool.notify_pipe[0], F_GETFL) | O_NONBLOCK)
+					< 0
+			|| fcntl(tcp_rpool.notify_pipe[1], F_SETFL,
+					   fcntl(tcp_rpool.notify_pipe[1], F_GETFL) | O_NONBLOCK)
+					   < 0) {
+		LM_ERR("reactor notify pipe O_NONBLOCK: %s\n", strerror(errno));
+		return -1;
+	}
+	if(io_watch_add(&io_h, tcp_rpool.notify_pipe[0], POLLIN,
+			   F_TCP_REACTOR_NOTIFY, NULL)
+			< 0) {
+		LM_ERR("failed to watch the reactor notify pipe\n");
+		return -1;
+	}
+	if(pthread_mutex_init(&tcp_rpool.done_lock, NULL) != 0) {
+		LM_ERR("failed to init reactor done_lock\n");
+		return -1;
+	}
+	tcp_rpool.threads = pkg_malloc(sizeof(pthread_t) * tcp_reactor_threads);
+	if(tcp_rpool.threads == NULL) {
+		PKG_MEM_ERROR;
+		return -1;
+	}
+	tcp_rpool.threads_no = 0;
+	tcp_rpool.stop = 0;
+	for(i = 0; i < tcp_reactor_threads; i++) {
+		if(pthread_create(&tcp_rpool.threads[i], NULL,
+				   tcp_reactor_thread_routine, (void *)(long)i)
+				!= 0) {
+			LM_ERR("failed to create reactor pool thread %d/%d\n", i,
+					tcp_reactor_threads);
+			return -1; /* threads_no counts started threads for destroy/join */
+		}
+		tcp_rpool.threads_no++;
+	}
+	LM_INFO("tcp reactor mode 2: started %d pool threads\n",
+			tcp_rpool.threads_no);
+	return 0;
+}
+
+/* stop + join the pool. Safe to call when the pool was never started. */
+static void tcp_reactor_pool_destroy(void)
+{
+	int i;
+
+	if(tcp_rpool.threads == NULL)
+		return;
+	tcp_cond_lock(&tcp_reactor_wq->cond);
+	tcp_rpool.stop = 1;
+	tcp_cond_broadcast(&tcp_reactor_wq->cond);
+	tcp_cond_unlock(&tcp_reactor_wq->cond);
+	for(i = 0; i < tcp_rpool.threads_no; i++)
+		pthread_join(tcp_rpool.threads[i], NULL);
+	pkg_free(tcp_rpool.threads);
+	tcp_rpool.threads = NULL;
+	tcp_rpool.threads_no = 0;
+}
+
 inline static int handle_io(struct fd_map *fm, short ev, int idx)
 {
 	int ret;
@@ -5616,6 +5828,16 @@ inline static int handle_io(struct fd_map *fm, short ev, int idx)
 		case F_PROC:
 			ret = handle_ser_child((struct process_table *)fm->data, idx);
 			break;
+		case F_TCP_REACTOR_NOTIFY: {
+			/* mode 2: a pool thread finished a job. Drain the notify byte(s)
+			 * and process all completed jobs (coalesced). */
+			char nbuf[64];
+			while(read(tcp_rpool.notify_pipe[0], nbuf, sizeof(nbuf)) > 0) {
+			}
+			tcp_reactor_handle_done();
+			ret = 0;
+			break;
+		}
 		case F_NONE:
 			LM_CRIT("empty fd map: %p {%d, %d, %p}, idx %d\n", fm, fm->fd,
 					fm->type, fm->data, idx);
@@ -5903,6 +6125,16 @@ void tcp_main_loop()
 	}
 
 
+	/* mode 2: start the reactor thread pool (notify pipe + worker threads).
+	 * io_h is already initialized; the threads spawn and block in
+	 * tcp_cond_wait until reads/writes are routed to them (Steps 3-4). */
+	if(ksr_tcp_main_threads == 2) {
+		if(tcp_reactor_pool_init() < 0) {
+			LM_CRIT("failed to start the tcp reactor thread pool\n");
+			goto error;
+		}
+	}
+
 	/* initialize the cfg framework */
 	if(cfg_child_init())
 		goto error;
@@ -5976,6 +6208,8 @@ void tcp_main_loop()
 			goto error;
 	}
 error:
+	if(ksr_tcp_main_threads == 2)
+		tcp_reactor_pool_destroy(); /* stop + join pool threads */
 #ifdef SEND_FD_QUEUE
 	destroy_send_fd_queues();
 #endif

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -2286,6 +2286,7 @@ inline static void tcp_fd_cache_add(struct tcp_connection *c, int fd)
 
 
 inline static int tcpconn_chld_put(struct tcp_connection *tcpconn);
+inline static void tcpconn_destroy(struct tcp_connection *tcpconn);
 
 static int tcpconn_send_put(struct tcp_connection *c, const char *buf,
 		unsigned len, snd_flags_t send_flags);
@@ -2299,6 +2300,11 @@ static int tcpconn_1st_send(int fd, struct tcp_connection *c, const char *buf,
 /* mode 2: enable POLLOUT watching on a hashed connection without freeing it on
  * io_watch failure (defined later, used from tcpconn_send_unsafe()). */
 static int tcp_reactor_enable_write_watch(struct tcp_connection *c);
+/* mode 2 write helpers (defined later, used from tcp_reactor_send_put() when it
+ * runs inside PROC_TCP_MAIN itself - e.g. a core read-path CRLF pong). */
+static int tcp_reactor_wbuf_enqueue(struct tcp_connection *c, char *buf,
+		unsigned len, snd_flags_t send_flags);
+static int tcp_reactor_watch_write(struct tcp_connection *c);
 #endif /* TCP_ASYNC */
 
 #define tcp_dst_ephemeral_set(n, c, dst)           \
@@ -2323,6 +2329,29 @@ static int tcp_reactor_send_put(struct tcp_connection *c, const char *buf,
 {
 	tcp_reactor_write_req_t *wreq;
 	long response[2];
+
+	if(unlikely(is_tcp_main())) {
+		/* called from within PROC_TCP_MAIN's own read path (e.g. a core CRLF
+		 * keepalive pong or an HTTP/1.1 100-continue, both sent via tcp_send()
+		 * from tcp_read_req()). We are already in the io_wait thread, so there
+		 * is no unix_tcp_sock self-send - queue the payload and arm POLLOUT
+		 * directly, mirroring the CONN_WRITE_REQ handler. Release the refcnt the
+		 * caller (tcp_send) took on c. */
+		if(unlikely(tcpconn_put(c))) {
+			tcpconn_destroy(c); /* was the last ref */
+			return -1;
+		}
+		if(unlikely((c->state == S_CONN_BAD) || !(c->flags & F_CONN_HASHED))) {
+			/* in the process of being destroyed => drop the write */
+			return -1;
+		}
+		if(unlikely(tcp_reactor_wbuf_enqueue(c, (char *)buf, len, send_flags)
+					< 0)) {
+			return -1;
+		}
+		tcp_reactor_watch_write(c);
+		return (int)len;
+	}
 
 	wreq = shm_malloc(sizeof(tcp_reactor_write_req_t));
 	if(unlikely(wreq == NULL)) {
@@ -2363,6 +2392,20 @@ static int tcp_reactor_connect_put(struct dest_info *dst,
 {
 	tcp_reactor_connect_req_t *creq;
 	long response[2];
+
+	if(unlikely(is_tcp_main())) {
+		/* A new outbound connection requested by code running inside
+		 * PROC_TCP_MAIN itself. The unix_tcp_sock self-send below is invalid
+		 * here. The known in-tcp_main senders (core read-path CRLF pong /
+		 * HTTP 100-continue) always target an already-established connection
+		 * (handled by tcp_reactor_send_put), so this path is not expected to be
+		 * reached; fail loudly rather than emit a confusing "send on 0" error.
+		 * (Full inline connect-from-tcp_main is left for the Phase 2 reactor.) */
+		LM_ERR("outbound connect requested from within PROC_TCP_MAIN to %s -"
+			   " not supported in mode 2, dropping\n",
+				su2a(&dst->to, sizeof(dst->to)));
+		return -1;
+	}
 
 	creq = shm_malloc(sizeof(tcp_reactor_connect_req_t));
 	if(unlikely(creq == NULL)) {

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -5850,13 +5850,55 @@ error:
  *            queued -- the receive buffer might still be non-empty)
  */
 /* ========================================================================
- * mode 2 (Phase 2): reactor thread pool living inside PROC_TCP_MAIN.
- * The io_wait thread (this process's main thread) owns epoll exclusively;
- * pool threads only run read/write callbacks and signal completion back over
- * notify_pipe. At this step the job-execution bodies are stubs - reads are
- * still done inline (Phase 1) and writes still go via CONN_WRITE_REQ - so the
- * threads simply spawn and block in tcp_cond_wait until Steps 3-4 wire up the
- * enqueue paths.
+ * mode 2 (Phase 2): reactor thread pool inside PROC_TCP_MAIN - concurrency
+ * contract (plain TCP; TLS/WS still inline pending the per-thread TLS buffers).
+ *
+ * Threads: one io_wait thread (this process's main thread) + N pool threads.
+ *
+ * Ownership / serialization:
+ *  - epoll (io_h) and the local timer (tcp_main_ltimer): io_wait thread ONLY.
+ *    Pool threads never call io_watch_*() or local_timer_*().
+ *  - F_CONN_POOL_BUSY = "a pool job owns this conn": set by the io_wait thread
+ *    when it shields the conn (removes it from io_h + the timer) and enqueues a
+ *    read/write job; cleared by the io_wait completion. While set, the conn has
+ *    at most ONE owner (one read OR write job at a time; chained jobs are
+ *    sequential), so its read/write callbacks never run concurrently with each
+ *    other or with the reactor.
+ *  - A single "in-pool" refcount is taken at shield and released at
+ *    unshield/close; it spans chained jobs and pins the conn so it cannot be
+ *    freed while a pool thread uses it.
+ *
+ * Per-field synchronization:
+ *  - c->flags        : io_wait thread ONLY (pool jobs never write c->flags;
+ *                      reads/buffers/state only). No race.
+ *  - c->req          : the read job exclusively while it runs (conn shielded).
+ *  - c->wbuf_q,c->wsq: c->write_lock (gen_lock). The completion's unlocked
+ *                      peeks (_wbufq_non_empty / wsq_head) are safe via the
+ *                      done_lock happens-before edge.
+ *  - c->refcnt       : atomic.
+ *  - handoff pool->io_wait: push to done_head under done_lock + a notify byte;
+ *                      io_wait reads done_head under done_lock - a
+ *                      release/acquire barrier, so completion sees the job's
+ *                      final writes.
+ *
+ * Known benign data races (safe on the target arch; would be flagged by
+ * tsan/helgrind, which also don't understand gen_lock or cross-process shm):
+ *  - c->state / c->send_flags / c->wbuf_q.wr_timeout are written non-atomically
+ *    by a pool job and read by the io_wait thread (e.g. the CONN_WRITE_REQ
+ *    "state==S_CONN_BAD" guard). They are word-aligned (atomic load/store on
+ *    x86-64, no torn value) and the logically-relevant decision is safe
+ *    (a stale read just stages the write; the completion handles the real
+ *    state). Convert to atomic accessors if/when strict tsan-cleanliness is
+ *    required (natural to do alongside the TLS step).
+ *  - The cross-process tcp_timer_check_connections() scan (PROC_INT) reads
+ *    c->req.tvrstart / c->state from the shm hash; benign, cross-process.
+ *
+ * Note: the shm write queue (tcp_reactor_wq->head/tail, tcp_reactor_wq_pop())
+ * is UNUSED in this POOL_BUSY design - writes route worker -> CONN_WRITE_REQ ->
+ * io_wait -> task_head so the conn is shielded before any pool thread sees it.
+ * tcp_reactor_wq->cond is just the in-process io_wait->pool wakeup. The wq_pop
+ * dequeue branch is neutered (LM_CRIT); it could be removed (left in place to
+ * minimise churn on validated code).
  * ======================================================================== */
 
 /* hardcoded for now (Phase2v2 §7.4); not a cfg param yet */

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -4432,7 +4432,15 @@ error:
  * The caller must NOT hold c->write_lock. Returns 0 on success, -1 on error
  * (marks c bad and forces timeout). Mirrors the TLS branch of
  * tcpconn_send_put(). */
-static int tcp_reactor_wbuf_enqueue(struct tcp_connection *c, char *buf,
+/* mode 2 (Phase 2): append a write payload to c's wbuf_q - encrypting first for
+ * TLS/WSS via tls_encode(), plain copy otherwise. The caller MUST already hold
+ * c->write_lock (the lock is left held on every path; the caller releases it).
+ * On a buffer/encode error the connection is marked bad + timed-out and -1 is
+ * returned. Shared by the inline tcp_reactor_wbuf_enqueue() path (io_wait
+ * thread) and the pool TCP_R_WRITE job, so TLS encode runs on whichever
+ * PROC_TCP_MAIN thread owns the connection. The direct-call trampoline used by
+ * tls_encode() picks up a per-thread scratch buffer (see tcp_mtops.c). */
+static int tcp_reactor_wbuf_add_locked(struct tcp_connection *c, char *buf,
 		unsigned len, snd_flags_t send_flags)
 {
 #ifdef USE_TLS
@@ -4440,10 +4448,7 @@ static int tcp_reactor_wbuf_enqueue(struct tcp_connection *c, char *buf,
 	unsigned t_len, rest_len;
 	snd_flags_t t_send_flags;
 	int wn;
-#endif /* USE_TLS */
 
-	lock_get(&c->write_lock);
-#ifdef USE_TLS
 	if(unlikely(c->type == PROTO_TLS || c->type == PROTO_WSS)) {
 		t_buf = buf;
 		t_len = len;
@@ -4453,7 +4458,6 @@ static int tcp_reactor_wbuf_enqueue(struct tcp_connection *c, char *buf,
 					c, &t_buf, &t_len, &rest_buf, &rest_len, &t_send_flags);
 			if(unlikely((wn < 0)
 						|| (t_len && (_wbufq_add(c, t_buf, t_len) < 0)))) {
-				lock_release(&c->write_lock);
 				c->state = S_CONN_BAD;
 				c->timeout = get_ticks_raw(); /* force timeout */
 				return -1;
@@ -4461,16 +4465,27 @@ static int tcp_reactor_wbuf_enqueue(struct tcp_connection *c, char *buf,
 			t_buf = rest_buf;
 			t_len = rest_len;
 		} while(unlikely(rest_len && wn > 0));
-	} else
+		return 0;
+	}
 #endif /* USE_TLS */
-		if(unlikely(len && (_wbufq_add(c, buf, len) < 0))) {
-			lock_release(&c->write_lock);
-			c->state = S_CONN_BAD;
-			c->timeout = get_ticks_raw(); /* force timeout */
-			return -1;
-		}
-	lock_release(&c->write_lock);
+	if(unlikely(len && (_wbufq_add(c, buf, len) < 0))) {
+		c->state = S_CONN_BAD;
+		c->timeout = get_ticks_raw(); /* force timeout */
+		return -1;
+	}
+	tcpconn_set_send_flags(c, send_flags);
 	return 0;
+}
+
+static int tcp_reactor_wbuf_enqueue(struct tcp_connection *c, char *buf,
+		unsigned len, snd_flags_t send_flags)
+{
+	int ret;
+
+	lock_get(&c->write_lock);
+	ret = tcp_reactor_wbuf_add_locked(c, buf, len, send_flags);
+	lock_release(&c->write_lock);
+	return ret;
 }
 
 /* mode 2: enable POLLOUT watching on an already-hashed connection (mirrors the
@@ -5030,12 +5045,16 @@ inline static int handle_ser_child(struct process_table *p, int fd_i)
 				break;
 			}
 #ifdef TCP_ASYNC
-			/* Step 4: plain TCP writes are offloaded to a pool thread. Stage the
-			 * plaintext, then - if the conn is not already owned by a pool job -
-			 * shield it and enqueue a write job. If it is busy, the data waits in
-			 * wsq and the running job's completion chains a write job. TLS keeps
-			 * the inline encode+watch path below. */
-			if(likely(tcpconn->type == PROTO_TCP)) {
+			/* Step 4/3b: plain TCP and TLS writes are offloaded to a pool thread.
+			 * Stage the plaintext, then - if the conn is not already owned by a
+			 * pool job - shield it and enqueue a write job; for TLS the job
+			 * tls_encode()s each staged chunk before flushing wbuf_q (the conn is
+			 * shielded, so that pool thread owns the SSL object exclusively). If
+			 * the conn is busy, the data waits in wsq and the running job's
+			 * completion chains a write job. WS / WSS keep the inline
+			 * encode+watch path below. */
+			if(likely(tcpconn->type == PROTO_TCP
+					   || tcpconn->type == PROTO_TLS)) {
 				if(unlikely(tcp_reactor_wsq_add(tcpconn, wreq->buf, wreq->len,
 									wreq->send_flags)
 							< 0)) {
@@ -5607,11 +5626,14 @@ inline static int handle_tcpconn_ev(
 
 		if(ev & (POLLIN | POLLERR | POLLHUP)) {
 #ifdef TCP_ASYNC
-			/* Step 3: plain TCP reads are offloaded to a pool thread. TLS / WS /
-			 * WSS stay inline for now (Step 3b) - they share the single TLS
-			 * scratch buffer with the io_wait thread's TLS encode and/or run
-			 * sr_event callbacks not yet made thread-safe. */
-			if(likely(tcpconn->type == PROTO_TCP)) {
+			/* Step 3/3b: plain TCP and TLS reads are offloaded to a pool thread.
+			 * The shield gives that thread exclusive ownership of the conn
+			 * (F_CONN_POOL_BUSY), so it may drive OpenSSL on it: the SSL object is
+			 * touched by a single thread at a time and the encode trampoline uses
+			 * a per-thread scratch buffer (see tcp_mtops.c). WS / WSS stay inline
+			 * for now - their websocket framing layer is not yet offloaded. */
+			if(likely(tcpconn->type == PROTO_TCP
+					   || tcpconn->type == PROTO_TLS)) {
 				/* shield the conn from the (level-triggered) reactor + timer so
 				 * a pool thread can own it exclusively, then enqueue the read */
 				if(ev
@@ -6041,18 +6063,20 @@ static void *tcp_reactor_thread_routine(void *arg)
 			}
 			case TCP_R_WRITE: {
 				/* drain the connection's plaintext staging list into wbuf_q
-				 * (PROTO_TCP: plain copy; no TLS at this step) and flush wbuf_q
-				 * to the socket. No c->flags writes here (the io_wait completion
-				 * owns those); only buffers/state under write_lock. */
+				 * (PROTO_TCP: plain copy; PROTO_TLS: tls_encode via the
+				 * direct-call trampoline on this pool thread) and flush wbuf_q to
+				 * the socket. No c->flags writes here (the io_wait completion owns
+				 * those); only buffers/state under write_lock. */
 				struct tcp_wchunk *ch;
 				int werr = 0, wempty = 0;
 				conn = job->conn;
 				lock_get(&conn->write_lock);
 				while((ch = conn->wsq_head) != NULL) {
 					conn->wsq_head = ch->next;
-					if(ch->len && _wbufq_add(conn, ch->buf, ch->len) < 0)
+					if(tcp_reactor_wbuf_add_locked(
+							   conn, ch->buf, ch->len, ch->send_flags)
+							< 0)
 						werr = 1;
-					tcpconn_set_send_flags(conn, ch->send_flags);
 					shm_free(ch->buf);
 					shm_free(ch);
 				}

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -207,6 +207,11 @@ int ksr_tcp_reactor_get_dispatch_rfd(void)
 	return ksr_tcp_reactor_dsock[0];
 }
 
+int ksr_tcp_reactor_get_dispatch_wfd(void)
+{
+	return ksr_tcp_reactor_dsock[1];
+}
+
 static int tcp_proto_no = -1; /* tcp protocol number as returned by
 							   getprotobyname */
 

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -4475,6 +4475,13 @@ static int tcp_reactor_enable_write_watch(struct tcp_connection *c)
 	if(c->flags & F_CONN_WANTS_WR)
 		return 0;
 	c->flags |= F_CONN_WANTS_WR;
+	/* mode 2 (Phase 2): if the conn is currently shielded for an in-flight pool
+	 * read job, its fd is not in io_h and only the io_wait thread may touch
+	 * io_h anyway. Just record the write intent; the read completion
+	 * (tcp_reactor_read_rearm) re-arms POLLOUT from the wbuf_q. This makes the
+	 * function safe to call from a pool thread's TLS write-back too. */
+	if(c->flags & F_CONN_REMOVED_READ)
+		return 0;
 	t = get_ticks_raw();
 	if(likely((c->flags & F_CONN_MAIN_TIMER)
 			   && (TICKS_LT(c->wbuf_q.wr_timeout, c->timeout))
@@ -4554,6 +4561,71 @@ static void tcp_reactor_arm_read_timeout(struct tcp_connection *c, ticks_t t)
 		local_timer_reinit(&c->timer);
 		local_timer_add(&tcp_main_ltimer, &c->timer, c->timeout - t, t);
 	}
+}
+
+/* mode 2 (Phase 2): enqueue a TCP_R_READ job for c onto the pool task queue.
+ * Caller (io_wait thread) has already shielded the fd. Returns 0/-1. */
+static int tcp_reactor_enqueue_read(struct tcp_connection *c)
+{
+	struct tcp_reactor_job *job;
+
+	job = pkg_malloc(sizeof(*job));
+	if(unlikely(job == NULL)) {
+		PKG_MEM_ERROR;
+		return -1;
+	}
+	memset(job, 0, sizeof(*job));
+	job->conn = c;
+	job->op = TCP_R_READ;
+	tcp_cond_lock(&tcp_reactor_wq->cond);
+	job->next = NULL;
+	if(tcp_rpool.task_tail != NULL)
+		tcp_rpool.task_tail->next = job;
+	else
+		tcp_rpool.task_head = job;
+	tcp_rpool.task_tail = job;
+	tcp_cond_signal(&tcp_reactor_wq->cond);
+	tcp_cond_unlock(&tcp_reactor_wq->cond);
+	return 0;
+}
+
+/* mode 2 (Phase 2): re-arm a connection in the reactor after a pool read job
+ * completed successfully (unshield). Runs in the io_wait thread. Adds POLLIN,
+ * plus POLLOUT if a write accumulated while the read was in flight. Refreshes
+ * the idle / partial-read timeout. Returns 0 on success, -1 on io_watch error
+ * (caller should then close the connection). */
+static int tcp_reactor_read_rearm(struct tcp_connection *c)
+{
+	short events = POLLIN;
+	ticks_t t;
+
+	c->flags &= ~F_CONN_REMOVED_READ;
+	c->flags |= F_CONN_READ_W | F_CONN_WANTS_RD;
+	if(_wbufq_non_empty(c)) {
+		events |= POLLOUT;
+		c->flags |= F_CONN_WRITE_W | F_CONN_WANTS_WR;
+	}
+	if(unlikely(io_watch_add(&io_h, c->s, events, F_TCPCONN, c) < 0)) {
+		LM_ERR("reactor: failed to re-arm read watch for %p fd %d\n", c, c->s);
+		c->flags &= ~(F_CONN_READ_W | F_CONN_WRITE_W);
+		return -1;
+	}
+	t = get_ticks_raw();
+	c->timeout = t + cfg_get(tcp, tcp_cfg, con_lifetime);
+	tcp_reactor_arm_read_timeout(c, t);
+	return 0;
+}
+
+/* mode 2 (Phase 2): tear down a connection after a pool read job reported
+ * EOF/error. The conn is already shielded (removed from io_h, READ_W/WRITE_W
+ * cleared) so there is no io_watch_del here. Runs in the io_wait thread.
+ * Mirrors the reactor_close teardown. */
+static void tcp_reactor_read_close(struct tcp_connection *c)
+{
+	if(tcpconn_try_unhash(c))
+		tcpconn_put(c);
+	c->flags &= ~(F_CONN_REMOVED_READ | F_CONN_WANTS_RD | F_CONN_WANTS_WR);
+	tcpconn_put_destroy(c);
 }
 #endif /* TCP_ASYNC */
 
@@ -5380,6 +5452,40 @@ inline static int handle_tcpconn_ev(
 #endif /* TCP_ASYNC */
 
 		if(ev & (POLLIN | POLLERR | POLLHUP)) {
+#ifdef TCP_ASYNC
+			/* Step 3: plain TCP reads are offloaded to a pool thread. TLS / WS /
+			 * WSS stay inline for now (Step 3b) - they share the single TLS
+			 * scratch buffer with the io_wait thread's TLS encode and/or run
+			 * sr_event callbacks not yet made thread-safe. */
+			if(likely(tcpconn->type == PROTO_TCP)) {
+				/* shield the fd from the (level-triggered) reactor so it is not
+				 * re-fired while the pool thread owns it, then enqueue the job */
+				if(ev
+						& (POLLHUP | POLLERR
+#ifdef POLLRDHUP
+								| POLLRDHUP
+#endif /* POLLRDHUP */
+								))
+					tcpconn->flags |= F_CONN_FORCE_EOF;
+				if(unlikely(io_watch_del(&io_h, tcpconn->s, fd_i, 0) < 0)) {
+					LM_ERR("reactor: io_watch_del (read shield) failed for %p "
+						   "fd %d\n",
+							tcpconn, tcpconn->s);
+					goto reactor_close;
+				}
+				tcpconn->flags &= ~(F_CONN_READ_W | F_CONN_WRITE_W
+									| F_CONN_WANTS_RD | F_CONN_WANTS_WR);
+				tcpconn->flags |= F_CONN_REMOVED_READ;
+				tcpconn_ref(tcpconn); /* held by the job until completion */
+				if(unlikely(tcp_reactor_enqueue_read(tcpconn) < 0)) {
+					/* could not enqueue: undo the shield and keep the conn */
+					tcpconn_put(tcpconn);
+					if(tcp_reactor_read_rearm(tcpconn) < 0)
+						goto reactor_close;
+				}
+				return 0;
+			}
+#endif /* TCP_ASYNC */
 			/* fold any error/EOF event into a forced EOF so a final buffered
 			 * message is still drained before the connection is closed */
 			read_flags =
@@ -5629,12 +5735,14 @@ static struct tcp_connection *tcp_reactor_wq_pop(void)
 	return conn;
 }
 
-/* runs in the io_wait thread on notify_pipe readiness. Steps 3-5 fill in the
- * re-arm / close logic; for now just drain and free any completed jobs so a
- * stray job (none are produced yet) cannot leak. */
+/* runs in the io_wait thread on notify_pipe readiness: process all completed
+ * jobs (coalesced). Only the io_wait thread touches io_h, so all re-arm / close
+ * happens here, never in a pool thread. */
 static void tcp_reactor_handle_done(void)
 {
 	struct tcp_reactor_job *job, *next;
+	struct tcp_connection *conn;
+	int op, resp;
 
 	pthread_mutex_lock(&tcp_rpool.done_lock);
 	job = tcp_rpool.done_head;
@@ -5643,9 +5751,32 @@ static void tcp_reactor_handle_done(void)
 
 	while(job != NULL) {
 		next = job->next;
-		/* TODO(step 3-5): re-arm job->conn in io_h or close on error, and
-		 * release the job's connection refcount before freeing */
+		conn = job->conn;
+		op = job->op;
+		resp = job->resp;
 		pkg_free(job);
+
+		switch(op) {
+#ifdef TCP_ASYNC
+			case TCP_R_READ:
+				/* release the job's connection refcount; if it was the last
+				 * (conn unhashed under us) the conn is already gone */
+				if(unlikely(tcpconn_put(conn))) {
+					tcpconn_destroy(conn);
+					break;
+				}
+				if(likely(resp >= 0 && (conn->flags & F_CONN_HASHED))) {
+					if(unlikely(tcp_reactor_read_rearm(conn) < 0))
+						tcp_reactor_read_close(conn);
+				} else {
+					tcp_reactor_read_close(conn);
+				}
+				break;
+#endif /* TCP_ASYNC */
+			default:
+				/* TCP_R_WRITE completion lands here in Step 4 */
+				break;
+		}
 		job = next;
 	}
 }
@@ -5706,10 +5837,27 @@ static void *tcp_reactor_thread_routine(void *arg)
 				job->ret = (job->run != NULL) ? job->run(job->data) : -1;
 				pkg_free(job); /* RUN frees in-thread, no completion needed */
 				continue;
-			case TCP_R_READ:
-				/* TODO(step 3): tcp_read_req(job->conn) on conn->s */
-				job->ret = 0;
+			case TCP_R_READ: {
+				/* read + reassemble on conn->s (PROTO_TCP only at this step).
+				 * tcp_read_req() reads via _tconfd(conn)==conn->s and dispatches
+				 * complete SIP messages to workers via tcp_reactor_dispatch_msg().
+				 * No io_watch / no free here - the io_wait thread completes. */
+				rd_conn_flags_t read_flags;
+				int n, resp;
+				conn = job->conn;
+				read_flags =
+						(conn->flags & (F_CONN_EOF_SEEN | F_CONN_FORCE_EOF))
+								? RD_CONN_FORCE_EOF
+								: 0;
+				do {
+					resp = tcp_read_req(conn, &n, &read_flags);
+				} while(resp >= 0 && (read_flags & RD_CONN_REPEAT_READ));
+				if(resp < 0 && resp != CONN_EOF)
+					conn->state = S_CONN_BAD;
+				job->resp = resp;
+				job->ret = (resp < 0) ? -1 : 0;
 				break;
+			}
 			case TCP_R_WRITE:
 				/* TODO(step 4): drain conn->wsq -> tls_encode/copy -> wbuf_q */
 				job->ret = 0;

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -6178,6 +6178,17 @@ static ticks_t tcpconn_main_timeout(ticks_t t, struct timer_ln *tl, void *data)
 			c, t, c->timeout, TICKS_TO_S(c->timeout - t), c->wbuf_q.wr_timeout,
 			TICKS_TO_S(c->wbuf_q.wr_timeout - t), c->wbuf_q.queued);
 
+	/* mode 2 (Phase 2): a connection owned by a pool job is shielded out of the
+	 * local timer (tcp_reactor_shield does local_timer_del + clears
+	 * F_CONN_MAIN_TIMER), so this callback must not run for a busy conn. Guard
+	 * defensively: never reap a conn a pool thread is still using - re-arm and
+	 * let the job completion own its lifetime. */
+	if(unlikely(c->flags & F_CONN_POOL_BUSY)) {
+		LM_WARN("tcp reactor: timer fired on pool-busy conn %p - deferring\n",
+				c);
+		return (ticks_t)cfg_get(tcp, tcp_cfg, con_lifetime);
+	}
+
 	tcp_async = cfg_get(tcp, tcp_cfg, async);
 	if(likely(TICKS_LT(t, c->timeout)
 			   && (!tcp_async || _wbufq_empty(c)

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -98,6 +98,7 @@
 #include "tcp_info.h"
 #include "tcp_options.h"
 #include "tcp_mtops.h"
+#include "tcp_read.h"
 #include "ut.h"
 #include "events.h"
 #include "cfg/cfg_struct.h"
@@ -4864,6 +4865,87 @@ inline static int handle_tcpconn_ev(
 	int empty_q;
 	int bytes;
 #endif /* TCP_ASYNC */
+
+	if(unlikely(ksr_tcp_main_threads == 2)) {
+		/* full reactor mode: tcp_main owns the fd permanently, reads and
+		 * reassembles SIP messages directly (no fd-passing, no send2child).
+		 * busy tracking is intentionally bypassed (see send2child). */
+		rd_conn_flags_t read_flags;
+		int n;
+		int resp;
+
+#ifdef TCP_ASYNC
+		/* drain pending writes first if the fd is write-watched */
+		if((ev & (POLLOUT | POLLERR | POLLHUP))
+				&& (tcpconn->flags & F_CONN_WRITE_W)) {
+			int wempty_q = 0;
+			if(unlikely((ev & (POLLERR | POLLHUP))
+						|| (wbufq_run(tcpconn->s, tcpconn, &wempty_q) < 0))) {
+				/* write error or peer gone: tear the connection down */
+				goto reactor_close;
+			}
+			if(wempty_q) {
+				tcpconn->flags &= ~F_CONN_WANTS_WR;
+				if(!(tcpconn->flags & F_CONN_READ_W)) {
+					if(unlikely(io_watch_chg(&io_h, tcpconn->s, POLLIN, fd_i)
+								== -1)) {
+						LM_ERR("io_watch_chg (reactor wr) failed for %p fd "
+							   "%d\n",
+								tcpconn, tcpconn->s);
+						goto reactor_close;
+					}
+				}
+				tcpconn->flags &= ~F_CONN_WRITE_W;
+				if(tcpconn_close_after_send(tcpconn))
+					goto reactor_close;
+			}
+		}
+#endif /* TCP_ASYNC */
+
+		if(ev & (POLLIN | POLLERR | POLLHUP)) {
+			/* fold any error/EOF event into a forced EOF so a final buffered
+			 * message is still drained before the connection is closed */
+			read_flags =
+					((
+#ifdef POLLRDHUP
+							 (ev & POLLRDHUP) |
+#endif /* POLLRDHUP */
+							 (ev & (POLLHUP | POLLERR))
+							 | (tcpconn->flags
+									 & (F_CONN_EOF_SEEN | F_CONN_FORCE_EOF)))
+							&& !(ev & POLLPRI))
+							? RD_CONN_FORCE_EOF
+							: 0;
+		repeat_read:
+			resp = tcp_read_req(tcpconn, &n, &read_flags);
+			/* tcp_read_req() dispatches complete messages to workers via
+			 * tcp_reactor_dispatch_msg(); for TLS it may run OpenSSL through
+			 * the direct-call trampoline (KSR_TCPX_MAIN_PIDX). */
+			if(unlikely(resp < 0)) {
+				if(resp != CONN_EOF)
+					tcpconn->state = S_CONN_BAD;
+				goto reactor_close;
+			}
+			if(unlikely(read_flags & RD_CONN_REPEAT_READ))
+				goto repeat_read;
+			/* partial or complete read: keep the fd, refresh idle timeout */
+			tcpconn->timeout =
+					get_ticks_raw() + cfg_get(tcp, tcp_cfg, con_lifetime);
+		}
+		return 0;
+
+	reactor_close:
+		if(unlikely(io_watch_del(&io_h, tcpconn->s, fd_i, IO_FD_CLOSING) < 0)) {
+			LM_ERR("io_watch_del (reactor) failed for %p fd %d\n", tcpconn,
+					tcpconn->s);
+		}
+		tcpconn->flags &= ~(F_CONN_MAIN_TIMER | F_CONN_READ_W | F_CONN_WRITE_W
+							| F_CONN_WANTS_RD | F_CONN_WANTS_WR);
+		if(tcpconn_try_unhash(tcpconn))
+			tcpconn_put(tcpconn);
+		tcpconn_put_destroy(tcpconn);
+		return -1;
+	}
 
 	/* pass it to child, so remove it from the io watch list  and the local
 	 *  timer */

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -1717,6 +1717,15 @@ static inline void _tcpconn_free(struct tcp_connection *c)
 #ifdef TCP_ASYNC
 	if(unlikely(_wbufq_non_empty(c)))
 		_wbufq_destroy(&c->wbuf_q);
+	/* mode 2 (Phase 2): free any plaintext write chunks that were staged on the
+	 * connection but never drained (e.g. a write arrived just before close). */
+	while(c->wsq_head != NULL) {
+		struct tcp_wchunk *ch = c->wsq_head;
+		c->wsq_head = ch->next;
+		shm_free(ch->buf);
+		shm_free(ch);
+	}
+	c->wsq_tail = NULL;
 #endif
 	lock_destroy(&c->write_lock);
 #ifdef USE_TLS
@@ -4815,6 +4824,21 @@ inline static int handle_ser_child(struct process_table *p, int fd_i)
 					tcpconn, tcpconn->id, atomic_get(&tcpconn->refcnt),
 					tcpconn->flags);
 		case CONN_EOF: /* forced EOF after full send, due to send flags */
+#ifdef TCP_ASYNC
+			/* mode 2 (Phase 2): if a pool thread currently owns this conn (a
+			 * read/write job is in flight), do NOT unhash/io_watch_del/free it
+			 * here - that would race the pool thread. The in-pool refcount keeps
+			 * it alive; mark it bad and let the job completion close it (its
+			 * !HASHED/S_CONN_BAD check routes to tcp_reactor_read_close). Only
+			 * release the sender's reference. */
+			if(unlikely(tcpconn->flags & F_CONN_POOL_BUSY)) {
+				tcpconn->state = S_CONN_BAD;
+				tcpconn->timeout = get_ticks_raw();
+				if(unlikely(tcpconn_put(tcpconn)))
+					tcpconn_destroy(tcpconn); /* can't happen while busy */
+				break;
+			}
+#endif /* TCP_ASYNC */
 #ifdef TCP_CONNECT_WAIT
 			/* if the connection is marked as pending => it might be on
 			 *  the way of reaching tcp_main (e.g. CONN_NEW_COMPLETE or

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -2348,6 +2348,52 @@ static int tcp_reactor_send_put(struct tcp_connection *c, const char *buf,
 	}
 	return (int)len;
 }
+
+/* mode 2: no usable connection exists - ask PROC_TCP_MAIN to open a new
+ * outbound connection and send on it. The worker opens no socket and creates no
+ * tcp_connection. Returns len on success (optimistic), -1 on error. */
+static int tcp_reactor_connect_put(struct dest_info *dst,
+		union sockaddr_union *from, const char *buf, unsigned len)
+{
+	tcp_reactor_connect_req_t *creq;
+	long response[2];
+
+	creq = shm_malloc(sizeof(tcp_reactor_connect_req_t));
+	if(unlikely(creq == NULL)) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+	creq->buf = shm_malloc(len);
+	if(unlikely(creq->buf == NULL)) {
+		SHM_MEM_ERROR;
+		shm_free(creq);
+		return -1;
+	}
+	memcpy(creq->buf, buf, len);
+	creq->len = len;
+	creq->dst = dst->to;
+	if(from != NULL) {
+		creq->from = *from;
+		creq->have_from = 1;
+	} else {
+		creq->have_from = 0;
+	}
+	creq->proto = dst->proto;
+	creq->id = dst->id;
+	creq->try_local_port = (dst->send_sock) ? dst->send_sock->port_no : 0;
+	creq->send_flags = dst->send_flags;
+
+	response[0] = (long)(uintptr_t)creq;
+	response[1] = CONN_CONNECT_REQ;
+	if(unlikely(send_all(unix_tcp_sock, response, sizeof(response)) <= 0)) {
+		LM_ERR("failed to send connect request to tcp main: %s (%d)\n",
+				strerror(errno), errno);
+		shm_free(creq->buf);
+		shm_free(creq);
+		return -1;
+	}
+	return (int)len;
+}
 #endif /* TCP_ASYNC */
 
 /* finds a tcpconn & sends on it
@@ -2446,6 +2492,13 @@ int tcp_send(struct dest_info *dst, union sockaddr_union *from, const char *buf,
 					break;
 			}
 		}
+#ifdef TCP_ASYNC
+		if(unlikely(ksr_tcp_main_threads == 2)) {
+			/* mode 2: workers do not open sockets - ask PROC_TCP_MAIN to create
+			 * the outbound connection and send on it. */
+			return tcp_reactor_connect_put(dst, from, buf, len);
+		}
+#endif /* TCP_ASYNC */
 #if defined(TCP_CONNECT_WAIT) && defined(TCP_ASYNC)
 		if(likely(cfg_get(tcp, tcp_cfg, tcp_connect_wait)
 				   && cfg_get(tcp, tcp_cfg, async))) {
@@ -4273,6 +4326,101 @@ error:
 }
 
 
+#ifdef TCP_ASYNC
+/* mode 2: queue a payload into c's wbuf_q, encrypting first for TLS (tls_encode
+ * runs OpenSSL via the direct-call trampoline, valid here in PROC_TCP_MAIN).
+ * The caller must NOT hold c->write_lock. Returns 0 on success, -1 on error
+ * (marks c bad and forces timeout). Mirrors the TLS branch of
+ * tcpconn_send_put(). */
+static int tcp_reactor_wbuf_enqueue(struct tcp_connection *c, char *buf,
+		unsigned len, snd_flags_t send_flags)
+{
+#ifdef USE_TLS
+	const char *t_buf, *rest_buf;
+	unsigned t_len, rest_len;
+	snd_flags_t t_send_flags;
+	int wn;
+#endif /* USE_TLS */
+
+	lock_get(&c->write_lock);
+#ifdef USE_TLS
+	if(unlikely(c->type == PROTO_TLS || c->type == PROTO_WSS)) {
+		t_buf = buf;
+		t_len = len;
+		do {
+			t_send_flags = send_flags;
+			wn = tls_encode(
+					c, &t_buf, &t_len, &rest_buf, &rest_len, &t_send_flags);
+			if(unlikely((wn < 0)
+						|| (t_len && (_wbufq_add(c, t_buf, t_len) < 0)))) {
+				lock_release(&c->write_lock);
+				c->state = S_CONN_BAD;
+				c->timeout = get_ticks_raw(); /* force timeout */
+				return -1;
+			}
+			t_buf = rest_buf;
+			t_len = rest_len;
+		} while(unlikely(rest_len && wn > 0));
+	} else
+#endif /* USE_TLS */
+		if(unlikely(len && (_wbufq_add(c, buf, len) < 0))) {
+			lock_release(&c->write_lock);
+			c->state = S_CONN_BAD;
+			c->timeout = get_ticks_raw(); /* force timeout */
+			return -1;
+		}
+	lock_release(&c->write_lock);
+	return 0;
+}
+
+/* mode 2: enable POLLOUT watching on an already-hashed, read-watched connection
+ * (mirrors the CONN_QUEUED_WRITE logic). Returns 0 on success, -1 on error
+ * (connection is unhashed and destroyed on io_watch failure). */
+static int tcp_reactor_watch_write(struct tcp_connection *c)
+{
+	ticks_t t;
+
+	if(c->flags & F_CONN_WANTS_WR)
+		return 0;
+	c->flags |= F_CONN_WANTS_WR;
+	t = get_ticks_raw();
+	if(likely((c->flags & F_CONN_MAIN_TIMER)
+			   && (TICKS_LT(c->wbuf_q.wr_timeout, c->timeout))
+			   && TICKS_LT(t, c->wbuf_q.wr_timeout))) {
+		local_timer_del(&tcp_main_ltimer, &c->timer);
+		local_timer_reinit(&c->timer);
+		local_timer_add(
+				&tcp_main_ltimer, &c->timer, c->wbuf_q.wr_timeout - t, t);
+	}
+	if(!(c->flags & F_CONN_WRITE_W)) {
+		c->flags |= F_CONN_WRITE_W;
+		if(!(c->flags & F_CONN_READ_W)) {
+			if(unlikely(io_watch_add(&io_h, c->s, POLLOUT, F_TCPCONN, c) < 0)) {
+				LM_CRIT("failed to enable write watch (reactor)\n");
+				if(tcpconn_try_unhash(c))
+					tcpconn_put_destroy(c);
+				return -1;
+			}
+		} else {
+			if(unlikely(io_watch_chg(&io_h, c->s, POLLIN | POLLOUT, -1) < 0)) {
+				LM_CRIT("failed to change socket watch events (reactor)\n");
+				if(tcpconn_try_unhash(c)) {
+					io_watch_del(&io_h, c->s, -1, IO_FD_CLOSING);
+					c->flags &= ~F_CONN_READ_W;
+					tcpconn_put_destroy(c);
+				} else {
+					BUG("unhashed connection watched for IO\n");
+					io_watch_del(&io_h, c->s, -1, 0);
+					c->flags &= ~F_CONN_READ_W;
+				}
+				return -1;
+			}
+		}
+	}
+	return 0;
+}
+#endif /* TCP_ASYNC */
+
 /* handles io from a "generic" process (get fd or new_fd from a tcp_send)
  *
  * params: p     - pointer in the processes array (pt[]), to the entry for
@@ -4534,16 +4682,9 @@ inline static int handle_ser_child(struct process_table *p, int fd_i)
 		case CONN_WRITE_REQ: {
 			/* mode 2: worker queued a write; response[0] is the write request,
 			 * not a tcp_connection. tcp_main queues the payload into the wbuf_q
-			 * (encrypting it first for TLS, since OpenSSL must run here) and
-			 * enables write watching, mirroring the CONN_QUEUED_WRITE logic. */
+			 * (encrypting it first for TLS) and enables write watching. */
 			tcp_reactor_write_req_t *wreq =
 					(tcp_reactor_write_req_t *)response[0];
-#ifdef USE_TLS
-			const char *t_buf, *rest_buf;
-			unsigned t_len, rest_len;
-			snd_flags_t t_send_flags;
-			int wn;
-#endif /* USE_TLS */
 			tcpconn = wreq->conn;
 			/* release the worker's refcnt; if it was the last, conn is gone */
 			if(unlikely(tcpconn_put(tcpconn))) {
@@ -4559,96 +4700,112 @@ inline static int handle_ser_child(struct process_table *p, int fd_i)
 				shm_free(wreq);
 				break;
 			}
-			lock_get(&tcpconn->write_lock);
-#ifdef USE_TLS
-			if(unlikely(tcpconn->type == PROTO_TLS
-						|| tcpconn->type == PROTO_WSS)) {
-				/* encrypt in tcp_main: tls_encode() runs OpenSSL through the
-				 * mode-2 direct-call trampoline (is_tcp_main() is true here).
-				 * The wire bytes go into the wbuf_q, mirroring the TLS branch
-				 * of tcpconn_send_put(). */
-				t_buf = wreq->buf;
-				t_len = wreq->len;
-				do {
-					t_send_flags = wreq->send_flags;
-					wn = tls_encode(tcpconn, &t_buf, &t_len, &rest_buf,
-							&rest_len, &t_send_flags);
-					if(unlikely((wn < 0)
-								|| (t_len
-										&& (_wbufq_add(tcpconn, t_buf, t_len)
-												< 0)))) {
-						lock_release(&tcpconn->write_lock);
-						tcpconn->state = S_CONN_BAD;
-						tcpconn->timeout = get_ticks_raw(); /* force timeout */
-						shm_free(wreq->buf);
-						shm_free(wreq);
-						goto write_req_end;
-					}
-					t_buf = rest_buf;
-					t_len = rest_len;
-				} while(unlikely(rest_len && wn > 0));
-			} else
-#endif /* USE_TLS */
-				if(unlikely(wreq->len
-							&& (_wbufq_add(tcpconn, wreq->buf, wreq->len)
-									< 0))) {
-					lock_release(&tcpconn->write_lock);
-					tcpconn->state = S_CONN_BAD;
-					tcpconn->timeout = get_ticks_raw(); /* force timeout */
-					shm_free(wreq->buf);
-					shm_free(wreq);
-					goto write_req_end;
-				}
-			lock_release(&tcpconn->write_lock);
+			if(unlikely(tcp_reactor_wbuf_enqueue(
+								tcpconn, wreq->buf, wreq->len, wreq->send_flags)
+						< 0)) {
+				shm_free(wreq->buf);
+				shm_free(wreq);
+				break;
+			}
 			shm_free(wreq->buf);
 			shm_free(wreq);
-			/* enable write watching if not already (same idiom as
-			 * CONN_QUEUED_WRITE) */
-			if(!(tcpconn->flags & F_CONN_WANTS_WR)) {
-				tcpconn->flags |= F_CONN_WANTS_WR;
-				t = get_ticks_raw();
-				if(likely((tcpconn->flags & F_CONN_MAIN_TIMER)
-						   && (TICKS_LT(tcpconn->wbuf_q.wr_timeout,
-								   tcpconn->timeout))
-						   && TICKS_LT(t, tcpconn->wbuf_q.wr_timeout))) {
-					local_timer_del(&tcp_main_ltimer, &tcpconn->timer);
-					local_timer_reinit(&tcpconn->timer);
-					local_timer_add(&tcp_main_ltimer, &tcpconn->timer,
-							tcpconn->wbuf_q.wr_timeout - t, t);
-				}
-				if(!(tcpconn->flags & F_CONN_WRITE_W)) {
-					tcpconn->flags |= F_CONN_WRITE_W;
-					if(!(tcpconn->flags & F_CONN_READ_W)) {
-						if(unlikely(io_watch_add(&io_h, tcpconn->s, POLLOUT,
-											F_TCPCONN, tcpconn)
-									< 0)) {
-							LM_CRIT("failed to enable write watch (reactor)\n");
-							if(tcpconn_try_unhash(tcpconn))
-								tcpconn_put_destroy(tcpconn);
-							break;
-						}
-					} else {
-						if(unlikely(io_watch_chg(&io_h, tcpconn->s,
-											POLLIN | POLLOUT, -1)
-									< 0)) {
-							LM_CRIT("failed to change socket watch events "
-									"(reactor)\n");
-							if(tcpconn_try_unhash(tcpconn)) {
-								io_watch_del(
-										&io_h, tcpconn->s, -1, IO_FD_CLOSING);
-								tcpconn->flags &= ~F_CONN_READ_W;
-								tcpconn_put_destroy(tcpconn);
-							} else {
-								BUG("unhashed connection watched for IO\n");
-								io_watch_del(&io_h, tcpconn->s, -1, 0);
-								tcpconn->flags &= ~F_CONN_READ_W;
-							}
-							break;
-						}
-					}
-				}
+			tcp_reactor_watch_write(tcpconn);
+			break;
+		}
+		case CONN_CONNECT_REQ: {
+			/* mode 2: worker has no usable connection - open a new outbound
+			 * one here in PROC_TCP_MAIN. response[0] is the connect request. */
+			tcp_reactor_connect_req_t *creq =
+					(tcp_reactor_connect_req_t *)response[0];
+			struct tcp_connection *cc;
+			union sockaddr_union *cfrom;
+			struct ip_addr cip;
+			int cport;
+
+			cfrom = creq->have_from ? &creq->from : NULL;
+			su2ip_addr(&cip, &creq->dst);
+			cport = su_getport(&creq->dst);
+			con_lifetime = cfg_get(tcp, tcp_cfg, con_lifetime);
+			/* dedup: another worker may have created a matching connection
+			 * since this worker's lookup missed => reuse it if so */
+			if(tcp_connection_match == TCPCONN_MATCH_STRICT
+					|| (creq->send_flags.f & SND_F_FORCE_PROTO)) {
+				cc = tcpconn_lookup(creq->id, &cip, cport, cfrom,
+						creq->try_local_port, con_lifetime, creq->proto);
+			} else {
+				cc = tcpconn_get(creq->id, &cip, cport, cfrom, con_lifetime);
 			}
-		write_req_end:
+			if(cc != NULL) {
+				/* reuse: queue the payload onto the existing connection */
+				if(unlikely(tcpconn_put(cc))) {
+					tcpconn_destroy(cc);
+					shm_free(creq->buf);
+					shm_free(creq);
+					break;
+				}
+				if(likely(!(cc->state == S_CONN_BAD)
+						   && (cc->flags & F_CONN_HASHED))) {
+					if(likely(tcp_reactor_wbuf_enqueue(cc, creq->buf, creq->len,
+									  creq->send_flags)
+							   == 0))
+						tcp_reactor_watch_write(cc);
+				}
+				shm_free(creq->buf);
+				shm_free(creq);
+				break;
+			}
+			/* open the connection (socket + non-blocking connect) here */
+			cc = tcpconn_connect(
+					&creq->dst, cfrom, creq->proto, &creq->send_flags);
+			if(unlikely(cc == NULL)) {
+				LM_ERR("failed to open outbound connection to %s\n",
+						su2a(&creq->dst, sizeof(creq->dst)));
+				shm_free(creq->buf);
+				shm_free(creq);
+				break;
+			}
+			atomic_set(&cc->refcnt, 1); /* owned solely by tcp_main (hash) */
+			if(unlikely(tcpconn_add(cc) == 0)) {
+				LM_ERR("failed to hash outbound connection %p\n", cc);
+				tcp_safe_close(cc->s);
+				cc->flags |= F_CONN_FD_CLOSED;
+				_tcpconn_free(cc);
+				shm_free(creq->buf);
+				shm_free(creq);
+				break;
+			}
+			(*tcp_connections_no)++;
+			if(unlikely(cc->type == PROTO_TLS))
+				(*tls_connections_no)++;
+			/* queue the payload (for TLS, tls_encode() buffers it until the
+			 * handshake completes - Step 12 drives the handshake) */
+			if(unlikely(tcp_reactor_wbuf_enqueue(
+								cc, creq->buf, creq->len, creq->send_flags)
+						< 0)) {
+				tcpconn_try_unhash(cc);
+				tcpconn_put_destroy(cc);
+				shm_free(creq->buf);
+				shm_free(creq);
+				break;
+			}
+			shm_free(creq->buf);
+			shm_free(creq);
+			/* register in the reactor: watch read + write. The POLLOUT event
+			 * completes the connect and drains the wbuf_q. */
+			t = get_ticks_raw();
+			cc->timeout = t + con_lifetime;
+			local_timer_add(&tcp_main_ltimer, &cc->timer, con_lifetime, t);
+			cc->flags |= F_CONN_MAIN_TIMER | F_CONN_READ_W | F_CONN_WANTS_RD
+						 | F_CONN_WRITE_W | F_CONN_WANTS_WR;
+			cc->flags &= ~F_CONN_FD_CLOSED;
+			if(unlikely(io_watch_add(
+								&io_h, cc->s, POLLIN | POLLOUT, F_TCPCONN, cc)
+						< 0)) {
+				LM_CRIT("failed to add outbound connection to the fd list\n");
+				cc->flags &= ~(F_CONN_WRITE_W | F_CONN_READ_W);
+				tcpconn_try_unhash(cc);
+				tcpconn_put_destroy(cc);
+			}
 			break;
 		}
 #ifdef TCP_CONNECT_WAIT
@@ -5109,14 +5266,21 @@ inline static int handle_tcpconn_ev(
 		return 0;
 
 	reactor_close:
-		if(unlikely(io_watch_del(&io_h, tcpconn->s, fd_i, IO_FD_CLOSING) < 0)) {
-			LM_ERR("io_watch_del (reactor) failed for %p fd %d\n", tcpconn,
-					tcpconn->s);
-		}
-		tcpconn->flags &= ~(F_CONN_MAIN_TIMER | F_CONN_READ_W | F_CONN_WRITE_W
-							| F_CONN_WANTS_RD | F_CONN_WANTS_WR);
+		/* unhash first, while F_CONN_MAIN_TIMER is still set, so the local
+		 * timer is removed before the connection is freed (try_unhash only
+		 * deletes the timer when the flag is set). Then stop watching the fd. */
 		if(tcpconn_try_unhash(tcpconn))
 			tcpconn_put(tcpconn);
+		if((tcpconn->flags & (F_CONN_WRITE_W | F_CONN_READ_W))
+				&& (tcpconn->s != -1)) {
+			if(unlikely(io_watch_del(&io_h, tcpconn->s, fd_i, IO_FD_CLOSING)
+						< 0)) {
+				LM_ERR("io_watch_del (reactor) failed for %p fd %d\n", tcpconn,
+						tcpconn->s);
+			}
+			tcpconn->flags &= ~(F_CONN_WRITE_W | F_CONN_READ_W);
+		}
+		tcpconn->flags &= ~(F_CONN_WANTS_RD | F_CONN_WANTS_WR);
 		tcpconn_put_destroy(tcpconn);
 		return -1;
 	}

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -99,6 +99,7 @@
 #include "tcp_options.h"
 #include "tcp_mtops.h"
 #include "tcp_read.h"
+#include "tcp_reactor.h"
 #include "ut.h"
 #include "events.h"
 #include "cfg/cfg_struct.h"
@@ -4477,6 +4478,87 @@ inline static int handle_ser_child(struct process_table *p, int fd_i)
 				LM_WARN("connection %p already watched for write\n", tcpconn);
 			}
 			break;
+		case CONN_WRITE_REQ: {
+			/* mode 2: worker queued a write; response[0] is the write request,
+			 * not a tcp_connection. tcp_main appends to the wbuf_q and enables
+			 * write watching, mirroring the CONN_QUEUED_WRITE logic above. */
+			tcp_reactor_write_req_t *wreq =
+					(tcp_reactor_write_req_t *)response[0];
+			tcpconn = wreq->conn;
+			/* release the worker's refcnt; if it was the last, conn is gone */
+			if(unlikely(tcpconn_put(tcpconn))) {
+				tcpconn_destroy(tcpconn);
+				shm_free(wreq->buf);
+				shm_free(wreq);
+				break;
+			}
+			if(unlikely((tcpconn->state == S_CONN_BAD)
+						|| !(tcpconn->flags & F_CONN_HASHED))) {
+				/* in the process of being destroyed => drop the write */
+				shm_free(wreq->buf);
+				shm_free(wreq);
+				break;
+			}
+			lock_get(&tcpconn->write_lock);
+			if(unlikely(_wbufq_add(tcpconn, wreq->buf, wreq->len) < 0)) {
+				lock_release(&tcpconn->write_lock);
+				tcpconn->state = S_CONN_BAD;
+				tcpconn->timeout = get_ticks_raw(); /* force timeout */
+				shm_free(wreq->buf);
+				shm_free(wreq);
+				break;
+			}
+			lock_release(&tcpconn->write_lock);
+			shm_free(wreq->buf);
+			shm_free(wreq);
+			/* enable write watching if not already (same idiom as
+			 * CONN_QUEUED_WRITE) */
+			if(!(tcpconn->flags & F_CONN_WANTS_WR)) {
+				tcpconn->flags |= F_CONN_WANTS_WR;
+				t = get_ticks_raw();
+				if(likely((tcpconn->flags & F_CONN_MAIN_TIMER)
+						   && (TICKS_LT(tcpconn->wbuf_q.wr_timeout,
+								   tcpconn->timeout))
+						   && TICKS_LT(t, tcpconn->wbuf_q.wr_timeout))) {
+					local_timer_del(&tcp_main_ltimer, &tcpconn->timer);
+					local_timer_reinit(&tcpconn->timer);
+					local_timer_add(&tcp_main_ltimer, &tcpconn->timer,
+							tcpconn->wbuf_q.wr_timeout - t, t);
+				}
+				if(!(tcpconn->flags & F_CONN_WRITE_W)) {
+					tcpconn->flags |= F_CONN_WRITE_W;
+					if(!(tcpconn->flags & F_CONN_READ_W)) {
+						if(unlikely(io_watch_add(&io_h, tcpconn->s, POLLOUT,
+											F_TCPCONN, tcpconn)
+									< 0)) {
+							LM_CRIT("failed to enable write watch (reactor)\n");
+							if(tcpconn_try_unhash(tcpconn))
+								tcpconn_put_destroy(tcpconn);
+							break;
+						}
+					} else {
+						if(unlikely(io_watch_chg(&io_h, tcpconn->s,
+											POLLIN | POLLOUT, -1)
+									< 0)) {
+							LM_CRIT("failed to change socket watch events "
+									"(reactor)\n");
+							if(tcpconn_try_unhash(tcpconn)) {
+								io_watch_del(
+										&io_h, tcpconn->s, -1, IO_FD_CLOSING);
+								tcpconn->flags &= ~F_CONN_READ_W;
+								tcpconn_put_destroy(tcpconn);
+							} else {
+								BUG("unhashed connection watched for IO\n");
+								io_watch_del(&io_h, tcpconn->s, -1, 0);
+								tcpconn->flags &= ~F_CONN_READ_W;
+							}
+							break;
+						}
+					}
+				}
+			}
+			break;
+		}
 #ifdef TCP_CONNECT_WAIT
 		case CONN_NEW_COMPLETE:
 		case CONN_NEW_PENDING_WRITE:

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -2295,6 +2295,12 @@ static int tcpconn_do_send(int fd, struct tcp_connection *c, const char *buf,
 static int tcpconn_1st_send(int fd, struct tcp_connection *c, const char *buf,
 		unsigned len, snd_flags_t send_flags, long *resp, int locked);
 
+#ifdef TCP_ASYNC
+/* mode 2: enable POLLOUT watching on a hashed connection without freeing it on
+ * io_watch failure (defined later, used from tcpconn_send_unsafe()). */
+static int tcp_reactor_enable_write_watch(struct tcp_connection *c);
+#endif /* TCP_ASYNC */
+
 #define tcp_dst_ephemeral_set(n, c, dst)           \
 	do {                                           \
 		if(n >= 0) {                               \
@@ -3147,6 +3153,38 @@ int tcpconn_send_unsafe(int fd, struct tcp_connection *c, const char *buf,
 {
 	int n;
 	long response[2];
+
+#ifdef TCP_ASYNC
+	if(unlikely(ksr_tcp_main_threads == 2 && is_tcp_main())) {
+		/* full reactor mode: we are already inside PROC_TCP_MAIN's event loop,
+		 * so there is no fd-passing / unix_sock self-send. This is reached from
+		 * the TLS read path (tls_h_read_*), which drives the handshake and may
+		 * need to push out ciphertext (handshake records, write-wants-read
+		 * flush, renegotiation). Handle the write result against our own
+		 * reactor instead of shipping a CONN_* command to ourselves.
+		 * The caller holds c->write_lock (locked=1) and keeps using c after we
+		 * return, so on failure we mark the connection for the reaper rather
+		 * than freeing it here. */
+		n = tcpconn_do_send(fd, c, buf, len, send_flags, &response[1], 1);
+		switch(response[1]) {
+			case CONN_NOP:
+				break;
+			case CONN_QUEUED_WRITE:
+				if(unlikely(tcp_reactor_enable_write_watch(c) < 0)) {
+					c->state = S_CONN_BAD;
+					c->timeout = get_ticks_raw(); /* force timeout reaper */
+				}
+				break;
+			default: /* CONN_ERROR / CONN_EOF: defer close to the reaper */
+				c->state = S_CONN_BAD;
+				c->timeout = get_ticks_raw();
+				if(response[1] == CONN_ERROR)
+					n = -1;
+				break;
+		}
+		return n;
+	}
+#endif /* TCP_ASYNC */
 
 	n = tcpconn_do_send(fd, c, buf, len, send_flags, &response[1], 1);
 	if(unlikely(response[1] != CONN_NOP)) {
@@ -4373,10 +4411,11 @@ static int tcp_reactor_wbuf_enqueue(struct tcp_connection *c, char *buf,
 	return 0;
 }
 
-/* mode 2: enable POLLOUT watching on an already-hashed, read-watched connection
- * (mirrors the CONN_QUEUED_WRITE logic). Returns 0 on success, -1 on error
- * (connection is unhashed and destroyed on io_watch failure). */
-static int tcp_reactor_watch_write(struct tcp_connection *c)
+/* mode 2: enable POLLOUT watching on an already-hashed connection (mirrors the
+ * CONN_QUEUED_WRITE logic). Non-destructive: on io_watch failure it clears the
+ * write-watch flag and returns -1 WITHOUT freeing c, so callers that keep using
+ * c afterwards (e.g. the TLS read path) stay safe. Returns 0 on success. */
+static int tcp_reactor_enable_write_watch(struct tcp_connection *c)
 {
 	ticks_t t;
 
@@ -4397,25 +4436,36 @@ static int tcp_reactor_watch_write(struct tcp_connection *c)
 		if(!(c->flags & F_CONN_READ_W)) {
 			if(unlikely(io_watch_add(&io_h, c->s, POLLOUT, F_TCPCONN, c) < 0)) {
 				LM_CRIT("failed to enable write watch (reactor)\n");
-				if(tcpconn_try_unhash(c))
-					tcpconn_put_destroy(c);
+				c->flags &= ~F_CONN_WRITE_W;
 				return -1;
 			}
 		} else {
 			if(unlikely(io_watch_chg(&io_h, c->s, POLLIN | POLLOUT, -1) < 0)) {
 				LM_CRIT("failed to change socket watch events (reactor)\n");
-				if(tcpconn_try_unhash(c)) {
-					io_watch_del(&io_h, c->s, -1, IO_FD_CLOSING);
-					c->flags &= ~F_CONN_READ_W;
-					tcpconn_put_destroy(c);
-				} else {
-					BUG("unhashed connection watched for IO\n");
-					io_watch_del(&io_h, c->s, -1, 0);
-					c->flags &= ~F_CONN_READ_W;
-				}
+				c->flags &= ~F_CONN_WRITE_W;
 				return -1;
 			}
 		}
+	}
+	return 0;
+}
+
+/* mode 2: enable POLLOUT watching, destroying the connection on io_watch
+ * failure. Used by the IPC write/connect handlers, which do not touch c after
+ * this returns. Returns 0 on success, -1 on error (c unhashed and destroyed). */
+static int tcp_reactor_watch_write(struct tcp_connection *c)
+{
+	if(unlikely(tcp_reactor_enable_write_watch(c) < 0)) {
+		if(likely(tcpconn_try_unhash(c))) {
+			if((c->flags & F_CONN_READ_W) && (c->s != -1)) {
+				io_watch_del(&io_h, c->s, -1, IO_FD_CLOSING);
+				c->flags &= ~F_CONN_READ_W;
+			}
+			tcpconn_put_destroy(c);
+		} else {
+			BUG("unhashed connection watched for IO\n");
+		}
+		return -1;
 	}
 	return 0;
 }

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -149,7 +149,8 @@ enum fd_types
 	F_SOCKINFO /* a tcp_listen fd */,
 	F_TCPCONN,
 	F_TCPCHILD,
-	F_PROC
+	F_PROC,
+	F_TCP_REACTOR_NOTIFY /* mode 2: pool->reactor completion pipe (Phase 2) */
 };
 
 
@@ -213,6 +214,13 @@ int ksr_tcp_reactor_get_dispatch_wfd(void)
 {
 	return ksr_tcp_reactor_dsock[1];
 }
+
+/* mode 2 (Phase 2 thread pool): cross-process write-job queue (shm, allocated
+ * pre-fork) and the PROC_TCP_MAIN-local thread pool state. Declared in
+ * tcp_reactor.h. Unused until the pool is wired up (Step 2+); NULL/zero in
+ * modes 0/1. */
+struct tcp_shared_write_queue *tcp_reactor_wq = NULL;
+struct tcp_reactor_pool tcp_rpool;
 
 static int tcp_proto_no = -1; /* tcp protocol number as returned by
 							   getprotobyname */
@@ -6188,6 +6196,24 @@ static int ksr_tcp_reactor_dsock_init(void)
 	}
 	LM_INFO("tcp reactor dispatch socketpair created (rfd=%d wfd=%d)\n",
 			ksr_tcp_reactor_dsock[0], ksr_tcp_reactor_dsock[1]);
+
+	/* Phase 2 thread pool: the cross-process write-job queue must also live in
+	 * shm and be initialised before fork so workers and PROC_TCP_MAIN share the
+	 * same PROCESS_SHARED condvar. The pool threads + notify pipe (tcp_rpool)
+	 * are created later, inside PROC_TCP_MAIN (Step 2). */
+	tcp_reactor_wq = shm_malloc(sizeof(*tcp_reactor_wq));
+	if(tcp_reactor_wq == NULL) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+	memset(tcp_reactor_wq, 0, sizeof(*tcp_reactor_wq));
+	if(tcp_cond_init(&tcp_reactor_wq->cond) != 0) {
+		LM_ERR("failed to init reactor write-queue condvar\n");
+		shm_free(tcp_reactor_wq);
+		tcp_reactor_wq = NULL;
+		return -1;
+	}
+	LM_INFO("tcp reactor shared write queue initialized\n");
 	return 0;
 }
 

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -5283,7 +5283,17 @@ inline static int handle_tcpconn_ev(
 	if(unlikely(ksr_tcp_main_threads == 2)) {
 		/* full reactor mode: tcp_main owns the fd permanently, reads and
 		 * reassembles SIP messages directly (no fd-passing, no send2child).
-		 * busy tracking is intentionally bypassed (see send2child). */
+		 *
+		 * Worker busy-tracking (tcp_children[].busy) is intentionally bypassed:
+		 * .busy is only ever mutated by send2child() (increment, when a fd is
+		 * handed to a worker) and by its decrement counterparts in
+		 * handle_tcp_child() / the send2child() error paths. None of those run
+		 * in mode 2 -- this branch returns before the send2child() call below,
+		 * and the tcp_children[] unix sockets carry no fd-passing traffic -- so
+		 * every .busy stays 0. That is harmless: .busy only feeds the
+		 * least-busy worker selection in send2child(), which mode 2 does not
+		 * use (the kernel load-balances the shared dispatch DGRAM socket across
+		 * workers instead). No load-balancing fidelity is lost. */
 		rd_conn_flags_t read_flags;
 		int n;
 		int resp;

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -2305,6 +2305,51 @@ static int tcpconn_1st_send(int fd, struct tcp_connection *c, const char *buf,
 		}                                          \
 	} while(0)
 
+#ifdef TCP_ASYNC
+/* mode 2: ship a write payload to PROC_TCP_MAIN, which queues it (and, for TLS,
+ * encrypts it - Step 10) and drives the async write. The refcnt held by the
+ * caller on c is transferred to the write request and released by tcp_main on
+ * completion (see the CONN_WRITE_REQ handler in handle_ser_child()).
+ * Returns len on success (optimistic - tcp_main owns the actual send), or -1 on
+ * error (in which case c is released here). */
+static int tcp_reactor_send_put(struct tcp_connection *c, const char *buf,
+		unsigned len, snd_flags_t send_flags)
+{
+	tcp_reactor_write_req_t *wreq;
+	long response[2];
+
+	wreq = shm_malloc(sizeof(tcp_reactor_write_req_t));
+	if(unlikely(wreq == NULL)) {
+		SHM_MEM_ERROR;
+		tcpconn_chld_put(c);
+		return -1;
+	}
+	wreq->buf = shm_malloc(len);
+	if(unlikely(wreq->buf == NULL)) {
+		SHM_MEM_ERROR;
+		shm_free(wreq);
+		tcpconn_chld_put(c);
+		return -1;
+	}
+	memcpy(wreq->buf, buf, len);
+	wreq->len = len;
+	wreq->conn = c; /* refcnt transferred to tcp_main */
+	wreq->send_flags = send_flags;
+
+	response[0] = (long)(uintptr_t)wreq;
+	response[1] = CONN_WRITE_REQ;
+	if(unlikely(send_all(unix_tcp_sock, response, sizeof(response)) <= 0)) {
+		LM_ERR("failed to send write request to tcp main: %s (%d)\n",
+				strerror(errno), errno);
+		shm_free(wreq->buf);
+		shm_free(wreq);
+		tcpconn_chld_put(c);
+		return -1;
+	}
+	return (int)len;
+}
+#endif /* TCP_ASYNC */
+
 /* finds a tcpconn & sends on it
  * uses the dst members to, proto (TCP|TLS) and id and tries to send
  *  from the "from" address (if non null and id==0)
@@ -2715,6 +2760,14 @@ int tcp_send(struct dest_info *dst, union sockaddr_union *from, const char *buf,
 		goto release_c;
 	} /* if (c==0 or unusable) new connection */
 	tcp_dst_ephemeral_set(n, c, dst);
+#ifdef TCP_ASYNC
+	if(unlikely(ksr_tcp_main_threads == 2)) {
+		/* mode 2: existing connection - dispatch the write to PROC_TCP_MAIN
+		 * instead of getting the fd and writing here. New-connection (c==0)
+		 * handling is Step 11. */
+		return tcp_reactor_send_put(c, buf, len, dst->send_flags);
+	}
+#endif /* TCP_ASYNC */
 	/* existing connection, send on it */
 	n = tcpconn_send_put(c, buf, len, dst->send_flags);
 	/* no deref needed (automatically done inside tcpconn_send_put() */

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -5792,30 +5792,10 @@ void tcp_main_loop()
 			goto error;
 		}
 		LM_INFO("tcp main processing threads prepared\n");
-		if(ksr_tcp_main_threads == 2) {
-			if(socketpair(AF_UNIX, SOCK_DGRAM, 0, ksr_tcp_reactor_dsock) < 0) {
-				LM_ERR("failed to create reactor dispatch socketpair: %s\n",
-						strerror(errno));
-				goto error;
-			}
-			if(fcntl(ksr_tcp_reactor_dsock[0], F_SETFL,
-					   fcntl(ksr_tcp_reactor_dsock[0], F_GETFL) | O_NONBLOCK)
-					< 0) {
-				LM_ERR("failed to set O_NONBLOCK on reactor dsock[0]: %s\n",
-						strerror(errno));
-				goto error;
-			}
-			if(fcntl(ksr_tcp_reactor_dsock[1], F_SETFL,
-					   fcntl(ksr_tcp_reactor_dsock[1], F_GETFL) | O_NONBLOCK)
-					< 0) {
-				LM_ERR("failed to set O_NONBLOCK on reactor dsock[1]: %s\n",
-						strerror(errno));
-				goto error;
-			}
-			LM_INFO("tcp reactor dispatch socketpair created"
-					" (rfd=%d wfd=%d)\n",
-					ksr_tcp_reactor_dsock[0], ksr_tcp_reactor_dsock[1]);
-		}
+		/* mode 2: the reactor dispatch socketpair is created in the main
+		 * process by tcp_init_children() before any TCP child is forked, so it
+		 * is inherited here (and by every worker). Nothing to do at this point;
+		 * tcp_main uses ksr_tcp_reactor_get_dispatch_wfd() to ship tasks. */
 	} else {
 		LM_INFO("tcp main processing threads not enabled\n");
 	}
@@ -6134,6 +6114,41 @@ int tcp_fix_child_sockets(int *fd)
 }
 
 
+/* mode 2: create the reactor dispatch socketpair (AF_UNIX SOCK_DGRAM).
+ * MUST be called in the main process before any TCP child (workers AND
+ * PROC_TCP_MAIN) is forked, so all of them inherit the shared fds: workers
+ * recvfrom dsock[0] (the kernel load-balances across them) and PROC_TCP_MAIN
+ * sends reassembled SIP tasks on dsock[1]. Both ends are non-blocking.
+ * Returns 0 on success (or when not in mode 2), -1 on error. */
+static int ksr_tcp_reactor_dsock_init(void)
+{
+	if(ksr_tcp_main_threads != 2)
+		return 0;
+	if(socketpair(AF_UNIX, SOCK_DGRAM, 0, ksr_tcp_reactor_dsock) < 0) {
+		LM_ERR("failed to create reactor dispatch socketpair: %s\n",
+				strerror(errno));
+		return -1;
+	}
+	if(fcntl(ksr_tcp_reactor_dsock[0], F_SETFL,
+			   fcntl(ksr_tcp_reactor_dsock[0], F_GETFL) | O_NONBLOCK)
+			< 0) {
+		LM_ERR("failed to set O_NONBLOCK on reactor dsock[0]: %s\n",
+				strerror(errno));
+		return -1;
+	}
+	if(fcntl(ksr_tcp_reactor_dsock[1], F_SETFL,
+			   fcntl(ksr_tcp_reactor_dsock[1], F_GETFL) | O_NONBLOCK)
+			< 0) {
+		LM_ERR("failed to set O_NONBLOCK on reactor dsock[1]: %s\n",
+				strerror(errno));
+		return -1;
+	}
+	LM_INFO("tcp reactor dispatch socketpair created (rfd=%d wfd=%d)\n",
+			ksr_tcp_reactor_dsock[0], ksr_tcp_reactor_dsock[1]);
+	return 0;
+}
+
+
 /* starts the tcp processes */
 int tcp_init_children(int *woneinit)
 {
@@ -6198,6 +6213,12 @@ int tcp_init_children(int *woneinit)
 
 	/* create the tcp sock_info structures */
 	/* copy the sockets --moved to main_loop*/
+
+	/* mode 2: create the reactor dispatch socketpair before forking, so the
+	 * workers (below) and PROC_TCP_MAIN (forked by the caller right after) all
+	 * inherit the shared fds */
+	if(ksr_tcp_reactor_dsock_init() < 0)
+		goto error;
 
 	/* fork children & create the socket pairs*/
 	for(r = 0; r < tcp_children_no; r++) {

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -4472,16 +4472,19 @@ static int tcp_reactor_enable_write_watch(struct tcp_connection *c)
 {
 	ticks_t t;
 
+	/* mode 2 (Phase 2): if the conn is currently shielded for an in-flight pool
+	 * read job it is owned exclusively by that pool thread - it is in neither
+	 * io_h nor the local timer. Return immediately WITHOUT touching c->flags or
+	 * io_h: a pool thread (this may be called from its TLS / CRLF-pong
+	 * write-back) must not race the io_wait thread on c->flags. The data is
+	 * already staged in wbuf_q and tcp_reactor_read_rearm() re-arms POLLOUT
+	 * from wbuf_q at completion. This check MUST come before any c->flags
+	 * write below. */
+	if(c->flags & F_CONN_REMOVED_READ)
+		return 0;
 	if(c->flags & F_CONN_WANTS_WR)
 		return 0;
 	c->flags |= F_CONN_WANTS_WR;
-	/* mode 2 (Phase 2): if the conn is currently shielded for an in-flight pool
-	 * read job, its fd is not in io_h and only the io_wait thread may touch
-	 * io_h anyway. Just record the write intent; the read completion
-	 * (tcp_reactor_read_rearm) re-arms POLLOUT from the wbuf_q. This makes the
-	 * function safe to call from a pool thread's TLS write-back too. */
-	if(c->flags & F_CONN_REMOVED_READ)
-		return 0;
 	t = get_ticks_raw();
 	if(likely((c->flags & F_CONN_MAIN_TIMER)
 			   && (TICKS_LT(c->wbuf_q.wr_timeout, c->timeout))
@@ -4612,6 +4615,14 @@ static int tcp_reactor_read_rearm(struct tcp_connection *c)
 	}
 	t = get_ticks_raw();
 	c->timeout = t + cfg_get(tcp, tcp_cfg, con_lifetime);
+	/* re-arm the local timer disarmed by the shield (it was removed from the
+	 * timer list, so reinit + add - no del). arm_read_timeout() below may then
+	 * shorten it to the partial-read deadline if a message is mid-read. */
+	if(!(c->flags & F_CONN_MAIN_TIMER)) {
+		local_timer_reinit(&c->timer);
+		local_timer_add(&tcp_main_ltimer, &c->timer, c->timeout - t, t);
+		c->flags |= F_CONN_MAIN_TIMER;
+	}
 	tcp_reactor_arm_read_timeout(c, t);
 	return 0;
 }
@@ -5472,6 +5483,14 @@ inline static int handle_tcpconn_ev(
 						   "fd %d\n",
 							tcpconn, tcpconn->s);
 					goto reactor_close;
+				}
+				/* disarm the local timer too: while the pool thread owns the
+				 * conn, the io_wait thread must not run tcpconn_main_timeout()
+				 * on it (that would race c->flags / unhash under the reader).
+				 * The completion re-arms it. */
+				if(tcpconn->flags & F_CONN_MAIN_TIMER) {
+					local_timer_del(&tcp_main_ltimer, &tcpconn->timer);
+					tcpconn->flags &= ~F_CONN_MAIN_TIMER;
 				}
 				tcpconn->flags &= ~(F_CONN_READ_W | F_CONN_WRITE_W
 									| F_CONN_WANTS_RD | F_CONN_WANTS_WR);

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -4469,6 +4469,39 @@ static int tcp_reactor_watch_write(struct tcp_connection *c)
 	}
 	return 0;
 }
+
+/* mode 2: while a SIP message is mid-read on c (tvrstart set), cap the
+ * connection timeout to the message-read deadline
+ * (tvrstart + ksr_tcp_msg_read_timeout) and re-arm the local timer so tcp_main
+ * reaps a stalled partial read by itself, without relying on the cross-process
+ * tcp_timer_check_connections() scan. No-op when no message is in flight
+ * (tvrstart == 0) or the timeout is disabled, so completed/idle connections
+ * keep the normal con_lifetime idle timeout. t must be the current tick. */
+static void tcp_reactor_arm_read_timeout(struct tcp_connection *c, ticks_t t)
+{
+	struct timeval tvnow;
+	long long elapsed_us, remaining_ms;
+	ticks_t deadline;
+
+	if(likely(ksr_tcp_msg_read_timeout <= 0 || c->state != S_CONN_OK
+			   || c->req.tvrstart.tv_sec == 0))
+		return;
+	gettimeofday(&tvnow, NULL);
+	elapsed_us = 1000000LL * (tvnow.tv_sec - c->req.tvrstart.tv_sec)
+				 + (tvnow.tv_usec - c->req.tvrstart.tv_usec);
+	remaining_ms = (1000000LL * ksr_tcp_msg_read_timeout - elapsed_us) / 1000LL;
+	if(remaining_ms < 0)
+		remaining_ms = 0;
+	deadline = t + MS_TO_TICKS((ticks_t)remaining_ms);
+	if(TICKS_LT(deadline, c->timeout))
+		c->timeout = deadline;
+	/* re-arm the local timer to (possibly) fire earlier at the read deadline */
+	if(likely(c->flags & F_CONN_MAIN_TIMER)) {
+		local_timer_del(&tcp_main_ltimer, &c->timer);
+		local_timer_reinit(&c->timer);
+		local_timer_add(&tcp_main_ltimer, &c->timer, c->timeout - t, t);
+	}
+}
 #endif /* TCP_ASYNC */
 
 /* handles io from a "generic" process (get fd or new_fd from a tcp_send)
@@ -5309,9 +5342,16 @@ inline static int handle_tcpconn_ev(
 			}
 			if(unlikely(read_flags & RD_CONN_REPEAT_READ))
 				goto repeat_read;
-			/* partial or complete read: keep the fd, refresh idle timeout */
-			tcpconn->timeout =
-					get_ticks_raw() + cfg_get(tcp, tcp_cfg, con_lifetime);
+			/* partial or complete read: keep the fd, refresh the idle timeout.
+			 * If a message is still mid-read, also bound the timeout to the
+			 * message-read deadline so a stalled partial read is reaped. */
+			{
+				ticks_t tnow = get_ticks_raw();
+				tcpconn->timeout = tnow + cfg_get(tcp, tcp_cfg, con_lifetime);
+#ifdef TCP_ASYNC
+				tcp_reactor_arm_read_timeout(tcpconn, tnow);
+#endif /* TCP_ASYNC */
+			}
 		}
 		return 0;
 
@@ -5555,6 +5595,25 @@ static ticks_t tcpconn_main_timeout(ticks_t t, struct timer_ln *tl, void *data)
 		else
 			return (ticks_t)(c->timeout - t);
 	}
+	/* mode 2: reap a connection whose partial SIP message stalled past the
+	 * read deadline. The read path (tcp_reactor_arm_read_timeout) bounds
+	 * c->timeout to that deadline, so reaching here with a message still
+	 * mid-read (tvrstart set) and the read window elapsed means a stalled
+	 * partial read; report it as such instead of idle/send timeout. */
+	if(unlikely(ksr_tcp_main_threads == 2 && ksr_tcp_msg_read_timeout > 0
+				&& c->state == S_CONN_OK && c->req.tvrstart.tv_sec > 0)) {
+		struct timeval tvnow;
+		long long tvdiff;
+		gettimeofday(&tvnow, NULL);
+		tvdiff = 1000000LL * (tvnow.tv_sec - c->req.tvrstart.tv_sec)
+				 + (tvnow.tv_usec - c->req.tvrstart.tv_usec);
+		if(tvdiff >= 1000000LL * ksr_tcp_msg_read_timeout) {
+			LM_DBG("reactor: message read timeout for %p after %lld us\n", c,
+					tvdiff);
+			TCP_STATS_CON_TIMEOUT();
+			goto reap;
+		}
+	}
 	/* if time out due to write, add it to the blocklist */
 	if(tcp_async && _wbufq_non_empty(c) && TICKS_GE(t, c->wbuf_q.wr_timeout)) {
 		if(unlikely(c->state == S_CONN_CONNECT)) {
@@ -5586,6 +5645,9 @@ static ticks_t tcpconn_main_timeout(ticks_t t, struct timer_ln *tl, void *data)
 	/* idle timeout */
 	TCP_EV_IDLE_CONN_CLOSED(0, &c->rcv);
 	TCP_STATS_CON_TIMEOUT();
+#endif /* TCP_ASYNC */
+#ifdef TCP_ASYNC
+reap:
 #endif /* TCP_ASYNC */
 	LM_DBG("timeout for %p\n", c);
 	if(likely(c->flags & F_CONN_HASHED)) {

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -4533,10 +4533,17 @@ inline static int handle_ser_child(struct process_table *p, int fd_i)
 			break;
 		case CONN_WRITE_REQ: {
 			/* mode 2: worker queued a write; response[0] is the write request,
-			 * not a tcp_connection. tcp_main appends to the wbuf_q and enables
-			 * write watching, mirroring the CONN_QUEUED_WRITE logic above. */
+			 * not a tcp_connection. tcp_main queues the payload into the wbuf_q
+			 * (encrypting it first for TLS, since OpenSSL must run here) and
+			 * enables write watching, mirroring the CONN_QUEUED_WRITE logic. */
 			tcp_reactor_write_req_t *wreq =
 					(tcp_reactor_write_req_t *)response[0];
+#ifdef USE_TLS
+			const char *t_buf, *rest_buf;
+			unsigned t_len, rest_len;
+			snd_flags_t t_send_flags;
+			int wn;
+#endif /* USE_TLS */
 			tcpconn = wreq->conn;
 			/* release the worker's refcnt; if it was the last, conn is gone */
 			if(unlikely(tcpconn_put(tcpconn))) {
@@ -4553,14 +4560,45 @@ inline static int handle_ser_child(struct process_table *p, int fd_i)
 				break;
 			}
 			lock_get(&tcpconn->write_lock);
-			if(unlikely(_wbufq_add(tcpconn, wreq->buf, wreq->len) < 0)) {
-				lock_release(&tcpconn->write_lock);
-				tcpconn->state = S_CONN_BAD;
-				tcpconn->timeout = get_ticks_raw(); /* force timeout */
-				shm_free(wreq->buf);
-				shm_free(wreq);
-				break;
-			}
+#ifdef USE_TLS
+			if(unlikely(tcpconn->type == PROTO_TLS
+						|| tcpconn->type == PROTO_WSS)) {
+				/* encrypt in tcp_main: tls_encode() runs OpenSSL through the
+				 * mode-2 direct-call trampoline (is_tcp_main() is true here).
+				 * The wire bytes go into the wbuf_q, mirroring the TLS branch
+				 * of tcpconn_send_put(). */
+				t_buf = wreq->buf;
+				t_len = wreq->len;
+				do {
+					t_send_flags = wreq->send_flags;
+					wn = tls_encode(tcpconn, &t_buf, &t_len, &rest_buf,
+							&rest_len, &t_send_flags);
+					if(unlikely((wn < 0)
+								|| (t_len
+										&& (_wbufq_add(tcpconn, t_buf, t_len)
+												< 0)))) {
+						lock_release(&tcpconn->write_lock);
+						tcpconn->state = S_CONN_BAD;
+						tcpconn->timeout = get_ticks_raw(); /* force timeout */
+						shm_free(wreq->buf);
+						shm_free(wreq);
+						goto write_req_end;
+					}
+					t_buf = rest_buf;
+					t_len = rest_len;
+				} while(unlikely(rest_len && wn > 0));
+			} else
+#endif /* USE_TLS */
+				if(unlikely(wreq->len
+							&& (_wbufq_add(tcpconn, wreq->buf, wreq->len)
+									< 0))) {
+					lock_release(&tcpconn->write_lock);
+					tcpconn->state = S_CONN_BAD;
+					tcpconn->timeout = get_ticks_raw(); /* force timeout */
+					shm_free(wreq->buf);
+					shm_free(wreq);
+					goto write_req_end;
+				}
 			lock_release(&tcpconn->write_lock);
 			shm_free(wreq->buf);
 			shm_free(wreq);
@@ -4610,6 +4648,7 @@ inline static int handle_ser_child(struct process_table *p, int fd_i)
 					}
 				}
 			}
+		write_req_end:
 			break;
 		}
 #ifdef TCP_CONNECT_WAIT

--- a/src/core/tcp_mtops.c
+++ b/src/core/tcp_mtops.c
@@ -39,6 +39,7 @@
 #include "dprint.h"
 #include "pt.h"
 #include "mem/shm.h"
+#include "globals.h"
 
 #include "tcp_mtops.h"
 
@@ -169,6 +170,11 @@ int ksr_tcpx_proc_list_init(void)
 		return 0;
 	}
 
+	if(ksr_tcp_main_threads == 2) {
+		/* mode 2: no per-process trampoline threads or socketpairs needed */
+		return 0;
+	}
+
 	_ksr_tcpx_proc_list_size = get_max_procs();
 
 	if(_ksr_tcpx_proc_list_size <= 0) {
@@ -214,6 +220,11 @@ error:
 int ksr_tcpx_proc_list_prepare(void)
 {
 	int i;
+
+	if(ksr_tcp_main_threads == 2) {
+		/* mode 2: direct-call path (step 4) replaces per-process threads */
+		return 0;
+	}
 
 	for(i = 0; i < _ksr_tcpx_proc_list_size; i++) {
 		if(pthread_create(&_ksr_tcpx_proc_list[i].ethread, NULL,

--- a/src/core/tcp_mtops.c
+++ b/src/core/tcp_mtops.c
@@ -67,6 +67,13 @@ static ksr_tcpx_proc_t *_ksr_tcpx_proc_list = NULL;
  */
 static int _ksr_tcpx_proc_list_size = 0;
 
+/* mode 2: tcp_main-local write buffer and synchronous result slot.
+ * Used by the direct-call path (KSR_TCPX_MAIN_PIDX) instead of the
+ * per-process socketpair relay used in mode 1. */
+extern int is_tcp_main(void);
+static unsigned char ksr_tcp_main_wrbuf[TLS_WR_MBUF_SZ];
+static tcpx_task_result_t *ksr_tcp_main_eresult = NULL;
+
 /**
  * Set a unique id per thread
  */
@@ -111,6 +118,13 @@ static void *ksr_tcpx_thread_etask(void *param)
 int ksr_tcpx_thread_eresult(tcpx_task_result_t *rtask, int pidx)
 {
 	int len;
+
+	if(pidx == KSR_TCPX_MAIN_PIDX) {
+		/* mode 2 direct-call path: store result for synchronous retrieval */
+		ksr_tcp_main_eresult = rtask;
+		return 0;
+	}
+
 	len = write(_ksr_tcpx_proc_list[pidx].rcvsock[1], &rtask,
 			sizeof(tcpx_task_result_t *));
 	if(len <= 0) {
@@ -128,6 +142,20 @@ int ksr_tcpx_thread_eresult(tcpx_task_result_t *rtask, int pidx)
 int ksr_tcpx_task_send(tcpx_task_t *task, int pidx)
 {
 	int len;
+
+	if(ksr_tcp_main_threads == 2) {
+		if(!is_tcp_main()) {
+			/* worker calling trampoline in mode 2 — socketpair not allocated */
+			LM_ERR("tcpx task send from non-main process unsupported in"
+				   " mode 2\n");
+			return -1;
+		}
+		/* already in PROC_TCP_MAIN: call exec() directly, no relay needed */
+		if(task->exec)
+			task->exec(task->param, KSR_TCPX_MAIN_PIDX);
+		return 0;
+	}
+
 	len = write(
 			_ksr_tcpx_proc_list[pidx].sndsock[1], &task, sizeof(tcpx_task_t *));
 	if(len <= 0) {
@@ -144,6 +172,14 @@ int ksr_tcpx_task_send(tcpx_task_t *task, int pidx)
 int ksr_tcpx_task_result_recv(tcpx_task_result_t **rtask, int pidx)
 {
 	int received;
+
+	if(ksr_tcp_main_threads == 2) {
+		/* mode 2: exec() ran synchronously; result already in the slot */
+		*rtask = ksr_tcp_main_eresult;
+		ksr_tcp_main_eresult = NULL;
+		return 0;
+	}
+
 	if((received = recvfrom(_ksr_tcpx_proc_list[pidx].rcvsock[0], rtask,
 				sizeof(tcpx_task_result_t *), 0, NULL, 0))
 			< 0) {
@@ -248,6 +284,8 @@ error:
  */
 unsigned char *ksr_tcpx_thread_wrbuf(int pidx)
 {
+	if(pidx == KSR_TCPX_MAIN_PIDX)
+		return ksr_tcp_main_wrbuf;
 	if(_ksr_tcpx_proc_list == NULL)
 		return NULL;
 	if(pidx >= _ksr_tcpx_proc_list_size)

--- a/src/core/tcp_mtops.c
+++ b/src/core/tcp_mtops.c
@@ -69,10 +69,19 @@ static int _ksr_tcpx_proc_list_size = 0;
 
 /* mode 2: tcp_main-local write buffer and synchronous result slot.
  * Used by the direct-call path (KSR_TCPX_MAIN_PIDX) instead of the
- * per-process socketpair relay used in mode 1. */
+ * per-process socketpair relay used in mode 1.
+ *
+ * In the full reactor (mode 2) the direct-call trampoline runs OpenSSL on
+ * whichever PROC_TCP_MAIN thread owns the connection: the io_wait thread for
+ * inline WSS / outbound-connect encode, or a pool thread for an offloaded TLS
+ * read/write job. Several such threads encode concurrently (on different
+ * connections), so each needs its OWN scratch buffer and result slot - a single
+ * process-global would let them clobber each other. _Thread_local supplies one
+ * copy per thread automatically; F_CONN_POOL_BUSY already guarantees a single
+ * thread per SSL object at a time, so per-thread (not per-conn) is sufficient. */
 extern int is_tcp_main(void);
-static unsigned char ksr_tcp_main_wrbuf[TLS_WR_MBUF_SZ];
-static tcpx_task_result_t *ksr_tcp_main_eresult = NULL;
+static _Thread_local unsigned char ksr_tcp_main_wrbuf[TLS_WR_MBUF_SZ];
+static _Thread_local tcpx_task_result_t *ksr_tcp_main_eresult = NULL;
 
 /**
  * Set a unique id per thread
@@ -284,7 +293,11 @@ error:
  */
 unsigned char *ksr_tcpx_thread_wrbuf(int pidx)
 {
-	if(pidx == KSR_TCPX_MAIN_PIDX)
+	/* mode 2: the encode trampoline passes pidx == process_no (a single value
+	 * for PROC_TCP_MAIN), but the work runs on many threads. Return the
+	 * thread-local buffer for every mode-2 caller, regardless of pidx, so
+	 * concurrent pool-thread TLS encodes do not share one buffer. */
+	if(ksr_tcp_main_threads == 2 || pidx == KSR_TCPX_MAIN_PIDX)
 		return ksr_tcp_main_wrbuf;
 	if(_ksr_tcpx_proc_list == NULL)
 		return NULL;

--- a/src/core/tcp_mtops.h
+++ b/src/core/tcp_mtops.h
@@ -26,6 +26,10 @@
 #define TLS_RD_MBUF_SZ 65536
 #define TLS_WR_MBUF_SZ 65536
 
+/* pidx sentinel used in mode 2: identifies the tcp_main thread context.
+ * No per-process trampoline thread exists; exec() is called directly. */
+#define KSR_TCPX_MAIN_PIDX (-1)
+
 typedef void (*tcpx_cbe_f)(void *p, int pidx);
 
 typedef struct tcpx_task

--- a/src/core/tcp_reactor.c
+++ b/src/core/tcp_reactor.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 S-P Chan
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <sys/socket.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+
+#include "dprint.h"
+#include "mem/shm_mem.h"
+#include "tcp_reactor.h"
+#include "tcp_server.h" /* ksr_tcp_reactor_get_dispatch_wfd() */
+
+/*
+ * Allocate a tcp_reactor_task_t in shm, copy the reassembled SIP message
+ * and receive_info into it, then send the pointer to the workers via the
+ * dispatch socketpair write end.
+ *
+ * Called from PROC_TCP_MAIN's io_wait loop (mode 2) at the point where
+ * receive_tcp_msg() would normally be called in modes 0/1.
+ *
+ * The receiving worker calls receive_msg() then shm_free()s the task.
+ */
+int tcp_reactor_dispatch_msg(
+		char *buf, unsigned int len, struct receive_info *rcv)
+{
+	tcp_reactor_task_t *task;
+	uintptr_t ptr;
+	ssize_t sent;
+
+	task = shm_malloc(sizeof(tcp_reactor_task_t) + len + 1);
+	if(task == NULL) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+	task->rcv = *rcv;
+	task->msg_len = len;
+	memcpy(task->msg_buf, buf, len);
+	task->msg_buf[len] = '\0';
+
+	ptr = (uintptr_t)task;
+	sent = send(ksr_tcp_reactor_get_dispatch_wfd(), &ptr, sizeof(ptr), 0);
+	if(sent != (ssize_t)sizeof(ptr)) {
+		LM_ERR("failed to dispatch SIP task to workers (%s)\n",
+				(sent < 0) ? strerror(errno) : "short write");
+		shm_free(task);
+		return -1;
+	}
+	return 0;
+}

--- a/src/core/tcp_reactor.c
+++ b/src/core/tcp_reactor.c
@@ -24,11 +24,19 @@
 #include <stdint.h>
 #include <string.h>
 #include <errno.h>
+#include <limits.h>
 
 #include "dprint.h"
 #include "mem/shm_mem.h"
 #include "tcp_reactor.h"
 #include "tcp_server.h" /* ksr_tcp_reactor_get_dispatch_wfd() */
+
+/* The dispatch socket carries a single task pointer per datagram, and the
+ * Phase 2 notify pipe carries single bytes - both must be written atomically.
+ * A write of at most PIPE_BUF bytes is guaranteed atomic; a pointer is far
+ * smaller, but assert it so a hypothetical exotic platform can't slip by. */
+_Static_assert(sizeof(uintptr_t) <= PIPE_BUF,
+		"task pointer too wide for atomic dispatch write");
 
 /*
  * Allocate a tcp_reactor_task_t in shm, copy the reassembled SIP message

--- a/src/core/tcp_reactor.h
+++ b/src/core/tcp_reactor.h
@@ -61,6 +61,27 @@ typedef struct tcp_reactor_write_req
 	snd_flags_t send_flags;
 } tcp_reactor_write_req_t;
 
+/*
+ * Connect request sent from a TCP worker to PROC_TCP_MAIN (mode 2) when no
+ * usable connection exists for a destination. The worker creates no struct and
+ * opens no socket; tcp_main performs socket()/connect(), creates and hashes the
+ * tcp_connection, queues the payload, and watches the fd. Allocated in shm by
+ * the worker; passed as response[0] with command CONN_CONNECT_REQ. tcp_main
+ * frees buf and the request struct.
+ */
+typedef struct tcp_reactor_connect_req
+{
+	union sockaddr_union dst;  /* destination (dst->to) */
+	union sockaddr_union from; /* bind source (valid only if have_from) */
+	int have_from;
+	int proto;			/* PROTO_TCP / PROTO_TLS / PROTO_WS / PROTO_WSS */
+	int id;				/* dst->id, for the dedup re-check */
+	int try_local_port; /* send_sock local port, for strict matching */
+	snd_flags_t send_flags;
+	char *buf; /* shm payload (plaintext for TLS) */
+	unsigned int len;
+} tcp_reactor_connect_req_t;
+
 /* Allocate a tcp_reactor_task_t in shm, copy buf+rcv into it, and write
  * the pointer to the dispatch socketpair write end. Called from
  * PROC_TCP_MAIN in mode 2 wherever receive_tcp_msg() would be called. */

--- a/src/core/tcp_reactor.h
+++ b/src/core/tcp_reactor.h
@@ -23,7 +23,9 @@
 #ifndef _TCP_REACTOR_H_
 #define _TCP_REACTOR_H_
 
-#include "ip_addr.h" /* struct receive_info */
+#include "ip_addr.h" /* struct receive_info, snd_flags_t */
+
+struct tcp_connection;
 
 /*
  * Task dispatched from PROC_TCP_MAIN to a TCP worker (mode 2).
@@ -41,6 +43,23 @@ typedef struct tcp_reactor_task
 	unsigned int msg_len;
 	char msg_buf[0]; /* inline message buffer, null-terminated */
 } tcp_reactor_task_t;
+
+/*
+ * Write request sent from a TCP worker to PROC_TCP_MAIN (mode 2).
+ *
+ * Allocated in shared memory by the worker in tcp_send(); the pointer is
+ * passed to tcp_main via pt[process_no].unix_sock as response[0] with
+ * command CONN_WRITE_REQ. tcp_main queues buf into conn->wbuf_q, enables
+ * POLLOUT watching, releases the worker's connection refcnt, and frees
+ * both buf and the request struct.
+ */
+typedef struct tcp_reactor_write_req
+{
+	struct tcp_connection *conn; /* refcnt held by worker; tcp_main releases */
+	char *buf;					 /* shm-allocated payload */
+	unsigned int len;
+	snd_flags_t send_flags;
+} tcp_reactor_write_req_t;
 
 /* Allocate a tcp_reactor_task_t in shm, copy buf+rcv into it, and write
  * the pointer to the dispatch socketpair write end. Called from

--- a/src/core/tcp_reactor.h
+++ b/src/core/tcp_reactor.h
@@ -24,6 +24,7 @@
 #define _TCP_REACTOR_H_
 
 #include "ip_addr.h" /* struct receive_info, snd_flags_t */
+#include "tcp_cond.h" /* tcp_cond_t (pulls in <pthread.h>) - mode 2 thread pool */
 
 struct tcp_connection;
 
@@ -87,5 +88,65 @@ typedef struct tcp_reactor_connect_req
  * PROC_TCP_MAIN in mode 2 wherever receive_tcp_msg() would be called. */
 int tcp_reactor_dispatch_msg(
 		char *buf, unsigned int len, struct receive_info *rcv);
+
+/* =========================================================================
+ * Phase 2 - tcp_main_threads == 2 thread pool (OpenSIPS-style)
+ *
+ * The reactor (single io_wait thread in PROC_TCP_MAIN) owns epoll exclusively;
+ * pool threads only run read/write callbacks on connections handed to them and
+ * signal completion back over a notify pipe. Read/run jobs are enqueued by the
+ * reactor thread (pkg memory); write jobs are submitted by TCP worker processes
+ * by linking the connection onto the shm write queue and signalling the
+ * PROCESS_SHARED condvar.
+ * ========================================================================= */
+
+/* job kinds (cf. OpenSIPS TCP_READ_JOB / TCP_WRITE_JOB / TCP_RUN_JOB) */
+enum tcp_reactor_op
+{
+	TCP_R_READ = 1,	 /* run the read callback on conn (reactor-enqueued) */
+	TCP_R_WRITE = 2, /* drain conn's write staging (worker-submitted) */
+	TCP_R_RUN = 3	 /* run an arbitrary fn(data) on a pool thread */
+};
+
+/* A job references only the connection (+op); it never carries a payload -
+ * write data lives on the connection's wsq staging list. The job holds a
+ * refcount on conn (taken at enqueue, released in completion). Read/run jobs
+ * are pkg-allocated by the reactor thread. */
+struct tcp_reactor_job
+{
+	struct tcp_connection *conn;
+	enum tcp_reactor_op op;
+	int (*run)(void *data); /* TCP_R_RUN only */
+	void *data;				/* TCP_R_RUN only */
+	int resp;				/* callback result (e.g. wbuf still pending) */
+	int ret;				/* completion disposition */
+	struct tcp_reactor_job *next;
+};
+
+/* shared-memory write queue: a deduped list of CONNECTIONS (linked via
+ * conn->wq_next), not jobs. Worker processes signal cond to submit; pool
+ * threads in PROC_TCP_MAIN wait on it. Allocated in shm before fork. */
+struct tcp_shared_write_queue
+{
+	tcp_cond_t cond; /* PROCESS_SHARED + ROBUST mutex + cond */
+	struct tcp_connection *head;
+	struct tcp_connection *tail;
+};
+extern struct tcp_shared_write_queue *tcp_reactor_wq;
+
+/* thread pool state, local to PROC_TCP_MAIN (pkg / process-private memory) */
+struct tcp_reactor_pool
+{
+	pthread_t *threads;
+	int threads_no;
+	int stop;
+	struct tcp_reactor_job *task_head; /* read/run jobs (reactor-enqueued) */
+	struct tcp_reactor_job *task_tail;
+	pthread_mutex_t done_lock; /* plain mutex: same process only */
+	struct tcp_reactor_job *done_head;
+	struct tcp_reactor_job *done_tail;
+	int notify_pipe[2]; /* [0] watched by reactor, [1] written by threads */
+};
+extern struct tcp_reactor_pool tcp_rpool;
 
 #endif /* _TCP_REACTOR_H_ */

--- a/src/core/tcp_reactor.h
+++ b/src/core/tcp_reactor.h
@@ -42,4 +42,10 @@ typedef struct tcp_reactor_task
 	char msg_buf[0]; /* inline message buffer, null-terminated */
 } tcp_reactor_task_t;
 
+/* Allocate a tcp_reactor_task_t in shm, copy buf+rcv into it, and write
+ * the pointer to the dispatch socketpair write end. Called from
+ * PROC_TCP_MAIN in mode 2 wherever receive_tcp_msg() would be called. */
+int tcp_reactor_dispatch_msg(
+		char *buf, unsigned int len, struct receive_info *rcv);
+
 #endif /* _TCP_REACTOR_H_ */

--- a/src/core/tcp_reactor.h
+++ b/src/core/tcp_reactor.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 S-P Chan
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _TCP_REACTOR_H_
+#define _TCP_REACTOR_H_
+
+#include "ip_addr.h" /* struct receive_info */
+
+/*
+ * Task dispatched from PROC_TCP_MAIN to a TCP worker (mode 2).
+ *
+ * Allocated in shared memory with the message buffer inline:
+ *   shm_malloc(sizeof(tcp_reactor_task_t) + msg_len + 1)
+ *
+ * The pointer is written to ksr_tcp_reactor_dsock[1] as a uintptr_t.
+ * Workers recvfrom ksr_tcp_reactor_dsock[0], cast back, call
+ * receive_msg(), then shm_free the task.
+ */
+typedef struct tcp_reactor_task
+{
+	struct receive_info rcv; /* copied from con->rcv at reassembly time */
+	unsigned int msg_len;
+	char msg_buf[0]; /* inline message buffer, null-terminated */
+} tcp_reactor_task_t;
+
+#endif /* _TCP_REACTOR_H_ */

--- a/src/core/tcp_read.c
+++ b/src/core/tcp_read.c
@@ -41,6 +41,7 @@
 
 #include <unistd.h>
 #include <stdlib.h> /* for abort() */
+#include <stdint.h> /* for uintptr_t */
 
 #include "dprint.h"
 #include "tcp_conn.h"
@@ -49,7 +50,9 @@
 #include "tcp_ev.h"
 #include "pass_fd.h"
 #include "globals.h"
+#include "tcp_server.h"
 #include "tcp_reactor.h"
+#include "mem/shm_mem.h"
 #include "receive.h"
 #include "timer.h"
 #include "local_timer.h"
@@ -118,7 +121,8 @@ enum fd_types
 {
 	F_NONE,
 	F_TCPMAIN,
-	F_TCPCONN
+	F_TCPCONN,
+	F_TCP_REACTOR /* mode 2: shared dispatch socket carrying SIP task pointers */
 };
 
 /* list of tcp connections handled by this process */
@@ -2096,6 +2100,43 @@ inline static int handle_io(struct fd_map *fm, short events, int idx)
 				goto con_error;
 			}
 			break;
+		case F_TCP_REACTOR: {
+			/* mode 2: PROC_TCP_MAIN dispatched a reassembled SIP message as a
+			 * shm task pointer over the shared dgram socket. Consume it, run
+			 * the message, and free the task. */
+			tcp_reactor_task_t *task;
+			uintptr_t task_ptr;
+		again_reactor:
+			ret = n = recv(fm->fd, &task_ptr, sizeof(task_ptr), MSG_DONTWAIT);
+			if(unlikely(n < 0)) {
+				if(errno == EWOULDBLOCK || errno == EAGAIN) {
+					ret = 0;
+					break;
+				} else if(errno == EINTR) {
+					goto again_reactor;
+				} else {
+					LM_CRIT("recv on reactor dispatch socket failed: %s [%d]\n",
+							strerror(errno), errno);
+					goto error;
+				}
+			}
+			if(unlikely(n == 0)) {
+				LM_ERR("EOF on reactor dispatch socket\n");
+				goto error;
+			}
+			if(unlikely(n != (int)sizeof(task_ptr))) {
+				LM_CRIT("short read on reactor dispatch socket: %d bytes\n", n);
+				goto error;
+			}
+			task = (tcp_reactor_task_t *)(uintptr_t)task_ptr;
+			if(unlikely(task == NULL)) {
+				LM_CRIT("null task pointer from tcp main\n");
+				break;
+			}
+			receive_msg(task->msg_buf, task->msg_len, &task->rcv);
+			shm_free(task);
+			break;
+		}
 		case F_TCPCONN:
 			con = (struct tcp_connection *)fm->data;
 			if(unlikely(con->state == S_CONN_BAD)) {
@@ -2206,9 +2247,22 @@ void tcp_receive_loop(int unix_sock)
 	if(init_local_timer(&tcp_reader_ltimer, get_ticks_raw()) != 0)
 		goto error;
 	/* add the unix socket */
-	if(io_watch_add(&io_w, tcpmain_sock, POLLIN, F_TCPMAIN, 0) < 0) {
-		LM_CRIT("failed to add tcp main socket to the fd list\n");
-		goto error;
+	if(ksr_tcp_main_threads == 2) {
+		/* mode 2: this worker is a pure SIP engine - it does not own tcp fds
+		 * and never receives them via fd-passing. Instead it consumes
+		 * reassembled SIP messages dispatched by PROC_TCP_MAIN over the shared
+		 * dgram socket. */
+		if(io_watch_add(&io_w, ksr_tcp_reactor_get_dispatch_rfd(), POLLIN,
+				   F_TCP_REACTOR, 0)
+				< 0) {
+			LM_CRIT("failed to add reactor dispatch socket to the fd list\n");
+			goto error;
+		}
+	} else {
+		if(io_watch_add(&io_w, tcpmain_sock, POLLIN, F_TCPMAIN, 0) < 0) {
+			LM_CRIT("failed to add tcp main socket to the fd list\n");
+			goto error;
+		}
 	}
 
 	/* initialize the config framework */

--- a/src/core/tcp_read.c
+++ b/src/core/tcp_read.c
@@ -434,7 +434,11 @@ int tcp_read(struct tcp_connection *c, rd_conn_flags_t *flags)
 	unsigned int len;
 
 	r = &c->req;
-	fd = c->fd;
+	/* mode 2: tcp_main owns and reads the connection, where the socket fd is
+	 * c->s (c->fd is the fd-passing copy, only valid in a worker). _tconfd()
+	 * selects c->s in tcp_main and c->fd in a worker, so modes 0/1 are
+	 * unchanged. Matches the TLS read path, which already uses _tconfd(c). */
+	fd = _tconfd(c);
 	bytes_free = r->b_size - (unsigned int)(r->pos - r->buf);
 
 	if(unlikely(bytes_free <= 0)) {

--- a/src/core/tcp_read.c
+++ b/src/core/tcp_read.c
@@ -49,6 +49,7 @@
 #include "tcp_ev.h"
 #include "pass_fd.h"
 #include "globals.h"
+#include "tcp_reactor.h"
 #include "receive.h"
 #include "timer.h"
 #include "local_timer.h"
@@ -1822,26 +1823,43 @@ again:
 			// if (unlikely(req->flags&F_TCP_REQ_MSRP_FRAME)){
 			if(unlikely(req->state == H_MSRP_FINISH)) {
 				/* msrp frame */
-				ret = receive_tcp_msg(
-						req->start, req->parsed - req->start, &con->rcv, con);
+				if(ksr_tcp_main_threads == 2)
+					ret = tcp_reactor_dispatch_msg(
+							req->start, req->parsed - req->start, &con->rcv);
+				else
+					ret = receive_tcp_msg(req->start, req->parsed - req->start,
+							&con->rcv, con);
 			} else
 #endif
 #ifdef READ_HTTP11
 					if(unlikely(req->state == H_HTTP11_CHUNK_FINISH)) {
 				/* http chunked request */
 				req->body[req->content_len] = 0;
-				ret = receive_tcp_msg(req->start,
-						req->body + req->content_len - req->start, &con->rcv,
-						con);
+				if(ksr_tcp_main_threads == 2)
+					ret = tcp_reactor_dispatch_msg(req->start,
+							req->body + req->content_len - req->start,
+							&con->rcv);
+				else
+					ret = receive_tcp_msg(req->start,
+							req->body + req->content_len - req->start,
+							&con->rcv, con);
 			} else
 #endif
 #ifdef READ_WS
 					if(unlikely(con->type == PROTO_WS
 								|| con->type == PROTO_WSS)) {
-				ret = receive_tcp_msg(
-						req->start, req->parsed - req->start, &con->rcv, con);
+				if(ksr_tcp_main_threads == 2)
+					ret = tcp_reactor_dispatch_msg(
+							req->start, req->parsed - req->start, &con->rcv);
+				else
+					ret = receive_tcp_msg(req->start, req->parsed - req->start,
+							&con->rcv, con);
 			} else
 #endif
+					if(ksr_tcp_main_threads == 2)
+				ret = tcp_reactor_dispatch_msg(
+						req->start, req->parsed - req->start, &con->rcv);
+			else
 				ret = receive_tcp_msg(
 						req->start, req->parsed - req->start, &con->rcv, con);
 

--- a/src/core/tcp_read.h
+++ b/src/core/tcp_read.h
@@ -40,6 +40,9 @@ int tcp_read_headers(
 int tcp_read_data(int fd, struct tcp_connection *c, char *buf, int b_size,
 		rd_conn_flags_t *flags);
 
+int tcp_read_req(struct tcp_connection *con, int *bytes_read,
+		rd_conn_flags_t *read_flags);
+
 
 #endif /*__tcp_read_h*/
 

--- a/src/core/tcp_server.h
+++ b/src/core/tcp_server.h
@@ -32,6 +32,10 @@
 int tcp_send(struct dest_info *dst, union sockaddr_union *from, const char *buf,
 		unsigned len);
 
+/* mode 2 reactor: returns the read end of the dispatch socketpair.
+ * Workers call this once during init to obtain the fd to watch. */
+int ksr_tcp_reactor_get_dispatch_rfd(void);
+
 int tcpconn_add_alias(int id, int port, int proto);
 
 

--- a/src/core/tcp_server.h
+++ b/src/core/tcp_server.h
@@ -32,9 +32,11 @@
 int tcp_send(struct dest_info *dst, union sockaddr_union *from, const char *buf,
 		unsigned len);
 
-/* mode 2 reactor: returns the read end of the dispatch socketpair.
- * Workers call this once during init to obtain the fd to watch. */
+/* mode 2 reactor: dispatch socketpair accessors.
+ * rfd: read end — workers watch this fd (recvfrom task pointers).
+ * wfd: write end — tcp_main sends task pointers here. */
 int ksr_tcp_reactor_get_dispatch_rfd(void);
+int ksr_tcp_reactor_get_dispatch_wfd(void);
 
 int tcpconn_add_alias(int id, int port, int proto);
 

--- a/src/modules/tls/tls_server.c
+++ b/src/modules/tls/tls_server.c
@@ -27,6 +27,7 @@
 
 
 #include <poll.h>
+#include <pthread.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #include "../../core/dprint.h"
@@ -2143,6 +2144,17 @@ void tls_lookup_event_routes(void)
 /**
  *
  */
+/* Serializes tls_run_event_routes(). In the full tcp reactor (tcp_main_threads
+ * == 2) TLS reads run on pool threads, so an outbound handshake can complete on
+ * any pool thread and this function runs config script (the tls:connection-out
+ * event route). That script touches process-global state - the faked sip_msg
+ * (core/fmsg.c _faked_msg), the current route type, the $tls PVs - none of which
+ * is thread-safe. PROC_TCP_MAIN runs no other config script, so a single
+ * process-local lock makes all such execution single-threaded again, restoring
+ * the property the inline (single io_wait thread) path had. Uncontended and
+ * harmless in modes 0/1 (workers are separate processes). */
+static pthread_mutex_t _ksr_tls_evrt_lock = PTHREAD_MUTEX_INITIALIZER;
+
 int tls_run_event_routes(struct tcp_connection *c)
 {
 	int backup_rt;
@@ -2157,8 +2169,11 @@ int tls_run_event_routes(struct tcp_connection *c)
 	if(p_onsend == 0 || p_onsend->msg == 0)
 		return 0;
 
-	if(faked_msg_init() < 0)
+	pthread_mutex_lock(&_ksr_tls_evrt_lock);
+	if(faked_msg_init() < 0) {
+		pthread_mutex_unlock(&_ksr_tls_evrt_lock);
 		return -1;
+	}
 	fmsg = faked_msg_next();
 
 	backup_rt = get_route_type();
@@ -2174,6 +2189,9 @@ int tls_run_event_routes(struct tcp_connection *c)
 					   &sr_tls_event_callback, &evname)
 					< 0) {
 				LM_ERR("error running event route kemi callback\n");
+				tls_set_pv_con(0);
+				set_route_type(backup_rt);
+				pthread_mutex_unlock(&_ksr_tls_evrt_lock);
 				return -1;
 			}
 		}
@@ -2184,5 +2202,6 @@ int tls_run_event_routes(struct tcp_connection *c)
 	}
 	tls_set_pv_con(0);
 	set_route_type(backup_rt);
+	pthread_mutex_unlock(&_ksr_tls_evrt_lock);
 	return 0;
 }

--- a/src/modules/tls_wolfssl/tls_server.c
+++ b/src/modules/tls_wolfssl/tls_server.c
@@ -27,6 +27,7 @@
 
 
 #include <poll.h>
+#include <pthread.h>
 #include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 
@@ -1904,6 +1905,13 @@ void tls_lookup_event_routes(void)
 /**
  *
  */
+/* See the openssl tls module for the rationale: in the full tcp reactor
+ * (tcp_main_threads == 2) TLS reads run on PROC_TCP_MAIN pool threads, so this
+ * config-script event route can run on any of them. It touches process-global
+ * state (the faked sip_msg, route type, $tls PVs) that is not thread-safe, so it
+ * is serialized here. Uncontended/harmless in modes 0/1. */
+static pthread_mutex_t _ksr_tls_evrt_lock = PTHREAD_MUTEX_INITIALIZER;
+
 int tls_run_event_routes(struct tcp_connection *c)
 {
 	int backup_rt;
@@ -1918,8 +1926,11 @@ int tls_run_event_routes(struct tcp_connection *c)
 	if(p_onsend == 0 || p_onsend->msg == 0)
 		return 0;
 
-	if(faked_msg_init() < 0)
+	pthread_mutex_lock(&_ksr_tls_evrt_lock);
+	if(faked_msg_init() < 0) {
+		pthread_mutex_unlock(&_ksr_tls_evrt_lock);
 		return -1;
+	}
 	fmsg = faked_msg_next();
 
 	backup_rt = get_route_type();
@@ -1935,6 +1946,9 @@ int tls_run_event_routes(struct tcp_connection *c)
 					   &sr_tls_event_callback, &evname)
 					< 0) {
 				LM_ERR("error running event route kemi callback\n");
+				tls_set_pv_con(0);
+				set_route_type(backup_rt);
+				pthread_mutex_unlock(&_ksr_tls_evrt_lock);
 				return -1;
 			}
 		}
@@ -1945,5 +1959,6 @@ int tls_run_event_routes(struct tcp_connection *c)
 	}
 	tls_set_pv_con(0);
 	set_route_type(backup_rt);
+	pthread_mutex_unlock(&_ksr_tls_evrt_lock);
 	return 0;
 }


### PR DESCRIPTION

## Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [ ] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

## Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

## Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

## Description
Update: the code change and description was conducted together with Claude code.

This PR adds a new operating mode for kamailio's TCP layer, selected by the
existing global `tcp_main_threads`:

- `0` — fd-passing (unchanged)
- `1` — fd-passing + OpenSSL trampoline threads (was `>0`)
- `2` — **full TCP reactor (new):** `PROC_TCP_MAIN` owns every TCP fd and performs
  all network I/O; the TCP worker processes become pure SIP engines.

In mode 2 there is **no fd-passing**. Connections are accepted, read,
reassembled, written, opened, closed, and timed out entirely inside
`PROC_TCP_MAIN`. Reassembled SIP messages are dispatched to worker processes as
small shared-memory task objects over a kernel-load-balanced datagram socket.
The mode is opt-in and additive; modes 0 and 1 are unchanged.

The motivation is architectural: **handling all network I/O in one process is
simpler than shuttling connection file descriptors
between processes with `sendmsg(SCM_RIGHTS)`.**

---

### Background: the fd-passing model

In the current TCP architecture, `PROC_TCP_MAIN` owns the listen sockets and
accepts connections, then **hands each connection's file descriptor to a TCP
worker** via `sendmsg()`/`SCM_RIGHTS` over a UNIX socket. The worker then owns
that fd and does the reads, reassembly, `receive_msg()`, and writes for that
connection.

This has served kamailio well, but the fd-passing at its core carries recurring
structural costs:

1. **Every handoff is a control-message syscall.** Passing an fd is a
   `sendmsg`/`recvmsg` pair carrying ancillary `SCM_RIGHTS` data; the kernel
   installs (dups) the fd into the receiver's descriptor table. This happens on
   every inbound accept→worker handoff, and the async write path adds further
   fd movement to let a process write on a connection it does not currently hold.

2. **A passed fd is duplicated across processes.** After a pass, the same
   connection fd exists in *both* processes until closed in both. Descriptor
   accounting doubles for in-flight connections, and close/teardown must be
   coordinated across processes to avoid leaking or closing too early.

3. **Connection ownership is smeared across processes.** Because an fd can move,
   more than one process can end up wanting to write to the same connection, and
   **outbound connection creation to the same peer can race across workers**
   (multiple workers independently opening a socket to the same destination).

4. **The write path is the most complex part of the subsystem.** Writing on a
   connection you do not own requires either passing the fd back or driving a
   fd-shuffling async write queue. This is a large, subtle body of code precisely
   because ownership is distributed.

5. **Connection state is scattered.** Read buffers, partial-message reassembly
   state, write queues, and per-connection timers live in whichever worker
   currently holds the fd. Reasoning about, monitoring, and reaping connections
   means reasoning about distributed state across N workers.

---

### What this PR introduces (mode 2)

`PROC_TCP_MAIN` runs one `io_wait` thread plus a small pool of I/O worker
threads (hardcoded to 8 at the moment). It owns all TCP fds for their entire lifetime.

- **Reads:** `PROC_TCP_MAIN` reads and reassembles complete SIP messages. Each
  assembled message is copied into a shared-memory task object and its pointer is
  written to an `AF_UNIX`/`SOCK_DGRAM` socketpair. All TCP workers `recvfrom()`
  that one socket; **the kernel load-balances** delivery across them — no explicit
  worker assignment or affinity is needed.
- **Writes:** any process that wants to send posts a *write request* to
  `PROC_TCP_MAIN` (`CONN_WRITE_REQ`) with the payload in shared memory.
  `PROC_TCP_MAIN` queues and transmits it. **No fd is passed for writes.**
- **Outbound:** a worker with no usable connection posts a *connect request*
  (`CONN_CONNECT_REQ`); `PROC_TCP_MAIN` performs the `socket()`+`connect()`,
  hashes the connection, and sends the first payload. Creation is serialized in
  one process.
- **Workers:** own no fds, run no io_wait loop, do no raw socket I/O, and (see
  below) run no OpenSSL. They are stateless SIP processors fed by the dispatch
  socket.

Inside `PROC_TCP_MAIN`, per-connection work (read/reassemble, encrypt/decrypt,
write) is handed to the thread pool under a single-owner-per-connection rule, so
the io_wait thread never blocks on a slow read, a large write, or a TLS handshake.

---

### Why: the value of owning all network I/O in one process

#### 1. No `SCM_RIGHTS` shuttling
The per-connection `sendmsg`/`recvmsg` fd handoff disappears from the hot path.
Inbound connections are never passed; writes are never passed; the async write
path no longer moves descriptors. What crosses a process boundary instead is a
single pointer (to a shm task) over a datagram socket — a fixed, tiny,
ancillary-data-free transfer that the kernel fans out for free.

#### 2. No cross-process fd duplication or split lifecycle
Each connection fd exists in exactly one process. There is no window where the
same descriptor lives in two descriptor tables, and no cross-process protocol for
"who closes it." Descriptor accounting and connection teardown become local and
unambiguous.

#### 3. Multi-writer races are eliminated by construction
Only `PROC_TCP_MAIN` ever opens, writes, or closes a connection. The
outbound-connect-to-same-peer race is gone because creation is serialized in one
process. "Two workers writing the same socket" cannot occur because workers hold
no sockets.

#### 4. The write path collapses
"Write on a connection you don't own" becomes "post a write request to the one
owner." The distributed async-write / fd-shuffle machinery is replaced by a
single queue owned by a single process. Less code, fewer states, fewer corners.

#### 5. Connection lifecycle is centralized
One hash table, one timer wheel, one reaper, in one process. Idle timeouts,
partial-read timeouts, and error teardown are local decisions on local state
rather than a cross-process dance.

#### 6. Clean separation of concerns → independent scaling
The reactor does network I/O; the workers do SIP logic. Workers become CPU-bound,
stateless message processors with no I/O responsibilities, fed by a
kernel-balanced queue. The number of I/O threads and the number of SIP processors
are now independent knobs rather than both being tied to "one fd owner per
worker."

#### 7. TLS: the single-process constraint, resolved rather than worked around
OpenSSL's per-connection `SSL` objects and the shared `SSL_CTX` carry
process-local heap pointers and assume in-process locking. They **cannot be
shared across processes** without installing custom shared-memory crypto
allocators *and* `PROCESS_SHARED` pthread-mutex hooks — a fragile arrangement.
The practical consequence under fd-passing is that a TLS
connection's cryptographic state cannot follow its fd to an arbitrary worker.

`tcp_main_threads=1` already acknowledges this: its trampoline relays each
OpenSSL operation from the worker to a dedicated thread *inside* `PROC_TCP_MAIN`
over a per-worker socketpair — keeping the socket in the worker but the crypto in
`PROC_TCP_MAIN`. It works, but it is inherently a **two-mechanism** design: the
fd lives in one process and its crypto in another, coordinated on every call, with
one relay thread and socketpair pair per worker.

Mode 2 dissolves the split. The fd **and** its `SSL` object live and are used in
the same process, so the single-process constraint is satisfied *by construction*
— no relay, no cross-process crypto, no allocator/mutex hooks. Since the crypto
had to be centralized in `PROC_TCP_MAIN` anyway, centralizing the I/O alongside it
is the natural simplification, and it removes the trampoline relay entirely. One
pool thread owns a connection (and thus its `SSL`) at a time, so OpenSSL is driven
correctly with nothing more than modern OpenSSL's own in-process thread safety.

---

### Design notes

- **Dispatch:** assembled messages are shm task objects (receive-info + message
  buffer); the pointer is a single `uintptr_t` written to the dispatch socketpair
  — well within `PIPE_BUF`, so delivery is atomic and lossless. Workers cast back
  and call `receive_msg()`, then free the task.
- **In-process pool:** a `io_wait` thread owns file descriptors/timers/hash/lifecycle
  exclusively; pool threads run read/write/crypto on a connection that has been
  *shielded* (removed from io_wait and the timer) for the duration of a job, then
  signal completion back to the io_wait thread. This keeps a strict, small
  concurrency contract: connection metadata mutation stays on one thread.
- **Cross-process wakeups** use a `PROCESS_SHARED`, robust condition variable with
  owner-died recovery.

---

### Compatibility and safety

- **Opt-in.** Behaviour is unchanged unless `tcp_main_threads=2` is set.
- **Modes 0 and 1 are unchanged** — verified: the reworked paths are gated on
  `tcp_main_threads == 2`; the legacy fd-passing and trampoline code paths are not
  modified.
- **Incremental.** The series builds the mode step by step (dispatch socket, task
  struct, read path, write path, outbound path, then the in-process thread pool,
  then TLS offload), each step preserving the mode-0 path.

---

### Testing / validation

- **No regression** on the plain-TCP path in mode 2, including the outbound
  dispatcher probe socket.
- **Inbound TLS** (TLS 1.2 and 1.3): handshake + REGISTER + in-dialog request/
  response handled entirely through the reactor and its pool.
- **Writes from a non-TCP process:** a config that relays inbound TLS to UDP and
  back exercises a UDP receiver issuing a TLS write — validating that *any* process
  can write without owning the fd.
- **Outbound TLS:** connection opened in `PROC_TCP_MAIN`, handshake driven by the
  pool, OPTIONS ping answered (dispatcher marks the target active).
- **Concurrency soak:** 256 simultaneous TLS UACs, repeated. No crash; connections
  drain back to baseline; shared memory and fragmentation flat across repeated
  runs (no leak); no TLS record corruption under contention (confirms per-thread
  crypto isolation).
- TODO: add a container to the kamailio test repo for this use case

---

### Known limitations / follow-ups (tracked)

- **WS/WSS** are not yet offloaded to the pool in mode 2 (handled inline on the
  io_wait thread). Functional, but the websocket framing layer still needs a
  thread-safety audit before offload.
- **`event_route[tls:connection-out]`** does not fire under `tcp_main_threads > 0`
  (the handshake completes where the outbound-send context is not populated). It
  is documented as unsupported in this mode pending a rework that runs the event
  on a worker. This is a pre-existing property of TLS-in-`PROC_TCP_MAIN` (modes 1
  and 2), not introduced here.
- Mode 2 relies on OpenSSL ≥ 1.1.0 (in-process thread safety); this should be made
  an explicit requirement.

---

### Risk & rollback

The feature is gated behind a single global that defaults off. Setting
`tcp_main_threads` back to `0` (or `1`) fully restores the prior behaviour with no
residual effect, because those code paths are untouched. The blast radius of a
problem is therefore bounded to deployments that explicitly opt into mode 2.
