### PR TITLE
Revert "dialog: replicate if same state"

### DIFF
--- a/src/modules/dialog/dlg_handlers.c
+++ b/src/modules/dialog/dlg_handlers.c
@@ -599,7 +599,7 @@ static void dlg_onreply(struct cell *t, int type, struct tmcb_params *param)
 
 done:
 	if(dlg_enable_dmq && (dlg->iflags & DLG_IFLAG_DMQ_SYNC)
-			&& new_state >= old_state) {
+			&& new_state > old_state) {
 		dlg_dmq_replicate_action(DLG_DMQ_STATE, dlg, 0, 0);
 	}
 
@@ -1580,7 +1580,7 @@ void dlg_onroute(struct sip_msg *req, str *route_params, void *param)
 
 done:
 	if(dlg_enable_dmq && (dlg->iflags & DLG_IFLAG_DMQ_SYNC)
-			&& new_state >= old_state) {
+			&& new_state > old_state) {
 		dlg_dmq_replicate_action(DLG_DMQ_STATE, dlg, 0, 0);
 	}
 
@@ -1700,7 +1700,7 @@ void dlg_ontimeout(struct dlg_tl *tl)
 	}
 
 	if(dlg_enable_dmq && (dlg->iflags & DLG_IFLAG_DMQ_SYNC)
-			&& new_state >= old_state) {
+			&& new_state > old_state) {
 		dlg_dmq_replicate_action(DLG_DMQ_STATE, dlg, 0, 0);
 	}
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [ ] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This reverts commit b3b35bc55aa825a5a0aab98ba705fda9afb4fb06.

I've done the initial commit (root author), thinking is a good idea to share the in-dialog leg contact among all nodes of a dmq cluster, as the client moves to different node of the cluster. Looks like this is not a good idea due to symmetric NAT (e.g. in-dialog pinging will fail and may cause unexpected dialog termination by the cluster node).

Each dmq cluster node need to have its own dialog leg contact, received as the client moves to different nodes due to re-INVITEs.