### PR TITLE
core: fix case-insensitive search in _strnistr

### DIFF
--- a/src/core/str.c
+++ b/src/core/str.c
@@ -79,15 +79,17 @@ char *_strnstr(const char *s, const char *find, size_t slen)
 char *_strnistr(const char *s, const char *find, size_t slen)
 {
 	char c, sc;
+	char c_alt;
 	size_t len;
 
 	if((c = *find++) != '\0') {
+		c_alt = (c >= 'a' && c <= 'z') ? (c - 32) : ((c >= 'A' && c <= 'Z') ? (c + 32) : c);
 		len = strlen(find);
 		do {
 			do {
 				if((sc = *s++) == '\0' || slen-- < 1)
 					return (NULL);
-			} while(sc != c);
+			} while(sc != c && sc != c_alt);
 			if(len > slen)
 				return (NULL);
 		} while(strncasecmp(s, find, len) != 0);


### PR DESCRIPTION
While reviewing the string utilities in src/core/str.c, I noticed a bug in the implementation of `_strnistr()`. 

Although the function is meant to find case-insensitive occurrences of a substring, the inner loop that scans for the first character of the search pattern performs a case-sensitive check (`sc != c`). As a result, it completely skips matches if the first character of the target string has a different case than the search pattern (e.g., searching for "alias=" in a string starting with "Alias=" returns NULL).

To fix this cleanly:
1. We compute the alternative ASCII case of the first character once outside of the loop.
2. The inner loop now checks `sc != c && sc != c_alt`, which maintains maximum performance (zero function calls in the loop).
3. The check is restricted to ASCII letters to avoid corrupting or misinterpreting multibyte UTF-8 sequences.
