### PR TITLE
topos: add sn_refresh_topology modparam

### DIFF
--- a/src/modules/topos/doc/topos_admin.xml
+++ b/src/modules/topos/doc/topos_admin.xml
@@ -538,6 +538,41 @@ modparam("topos", "rr_update", 1)
 </programlisting>
 		</example>
 	</section>
+	<section id="topos.p.sn_refresh_topology">
+		<title><varname>sn_refresh_topology</varname> (int)</title>
+		<para>
+			When set to 1, topos module will get local IPs based on
+			<emphasis>;sn=&lt;sockname&gt;</emphasis> embedded in the already stored s_rr.
+			Will compare them with the host:port part of the as_/bs_/s_rr.
+			Will do this for ANY in-dialog method except <emphasis>OPTIONS</emphasis>.
+			Will write to storage only if client "roamed" to different topos node.
+			(e.g. when "sn=" local IPs differ from what is already stored)
+		</para>
+		<para>
+			The masked user part (<emphasis>atpsh-/btpsh-&lt;uuid&gt;</emphasis> for the
+			as_/bs_contact) and all original URI parameters (e.g.
+			<emphasis>;sn=</emphasis> or <emphasis>;transport=</emphasis>) are preserved verbatim;
+			only the host:port slice is updated.
+		</para>
+		<para>
+			Also, if FQDN is found among as_/bs_/s_rr, refresh is skipped for them and same FQDN used.
+			This is useful in deployments where listen advertised address is IP (needed for Via),
+			but as_/bs_/s_rr host part is FQDN.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0 (no refresh on in-dialog requests).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>sn_refresh_topology</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("topos", "sn_refresh_topology", 1)
+...
+</programlisting>
+		</example>
+	</section>
 	<section id="topos.p.context">
 		<title><varname>context</varname> (str)</title>
 		<para>

--- a/src/modules/topos/topos_mod.c
+++ b/src/modules/topos/topos_mod.c
@@ -88,6 +88,7 @@ int _tps_param_mask_callid = 0;
 int _tps_sanity_checks = 0;
 int _tps_rr_update = 0;
 int _tps_header_mode = 0;
+int _tps_sn_refresh_topology = 0;
 str _tps_storage = str_init("db");
 str _tps_methods_update_time_list = str_init("SUBSCRIBE");
 
@@ -189,6 +190,7 @@ static param_export_t params[] = {
 	{"xavu_field_a_contact_host", PARAM_STR, &_tps_xavu_field_acontact_host},
 	{"xavu_field_b_contact_host", PARAM_STR, &_tps_xavu_field_bcontact_host},
 	{"rr_update", PARAM_INT, &_tps_rr_update},
+	{"sn_refresh_topology", PARAM_INT, &_tps_sn_refresh_topology},
 	{"context", PARAM_STR, &_tps_context_param},
 	{"methods_nocontact", PARAM_STR, &_tps_methods_nocontact_list},
 	{"methods_noinitial", PARAM_STR, &_tps_methods_noinitial_list},

--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -21,9 +21,9 @@
 
 /*!
  * \file
- * \brief SIP-router topoh ::
- * \ingroup topoh
- * Module: \ref topoh
+ * \brief SIP-router topos ::
+ * \ingroup topos
+ * Module: \ref topos
  */
 
 #include <string.h>
@@ -43,6 +43,7 @@
 #include "../../core/parser/parse_via.h"
 #include "../../core/parser/contact/parse_contact.h"
 #include "../../core/parser/parse_refer_to.h"
+#include "tps_sn.h"
 
 
 #include "tps_msg.h"
@@ -54,6 +55,7 @@ extern str _tps_cparam_name;
 extern int _tps_rr_update;
 extern int _tps_header_mode;
 extern unsigned int _tps_methods_update_time;
+extern int _tps_sn_refresh_topology;
 
 extern str _tps_context_param;
 extern str _tps_context_value;
@@ -1032,6 +1034,8 @@ int tps_request_received(sip_msg_t *msg, int dialog)
 	int ret;
 	int use_branch = 0;
 	unsigned int metid = 0;
+	uint32_t up_mode = 0;
+	rr_t *srr = NULL;
 
 	LM_DBG("handling incoming request\n");
 
@@ -1174,6 +1178,55 @@ int tps_request_received(sip_msg_t *msg, int dialog)
 					< 0) {
 				goto error;
 			}
