### PR TITLE
topos: add handle_unmask_miss modparam

### DIFF
--- a/src/modules/topos/doc/topos_admin.xml
+++ b/src/modules/topos/doc/topos_admin.xml
@@ -538,6 +538,58 @@ modparam("topos", "rr_update", 1)
 </programlisting>
 		</example>
 	</section>
+	<section id="topos.p.handle_unmask_miss">
+		<title><varname>handle_unmask_miss</varname> (int)</title>
+		<para>
+			Handles the "unmask-miss" race that can happen in an active-active
+			cluster with topos_htable storage: roamed in-dialog request
+			(e.g. ACK after initial INVITE)	before KDMQ synced for topos_dialog.
+		</para>
+		<para>
+			When enabled, and "unmask-miss" happens, leaves ruri masked and adds
+			<emphasis>P-TPS-Owner</emphasis> header with hint for original owner.
+			The configuration must, in the within-dialog route and
+			<emphasis>before</emphasis> <function>loose_route()</function>,
+			use that hint as <emphasis>$du</emphasis>, and relay
+			the still-masked request to the owner, for example:
+		</para>
+		<programlisting format="linespecific">
+...
+if ($rU =~ "^[ab]tpsh-") {              # topos left it masked => unmask-miss
+    if (is_present_hf("P-TPS-Owner")) {
+        $du = $hdr(P-TPS-Owner);       # forced dst, masked ruri preserved
+        remove_hf("P-TPS-Owner");
+        t_relay();
+    }
+    exit;
+}
+loose_route();
+...
+</programlisting>
+		<para>
+			<emphasis>P-TPS-Owner</emphasis> is a topos-internal header; when this
+			parameter is enabled, any copy arriving from the wire is stripped on
+			the receiving path, so the value read by the configuration is always
+			the one topos generated locally. This prevents a spoofed
+			<emphasis>P-TPS-Owner</emphasis> from being used as a forced
+			destination. The ingress strip and the configuration snippet above
+			are one coupled feature: only deploy that snippet when
+			<varname>handle_unmask_miss</varname> is set to 1.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 0 (disabled).
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>handle_unmask_miss</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("topos", "handle_unmask_miss", 1)
+...
+</programlisting>
+		</example>
+	</section>
 	<section id="topos.p.context">
 		<title><varname>context</varname> (str)</title>
 		<para>

--- a/src/modules/topos/topos_mod.c
+++ b/src/modules/topos/topos_mod.c
@@ -88,6 +88,7 @@ int _tps_param_mask_callid = 0;
 int _tps_sanity_checks = 0;
 int _tps_rr_update = 0;
 int _tps_header_mode = 0;
+int _tps_handle_unmask_miss = 0;
 str _tps_storage = str_init("db");
 str _tps_methods_update_time_list = str_init("SUBSCRIBE");
 
@@ -189,6 +190,7 @@ static param_export_t params[] = {
 	{"xavu_field_a_contact_host", PARAM_STR, &_tps_xavu_field_acontact_host},
 	{"xavu_field_b_contact_host", PARAM_STR, &_tps_xavu_field_bcontact_host},
 	{"rr_update", PARAM_INT, &_tps_rr_update},
+	{"handle_unmask_miss", PARAM_INT, &_tps_handle_unmask_miss},
 	{"context", PARAM_STR, &_tps_context_param},
 	{"methods_nocontact", PARAM_STR, &_tps_methods_nocontact_list},
 	{"methods_noinitial", PARAM_STR, &_tps_methods_noinitial_list},

--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -32,6 +32,7 @@
 #include "../../core/mem/mem.h"
 #include "../../core/data_lump.h"
 #include "../../core/forward.h"
+#include "../../core/resolve.h"
 #include "../../core/trim.h"
 #include "../../core/dset.h"
 #include "../../core/msg_translator.h"
@@ -54,6 +55,7 @@ extern str _tps_cparam_name;
 extern int _tps_rr_update;
 extern int _tps_header_mode;
 extern unsigned int _tps_methods_update_time;
+extern int _tps_handle_unmask_miss;
 
 extern str _tps_context_param;
 extern str _tps_context_value;
@@ -772,6 +774,7 @@ int tps_remove_name_headers(sip_msg_t *msg, str *hname)
 {
 	hdr_field_t *hf;
 	struct lump *l;
+	/* remove every occurrence, not just the first one */
 	for(hf = msg->headers; hf; hf = hf->next) {
 		if(hf->name.len == hname->len
 				&& strncasecmp(hf->name.s, hname->s, hname->len) == 0) {
@@ -781,7 +784,6 @@ int tps_remove_name_headers(sip_msg_t *msg, str *hname)
 						hname->s);
 				return -1;
 			}
-			return 0;
 		}
 	}
 	return 0;
