### PR TITLE
htable: Last-Write-Win for SET_CELL only

### DIFF
--- a/src/modules/htable/api.c
+++ b/src/modules/htable/api.c
@@ -40,14 +40,7 @@ int ht_api_set_cell(str *hname, str *name, int type, int_str *val, int mode)
 	if(ht == NULL)
 		return -1;
 
-	if(ht->dmqreplicate > 0
-			&& ht_dmq_replicate_action(
-					   HT_DMQ_SET_CELL, hname, name, type, val, mode)
-					   != 0) {
-		LM_ERR("dmq replication failed\n");
-	}
-
-	return ht_set_cell(ht, name, type, val, mode);
+	return ht_set_cell_and_replicate(ht, hname, name, type, val, mode, 0);
 }
 
 /**
@@ -60,7 +53,8 @@ int ht_api_del_cell(str *hname, str *name)
 	if(ht == NULL)
 		return -1;
 	if(ht->dmqreplicate > 0
-			&& ht_dmq_replicate_action(HT_DMQ_DEL_CELL, hname, name, 0, NULL, 0)
+			&& ht_dmq_replicate_action(
+					   HT_DMQ_DEL_CELL, hname, name, 0, NULL, 0, 0)
 					   != 0) {
 		LM_ERR("dmq replication failed\n");
 	}
@@ -78,7 +72,7 @@ int ht_api_set_cell_expire(str *hname, str *name, int type, int_str *val)
 		return -1;
 	if(ht->dmqreplicate > 0
 			&& ht_dmq_replicate_action(
-					   HT_DMQ_SET_CELL_EXPIRE, hname, name, type, val, 0)
+					   HT_DMQ_SET_CELL_EXPIRE, hname, name, type, val, 0, 0)
 					   != 0) {
 		LM_ERR("dmq replication failed\n");
 	}
@@ -124,7 +118,7 @@ int ht_api_rm_cell_re(str *hname, str *sre, int mode)
 		isval.s.s = sre->s;
 		isval.s.len = sre->len;
 		if(ht_dmq_replicate_action(
-				   HT_DMQ_RM_CELL_RE, hname, NULL, AVP_VAL_STR, &isval, mode)
+				   HT_DMQ_RM_CELL_RE, hname, NULL, AVP_VAL_STR, &isval, mode, 0)
 				!= 0) {
 			LM_ERR("dmq replication failed\n");
 		}

--- a/src/modules/htable/doc/htable_admin.xml
+++ b/src/modules/htable/doc/htable_admin.xml
@@ -419,6 +419,14 @@ $ kamctl rpc htable.dump htable
 			peers). Please note, module parameter <quote>enable_dmq</quote> must also be set in
 			order for this to apply (see below). Default is 0 (no replication).
 		</para>
+		<para>
+			When replication is enabled for a htable, each cell carries a 'last_modified'
+			timestamp with millisecond precision, updated on every value change. This
+			is included in <emphasis>SET_CELL</emphasis> and <emphasis>SYNC</emphasis>
+			DMQ payloads. A receiving peer applies an incoming value only if its 'last_modified'
+			timestamp is newer than the local cell's one (Last-Write-Wins); otherwise it keeps the local value.
+			All other DMQ actions carry no 'last_modified' timestamp and remain last-arrived-wins.
+		</para>
 		</listitem>
 		<listitem>
 			<para>

--- a/src/modules/htable/ht_api.c
+++ b/src/modules/htable/ht_api.c
@@ -37,6 +37,7 @@
 
 #include "ht_api.h"
 #include "ht_db.h"
+#include "ht_dmq.h"
 
 
 extern str ht_event_callback;
@@ -174,6 +175,16 @@ void ht_slot_unlock(ht_t *ht, int idx)
 		/* recursive locked => decrease lock count */
 		ht->entries[idx].rec_lock_level--;
 	}
+}
+
+/* returns current wall-clock time in milliseconds */
+static uint64_t ht_now_ms(void)
+{
+	struct timespec ts;
+	if(ksr_clock_gettime(&ts) != 0) {
+		return (uint64_t)time(NULL) * 1000;
+	}
+	return (uint64_t)ts.tv_sec * 1000 + (uint64_t)(ts.tv_nsec / 1000000);
 }
 
 ht_cell_t *ht_cell_new(str *name, int type, int_str *val, unsigned int cellid)
@@ -484,11 +495,15 @@ int ht_destroy(void)
 }
 
 