+		}
+
+		/* refresh topology */
+		if(_tps_sn_refresh_topology && !(metid & METHOD_OPTIONS)) {
+
+			/* reset all interesting headers needed for refresh */
+			mtsd.s_rr.s = mtsd.as_contact.s = mtsd.bs_contact.s = 0;
+			mtsd.s_rr.len = mtsd.as_contact.len = mtsd.bs_contact.len = 0;
+
+			if(stsd.s_rr.len > 0
+					&& parse_rr_body(stsd.s_rr.s, stsd.s_rr.len, &srr) < 0) {
+				LM_ERR("failed to parse stored s_rr [%.*s]\n", stsd.s_rr.len,
+						stsd.s_rr.s);
+				srr = NULL;
+			}
+
+			/* refresh mtsd's s_rr */
+			tps_refresh_srr_from_sn(&mtsd, srr);
+			if(mtsd.s_rr.len > 0) {
+				up_mode |= TPS_DBU_SRR;
+			}
+
+			/* refresh mtsd's as/bs contacts */
+			tps_refresh_scontacts_from_sn(&mtsd, &stsd, srr);
+			if(mtsd.as_contact.len > 0 || mtsd.bs_contact.len > 0) {
+				up_mode |= TPS_DBU_SCONTACT;
+			}
+
+			/* store mtsd's s_rr/as/bs contacts if refreshed */
+			if(up_mode != 0) {
+				LM_DBG("dialog refresh call_id=%.*s method=%.*s cseq=%.*s: "
+					   "do persist, mode=0x%x\n",
+						msg->callid->body.len, msg->callid->body.s,
+						get_cseq(msg)->method.len, get_cseq(msg)->method.s,
+						get_cseq(msg)->number.len, get_cseq(msg)->number.s,
+						up_mode);
+				if(tps_storage_update_dialog(msg, &mtsd, &stsd, up_mode) < 0) {
+					free_rr(&srr);
+					goto error;
+				}
+			} else {
+				LM_DBG("dialog refresh call_id=%.*s method=%.*s cseq=%.*s: "
+					   "skip persist\n",
+						msg->callid->body.len, msg->callid->body.s,
+						get_cseq(msg)->method.len, get_cseq(msg)->method.s,
+						get_cseq(msg)->number.len, get_cseq(msg)->number.s);
+			}
+
+			free_rr(&srr);
 		}
 	}
 	return 0;

