### PR TITLE
carrierroute: improved threading safety

### DIFF
--- a/src/modules/carrierroute/cr_data.c
+++ b/src/modules/carrierroute/cr_data.c
@@ -29,6 +29,7 @@
 
 #include <stdlib.h>
 #include "../../core/mem/shm_mem.h"
+#include "../../core/locking.h"
 #include "cr_data.h"
 #include "carrierroute.h"
 #include "cr_config.h"
@@ -41,7 +42,9 @@
 /**
  * Pointer to the routing data.
  */
-struct route_data_t **global_data = NULL;
+static struct route_data_t **global_data = NULL;
+// lock to protect the *global_data pointer itself, and each table's proc_cnt
+static gen_lock_t *global_data_lock;
 
 
 static int carrier_data_fixup(struct route_data_t *rd)
@@ -78,6 +81,13 @@ int init_route_data(void)
 			SHM_MEM_ERROR;
 			return -1;
 		}
+		global_data_lock = lock_alloc();
+		if(!global_data_lock) {
+			SHM_MEM_ERROR;
+			shm_free(global_data);
+			return -1;
+		}
+		lock_init(global_data_lock);
 	}
 	*global_data = NULL;
 	return 0;
@@ -95,6 +105,11 @@ void destroy_route_data(void)
 		*global_data = NULL;
 		shm_free(global_data);
 		global_data = NULL;
+	}
+	if(global_data_lock) {
+		lock_destroy(global_data_lock);
+		lock_dealloc(global_data_lock);
+		global_data_lock = NULL;
 	}
 }
 
@@ -228,17 +243,29 @@ int reload_route_data(void)
 
 	new_data->proc_cnt = 0;
 
+	lock_get(global_data_lock);
+
 	if(*global_data == NULL) {
 		*global_data = new_data;
+		lock_release(global_data_lock);
 	} else {
+		// swap out pointers with lock held
 		old_data = *global_data;
 		*global_data = new_data;
 		i = 0;
+		// lock still held for proc_cnt
 		while(old_data->proc_cnt > 0) {
+			// release lock while sleeping so other threads can drop reference.
+			// no other thread can be checking the same table as the pointers were
+			// swapped with the lock held
+			lock_release(global_data_lock);
 			LM_ERR("data is still locked after %i seconds\n", i);
 			sleep_us(i * 1000000);
 			i++;
+			// re-obtain lock to check proc_cnt again
+			lock_get(global_data_lock);
 		}
+		lock_release(global_data_lock);
 		clear_route_data(old_data);
 	}
 	return 0;
@@ -259,21 +286,18 @@ errout:
 struct route_data_t *get_data(void)
 {
 	struct route_data_t *ret;
+	if(!global_data_lock)
+		return NULL;
+	lock_get(global_data_lock);
 	if(!global_data || !*global_data) {
+		lock_release(global_data_lock);
 		return NULL;
 	}
 	ret = *global_data;
-	lock_get(&ret->lock);
 	++ret->proc_cnt;
-	lock_release(&ret->lock);
-	if(ret == *global_data) {
-		return ret;
-	} else {
-		lock_get(&ret->lock);
-		--ret->proc_cnt;
-		lock_release(&ret->lock);
-		return NULL;
-	}
+	lock_release(global_data_lock);
+	// safe reference to "ret" held here
+	return ret;
 }
 
 
@@ -284,9 +308,9 @@ struct route_data_t *get_data(void)
  */
 void release_data(struct route_data_t *data)
 {
-	lock_get(&data->lock);
+	lock_get(global_data_lock);
 	--data->proc_cnt;
-	lock_release(&data->lock);
+	lock_release(global_data_lock);
 }
 
 

--- a/src/modules/carrierroute/cr_data.h
+++ b/src/modules/carrierroute/cr_data.h
@@ -31,7 +31,6 @@
 #define CR_DATA_H
 
 #include <sys/types.h>
-#include "../../core/locking.h"
 #include "../../core/flags.h"
 #include "cr_map.h"
 
@@ -50,8 +49,7 @@ struct route_data_t
 	size_t first_empty_carrier; /*!< the index of the first empty entry in carriers */
 	size_t domain_num;			/*!< total number of different domains */
 	int default_carrier_id;
-	int proc_cnt;	 /*!< a ref counter for the shm data */
-	gen_lock_t lock; /*!< lock for ref counter updates */
+	int proc_cnt; /*!< a ref counter for the shm data */
 };
 
 /**


### PR DESCRIPTION
The current lock/refcount handling of the global data table is (very slightly) racy during reloads and could theoretically lead to a crash.

- the *global_data pointer itself must be accessed and swapped out atomatically to eliminate possible race conditions
- reading the pointer _and_ increasing the reference count for the pointed-to table atomically is only possible with a global lock
- usually there are only one or two tables in existence at any given time, so we can drop the per-table lock and use the global lock to also protect the per-table reference count (this could be done with an atomic int as well, but we already have a lock anyway)
- the global lock implicitly guarantees both memory fences and compiler fences

Came up in a (marginally) related discussion in #4809

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [ ] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