-int ht_set_cell_ex(
-		ht_t *ht, str *name, int type, int_str *val, int mode, int exv)
+/* core set_cell: setlm>0 = remote gated set; outlm!=NULL = local set returning new ts */
+static int ht_set_cell_core(ht_t *ht, str *name, int type, int_str *val,
+		int mode, int exv, uint64_t setlm, uint64_t *outlm)
 {
 	unsigned int idx;
 	unsigned int hid;
+	uint64_t newlm = 0;
+	int dolm = (ht != NULL && ht->dmqreplicate > 0
+				&& (setlm > 0 || outlm != NULL));
 	ht_cell_t *it, *prev, *cell;
 	time_t now;
 
@@ -519,6 +534,30 @@ int ht_set_cell_ex(
 	while(it != NULL && it->cellid == hid) {
 		if(name->len == it->name.len
 				&& strncmp(name->s, it->name.s, name->len) == 0) {
+			/* decide the timestamp (or reject a stale remote) */
+			if(dolm) {
+				if(setlm > 0) {
+					if(setlm <= it->last_modified) {
+						/* stale write, keep current timestamp */
+						LM_DBG("LWW: skipping stale set for "
+							   "[%.*s]=>[%.*s] local=%llu incoming=%llu\n",
+								ht->name.len, ht->name.s, name->len, name->s,
+								(unsigned long long)it->last_modified,
+								(unsigned long long)setlm);
+						if(mode)
+							ht_slot_unlock(ht, idx);
+						return 0;
+					}
+					newlm = setlm;
+				} else {
+					/* new write, get timestamp */
+					newlm = ht_now_ms();
+					if(newlm <= it->last_modified)
+						newlm = it->last_modified + 1;
+				}
+				if(outlm)
+					*outlm = newlm;
+			}
 			/* update value */
 			if(it->flags & AVP_VAL_STR) {
 				if(type & AVP_VAL_STR) {
@@ -533,6 +572,8 @@ int ht_set_cell_ex(
 						} else {
 							it->expire = now + exv;
 						}
+						if(dolm)
+							it->last_modified = newlm;
 					} else {
 						/* new */
 						cell = ht_cell_new(name, type, val, hid);
@@ -542,6 +583,8 @@ int ht_set_cell_ex(
 								ht_slot_unlock(ht, idx);
 							return -1;
 						}
+						if(dolm)
+							cell->last_modified = newlm;
 						cell->next = it->next;
 						cell->prev = it->prev;
 						if(exv <= 0) {
@@ -566,6 +609,8 @@ int ht_set_cell_ex(
 					} else {
 						it->expire = now + exv;
 					}
+					if(dolm)
+						it->last_modified = newlm;
 				}
 				if(mode)
 					ht_slot_unlock(ht, idx);
@@ -580,6 +625,8 @@ int ht_set_cell_ex(
 							ht_slot_unlock(ht, idx);
 						return -1;
 					}
+					if(dolm)
+						cell->last_modified = newlm;
 					if(exv <= 0) {
 						HT_COPY_EXPIRE(ht, cell, now, it);
 					} else {
@@ -603,6 +650,8 @@ int ht_set_cell_ex(
 					} else {
 						it->expire = now + exv;
 					}
+					if(dolm)
+						it->last_modified = newlm;
 				}
 				if(mode)
 					ht_slot_unlock(ht, idx);
@@ -612,7 +661,12 @@ int ht_set_cell_ex(
 		prev = it;
 		it = it->next;
 	}
-	/* add */
+	/* add - no existing cell, nothing to compare against */
+	if(dolm) {
+		newlm = (setlm > 0) ? setlm : ht_now_ms();
+		if(outlm)
+			*outlm = newlm;
+	}
 	cell = ht_cell_new(name, type, val, hid);
 	if(cell == NULL) {
 		LM_ERR("cannot create new cell.\n");
@@ -620,6 +674,8 @@ int ht_set_cell_ex(
 			ht_slot_unlock(ht, idx);
 		return -1;
 	}
+	if(dolm)
+		cell->last_modified = newlm;
 	if(exv <= 0) {
 		cell->expire = now + ht->htexpire;
 	} else {
@@ -644,9 +700,41 @@ int ht_set_cell_ex(
 	return 0;
 }
 
+int ht_set_cell_ex(
+		ht_t *ht, str *name, int type, int_str *val, int mode, int exv)
+{
+	return ht_set_cell_core(ht, name, type, val, mode, exv, 0, NULL);
+}
+
 int ht_set_cell(ht_t *ht, str *name, int type, int_str *val, int mode)
 {
-	return ht_set_cell_ex(ht, name, type, val, mode, 0);
+	return ht_set_cell_core(ht, name, type, val, mode, 0, 0, NULL);
+}
+
+int ht_set_cell_lww(ht_t *ht, str *name, int type, int_str *val, int mode,
+		int exv, uint64_t setlm)
+{
+	return ht_set_cell_core(ht, name, type, val, mode, exv, setlm, NULL);
+}
+
+int ht_set_cell_and_replicate(ht_t *ht, str *hname, str *name, int type,
+		int_str *val, int mode, int exv)
+{
+	uint64_t lm = 0;
+	int ret;
+
+	if(ht == NULL) {
+		return -1;
+	}
+	/* local set assigns the timestamp; replicate only on success */
+	ret = ht_set_cell_core(ht, name, type, val, mode, exv, 0, &lm);
+	if(ret == 0 && ht->dmqreplicate > 0
+			&& ht_dmq_replicate_action(
+					   HT_DMQ_SET_CELL, hname, name, type, val, mode, lm)
+					   != 0) {
+		LM_ERR("dmq replication failed\n");
+	}
+	return ret;
 }
 
 static void ht_cell_unlink(ht_t *ht, int idx, ht_cell_t *it)
@@ -730,6 +818,7 @@ ht_cell_t *ht_cell_value_add(ht_t *ht, str *name, int val, ht_cell_t *old)
 {
 	unsigned int idx;
 	unsigned int hid;
+	uint64_t newlm = 0;
 	ht_cell_t *it, *prev, *cell;
 	time_t now;
 	int_str isval;
@@ -785,6 +874,14 @@ ht_cell_t *ht_cell_value_add(ht_t *ht, str *name, int val, ht_cell_t *old)
 				it->value.n += val;
 				if(ht->updateexpire)
 					it->expire = now + ht->htexpire;
+				/* timestamp the inc/dec so replication converges by LWW */
+				/* stamp only on replicated tables */
+				if(ht->dmqreplicate > 0) {
+					newlm = ht_now_ms();
+					if(newlm <= it->last_modified)
+						newlm = it->last_modified + 1;
+					it->last_modified = newlm;
+				}
 				if(old != NULL) {
 					if(old->msize >= it->msize) {
 						memcpy(old, it, it->msize);
@@ -815,6 +912,9 @@ ht_cell_t *ht_cell_value_add(ht_t *ht, str *name, int val, ht_cell_t *old)
 		ht_slot_unlock(ht, idx);
 		return NULL;
 	}
+	/* stamp only on replicated tables */
+	if(ht->dmqreplicate > 0)
+		it->last_modified = ht_now_ms();
 	it->expire = now + ht->htexpire;
 	if(prev == NULL) {
 		if(ht->entries[idx].first != NULL) {

--- a/src/modules/htable/ht_api.h
+++ b/src/modules/htable/ht_api.h
@@ -23,6 +23,7 @@
 #define _HT_API_H_
 
 #include <time.h>
+#include <stdint.h>
 
 #include "../../core/usr_avp.h"
 #include "../../core/locking.h"
@@ -30,7 +31,7 @@
 #include "../../core/atomic_ops.h"
 
 #define ht_compute_hash(_s) core_case_hash(_s, 0, 0)
-#define ht_get_entry(_h, _size) (_h) & ((_size)-1)
+#define ht_get_entry(_h, _size) (_h) & ((_size) - 1)
 
 typedef struct _ht_cell
 {
@@ -40,6 +41,7 @@ typedef struct _ht_cell
 	str name;
 	int_str value;
 	time_t expire;
+	uint64_t last_modified; /* per-cell write ms timestamp */
 	struct _ht_cell *prev;
 	struct _ht_cell *next;
 } ht_cell_t;
@@ -97,6 +99,12 @@ int ht_add_table(str *name, int autoexp, str *dbtable, str *dbcols, int size,
 int ht_init_tables(void);
 int ht_destroy(void);
 int ht_set_cell(ht_t *ht, str *name, int type, int_str *val, int mode);
+/* remote set with timestamp: set only if setlm > the stored last_modified */
+int ht_set_cell_lww(ht_t *ht, str *name, int type, int_str *val, int mode,
+		int exv, uint64_t setlm);
+/* local set with timestamp AND dmq replicate */
+int ht_set_cell_and_replicate(ht_t *ht, str *hname, str *name, int type,
+		int_str *val, int mode, int exv);
 int ht_del_cell(ht_t *ht, str *name);
 int ht_del_cell_confirm(ht_t *ht, str *name);
 ht_cell_t *ht_cell_value_add(ht_t *ht, str *name, int val, ht_cell_t *old);

--- a/src/modules/htable/ht_dmq.c
+++ b/src/modules/htable/ht_dmq.c
@@ -112,6 +112,8 @@ static int ht_dmq_cell_group_write(str *htname, ht_cell_t *ptr)
 	// jsonify cell and add to array
 
 	str tmp;
+	uint64_t lmv;
+	int lmlen;
 	srjson_doc_t *jdoc = &ht_dmq_jdoc_cell_group.jdoc;
 	srjson_t *jdoc_cells = ht_dmq_jdoc_cell_group.jdoc_cells;
 	srjson_t *jdoc_cell = srjson_CreateObject(jdoc);
@@ -153,6 +155,20 @@ static int ht_dmq_cell_group_write(str *htname, ht_cell_t *ptr)
 	srjson_AddNumberToObject(jdoc, jdoc_cell, "expire", ptr->expire);
 	tmp.s = sint2str((long)ptr->expire, &tmp.len);
 	ht_dmq_jdoc_cell_group.size += tmp.len;
+
+	/* per-cell timestamp */
+	if(ptr->last_modified > 0) {
+		srjson_AddNumberToObject(
+				jdoc, jdoc_cell, "last_modified", ptr->last_modified);
+		/* count digits without truncating the 64-bit value */
+		lmv = ptr->last_modified;
+		lmlen = 1;
+		while(lmv >= 10) {
+			lmv /= 10;
+			lmlen++;
+		}
+		ht_dmq_jdoc_cell_group.size += 17 + lmlen; // ,"last_modified":
+	}
 
 	srjson_AddItemToArray(jdoc, jdoc_cells, jdoc_cell);
 
@@ -278,9 +294,11 @@ int ht_dmq_handle_msg(
 	str body;
 	ht_dmq_action_t action = HT_DMQ_NONE;
 	str htname = str_init("");
-	str cname;
+	str cname = str_init("");
 	int type = 0, mode = 0;
-	int_str val;
+	int_str val = {0};
+	int got_val = 0;
+	uint64_t lm = 0;
 	srjson_doc_t jdoc;
 	srjson_t *it = NULL;
 
@@ -342,20 +360,31 @@ int ht_dmq_handle_msg(
 			} else if(strcmp(it->string, "strval") == 0) {
 				if(ht_dmq_json_get_str(it, &val.s, "strval") < 0)
 					goto invalid;
+				got_val = 1;
 			} else if(strcmp(it->string, "intval") == 0) {
 				val.n = SRJSON_GET_INT(it);
+				got_val = 1;
 			} else if(strcmp(it->string, "mode") == 0) {
 				mode = SRJSON_GET_INT(it);
+			} else if(strcmp(it->string, "last_modified") == 0) {
+				lm = SRJSON_GET_ULLONG(it);
 			} else {
-				LM_ERR("unrecognized field in json object\n");
-				goto invalid;
+				/* warn and skip unknown fields */
+				LM_WARN("unrecognized field in json object: %s\n", it->string);
 			}
 		}
 
 		if(unlikely(action == HT_DMQ_SYNC)) {
 			ht_dmq_send_sync(dmq_node, &htname);
 		} else {
-			if(ht_dmq_replay_action(action, &htname, &cname, type, &val, mode)
+			if(action == HT_DMQ_SET_CELL && !got_val) {
+				LM_ERR("SET_CELL without a value field "
+					   "(strval/intval) for [%.*s]=>[%.*s], dropping\n",
+						htname.len, htname.s, cname.len, cname.s);
+				goto invalid;
+			}
+			if(ht_dmq_replay_action(
+					   action, &htname, &cname, type, &val, mode, lm)
 					!= 0) {
 				LM_ERR("failed to replay action\n");
 				goto error;
@@ -382,7 +411,7 @@ error:
 }
 
 int ht_dmq_replicate_action(ht_dmq_action_t action, str *htname, str *cname,
-		int type, int_str *val, int mode)
+		int type, int_str *val, int mode, uint64_t lm)
 {
 
 	srjson_doc_t jdoc;
@@ -411,6 +440,10 @@ int ht_dmq_replicate_action(ht_dmq_action_t action, str *htname, str *cname,
 					&jdoc, jdoc.root, "strval", val->s.s, val->s.len);
 		} else {
 			srjson_AddNumberToObject(&jdoc, jdoc.root, "intval", val->n);
+		}
+		/* per-cell timestamp */
+		if(action == HT_DMQ_SET_CELL && lm > 0) {
+			srjson_AddNumberToObject(&jdoc, jdoc.root, "last_modified", lm);
 		}
 	}
 
@@ -447,7 +480,7 @@ error:
 Return 0 for non-error. Allt other returns are parsed as error.
 */
 int ht_dmq_replay_action(ht_dmq_action_t action, str *htname, str *cname,
-		int type, int_str *val, int mode)
+		int type, int_str *val, int mode, uint64_t lm)
 {
 
 	ht_t *ht;
@@ -461,6 +494,10 @@ int ht_dmq_replay_action(ht_dmq_action_t action, str *htname, str *cname,
 			htname->s, cname->len, cname->s);
 
 	if(action == HT_DMQ_SET_CELL) {
+		/* lm > 0: gated apply (set only if newer); lm == 0: old-peer fallback */
+		if(lm > 0) {
+			return ht_set_cell_lww(ht, cname, type, val, mode, 0, lm);
+		}
 		return ht_set_cell(ht, cname, type, val, mode);
 	} else if(action == HT_DMQ_SET_CELL_EXPIRE) {
 		return ht_set_cell_expire(ht, cname, 0, val);
@@ -612,6 +649,8 @@ int ht_dmq_handle_sync(srjson_doc_t *jdoc)
 	int type = 0;
 	int_str val = {0};
 	int expire = 0;
+	uint64_t lm = 0;
+	int rc = 0;
 	ht_t *ht = NULL;
 	time_t now = 0;
 
@@ -621,6 +660,7 @@ int ht_dmq_handle_sync(srjson_doc_t *jdoc)
 	now = time(NULL);
 
 	while(cell) {
+		lm = 0;
 		for(it = cell->child; it; it = it->next) {
 			if(strcmp(it->string, "htname") == 0) {
 				if(ht_dmq_json_get_str(it, &htname, "htname") < 0)
@@ -637,6 +677,8 @@ int ht_dmq_handle_sync(srjson_doc_t *jdoc)
 				val.n = SRJSON_GET_INT(it);
 			} else if(strcmp(it->string, "expire") == 0) {
 				expire = SRJSON_GET_INT(it);
+			} else if(strcmp(it->string, "last_modified") == 0) {
+				lm = SRJSON_GET_ULLONG(it);
 			} else {
 				LM_WARN("unrecognized field in json object\n");
 			}
@@ -649,8 +691,15 @@ int ht_dmq_handle_sync(srjson_doc_t *jdoc)
 				LM_WARN("unable to get table %.*s\n", htname.len,
 						(htname.s) ? htname.s : "");
 			} else {
-				if(ht_set_cell_ex(ht, &cname, type, &val, 0, expire - now)
-						< 0) {
+				/* lm > 0: gated apply; lm == 0: old-peer fallback */
+				if(lm > 0) {
+					rc = ht_set_cell_lww(
+							ht, &cname, type, &val, 0, expire - now, lm);
+				} else {
+					rc = ht_set_cell_ex(
+							ht, &cname, type, &val, 0, expire - now);
+				}
+				if(rc < 0) {
 					LM_WARN("unable to set cell %.*s in table %.*s\n",
 							cname.len, cname.s, ht->name.len, ht->name.s);
 				}

--- a/src/modules/htable/ht_dmq.h
+++ b/src/modules/htable/ht_dmq.h
@@ -24,6 +24,8 @@
 #ifndef _HT_DMQ_H_
 #define _HT_DMQ_H_
 
+#include <stdint.h>
+
 #include "../dmq/bind_dmq.h"
 #include "../../core/utils/srjson.h"
 #include "../../core/parser/msg_parser.h"
@@ -49,9 +51,9 @@ int ht_dmq_initialize();
 int ht_dmq_handle_msg(
 		struct sip_msg *msg, peer_reponse_t *resp, dmq_node_t *dmq_node);
 int ht_dmq_replicate_action(ht_dmq_action_t action, str *htname, str *cname,
-		int type, int_str *val, int mode);
+		int type, int_str *val, int mode, uint64_t lm);
 int ht_dmq_replay_action(ht_dmq_action_t action, str *htname, str *cname,
-		int type, int_str *val, int mode);
+		int type, int_str *val, int mode, uint64_t lm);
 int ht_dmq_request_sync(str *htname, dmq_node_t *dmq_node);
 int ht_dmq_request_sync_all(dmq_node_t *dmq_node);
 

--- a/src/modules/htable/ht_var.c
+++ b/src/modules/htable/ht_var.c
@@ -91,8 +91,8 @@ int pv_set_ht_cell(
 	if((val == NULL) || (val->flags & PV_VAL_NULL)) {
 		/* delete it */
 		if(hpv->ht->dmqreplicate > 0
-				&& ht_dmq_replicate_action(
-						   HT_DMQ_DEL_CELL, &hpv->htname, &htname, 0, NULL, 0)
+				&& ht_dmq_replicate_action(HT_DMQ_DEL_CELL, &hpv->htname,
+						   &htname, 0, NULL, 0, 0)
 						   != 0) {
 			LM_ERR("dmq replication failed\n");
 		}
@@ -102,25 +102,17 @@ int pv_set_ht_cell(
 
 	if(val->flags & PV_TYPE_INT) {
 		isval.n = val->ri;
-		if(hpv->ht->dmqreplicate > 0
-				&& ht_dmq_replicate_action(
-						   HT_DMQ_SET_CELL, &hpv->htname, &htname, 0, &isval, 1)
-						   != 0) {
-			LM_ERR("dmq replication failed\n");
-		}
-		if(ht_set_cell(hpv->ht, &htname, 0, &isval, 1) != 0) {
+		if(ht_set_cell_and_replicate(
+				   hpv->ht, &hpv->htname, &htname, 0, &isval, 1, 0)
+				!= 0) {
 			LM_ERR("cannot set $sht(%.*s)\n", htname.len, htname.s);
 			return -1;
 		}
 	} else {
 		isval.s = val->rs;
-		if(hpv->ht->dmqreplicate > 0
-				&& ht_dmq_replicate_action(HT_DMQ_SET_CELL, &hpv->htname,
-						   &htname, AVP_VAL_STR, &isval, 1)
-						   != 0) {
-			LM_ERR("dmq replication failed\n");
-		}
-		if(ht_set_cell(hpv->ht, &htname, AVP_VAL_STR, &isval, 1) != 0) {
+		if(ht_set_cell_and_replicate(
+				   hpv->ht, &hpv->htname, &htname, AVP_VAL_STR, &isval, 1, 0)
+				!= 0) {
 			LM_ERR("cannot set $sht(%.*s)\n", htname.len, htname.s);
 			return -1;
 		}
@@ -259,7 +251,7 @@ int pv_set_ht_cell_expire(
 	}
 	if(hpv->ht->dmqreplicate > 0
 			&& ht_dmq_replicate_action(HT_DMQ_SET_CELL_EXPIRE, &hpv->htname,
-					   &htname, 0, &isval, 0)
+					   &htname, 0, &isval, 0, 0)
 					   != 0) {
 		LM_ERR("dmq replication failed\n");
 	}
@@ -351,8 +343,8 @@ int pv_get_ht_add(
 
 	/* integer */
 	if(hpv->ht->dmqreplicate > 0) {
-		if(ht_dmq_replicate_action(
-				   HT_DMQ_SET_CELL, &hpv->htname, &htname, 0, &htc->value, 1)
+		if(ht_dmq_replicate_action(HT_DMQ_SET_CELL, &hpv->htname, &htname, 0,
+				   &htc->value, 1, htc->last_modified)
 				!= 0) {
 			LM_ERR("dmq replication failed\n");
 		}

--- a/src/modules/htable/htable.c
+++ b/src/modules/htable/htable.c
@@ -409,7 +409,7 @@ static int ht_rm_re_helper(sip_msg_t *msg, ht_t *ht, str *rexp, int rmode)
 	if(ht->dmqreplicate > 0) {
 		isval.s = *rexp;
 		if(ht_dmq_replicate_action(HT_DMQ_RM_CELL_RE, &ht->name, NULL,
-				   AVP_VAL_STR, &isval, rmode)
+				   AVP_VAL_STR, &isval, rmode, 0)
 				!= 0) {
 			LM_ERR("dmq replication failed for [%.*s]\n", ht->name.len,
 					ht->name.s);
@@ -515,7 +515,7 @@ static int ht_rm_items(sip_msg_t *msg, str *hname, str *op, str *val, int mkey)
 				isval.s = *val;
 				if((ht->dmqreplicate > 0)
 						&& ht_dmq_replicate_action(HT_DMQ_RM_CELL_RE, &ht->name,
-								   NULL, AVP_VAL_STR, &isval, mkey)
+								   NULL, AVP_VAL_STR, &isval, mkey, 0)
 								   != 0) {
 					LM_ERR("dmq replication failed (op %d)\n", mkey);
 				}
@@ -527,7 +527,7 @@ static int ht_rm_items(sip_msg_t *msg, str *hname, str *op, str *val, int mkey)
 				isval.s = *val;
 				if((ht->dmqreplicate > 0)
 						&& ht_dmq_replicate_action(HT_DMQ_RM_CELL_SW, &ht->name,
-								   NULL, AVP_VAL_STR, &isval, mkey)
+								   NULL, AVP_VAL_STR, &isval, mkey, 0)
 								   != 0) {
 					LM_ERR("dmq replication failed (op %d)\n", mkey);
 				}
@@ -539,7 +539,7 @@ static int ht_rm_items(sip_msg_t *msg, str *hname, str *op, str *val, int mkey)
 				isval.s = *val;
 				if((ht->dmqreplicate > 0)
 						&& ht_dmq_replicate_action(HT_DMQ_RM_CELL_EW, &ht->name,
-								   NULL, AVP_VAL_STR, &isval, mkey)
+								   NULL, AVP_VAL_STR, &isval, mkey, 0)
 								   != 0) {
 					LM_ERR("dmq replication failed (op %d)\n", mkey);
 				}
@@ -551,7 +551,7 @@ static int ht_rm_items(sip_msg_t *msg, str *hname, str *op, str *val, int mkey)
 				isval.s = *val;
 				if((ht->dmqreplicate > 0)
 						&& ht_dmq_replicate_action(HT_DMQ_RM_CELL_IN, &ht->name,
-								   NULL, AVP_VAL_STR, &isval, mkey)
+								   NULL, AVP_VAL_STR, &isval, mkey, 0)
 								   != 0) {
 					LM_ERR("dmq replication failed (op %d)\n", mkey);
 				}
@@ -624,7 +624,7 @@ static int ki_ht_rm(sip_msg_t *msg, str *hname, str *iname)
 	/* delete it */
 	if(ht->dmqreplicate > 0
 			&& ht_dmq_replicate_action(
-					   HT_DMQ_DEL_CELL, hname, iname, 0, NULL, 0)
+					   HT_DMQ_DEL_CELL, hname, iname, 0, NULL, 0, 0)
 					   != 0) {
 		LM_ERR("dmq replication failed\n");
 	}
@@ -1233,14 +1233,9 @@ static int ki_ht_sets(sip_msg_t *msg, str *htname, str *itname, str *itval)
 
 	isvalue.s = *itval;
 
-	if(ht->dmqreplicate > 0
-			&& ht_dmq_replicate_action(HT_DMQ_SET_CELL, &ht->name, itname,
-					   AVP_VAL_STR, &isvalue, 1)
-					   != 0) {
-		LM_ERR("dmq replication failed\n");
-	}
-
-	if(ht_set_cell(ht, itname, AVP_VAL_STR, &isvalue, 1) != 0) {
+	if(ht_set_cell_and_replicate(
+			   ht, &ht->name, itname, AVP_VAL_STR, &isvalue, 1, 0)
+			!= 0) {
 		LM_ERR("cannot set sht: %.*s key: %.*s\n", htname->len, htname->s,
 				itname->len, itname->s);
 		return -1;
@@ -1266,14 +1261,8 @@ static int ki_ht_seti(sip_msg_t *msg, str *htname, str *itname, int itval)
 
 	isvalue.n = itval;
 
-	if(ht->dmqreplicate > 0
-			&& ht_dmq_replicate_action(
-					   HT_DMQ_SET_CELL, &ht->name, itname, 0, &isvalue, 1)
-					   != 0) {
-		LM_ERR("dmq replication failed\n");
-	}
-
-	if(ht_set_cell(ht, itname, 0, &isvalue, 1) != 0) {
+	if(ht_set_cell_and_replicate(ht, &ht->name, itname, 0, &isvalue, 1, 0)
+			!= 0) {
 		LM_ERR("cannot set sht: %.*s key: %.*s\n", htname->len, htname->s,
 				itname->len, itname->s);
 		return -1;
@@ -1303,7 +1292,7 @@ static int ki_ht_setex(sip_msg_t *msg, str *htname, str *itname, int itval)
 	isval.n = itval;
 	if(ht->dmqreplicate > 0
 			&& ht_dmq_replicate_action(
-					   HT_DMQ_SET_CELL_EXPIRE, htname, itname, 0, &isval, 0)
+					   HT_DMQ_SET_CELL_EXPIRE, htname, itname, 0, &isval, 0, 0)
 					   != 0) {
 		LM_ERR("dmq replication failed\n");
 	}
@@ -1336,27 +1325,22 @@ static int ki_ht_setxs(
 			htname->len, htname->s, itname->len, itname->s,
 			(itval->len > 100) ? 100 : itval->len, itval->s, exval);
 
-	if(ht->dmqreplicate > 0) {
-		isval.s = *itval;
-		if(ht->dmqreplicate > 0
-				&& ht_dmq_replicate_action(HT_DMQ_SET_CELL, &ht->name, itname,
-						   AVP_VAL_STR, &isval, 1)
-						   != 0) {
-			LM_ERR("dmq set value replication failed\n");
-		} else {
-			isval.n = exval;
-			if(ht_dmq_replicate_action(
-					   HT_DMQ_SET_CELL_EXPIRE, htname, itname, 0, &isval, 0)
-					!= 0) {
-				LM_ERR("dmq set expire relication failed\n");
-			}
-		}
-	}
 	isval.s = *itval;
-	if(ht_set_cell_ex(ht, itname, AVP_VAL_STR, &isval, 1, exval) != 0) {
+	/* set the value (timestamped) and replicate it as a SET_CELL */
+	if(ht_set_cell_and_replicate(
+			   ht, &ht->name, itname, AVP_VAL_STR, &isval, 1, exval)
+			!= 0) {
 		LM_ERR("cannot set hash table: %.*s key: %.*s\n", htname->len,
 				htname->s, itname->len, itname->s);
 		return -1;
+	}
+	if(ht->dmqreplicate > 0) {
+		isval.n = exval;
+		if(ht_dmq_replicate_action(
+				   HT_DMQ_SET_CELL_EXPIRE, &ht->name, itname, 0, &isval, 0, 0)
+				!= 0) {
+			LM_ERR("dmq set expire replication failed\n");
+		}
 	}
 
 	return 1;
@@ -1414,27 +1398,21 @@ static int ki_ht_setxi(
 	LM_DBG("set value and expire for sht: %.*s key: %.*s val: %d exp: %d\n",
 			htname->len, htname->s, itname->len, itname->s, itval, exval);
 
-	if(ht->dmqreplicate > 0) {
-		isval.n = itval;
-		if(ht_dmq_replicate_action(
-				   HT_DMQ_SET_CELL, &ht->name, itname, 0, &isval, 1)
-				!= 0) {
-			LM_ERR("dmq set value relication failed\n");
-		} else {
-			isval.n = exval;
-			if(ht_dmq_replicate_action(
-					   HT_DMQ_SET_CELL_EXPIRE, htname, itname, 0, &isval, 0)
-					!= 0) {
-				LM_ERR("dmq set expire replication failed\n");
-			}
-		}
-	}
 	isval.n = itval;
-
-	if(ht_set_cell_ex(ht, itname, 0, &isval, 1, exval) != 0) {
+	/* set the value (timestamped) and replicate it as a SET_CELL */
+	if(ht_set_cell_and_replicate(ht, &ht->name, itname, 0, &isval, 1, exval)
+			!= 0) {
 		LM_ERR("cannot set value and expire for sht: %.*s key: %.*s\n",
 				htname->len, htname->s, itname->len, itname->s);
 		return -1;
+	}
+	if(ht->dmqreplicate > 0) {
+		isval.n = exval;
+		if(ht_dmq_replicate_action(
+				   HT_DMQ_SET_CELL_EXPIRE, &ht->name, itname, 0, &isval, 0, 0)
+				!= 0) {
+			LM_ERR("dmq set expire replication failed\n");
+		}
 	}
 
 	return 1;
@@ -1515,8 +1493,8 @@ static int w_ht_add_opp(sip_msg_t *msg, char *htname, char *itname, int ival)
 	}
 
 	if(ht->dmqreplicate > 0) {
-		if(ht_dmq_replicate_action(
-				   HT_DMQ_SET_CELL, &shtname, &sitname, 0, &htc->value, 1)
+		if(ht_dmq_replicate_action(HT_DMQ_SET_CELL, &shtname, &sitname, 0,
+				   &htc->value, 1, htc->last_modified)
 				!= 0) {
 			LM_ERR("dmq replication failed\n");
 		}
@@ -1559,8 +1537,8 @@ static int ki_ht_add_op(sip_msg_t *msg, str *htname, str *itname, int itval)
 
 	/* integer */
 	if(ht->dmqreplicate > 0) {
-		if(ht_dmq_replicate_action(
-				   HT_DMQ_SET_CELL, htname, itname, 0, &htc->value, 1)
+		if(ht_dmq_replicate_action(HT_DMQ_SET_CELL, htname, itname, 0,
+				   &htc->value, 1, htc->last_modified)
 				!= 0) {
 			LM_ERR("dmq replication failed\n");
 		}
@@ -1706,7 +1684,7 @@ static void htable_rpc_delete(rpc_t *rpc, void *c)
 
 	if(ht->dmqreplicate > 0
 			&& ht_dmq_replicate_action(
-					   HT_DMQ_DEL_CELL, &ht->name, &keyname, 0, NULL, 0)
+					   HT_DMQ_DEL_CELL, &ht->name, &keyname, 0, NULL, 0, 0)
 					   != 0) {
 		LM_ERR("dmq replication failed\n");
 	}
@@ -1815,14 +1793,9 @@ static void htable_rpc_sets(rpc_t *rpc, void *c)
 		return;
 	}
 
-	if(ht->dmqreplicate > 0
-			&& ht_dmq_replicate_action(HT_DMQ_SET_CELL, &ht->name, &keyname,
-					   AVP_VAL_STR, &keyvalue, 1)
-					   != 0) {
-		LM_ERR("dmq replication failed\n");
-	}
-
-	if(ht_set_cell(ht, &keyname, AVP_VAL_STR, &keyvalue, 1) != 0) {
+	if(ht_set_cell_and_replicate(
+			   ht, &ht->name, &keyname, AVP_VAL_STR, &keyvalue, 1, 0)
+			!= 0) {
 		LM_ERR("cannot set $sht(%.*s=>%.*s)\n", htname.len, htname.s,
 				keyname.len, keyname.s);
 		rpc->fault(c, 500, "Failed to set the item");
@@ -1853,14 +1826,8 @@ static void htable_rpc_seti(rpc_t *rpc, void *c)
 		return;
 	}
 
-	if(ht->dmqreplicate > 0
-			&& ht_dmq_replicate_action(
-					   HT_DMQ_SET_CELL, &ht->name, &keyname, 0, &keyvalue, 1)
-					   != 0) {
-		LM_ERR("dmq replication failed\n");
-	}
-
-	if(ht_set_cell(ht, &keyname, 0, &keyvalue, 1) != 0) {
+	if(ht_set_cell_and_replicate(ht, &ht->name, &keyname, 0, &keyvalue, 1, 0)
+			!= 0) {
 		LM_ERR("cannot set $sht(%.*s=>%.*s)\n", htname.len, htname.s,
 				keyname.len, keyname.s);
 		rpc->fault(c, 500, "Failed to set the item");


### PR DESCRIPTION
Do lww stamping only for htables that have dmqreplicate on

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [X] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Main motivation for this is again topos_htable storage.
In addition to the races described in #4813 there can be races between 2 x topos_dialog htable KDMQs and old one can overwrite new one. For example 200OK incoming(old) vs 200OK outgoing(new), both trigger storage updates by topos. Sometimes, on the DMQ peer, the old KDMQ is processed as newest one and overwrites the whole topos_dialog htable row => this in turn shows up as "unmask miss" for BYEs too, from clients (if no other in-dialog refreshes happened), because b_contact is 0 after old KDMQ overwrites.

Notes:
Not tested 100% as in this PR. There were (minor) conflicts resolved on cherry-pick.
Fully tested on older kamailio version, pre-production level.