--- a/src/modules/topos/tps_sn.c
+++ b/src/modules/topos/tps_sn.c
@@ -1,0 +1,450 @@
+/**
+ * Copyright (C) 2026 Stefan-Cristian Mititelu (net2phone.com)
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/*!
+ * \file
+ * \brief SIP-router topos ::
+ * \ingroup topos
+ * Module: \ref topos
+ */
+
+#include "../../core/parser/parse_uri.h"
+#include "../../core/socket_info.h"
+#include "../../core/resolve.h"
+
+#include "tps_sn.h"
+#include "tps_msg.h"
+
+/**
+ * Return 1 if host is an IPv4 or IPv6
+ * Return 0 if host is an FQDN
+ */
+static int tps_host_is_ip(str *host)
+{
+	return (str2ip(host) != NULL) || (str2ip6(host) != NULL);
+}
+
+/**
+ * Return the next-write position in td->cbuf and remaining capacity.
+ * Lazily initializes td->cp to the start of cbuf on first call.
+ * Always sets *buf and *len to valid values.
+ */
+static inline void tps_data_write_buf(tps_data_t *td, char **buf, int *len)
+{
+	if(td->cp == NULL) {
+		td->cp = td->cbuf;
+	}
+	*buf = td->cp;
+	*len = TPS_DATA_SIZE - (int)(td->cp - td->cbuf);
+}
+
+/**
+ * Byte-equal two str values (including empty).
+ */
+static inline int tps_str_eq(const str *a, const str *b)
+{
+	return a->len == b->len && (a->len == 0 || memcmp(a->s, b->s, a->len) == 0);
+}
+
+/**
+ * Write `src` into `dst` with the host:port swapped for new_host:new_port.
+ * Returns total bytes written after swap
+ * Returns -1 on if no space to write those total bytes
+ */
+static int tps_swap_uri_hostport(const char *src, int src_len,
+		const struct sip_uri *puri, const str *new_host, const str *new_port,
+		char *dst, int dst_len)
+{
+	int host_off = (int)(puri->host.s - src);
+	int after_port = (puri->port.len > 0)
+							 ? (int)(puri->port.s + puri->port.len - src)
+							 : (int)(puri->host.s + puri->host.len - src);
+	int suffix_len = src_len - after_port;
+	int total = host_off + new_host->len + 1 + new_port->len + suffix_len;
+	char *p = dst;
+
+	if(total > dst_len) {
+		return -1;
+	}
+	memcpy(p, src, host_off);
+	p += host_off;
+	memcpy(p, new_host->s, new_host->len);
+	p += new_host->len;
+	*p++ = ':';
+	memcpy(p, new_port->s, new_port->len);
+	p += new_port->len;
+	if(suffix_len > 0) {
+		memcpy(p, src + after_port, suffix_len);
+	}
+	return total;
+}
+
+/**
+ * Extract the ;sn= value into out_sn, from a single, parsed, RR entry.
+ * Returns 1 if the RR entry has no parseable URI or no ;sn= param.
+ * Returns 0 if socket name extracted successfully
+ */
+static int tps_rr_entry_sn(rr_t *entry, str *out_sn)
+{
+	struct sip_uri puri;
+	str sn_name = str_init("sn");
+
+	out_sn->s = NULL;
+	out_sn->len = 0;
+	if(entry == NULL
+			|| parse_uri(entry->nameaddr.uri.s, entry->nameaddr.uri.len, &puri)
+					   < 0) {
+		return 1;
+	}
+	if(tps_get_param_value(&puri.params, &sn_name, out_sn) != 0
+			|| out_sn->len <= 0) {
+		return 1;
+	}
+	return 0;
+}
+
+/**
+ * Detect whether an RR entry would be rebuilt by tps_rebuild_srr_from_sn.
+ *
+ * Returns 1 if the entry has a ;sn= that resolves to a local socket
+ * whose host:port differs from the entry's stored host:port.
+ *
+ * Returns 0 for any reason that would route the entry through the verbatim-copy
+ * path (no ;sn=, unresolvable sockname, host:port already match).
+ */
+static int tps_rr_entry_needs_rebuild(rr_t *entry)
+{
+	struct sip_uri puri;
+	str sn_name = str_init("sn");
+	str sn;
+	socket_info_t *si;
+	str *host;
+	str *port;
+
+	if(entry == NULL
+			|| parse_uri(entry->nameaddr.uri.s, entry->nameaddr.uri.len, &puri)
+					   < 0) {
+		return 0;
+	}
+	/* FQDN host keep it as is */
+	if(!tps_host_is_ip(&puri.host)) {
+		return 0;
+	}
+	if(tps_get_param_value(&puri.params, &sn_name, &sn) != 0 || sn.len <= 0) {
+		return 0;
+	}
+	si = ksr_get_socket_by_name(&sn);
+	if(si == NULL) {
+		return 0;
+	}
+	if(si_get_signaling_data(si, &host, &port) < 0 || host == NULL
+			|| port == NULL || host->len <= 0 || port->len <= 0) {
+		return 0;
+	}
+	if(tps_str_eq(&puri.host, host) && tps_str_eq(&puri.port, port)) {
+		return 0;
+	}
+	return 1;
+}
+
+/**
+ * Build a refreshed topos self-contact value (with surrounding <>) into
+ * `buf`. Swaps the host:port slice of the stored URI for the local
+ * socket's host:port, preserving everything else.
+ *
+ * A stored host that is a FQDN is left untouched
+ *
+ * Returns 0 for rebuilt value != stored_scontact.
+ * Returns 1 for rebuilt value == stored_scontact (or kept as-is).
+ * Returns -1 on error.
+ */
+static int tps_rebuild_scontact_from_sn(
+		str *sn, str *stored_scontact, char *buf, int buf_len, str *out)
+{
+	socket_info_t *si;
+	str *host;
+	str *port;
+	struct sip_uri puri;
+	const char *src;
+	int src_len;
+	const char *inner;
+	int inner_len;
+	int n;
+
+	if(sn == NULL || sn->len <= 0 || stored_scontact == NULL
+			|| stored_scontact->len <= 0 || buf == NULL || out == NULL) {
+		return -1;
+	}
+
+	si = ksr_get_socket_by_name(sn);
+	if(si == NULL) {
+		LM_DBG("no local socket named [%.*s]\n", sn->len, sn->s);
+		return -1;
+	}
+
+	/* get host/port part corresponding to that socket name */
+	if(si_get_signaling_data(si, &host, &port) < 0 || host == NULL
+			|| port == NULL || host->len <= 0 || port->len <= 0) {
+		return -1;
+	}
+
+	/* Stored value is "<sip:[ab]tpsh-UUID@host:port[;params]>".
+	 * Strip the wrapping <...> so parse_uri sees only the URI. */
+	src = stored_scontact->s;
+	src_len = stored_scontact->len;
+	inner = src;
+	inner_len = src_len;
+	if(inner_len >= 2 && inner[0] == '<' && inner[inner_len - 1] == '>') {
+		inner++;
+		inner_len -= 2;
+	}
+	if(inner_len <= 0 || parse_uri((char *)inner, inner_len, &puri) < 0) {
+		LM_ERR("stored scontact failed to parse [%.*s]\n", src_len, src);
+		return -1;
+	}
+	if(puri.host.len <= 0) {
+		LM_ERR("stored scontact has no host [%.*s]\n", src_len, src);
+		return -1;
+	}
+
+	/* FQDN host keep it as is */
+	if(!tps_host_is_ip(&puri.host)) {
+		LM_DBG("stored scontact host [%.*s] is a name, not refreshing\n",
+				puri.host.len, puri.host.s);
+		return 1;
+	}
+
+	/* host:port already match; node did not roam */
+	if(tps_str_eq(&puri.host, host) && tps_str_eq(&puri.port, port)) {
+		return 1;
+	}
+
+	if(buf_len < 2) {
+		LM_ERR("buffer too small for <> framing\n");
+		return -1;
+	}
+	buf[0] = '<';
+	n = tps_swap_uri_hostport(
+			inner, inner_len, &puri, host, port, buf + 1, buf_len - 2);
+	if(n < 0) {
+		LM_ERR("buffer too small rebuilding scontact\n");
+		return -1;
+	}
+	buf[1 + n] = '>';
+	out->s = buf;
+	out->len = 1 + n + 1;
+	return 0;
+}
+
+/**
+ * Rebuild a stored RR-value by swapping the host:port of each entry that
+ * carries ;sn=<sockname> for the host:port of the local socket resolved
+ * from that sockname.
+ *
+ * A stored host that is a FQDN is skipped or just copied as is
+ *
+ * Returns 0 when the rebuilt value differs from the source.
+ * Returns 1 when no entry needed rebuilding (rebuilt == source).
+ * Returns -1 on buffer overflow / unrecoverable parse error.
+ */
+static int tps_rebuild_srr_from_sn(rr_t *head, char *buf, int buf_len, str *out)
+{
+	rr_t *cur;
+	struct sip_uri puri;
+	str sn_name = str_init("sn");
+	str sn;
+	socket_info_t *si;
+	str *host;
+	str *port;
+	const char *entry_s;
+	int entry_len;
+	int n;
+	int sep;
+	int wrote = 0;
+	int changed = 0;
+	int entry_idx = 0;
+
+	if(head == NULL || buf == NULL || out == NULL || buf_len <= 0) {
+		return -1;
+	}
+
+	/* here check if rebuilt s_rr would equal stored one, byte-for-byte */
+	for(cur = head; cur != NULL; cur = cur->next) {
+		if(tps_rr_entry_needs_rebuild(cur)) {
+			break;
+		}
+	}
+	if(cur == NULL) {
+		LM_DBG("s_rr refresh: no entry needs rebuild - skip\n");
+		return 1;
+	}
+
+	/* here at least one entry will be rebuilt - assemble full output. */
+	for(cur = head; cur != NULL; cur = cur->next) {
+		sn.s = NULL;
+		sn.len = 0;
+		si = NULL;
+		host = NULL;
+		port = NULL;
+		entry_s = cur->nameaddr.name.s;
+		entry_len = cur->nameaddr.len;
+		sep = (wrote > 0) ? 1 : 0;
+
+		entry_idx++;
+
+		/* Resolve ;sn= to a local socket. On any failure, fall through
+		 * to the verbatim-copy path below. */
+		if(parse_uri(cur->nameaddr.uri.s, cur->nameaddr.uri.len, &puri) == 0
+				&& tps_host_is_ip(&puri.host)
+				&& tps_get_param_value(&puri.params, &sn_name, &sn) == 0
+				&& sn.len > 0 && (si = ksr_get_socket_by_name(&sn)) != NULL
+				&& si_get_signaling_data(si, &host, &port) == 0 && host != NULL
+				&& port != NULL && host->len > 0 && port->len > 0
+				&& !(tps_str_eq(&puri.host, host)
+						&& tps_str_eq(&puri.port, port))) {
+			LM_DBG("rr entry #%d: sn=[%.*s] swap %.*s:%.*s -> %.*s:%.*s\n",
+					entry_idx, sn.len, sn.s, puri.host.len, ZSW(puri.host.s),
+					puri.port.len, ZSW(puri.port.s), host->len, host->s,
+					port->len, port->s);
+			if(sep) {
+				if(wrote + 1 > buf_len)
+					goto overflow;
+				buf[wrote++] = ',';
+			}
+			n = tps_swap_uri_hostport(entry_s, entry_len, &puri, host, port,
+					buf + wrote, buf_len - wrote);
+			if(n < 0)
+				goto overflow;
+			wrote += n;
+			changed = 1;
+			continue;
+		}
+
+		/* Verbatim copy: no ;sn=, sockname unresolvable, or host:port
+		 * already match the stored value. */
+		LM_DBG("rr entry #%d: copy verbatim [%.*s]\n", entry_idx, entry_len,
+				entry_s);
+		if(wrote + sep + entry_len > buf_len)
+			goto overflow;
+		if(sep)
+			buf[wrote++] = ',';
+		memcpy(buf + wrote, entry_s, entry_len);
+		wrote += entry_len;
+	}
+
+	if(!changed || wrote <= 0) {
+		return 1;
+	}
+
+	/* `changed` is set only when at least one entry was rebuilt with a
+	 * host:port that differs from the stored value. */
+	out->s = buf;
+	out->len = wrote;
+	return 0;
+
+overflow:
+	LM_ERR("buffer too small rebuilding rr (buf_len=%d)\n", buf_len);
+	return -1;
+}
+
+/**
+ * Refresh stored {a,b}s_contact IP/port based on the stored ;sn= param
+ */
+void tps_refresh_scontacts_from_sn(
+		tps_data_t *mtsd, tps_data_t *stsd, rr_t *srr)
+{
+	str sn1 = STR_NULL;
+	str sn2 = STR_NULL;
+	str *sn_for_a;
+	int has2 = 0;
+	str out;
+	char *wbuf;
+	int wlen;
+	int rc;
+	int has_bs;
+	int has_as;
+
+	if(mtsd == NULL || stsd == NULL) {
+		return;
+	}
+	has_bs = (stsd->bs_contact.len > 0);
+	has_as = (stsd->as_contact.len > 0);
+
+	if(srr == NULL) {
+		LM_DBG("no stored s_rr - skip scontact refresh\n");
+		return;
+	}
+	if(!has_bs && !has_as) {
+		LM_DBG("no stored scontacts - skip refresh\n");
+		return;
+	}
+
+	/* First entry covers bs_contact; second (if any) covers as_contact.
+	 * For single-RR we reuse sn1 for as_contact as well. */
+	if(tps_rr_entry_sn(srr, &sn1) != 0) {
+		LM_DBG("no ;sn= on first stored s_rr entry - skip refresh\n");
+		return;
+	}
+	has2 = (tps_rr_entry_sn(srr->next, &sn2) == 0);
+
+	if(has_bs) {
+		tps_data_write_buf(mtsd, &wbuf, &wlen);
+		rc = tps_rebuild_scontact_from_sn(
+				&sn1, &stsd->bs_contact, wbuf, wlen, &out);
+		if(rc == 0) {
+			mtsd->bs_contact = out;
+			mtsd->cp += out.len;
+		}
+	}
+	if(has_as) {
+		sn_for_a = has2 ? &sn2 : &sn1;
+		tps_data_write_buf(mtsd, &wbuf, &wlen);
+		rc = tps_rebuild_scontact_from_sn(
+				sn_for_a, &stsd->as_contact, wbuf, wlen, &out);
+		if(rc == 0) {
+			mtsd->as_contact = out;
+			mtsd->cp += out.len;
+		}
+	}
+}
+
+/**
+ * Refresh the stored self-RR (s_rr) IP/port based on stored ;sn= param
+ */
+void tps_refresh_srr_from_sn(tps_data_t *mtsd, rr_t *srr)
+{
+	str out;
+	char *wbuf;
+	int wlen;
+	int rc;
+
+	if(srr == NULL) {
+		LM_DBG("no stored s_rr - skip srr refresh\n");
+		return;
+	}
+
+	tps_data_write_buf(mtsd, &wbuf, &wlen);
+	rc = tps_rebuild_srr_from_sn(srr, wbuf, wlen, &out);
+	if(rc == 0) {
+		mtsd->s_rr = out;
+		mtsd->cp += out.len;
+	}
+}