@@ -1020,6 +1022,37 @@ int tps_reappend_route(sip_msg_t *msg, tps_data_t *ptsd, str *hbody, int rev)
 }
 
 /**
+ * Find the owner node address from the stored s_rr.
+ * returns 0 on success and fills *out_puri
+ * returns -1 when there is no usable bare-IP s_rr
+ */
+static int tps_owner_uri_from_srr(tps_data_t *stsd, sip_uri_t *out_puri)
+{
+	rr_t *srr = NULL;
+	rr_t *entry = NULL;
+	int ret = -1;
+
+	if(stsd == NULL || out_puri == NULL || stsd->s_rr.len <= 0) {
+		return -1;
+	}
+	if(parse_rr_body(stsd->s_rr.s, stsd->s_rr.len, &srr) < 0 || srr == NULL) {
+		return -1;
+	}
+	for(entry = srr; entry != NULL; entry = entry->next) {
+		if(parse_uri(entry->nameaddr.uri.s, entry->nameaddr.uri.len, out_puri)
+						== 0
+				&& (str2ip(&out_puri->host) != NULL
+						|| str2ip6(&out_puri->host) != NULL)) {
+			/* bare IP host only; an FQDN names no specific owner */
+			ret = 0;
+			break;
+		}
+	}
+	free_rr(&srr);
+	return ret;
+}
+
+/**
  *
  */
 int tps_request_received(sip_msg_t *msg, int dialog)
@@ -1032,12 +1065,22 @@ int tps_request_received(sip_msg_t *msg, int dialog)
 	int ret;
 	int use_branch = 0;
 	unsigned int metid = 0;
+	sip_uri_t opuri;
+	str oduri;
+	char odbuf[256];
+	str um_owner_hname = str_init("P-TPS-Owner");
+	int um_owner = 0;
 
 	LM_DBG("handling incoming request\n");
 
 	if(dialog == 0) {
 		/* nothing to do for initial request */
 		return 0;
+	}
+
+	/* P-TPS-Owner is a topos-internal hint; remove it from the received SIP */
+	if(_tps_handle_unmask_miss) {
+		tps_remove_name_headers(msg, &um_owner_hname);
 	}
 
 	memset(&mtsd, 0, sizeof(tps_data_t));
@@ -1066,6 +1109,20 @@ int tps_request_received(sip_msg_t *msg, int dialog)
 	if(tps_storage_load_dialog(msg, &mtsd, &stsd) < 0) {
 		goto error;
 	}
+
+	/* unmask-miss: capture the owner node from the dialog s_rr now */
+	if(_tps_handle_unmask_miss
+			&& (stsd.a_contact.len <= 0 || stsd.b_contact.len <= 0)
+			&& tps_owner_uri_from_srr(&stsd, &opuri) == 0) {
+		oduri.s = odbuf;
+		oduri.len =
+				snprintf(odbuf, sizeof(odbuf), "sip:%.*s:%u", opuri.host.len,
+						opuri.host.s, opuri.port_no ? opuri.port_no : SIP_PORT);
+		if(oduri.len > 0 && oduri.len < (int)sizeof(odbuf)) {
+			um_owner = 1;
+		}
+	}
+
 	metid = get_cseq(msg)->method_id;
 	if((metid
 			   & (METHOD_BYE | METHOD_INFO | METHOD_PRACK | METHOD_UPDATE
@@ -1113,6 +1170,27 @@ int tps_request_received(sip_msg_t *msg, int dialog)
 		} else {
 			LM_DBG("r-uri updated to: [%.*s]\n", nuri.len, nuri.s);
 		}
+	} else if(_tps_handle_unmask_miss
+			  && (mtsd.a_uuid.len > 0 || mtsd.b_uuid.len > 0)) {
+		/* unmask-miss: dialog loaded but the near contact is empty */
+		LM_WARN("[TOPOS-UNMASK-MISS] call_id=%.*s method=%.*s cseq=%.*s "
+				"dir=%s use_branch=%d um_owner=%d: near contact EMPTY "
+				"(a_contact_len=%d b_contact_len=%d) - r-uri [%.*s] left "
+				"masked\n",
+				msg->callid->body.len, msg->callid->body.s,
+				get_cseq(msg)->method.len, get_cseq(msg)->method.s,
+				get_cseq(msg)->number.len, get_cseq(msg)->number.s,
+				(direction == TPS_DIR_UPSTREAM) ? "UPSTREAM" : "DOWNSTREAM",
+				use_branch, um_owner, stsd.a_contact.len, stsd.b_contact.len,
+				msg->first_line.u.request.uri.len,
+				msg->first_line.u.request.uri.s);
+
+		if(um_owner) {
+			tps_add_headers(msg, &um_owner_hname, &oduri, 0);
+		}
+
+		/* return here on purpose; keep the request masked and skip topos */
+		return 0;
 	}
 	if(tps_unmask_refer_to(msg, &stsd, direction) < 0) {
 		LM_ERR("failed to update Refer-To header\n");


### PR DESCRIPTION
Use P-TPS-Owner header hing, when unmaks miss happens. Always remove all P-TPS-Owner headers upon topos receiving a message, to avoid spoofing.

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
When topos used with topos_htable storage, races can happen between:
SIP ACK of initial INVITE, roamed to different DMQ cluster node vs KDMQ sync of topos_dialog => sometimes SIP ACK can be faster and topos on the roamed node has no idea where to forward to.

Fix this problem by always forwarding to the "owner", that already has the routing info (the one that sent the KDMQ sync for topos_dialog)