--- a/src/modules/topos/tps_sn.h
+++ b/src/modules/topos/tps_sn.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Daniel-Constantin Mierla (asipto.com)
+ * Copyright (C) 2026 Stefan-Cristian Mititelu (net2phone.com)
  *
  * This file is part of Kamailio, a free SIP server.
  *
@@ -26,24 +26,14 @@
  * Module: \ref topos
  */
 
-#ifndef _TOPOS_MSG_H_
-#define _TOPOS_MSG_H_
+#ifndef _TOPOS_SN_H_
+#define _TOPOS_SN_H_
 
-#include "../../core/parser/msg_parser.h"
+#include "tps_storage.h"
+#include "../../core/parser/parse_rr.h"
 
-#define TPS_SPLIT_VIA (1 << 0)
-#define TPS_SPLIT_RECORD_ROUTE (1 << 1)
-#define TPS_SPLIT_ROUTE (1 << 2)
+void tps_refresh_scontacts_from_sn(
+		tps_data_t *mtsd, tps_data_t *stsd, rr_t *srr);
+void tps_refresh_srr_from_sn(tps_data_t *mtsd, rr_t *srr);
 
-int tps_update_hdr_replaces(sip_msg_t *msg);
-char *tps_msg_update(sip_msg_t *msg, unsigned int *olen);
-int tps_skip_msg(sip_msg_t *msg);
-
-int tps_request_received(sip_msg_t *msg, int dialog);
-int tps_response_received(sip_msg_t *msg);
-int tps_request_sent(sip_msg_t *msg, int dialog, int local);
-int tps_response_sent(sip_msg_t *msg);
-int tps_mask_callid(sip_msg_t *msg);
-int tps_unmask_callid(sip_msg_t *msg);
-int tps_get_param_value(str *in, str *name, str *value);
 #endif

--- a/src/modules/topos/tps_storage.c
+++ b/src/modules/topos/tps_storage.c
@@ -69,6 +69,8 @@ extern int _tps_methods_update_time;
 extern str _tps_context_param;
 extern str _tps_context_value;
 
+extern int _tps_sn_refresh_topology;
+
 #define TPS_STORAGE_LOCK_SIZE 1 << 9
 static gen_lock_set_t *_tps_storage_lock_set = NULL;
 
@@ -1843,6 +1845,14 @@ int tps_db_update_dialog(
 				db_ucols, db_uvals, nr_ucols, td_col_b_contact, md->b_contact);
 	}
 
+	/* persist {a,b}s_contact */
+	if(mode & TPS_DBU_SCONTACT) {
+		TPS_DB_ADD_STRV(db_ucols, db_uvals, nr_ucols, td_col_as_contact,
+				md->as_contact);
+		TPS_DB_ADD_STRV(db_ucols, db_uvals, nr_ucols, td_col_bs_contact,
+				md->bs_contact);
+	}
+
 	if((mode & TPS_DBU_RPLATTRS) && msg->first_line.type == SIP_REPLY) {
 		if(sd->b_tag.len <= 0 && msg->first_line.u.reply.statuscode >= 200
 				&& msg->first_line.u.reply.statuscode < 300) {
@@ -1897,6 +1907,11 @@ int tps_db_update_dialog(
 		nr_ucols++;
 	}
 
+	/* persist s_rr */
+	if(mode & TPS_DBU_SRR) {
+		TPS_DB_ADD_STRV(db_ucols, db_uvals, nr_ucols, td_col_s_rr, md->s_rr);
+	}
+
 	if(nr_ucols == 0) {
 		return 0;
 	}
@@ -1926,10 +1941,17 @@ int tps_storage_update_dialog(
 	if(msg == NULL || md == NULL || sd == NULL)
 		return -1;
 
-	if((md->s_method_id != METHOD_INVITE)
+	/* The sn_refresh_topology feature needs writes for any
+	 * in-dialog method (except OPTIONS) */
+	if((!_tps_sn_refresh_topology) && (md->s_method_id != METHOD_INVITE)
 			&& (md->s_method_id != METHOD_SUBSCRIBE)) {
 		return 0;
 	}
+
+	if(_tps_sn_refresh_topology && (md->s_method_id == METHOD_OPTIONS)) {
+		return 0;
+	}
+
 	if(msg->first_line.type == SIP_REPLY) {
 		if(msg->first_line.u.reply.statuscode < 200
 				|| msg->first_line.u.reply.statuscode >= 300) {

--- a/src/modules/topos/tps_storage.h
+++ b/src/modules/topos/tps_storage.h
@@ -48,6 +48,8 @@
 #define TPS_DBU_ARR (1 << 2)
 #define TPS_DBU_BRR (1 << 3)
 #define TPS_DBU_TIME (1 << 4)
+#define TPS_DBU_SRR (1 << 5)
+#define TPS_DBU_SCONTACT (1 << 6)
 #define TPS_DBU_ALL (0xffffffff)
 
 #define TPS_DATA_SIZE 16384

--- a/src/modules/topos_htable/topos_htable_storage.c
+++ b/src/modules/topos_htable/topos_htable_storage.c
@@ -1035,7 +1035,8 @@ int tps_htable_update_dialog(
 	memset(&hval, 0, sizeof(tps_data_t));
 	hval.cp = hval.cbuf;
 
-	if(mode & TPS_DBU_CONTACT) {
+	if((mode & TPS_DBU_CONTACT)
+			&& (md->a_contact.len > 0 || md->b_contact.len > 0)) {
 		if(!do_update) {
 			ret = tps_htable_load_dialog(msg, sd, &hval);
 			if(ret != 0) {
@@ -1050,6 +1051,26 @@ int tps_htable_update_dialog(
 		}
 		if(md->b_contact.len > 0) {
 			hval.b_contact = md->b_contact;
+		}
+	}
+
+	/* persist {a,b}s_contact */
+	if((mode & TPS_DBU_SCONTACT)
+			&& (md->as_contact.len > 0 || md->bs_contact.len > 0)) {
+		if(!do_update) {
+			ret = tps_htable_load_dialog(msg, sd, &hval);
+			if(ret != 0) {
+				LM_ERR("dialog not loaded\n");
+				return -1;
+			}
+		}
+		do_update = 1;
+
+		if(md->as_contact.len > 0) {
+			hval.as_contact = md->as_contact;
+		}
+		if(md->bs_contact.len > 0) {
+			hval.bs_contact = md->bs_contact;
 		}
 	}
 
@@ -1131,6 +1152,19 @@ int tps_htable_update_dialog(
 		if(md->expires > 0) {
 			hval.expires = md->expires;
 		}
+	}
+
+	/* persist s_rr */
+	if((mode & TPS_DBU_SRR) && md->s_rr.len > 0) {
+		if(!do_update) {
+			ret = tps_htable_load_dialog(msg, sd, &hval);
+			if(ret != 0) {
+				LM_ERR("dialog not loaded\n");
+				return -1;
+			}
+		}
+		do_update = 1;
+		hval.s_rr = md->s_rr;
 	}
 
 	if(!do_update) {

--- a/src/modules/topos_redis/topos_redis_storage.c
+++ b/src/modules/topos_redis/topos_redis_storage.c
@@ -1339,6 +1339,14 @@ int tps_redis_update_dialog(
 				&md->b_contact, argc, &td_key_b_contact, argv, argvlen);
 	}
 
+	/* persist {a,b}s_contact */
+	if(mode & TPS_DBU_SCONTACT) {
+		TPS_REDIS_SET_ARGS(
+				&md->as_contact, argc, &td_key_as_contact, argv, argvlen);
+		TPS_REDIS_SET_ARGS(
+				&md->bs_contact, argc, &td_key_bs_contact, argv, argvlen);
+	}
+
 	if((mode & TPS_DBU_RPLATTRS) && msg->first_line.type == SIP_REPLY) {
 		if(sd->b_tag.len <= 0 && msg->first_line.u.reply.statuscode >= 200
 				&& msg->first_line.u.reply.statuscode < 300) {
@@ -1379,6 +1387,11 @@ int tps_redis_update_dialog(
 		lval = (unsigned long)time(NULL);
 		TPS_REDIS_SET_ARGN(
 				lval, rp, &rval, argc, &td_key_rectime, argv, argvlen);
+	}
+
+	/* persist s_rr */
+	if(mode & TPS_DBU_SRR) {
+		TPS_REDIS_SET_ARGS(&md->s_rr, argc, &td_key_s_rr, argv, argvlen);
 	}
 
 	if(argc <= 2) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Adds the ability to refresh topology stored data, as the client moves in-dialog to different nodes of a DMQ cluster, that also uses topos module.