### PR TITLE
TCP threaded receiver mode - v2

### DIFF
--- a/cmake/lock_methods.cmake
+++ b/cmake/lock_methods.cmake
@@ -159,3 +159,49 @@ set(LOCK_METHOD_FINAL
     "${_SELECTED_LOCK_METHOD}"
     CACHE INTERNAL "Final locking method selected"
 )
+
+# Robust process-shared mutexes: PTHREAD_MUTEX_ROBUST / pthread_mutex_consistent()
+# are a POSIX option glibc and musl provide but some platforms (notably macOS) do
+# not. src/core/tcp_cond.c uses them for the tcp reactor condvar and guards them
+# on HAVE_PTHREAD_MUTEX_ROBUST. Probe the capability instead of guessing by OS.
+include(CheckSymbolExists)
+set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+set(CMAKE_REQUIRED_LIBRARIES pthread)
+check_symbol_exists(pthread_mutex_consistent "pthread.h" HAVE_PTHREAD_MUTEX_ROBUST)
+unset(CMAKE_REQUIRED_DEFINITIONS)
+unset(CMAKE_REQUIRED_LIBRARIES)
+if(HAVE_PTHREAD_MUTEX_ROBUST)
+  target_compile_definitions(common INTERFACE HAVE_PTHREAD_MUTEX_ROBUST)
+  message(STATUS "Robust process-shared mutex: supported")
+else()
+  message(STATUS "Robust process-shared mutex: NOT supported (tcp_cond uses non-robust fallback)")
+endif()
+
+# Per-thread names: pthread_setname_np() lets the tcp reactor label its io_wait
+# and pool threads so profilers / top -H / gdb show distinct threads instead of
+# one opaque "kamailio" comm. The symbol exists on Linux and macOS but with
+# different arity - Linux/glibc/musl take (pthread_t, name); macOS takes (name)
+# and renames only the caller. Probe the actual signature rather than guess by OS.
+include(CheckCSourceCompiles)
+set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+set(CMAKE_REQUIRED_LIBRARIES pthread)
+check_c_source_compiles(
+  "#include <pthread.h>
+int main(void) { pthread_setname_np(pthread_self(), \"x\"); return 0; }"
+  HAVE_PTHREAD_SETNAME_NP_2ARG
+)
+check_c_source_compiles(
+  "#include <pthread.h>
+int main(void) { pthread_setname_np(\"x\"); return 0; }" HAVE_PTHREAD_SETNAME_NP_1ARG
+)
+unset(CMAKE_REQUIRED_DEFINITIONS)
+unset(CMAKE_REQUIRED_LIBRARIES)
+if(HAVE_PTHREAD_SETNAME_NP_2ARG)
+  target_compile_definitions(common INTERFACE HAVE_PTHREAD_SETNAME_NP_2ARG)
+  message(STATUS "pthread_setname_np: 2-arg (tcp reactor threads named)")
+elseif(HAVE_PTHREAD_SETNAME_NP_1ARG)
+  target_compile_definitions(common INTERFACE HAVE_PTHREAD_SETNAME_NP_1ARG)
+  message(STATUS "pthread_setname_np: 1-arg self (tcp reactor threads named)")
+else()
+  message(STATUS "pthread_setname_np: not available (tcp reactor threads unnamed)")
+endif()

--- a/src/core/cfg.lex
+++ b/src/core/cfg.lex
@@ -395,6 +395,7 @@ TCP_MSG_READ_TIMEOUT tcp_msg_read_timeout
 TCP_MSG_DATA_TIMEOUT tcp_msg_data_timeout
 TCP_ACCEPT_IPLIMIT tcp_accept_iplimit
 TCP_MAIN_THREADS tcp_main_threads
+TCP_REACTOR_THREADS tcp_reactor_threads
 TCP_CHECK_TIMER tcp_check_timer
 CHILDREN children
 SOCKET socket
@@ -904,6 +905,7 @@ IMPORTFILE      "import_file"
 <INITIAL>{TCP_MSG_DATA_TIMEOUT}	{ count(); yylval.strval=yytext; return TCP_MSG_DATA_TIMEOUT; }
 <INITIAL>{TCP_ACCEPT_IPLIMIT}	{ count(); yylval.strval=yytext; return TCP_ACCEPT_IPLIMIT; }
 <INITIAL>{TCP_MAIN_THREADS}	{ count(); yylval.strval=yytext; return TCP_MAIN_THREADS; }
+<INITIAL>{TCP_REACTOR_THREADS}	{ count(); yylval.strval=yytext; return TCP_REACTOR_THREADS; }
 <INITIAL>{TCP_CHECK_TIMER}	{ count(); yylval.strval=yytext; return TCP_CHECK_TIMER; }
 <INITIAL>{CHILDREN}	{ count(); yylval.strval=yytext; return CHILDREN; }
 <INITIAL>{SOCKET}	{ count(); yylval.strval=yytext; return SOCKET; }

--- a/src/core/cfg.y
+++ b/src/core/cfg.y
@@ -439,6 +439,7 @@ extern char *default_routename;
 %token TCP_MSG_DATA_TIMEOUT
 %token TCP_ACCEPT_IPLIMIT
 %token TCP_MAIN_THREADS
+%token TCP_REACTOR_THREADS
 %token TCP_CHECK_TIMER
 %token USER
 %token GROUP
@@ -1089,6 +1090,8 @@ assign_stm:
 	| TCP_ACCEPT_IPLIMIT EQUAL error { yyerror("number expected"); }
 	| TCP_MAIN_THREADS EQUAL NUMBER { ksr_tcp_main_threads=$3; }
 	| TCP_MAIN_THREADS EQUAL error { yyerror("number expected"); }
+	| TCP_REACTOR_THREADS EQUAL NUMBER { ksr_tcp_reactor_threads=$3; }
+	| TCP_REACTOR_THREADS EQUAL error { yyerror("number expected"); }
 	| TCP_CHECK_TIMER EQUAL NUMBER { ksr_tcp_check_timer=$3; }
 	| TCP_CHECK_TIMER EQUAL error { yyerror("number expected"); }
 	| CHILDREN EQUAL NUMBER { children_no=$3; }

--- a/src/core/globals.h
+++ b/src/core/globals.h
@@ -260,6 +260,7 @@ extern int ksr_tcp_msg_read_timeout;
 extern int ksr_tcp_msg_data_timeout;
 extern int ksr_tcp_accept_iplimit;
 extern int ksr_tcp_main_threads;
+extern int ksr_tcp_reactor_threads;
 extern int ksr_tcp_check_timer;
 extern int ksr_udp_accept_proxy;
 

--- a/src/core/tcp_cond.c
+++ b/src/core/tcp_cond.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2026 S-P Chan
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/* pthread_mutexattr_setrobust()/pthread_mutex_consistent() need _GNU_SOURCE
+ * (or _POSIX_C_SOURCE >= 200809) on glibc; must be set before any include.
+ * Robust mutexes are a POSIX option not available on every platform (notably
+ * macOS). The build probes for them and defines HAVE_PTHREAD_MUTEX_ROBUST (see
+ * cmake/lock_methods.cmake). Without it the mutex is still process-shared but
+ * not robust: a process dying while holding the lock is not recovered - which is
+ * acceptable for the current in-process reactor use. */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <errno.h>
+#include <pthread.h>
+#include <string.h>
+
+#include "dprint.h"
+#include "tcp_cond.h"
+
+int tcp_cond_init(tcp_cond_t *cond)
+{
+	pthread_mutexattr_t mattr;
+	pthread_condattr_t cattr;
+
+	/* process-shared + robust mutex */
+	if(pthread_mutexattr_init(&mattr) != 0) {
+		LM_ERR("failed to init mutex attributes\n");
+		return -1;
+	}
+	if(pthread_mutexattr_setpshared(&mattr, PTHREAD_PROCESS_SHARED) != 0
+#ifdef HAVE_PTHREAD_MUTEX_ROBUST
+			|| pthread_mutexattr_setrobust(&mattr, PTHREAD_MUTEX_ROBUST) != 0
+#endif
+			|| pthread_mutex_init(&cond->m, &mattr) != 0) {
+		LM_ERR("failed to set up process-shared mutex\n");
+		pthread_mutexattr_destroy(&mattr);
+		return -1;
+	}
+	pthread_mutexattr_destroy(&mattr);
+
+	/* process-shared condition variable */
+	if(pthread_condattr_init(&cattr) != 0) {
+		LM_ERR("failed to init cond attributes\n");
+		pthread_mutex_destroy(&cond->m);
+		return -1;
+	}
+	if(pthread_condattr_setpshared(&cattr, PTHREAD_PROCESS_SHARED) != 0
+			|| pthread_cond_init(&cond->c, &cattr) != 0) {
+		LM_ERR("failed to set up process-shared cond\n");
+		pthread_condattr_destroy(&cattr);
+		pthread_mutex_destroy(&cond->m);
+		return -1;
+	}
+	pthread_condattr_destroy(&cattr);
+
+	return 0;
+}
+
+void tcp_cond_destroy(tcp_cond_t *cond)
+{
+	pthread_cond_destroy(&cond->c);
+	pthread_mutex_destroy(&cond->m);
+}
+
+#ifdef HAVE_PTHREAD_MUTEX_ROBUST
+/* Recover a robust mutex whose previous owner died while holding it: we now own
+ * the lock, but the data it protects may be inconsistent. Marking it consistent
+ * keeps the mutex usable; without this it would become ENOTRECOVERABLE and every
+ * future lock attempt would fail. */
+static void tcp_cond_recover_owner_dead(tcp_cond_t *cond)
+{
+	LM_WARN("robust mutex %p owner died; recovering (state may be partial)\n",
+			(void *)cond);
+	if(pthread_mutex_consistent(&cond->m) != 0)
+		LM_ERR("failed to make robust mutex %p consistent\n", (void *)cond);
+}
+#endif /* HAVE_PTHREAD_MUTEX_ROBUST */
+
+void tcp_cond_lock(tcp_cond_t *cond)
+{
+	int ret;
+
+	ret = pthread_mutex_lock(&cond->m);
+#ifdef HAVE_PTHREAD_MUTEX_ROBUST
+	if(ret == EOWNERDEAD) {
+		tcp_cond_recover_owner_dead(cond);
+		return;
+	}
+#endif /* HAVE_PTHREAD_MUTEX_ROBUST */
+	if(ret != 0) {
+		LM_ERR("pthread_mutex_lock failed: %s (%d)\n", strerror(ret), ret);
+	}
+}
+
+void tcp_cond_unlock(tcp_cond_t *cond)
+{
+	int ret;
+
+	ret = pthread_mutex_unlock(&cond->m);
+	if(ret != 0)
+		LM_ERR("pthread_mutex_unlock failed: %s (%d)\n", strerror(ret), ret);
+}
+
+void tcp_cond_wait(tcp_cond_t *cond)
+{
+	int ret;
+
+	/* re-acquires the mutex on wakeup; that re-acquire can also report a dead
+	 * previous owner on a robust mutex */
+	ret = pthread_cond_wait(&cond->c, &cond->m);
+#ifdef HAVE_PTHREAD_MUTEX_ROBUST
+	if(ret == EOWNERDEAD) {
+		tcp_cond_recover_owner_dead(cond);
+		return;
+	}
+#endif /* HAVE_PTHREAD_MUTEX_ROBUST */
+	if(ret != 0) {
+		LM_ERR("pthread_cond_wait failed: %s (%d)\n", strerror(ret), ret);
+	}
+}
+
+void tcp_cond_signal(tcp_cond_t *cond)
+{
+	int ret;
+
+	ret = pthread_cond_signal(&cond->c);
+	if(ret != 0)
+		LM_ERR("pthread_cond_signal failed: %s (%d)\n", strerror(ret), ret);
+}
+
+void tcp_cond_broadcast(tcp_cond_t *cond)
+{
+	int ret;
+
+	ret = pthread_cond_broadcast(&cond->c);
+	if(ret != 0)
+		LM_ERR("pthread_cond_broadcast failed: %s (%d)\n", strerror(ret), ret);
+}

--- a/src/core/tcp_cond.h
+++ b/src/core/tcp_cond.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 S-P Chan
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _TCP_COND_H_
+#define _TCP_COND_H_
+
+#include <pthread.h>
+
+/*
+ * Cross-process condition variable for the TCP reactor thread pool
+ * (tcp_main_threads == 2). The mutex and the condvar are PTHREAD_PROCESS_SHARED.
+ *
+ * The struct is meant to live in shared memory: TCP worker processes signal it
+ * to submit write jobs, while the pool threads inside PROC_TCP_MAIN wait on it.
+ *
+ * Where the platform supports it the mutex is additionally PTHREAD_MUTEX_ROBUST.
+ * On platforms without robust mutexes (e.g. macOS) the mutex is
+ * process-shared but not robust.
+ */
+typedef struct tcp_cond
+{
+	pthread_mutex_t m;
+	pthread_cond_t c;
+} tcp_cond_t;
+
+/* Initialize a tcp_cond_t (typically allocated in shared memory).
+ * Returns 0 on success, -1 on error. */
+int tcp_cond_init(tcp_cond_t *cond);
+
+/* Destroy a tcp_cond_t. Does not free the memory holding it. */
+void tcp_cond_destroy(tcp_cond_t *cond);
+
+/* Lock / unlock the embedded mutex. tcp_cond_lock() transparently recovers a
+ * robust mutex abandoned by a crashed owner. */
+void tcp_cond_lock(tcp_cond_t *cond);
+void tcp_cond_unlock(tcp_cond_t *cond);
+
+/* Wait on the condition. Must be called with the mutex held (via
+ * tcp_cond_lock()). Recovers the robust mutex if it was abandoned while being
+ * re-acquired on wakeup. */
+void tcp_cond_wait(tcp_cond_t *cond);
+
+/* Wake one / all waiters. */
+void tcp_cond_signal(tcp_cond_t *cond);
+void tcp_cond_broadcast(tcp_cond_t *cond);
+
+#endif /* _TCP_COND_H_ */

--- a/src/core/tcp_conn.h
+++ b/src/core/tcp_conn.h
@@ -66,6 +66,13 @@
 #define F_CONN_CLOSE_EV 32768 /* explicitely call tcpops ev route when closed */
 #define F_CONN_NOSEND 65536	  /* do not send data on this connection */
 #define F_CONN_NORECV (1 << 17) /* do not receive data on this connection */
+/* mode 2 (tcp reactor thread pool) flags */
+#define F_CONN_POOL_BUSY \
+	(1 << 18) /* owned by a pool job: shielded out of io_h + local timer.
+			   * Serializes read/write jobs per conn (one owner at a time). */
+#define F_CONN_CLOSE_EV_SENT \
+	(1 << 19) /* tcpops close event already emitted for this conn: fire-once
+			   * guard so racing teardown paths cannot double-fire the route */
 
 #ifndef NO_READ_HTTP11
 #define READ_HTTP11
@@ -182,6 +189,31 @@ typedef enum conn_cmds
 	,
 	CONN_NEW_COMPLETE /* like CONN_NEW_PENDING_WRITE, but there is no
 						* pending write (the write queue might be empty) */
+	,
+	CONN_WRITE_REQ /* mode 2: worker asks tcp_main to queue a write on an
+						* existing connection; response[0] is a
+						* tcp_reactor_write_req_t*, not a tcp_connection* */
+	,
+	CONN_CONNECT_REQ /* mode 2: worker asks tcp_main to open a new outbound
+						* connection and send on it; response[0] is a
+						* tcp_reactor_connect_req_t*, not a tcp_connection* */
+	,
+	CONN_TLS_EVENT_DONE /* mode 2: worker finished a dispatched
+						 * tls:connection-out event; response[0] is the
+						 * tcp_connection*, tcp_main drops the dispatch refcnt */
+	,
+	CONN_SCRIPT_CLOSE /* mode 2: for worker to signal a connection close on error
+                           * when tcp_script_mode = 0 */
+	,
+	CONN_TCPX_TASK_REQ /* mode 2: any process asks PROC_TCP_MAIN to run a
+						* tcpx_task_t on a pool thread (ksr_tcpx_task_send()'s
+						* generic trampoline, e.g. RPC handlers like
+						* tls.reload); response[0] is a tcpx_task_t* */
+	,
+	CONN_TCPX_TASK_DONE /* mode 2: PROC_TCP_MAIN replies with the result of a
+						 * CONN_TCPX_TASK_REQ, sent back over the requesting
+						 * process's own unix_sock; response[0] is a
+						 * tcpx_task_result_t* */
 } conn_cmds_t;
 /* CONN_RELEASE, EOF, ERROR, DESTROY can be used by "reader" processes
  * CONN_GET_FD, CONN_NEW*, CONN_QUEUED_WRITE only by writers */
@@ -201,6 +233,10 @@ typedef enum tcp_req_flags
 #endif
 	F_TCP_REQ_HEP3 = (1 << 6),
 	F_TCP_REQ_WS_HANDSHAKE = (1 << 7),
+	/* mode 2: reactor dispatch task carries a tls:connection-out event to run
+	 * in a worker, not a message. task->con is the connection; msg_buf is
+	 * empty. See tcp_reactor_dispatch_tls_event(). */
+	F_TCP_REQ_TLS_EVENT = (1 << 8),
 } tcp_req_flags_t;
 
 #define TCP_REQ_HAS_CLEN(tr) ((tr)->flags & F_TCP_REQ_HAS_CLEN)
@@ -290,6 +326,19 @@ typedef struct ksr_coninfo
 } ksr_coninfo_t;
 
 
+/* mode 2 TCP writes: per-connection plaintext write staging
+ * chunk. PROC_TCP_MAIN may still need to apply TLS so
+ * wbuf_q cannot be used yet.
+ */
+struct tcp_wchunk
+{
+	char *buf;
+	unsigned int len;
+	snd_flags_t send_flags;
+	struct tcp_wchunk *next;
+};
+
+
 typedef struct tcp_connection
 {
 	int s;	/*socket, used by "tcp main" */
@@ -322,6 +371,10 @@ typedef struct tcp_connection
 	int aliases; /* aliases number, at least 1 */
 #ifdef TCP_ASYNC
 	struct tcp_wbuffer_queue wbuf_q;
+	/* mode 2 (tcp reactor) write path: the per-connection plaintext staging
+	 * list, guarded by write_lock; unused (NULL) in modes 0/1. */
+	struct tcp_wchunk *wsq_head;
+	struct tcp_wchunk *wsq_tail;
 #endif
 } tcp_connection_t;
 
@@ -437,6 +490,11 @@ struct tcp_connection *tcpconn_get(int id, struct ip_addr *ip, int port,
 struct tcp_connection *tcpconn_lookup(int id, struct ip_addr *ip, int port,
 		union sockaddr_union *local_addr, int try_local_port, ticks_t timeout,
 		sip_protos_t proto);
+/* opens a new outbound tcp connection (socket()+non-blocking connect()); used
+ * from tcp_send() (tcp_main.c) and, in mode 2, tcp_reactor_handle_connect_req()
+ * (tcp_reactor.c) when CONN_CONNECT_REQ's dedup lookup finds nothing. */
+struct tcp_connection *tcpconn_connect(union sockaddr_union *server,
+		union sockaddr_union *from, int type, snd_flags_t *send_flags);
 void tcpconn_log_candidates(int id, struct ip_addr *ip, int port,
 		union sockaddr_union *local_addr, sip_protos_t proto);
 
@@ -471,5 +529,55 @@ int is_tcp_main(void);
 #define _tconfd(c) (is_tcp_main() ? (c)->s : (c)->fd)
 
 int ksr_tcp_parse_accept_protocols(char *protos);
+
+/* write-queue state predicates - used by tcp_main.c (modes 0/1/2) and
+ * tcp_reactor.c (mode 2 pool/completion code) */
+#define _wbufq_empty(con) ((con)->wbuf_q.first == 0)
+#define _wbufq_non_empty(con) ((con)->wbuf_q.first != 0)
+
+/* Connection-lifecycle primitives shared with tcp_reactor.c (mode 2):
+ * write-queueing, unhash/destroy, the close-event emitter. They stay defined
+ * (and mostly used) in tcp_main.c since modes 0/1 need them too; declared
+ * here so tcp_reactor.c can call them without duplicating them. None of these
+ * touch io_h or the local timer - see the tcpmain_* wrappers below for that. */
+int _wbufq_add(struct tcp_connection *c, const char *data, unsigned int size);
+int wbufq_run(int fd, struct tcp_connection *c, int *empty);
+int tcpconn_try_unhash(struct tcp_connection *tcpconn);
+int tcpconn_put_destroy(struct tcp_connection *tcpconn);
+void tcpconn_destroy(struct tcp_connection *tcpconn);
+int tcpconn_chld_put(struct tcp_connection *tcpconn);
+struct tcp_connection *tcpconn_add(struct tcp_connection *c);
+int tcp_emit_closed_event(struct tcp_connection *con);
+void _tcpconn_free(struct tcp_connection *c);
+int tcp_safe_close(int s);
+
+/* io_h and tcp_main_ltimer are process-private to tcp_main.c - only the
+ * io_wait thread may touch them. These wrappers are how tcp_reactor.c reaches
+ * them instead of taking a raw pointer, which would drop that exclusivity.
+ * Callable only from the io_wait thread, same rule as the io_watch_*()/
+ * local_timer_*() calls they forward to. Every conn-fd watch in tcp_reactor.c
+ * uses F_TCPCONN, so the add wrapper hardcodes it; the notify-pipe
+ * registration (F_TCP_REACTOR_NOTIFY) is a separate one-off, done directly in
+ * tcp_main.c after tcp_reactor_pool_init() returns. */
+int tcpmain_io_watch_add_conn(int fd, short events, void *data);
+/* is_closing maps to io_watch_del()'s IO_FD_CLOSING flag (0 otherwise) - a
+ * bool here rather than the raw io_wait.h flag value so tcp_reactor.c does
+ * not need to include io_wait.h (and, with it, define its own fd_type - see
+ * HANDLE_IO_INLINE in io_wait.h - just for one constant). */
+int tcpmain_io_watch_del(int fd, int idx, int is_closing);
+/* no tcpmain_io_watch_add_notify(): the notify-pipe io_watch_add() is a single
+ * call site in tcp_main_loop() itself, right after tcp_reactor_pool_init(). */
+int tcpmain_io_watch_chg(int fd, short events, int idx);
+void tcpmain_local_timer_add(
+		struct timer_ln *tl, ticks_t delta, ticks_t crt_ticks);
+void tcpmain_local_timer_del(struct timer_ln *tl);
+/* local_timer_reinit(tl) needs no wrapper: it's timer_reinit(tl), a macro
+ * that only touches the timer_ln itself, not tcp_main_ltimer. */
+
+/* tcp_connections_no/tls_connections_no accounting - not a hard concurrency
+ * invariant like io_h/the timer (every increment already runs on the
+ * io_wait thread, same as the pre-existing mode 0/1 call sites), exposed as a
+ * wrapper purely to keep the counters themselves private to tcp_main.c. */
+void tcpmain_note_new_conn(int is_tls);
 
 #endif

--- a/src/core/tcp_main.c
+++ b/src/core/tcp_main.c
@@ -55,6 +55,8 @@
 #include <stdint.h> /* UINT32_MAX */
 
 #include <unistd.h>
+#include <signal.h>	 /* sigfillset/pthread_sigmask - mode 2 pool threads */
+#include <pthread.h> /* mode 2 reactor thread pool */
 
 #include <errno.h>
 #include <string.h>
@@ -73,6 +75,7 @@
 #include "locking.h"
 #include "mem/mem.h"
 #include "mem/shm_mem.h"
+#include "tcp_reactor_mem.h" /* mode 2: pkg allocator serialization */
 #include "timer.h"
 #include "sr_module.h"
 #include "tcp_server.h"
@@ -98,6 +101,8 @@
 #include "tcp_info.h"
 #include "tcp_options.h"
 #include "tcp_mtops.h"
+#include "tcp_read.h"
+#include "tcp_reactor.h"
 #include "ut.h"
 #include "events.h"
 #include "cfg/cfg_struct.h"
@@ -147,7 +152,8 @@ enum fd_types
 	F_SOCKINFO /* a tcp_listen fd */,
 	F_TCPCONN,
 	F_TCPCHILD,
-	F_PROC
+	F_PROC,
+	F_TCP_REACTOR_NOTIFY /* mode 2: pool->reactor completion pipe */
 };
 
 
@@ -204,6 +210,43 @@ static io_wait_h io_h;
 
 static struct local_timer tcp_main_ltimer;
 static ticks_t tcp_main_prev_ticks;
+
+/* io_h/tcp_main_ltimer stay private to this file (only the io_wait thread may
+ * touch them); these wrappers are how tcp_reactor.c reaches them instead -
+ * see the prototypes in tcp_conn.h for why. Callable only from the io_wait
+ * thread, same as the io_watch_*()/local_timer_*() calls they forward to. */
+int tcpmain_io_watch_add_conn(int fd, short events, void *data)
+{
+	return io_watch_add(&io_h, fd, events, F_TCPCONN, data);
+}
+
+int tcpmain_io_watch_del(int fd, int idx, int is_closing)
+{
+	return io_watch_del(&io_h, fd, idx, is_closing ? IO_FD_CLOSING : 0);
+}
+
+int tcpmain_io_watch_chg(int fd, short events, int idx)
+{
+	return io_watch_chg(&io_h, fd, events, idx);
+}
+
+void tcpmain_local_timer_add(
+		struct timer_ln *tl, ticks_t delta, ticks_t crt_ticks)
+{
+	local_timer_add(&tcp_main_ltimer, tl, delta, crt_ticks);
+}
+
+void tcpmain_local_timer_del(struct timer_ln *tl)
+{
+	local_timer_del(&tcp_main_ltimer, tl);
+}
+
+void tcpmain_note_new_conn(int is_tls)
+{
+	(*tcp_connections_no)++;
+	if(unlikely(is_tls))
+		(*tls_connections_no)++;
+}
 
 /* tell if there are tcp workers that should handle only specific socket
  * - used to optimize the search of least loaded worker for a tcp socket
@@ -477,7 +520,7 @@ error:
  * @return - 0 on success, < 0 on error (whatever close() returns). On error
  *           errno is set.
  */
-static int tcp_safe_close(int s)
+int tcp_safe_close(int s)
 {
 	int ret;
 
@@ -662,15 +705,13 @@ end:
 #ifdef TCP_ASYNC
 
 
-/* unsafe version */
-#define _wbufq_empty(con) ((con)->wbuf_q.first == 0)
-/* unsafe version */
-#define _wbufq_non_empty(con) ((con)->wbuf_q.first != 0)
+/* _wbufq_empty()/_wbufq_non_empty() are in tcp_conn.h: tcp_reactor.c (mode 2)
+ * needs them too. */
 
 
-/* unsafe version, call while holding the connection write lock */
-inline static int _wbufq_add(
-		struct tcp_connection *c, const char *data, unsigned int size)
+/* unsafe version, call while holding the connection write lock.
+ * Not static: tcp_reactor.c (mode 2) calls this directly. */
+int _wbufq_add(struct tcp_connection *c, const char *data, unsigned int size)
 {
 	struct tcp_wbuffer_queue *q;
 	struct tcp_wbuffer *wb;
@@ -849,7 +890,7 @@ inline static void _wbufq_destroy(struct tcp_wbuffer_queue *q)
 /* tries to empty the queue  (safe version, c->write_lock must not be hold)
  * returns -1 on error, bytes written on success (>=0)
  * if the whole queue is emptied => sets *empty*/
-inline static int wbufq_run(int fd, struct tcp_connection *c, int *empty)
+int wbufq_run(int fd, struct tcp_connection *c, int *empty)
 {
 	struct tcp_wbuffer_queue *q;
 	struct tcp_wbuffer *wb;
@@ -1649,7 +1690,7 @@ int tcpconn_finish_connect(struct tcp_connection *c, union sockaddr_union *from)
 
 /* adds a tcp connection to the tcpconn hashes
  * Note: it's called _only_ from the tcp_main process */
-inline static struct tcp_connection *tcpconn_add(struct tcp_connection *c)
+struct tcp_connection *tcpconn_add(struct tcp_connection *c)
 {
 	struct ip_addr zero_ip;
 	int new_conn_alias_flags;
@@ -1717,11 +1758,20 @@ static inline void _tcpconn_detach(struct tcp_connection *c)
 }
 
 
-static inline void _tcpconn_free(struct tcp_connection *c)
+void _tcpconn_free(struct tcp_connection *c)
 {
 #ifdef TCP_ASYNC
 	if(unlikely(_wbufq_non_empty(c)))
 		_wbufq_destroy(&c->wbuf_q);
+	/* mode 2 : free any plaintext write chunks that were staged on the
+	 * connection but never drained (e.g. a write arrived just before close). */
+	while(c->wsq_head != NULL) {
+		struct tcp_wchunk *ch = c->wsq_head;
+		c->wsq_head = ch->next;
+		shm_free(ch->buf);
+		shm_free(ch);
+	}
+	c->wsq_tail = NULL;
 #endif
 	lock_destroy(&c->write_lock);
 #ifdef USE_TLS
@@ -2300,8 +2350,6 @@ inline static void tcp_fd_cache_add(struct tcp_connection *c, int fd)
 #endif /* TCP_FD_CACHE */
 
 
-inline static int tcpconn_chld_put(struct tcp_connection *tcpconn);
-
 static int tcpconn_send_put(struct tcp_connection *c, const char *buf,
 		unsigned len, snd_flags_t send_flags);
 static int tcpconn_do_send(int fd, struct tcp_connection *c, const char *buf,
@@ -2416,6 +2464,13 @@ int tcp_send(struct dest_info *dst, union sockaddr_union *from, const char *buf,
 					break;
 			}
 		}
+#ifdef TCP_ASYNC
+		if(unlikely(ksr_tcp_main_threads == 2)) {
+			/* mode 2: workers do not open sockets - ask PROC_TCP_MAIN to create
+			 * the outbound connection and send on it. */
+			return tcp_reactor_connect_put(dst, from, buf, len);
+		}
+#endif /* TCP_ASYNC */
 #if defined(TCP_CONNECT_WAIT) && defined(TCP_ASYNC)
 		if(likely(cfg_get(tcp, tcp_cfg, tcp_connect_wait)
 				   && cfg_get(tcp, tcp_cfg, async))) {
@@ -2732,6 +2787,14 @@ int tcp_send(struct dest_info *dst, union sockaddr_union *from, const char *buf,
 		goto release_c;
 	} /* if (c==0 or unusable) new connection */
 	tcp_dst_ephemeral_set(n, c, dst);
+#ifdef TCP_ASYNC
+	if(unlikely(ksr_tcp_main_threads == 2)) {
+		/* mode 2: existing connection - dispatch the write to PROC_TCP_MAIN
+		 * instead of getting the fd and writing here. (Opening a new outbound
+		 * connection, c==0, was handled in the branch above.) */
+		return tcp_reactor_send_put(c, buf, len, dst->send_flags);
+	}
+#endif /* TCP_ASYNC */
 	/* existing connection, send on it */
 	n = tcpconn_send_put(c, buf, len, dst->send_flags);
 	/* no deref needed (automatically done inside tcpconn_send_put() */
@@ -3062,6 +3125,48 @@ int tcpconn_send_unsafe(int fd, struct tcp_connection *c, const char *buf,
 {
 	int n;
 	long response[2];
+
+#ifdef TCP_ASYNC
+	if(unlikely(ksr_tcp_main_threads == 2 && is_tcp_main())) {
+		/* full reactor mode: we are already inside PROC_TCP_MAIN's event loop,
+		 * so there is no fd-passing / unix_sock self-send. This is reached from
+		 * the TLS read path (tls_h_read_*), which drives the handshake and may
+		 * need to push out ciphertext (handshake records, write-wants-read
+		 * flush, renegotiation). Handle the write result against our own
+		 * reactor instead of shipping a CONN_* command to ourselves.
+		 * The caller holds c->write_lock (locked=1) and keeps using c after we
+		 * return, so on failure we mark the connection for the reaper rather
+		 * than freeing it here. */
+		n = tcpconn_do_send(fd, c, buf, len, send_flags, &response[1], 1);
+		switch(response[1]) {
+			case CONN_NOP:
+				break;
+			case CONN_QUEUED_WRITE:
+				/* is_tcp_main() is true for the whole process. On a POOL thread
+				 * (this path is reached from tls_read() flushing handshake /
+				 * renegotiation ciphertext, which runs on a pool thread in
+				 * mode 2) we must NOT touch io_h: the conn is shielded out of
+				 * io_h for the duration of the read job, and io_watch_* from a
+				 * pool thread races the io_wait thread. The ciphertext is already
+				 * queued in wbuf_q; tcp_reactor_read_rearm() arms POLLOUT from
+				 * wbuf_q when the read job completes, so the flush is deferred
+				 * safely. Only the io_wait thread arms the watch directly. */
+				if(tcp_reactor_pool_thread_idx() < 0
+						&& unlikely(tcp_reactor_enable_write_watch(c) < 0)) {
+					c->state = S_CONN_BAD;
+					c->timeout = get_ticks_raw(); /* force timeout reaper */
+				}
+				break;
+			default: /* CONN_ERROR / CONN_EOF: defer close to the reaper */
+				c->state = S_CONN_BAD;
+				c->timeout = get_ticks_raw();
+				if(response[1] == CONN_ERROR)
+					n = -1;
+				break;
+		}
+		return n;
+	}
+#endif /* TCP_ASYNC */
 
 	n = tcpconn_do_send(fd, c, buf, len, send_flags, &response[1], 1);
 	if(unlikely(response[1] != CONN_NOP)) {
@@ -3653,7 +3758,7 @@ inline static void tcpconn_close_main_fd(struct tcp_connection *tcpconn)
  * returns 1 if the connection is freed, 0 otherwise
  *
  * WARNING: use only from child processes */
-inline static int tcpconn_chld_put(struct tcp_connection *tcpconn)
+int tcpconn_chld_put(struct tcp_connection *tcpconn)
 {
 	if(unlikely(atomic_dec_and_test(&tcpconn->refcnt))) {
 		LM_DBG("destroying connection %p (%d, %d) flags %04x\n", tcpconn,
@@ -3677,7 +3782,7 @@ inline static int tcpconn_chld_put(struct tcp_connection *tcpconn)
 /* simple destroy function (the connection should be already removed
  * from the hashes. refcnt 0 and the fds should not be watched anymore for IO)
  */
-inline static void tcpconn_destroy(struct tcp_connection *tcpconn)
+void tcpconn_destroy(struct tcp_connection *tcpconn)
 {
 	LM_DBG("destroying connection %p (%d, %d) flags %04x\n", tcpconn,
 			tcpconn->id, tcpconn->s, tcpconn->flags);
@@ -3717,7 +3822,7 @@ inline static void tcpconn_destroy(struct tcp_connection *tcpconn)
  *         - must be called _only_ from the tcp_main process context
  *          (or else the fd will remain open)
  */
-inline static int tcpconn_put_destroy(struct tcp_connection *tcpconn)
+int tcpconn_put_destroy(struct tcp_connection *tcpconn)
 {
 	if(unlikely((tcpconn->flags
 				 & (F_CONN_WRITE_W | F_CONN_HASHED | F_CONN_MAIN_TIMER
@@ -3769,7 +3874,7 @@ inline static int tcpconn_put_destroy(struct tcp_connection *tcpconn)
  * WARNING: call it only in the  tcp_main process context or else the
  *  timer removal won't work.
  */
-inline static int tcpconn_try_unhash(struct tcp_connection *tcpconn)
+int tcpconn_try_unhash(struct tcp_connection *tcpconn)
 {
 	if(likely(tcpconn->flags & F_CONN_HASHED)) {
 		tcpconn->state = S_CONN_BAD;
@@ -3986,12 +4091,19 @@ tcp_connection_t *ksr_tcpcon_evcb_get(void)
 	return _ksr_tcpcon_evcb;
 }
 
-static int tcp_emit_closed_event(struct tcp_connection *con)
+int tcp_emit_closed_event(struct tcp_connection *con)
 {
 	int ret;
 	tcp_closed_event_info_t tev;
 	sr_event_param_t evp = {0};
 	enum tcp_closed_reason reason;
+
+	/* Fire at most once per connection. In mode 2 a single reset can reach more
+	 * than one teardown path. All emits for a conn run on that one thread, so
+	 * a plain flag test-and-set is sufficient. */
+	if(con->flags & F_CONN_CLOSE_EV_SENT)
+		return 0;
+	con->flags |= F_CONN_CLOSE_EV_SENT;
 
 	if(con->event) {
 		reason = con->event;
@@ -4340,6 +4452,21 @@ inline static int handle_ser_child(struct process_table *p, int fd_i)
 					tcpconn, tcpconn->id, atomic_get(&tcpconn->refcnt),
 					tcpconn->flags);
 		case CONN_EOF: /* forced EOF after full send, due to send flags */
+#ifdef TCP_ASYNC
+			/* mode 2: if a pool thread currently owns this conn (a
+			 * read/write job is in flight), do NOT unhash/io_watch_del/free it
+			 * here - that would race the pool thread. The in-pool refcount keeps
+			 * it alive; mark it bad and let the job completion close it (its
+			 * !HASHED/S_CONN_BAD check routes to tcp_reactor_read_close). Only
+			 * release the sender's reference. */
+			if(unlikely(tcpconn->flags & F_CONN_POOL_BUSY)) {
+				tcpconn->state = S_CONN_BAD;
+				tcpconn->timeout = get_ticks_raw();
+				if(unlikely(tcpconn_put(tcpconn)))
+					tcpconn_destroy(tcpconn); /* can't happen while busy */
+				break;
+			}
+#endif /* TCP_ASYNC */
 #ifdef TCP_CONNECT_WAIT
 			/* if the connection is marked as pending => it might be on
 			 *  the way of reaching tcp_main (e.g. CONN_NEW_COMPLETE or
@@ -4510,6 +4637,29 @@ inline static int handle_ser_child(struct process_table *p, int fd_i)
 			} else {
 				LM_WARN("connection %p already watched for write\n", tcpconn);
 			}
+			break;
+		/* mode 2: worker->tcp_main commands, handled in tcp_reactor.c
+		 * (staging writes, shielding, dedup-and-connect, event/script-close
+		 * teardown). */
+		case CONN_TLS_EVENT_DONE:
+			tcp_reactor_handle_tls_event_done(
+					(struct tcp_connection *)response[0]);
+			break;
+		case CONN_SCRIPT_CLOSE:
+			tcp_reactor_handle_script_close((int)response[0]);
+			break;
+		case CONN_WRITE_REQ:
+			tcp_reactor_handle_write_req(
+					(tcp_reactor_write_req_t *)response[0]);
+			break;
+		case CONN_CONNECT_REQ:
+			tcp_reactor_handle_connect_req(
+					(tcp_reactor_connect_req_t *)response[0]);
+			break;
+		case CONN_TCPX_TASK_REQ:
+			/* mode 2 + mtops: send task to PROC_TCP_MAIN; needed by
+                         * tls.reload */
+			tcp_reactor_handle_tcpx_task_req((tcpx_task_t *)response[0]);
 			break;
 #ifdef TCP_CONNECT_WAIT
 		case CONN_NEW_COMPLETE:
@@ -4905,6 +5055,13 @@ inline static int handle_tcpconn_ev(
 	int bytes;
 #endif /* TCP_ASYNC */
 
+	if(unlikely(ksr_tcp_main_threads == 2)) {
+		/* mode 2: tcp_main owns the fd permanently and does all reads/writes
+		 * itself (no fd-passing, no send2child) - tcp_reactor.c handles the
+		 * shield/enqueue/unshield dance for it. */
+		return tcp_reactor_handle_tcpconn_ev(tcpconn, ev, fd_i);
+	}
+
 	/* pass it to child, so remove it from the io watch list  and the local
 	 *  timer */
 #ifdef TCP_ASYNC
@@ -5087,6 +5244,13 @@ inline static int handle_io(struct fd_map *fm, short ev, int idx)
 		case F_PROC:
 			ret = handle_ser_child((struct process_table *)fm->data, idx);
 			break;
+		case F_TCP_REACTOR_NOTIFY:
+			/* mode 2: a pool thread finished a job. Drain the notify pipe and
+			 * process all completed jobs (coalesced) - tcp_reactor.c owns the
+			 * pool/job state, so the drain+dispatch lives there too. */
+			tcp_reactor_handle_notify();
+			ret = 0;
+			break;
 		case F_NONE:
 			LM_CRIT("empty fd map: %p {%d, %d, %p}, idx %d\n", fm, fm->fd,
 					fm->type, fm->data, idx);
@@ -5117,6 +5281,17 @@ static ticks_t tcpconn_main_timeout(ticks_t t, struct timer_ln *tl, void *data)
 			c, t, c->timeout, TICKS_TO_S(c->timeout - t), c->wbuf_q.wr_timeout,
 			TICKS_TO_S(c->wbuf_q.wr_timeout - t), c->wbuf_q.queued);
 
+	/* mode 2: a connection owned by a pool job is shielded out of the
+	 * local timer (tcp_reactor_shield does local_timer_del + clears
+	 * F_CONN_MAIN_TIMER), so this callback must not run for a busy conn. Guard
+	 * defensively: never reap a conn a pool thread is still using - re-arm and
+	 * let the job completion own its lifetime. */
+	if(unlikely(c->flags & F_CONN_POOL_BUSY)) {
+		LM_WARN("tcp reactor: timer fired on pool-busy conn %p - deferring\n",
+				c);
+		return (ticks_t)cfg_get(tcp, tcp_cfg, con_lifetime);
+	}
+
 	tcp_async = cfg_get(tcp, tcp_cfg, async);
 	if(likely(TICKS_LT(t, c->timeout)
 			   && (!tcp_async || _wbufq_empty(c)
@@ -5126,6 +5301,25 @@ static ticks_t tcpconn_main_timeout(ticks_t t, struct timer_ln *tl, void *data)
 					c->timeout - t, c->wbuf_q.wr_timeout - t);
 		else
 			return (ticks_t)(c->timeout - t);
+	}
+	/* mode 2: reap a connection whose partial SIP message stalled past the
+	 * read deadline. The read path (tcp_reactor_arm_read_timeout) bounds
+	 * c->timeout to that deadline, so reaching here with a message still
+	 * mid-read (tvrstart set) and the read window elapsed means a stalled
+	 * partial read; report it as such instead of idle/send timeout. */
+	if(unlikely(ksr_tcp_main_threads == 2 && ksr_tcp_msg_read_timeout > 0
+				&& c->state == S_CONN_OK && c->req.tvrstart.tv_sec > 0)) {
+		struct timeval tvnow;
+		long long tvdiff;
+		gettimeofday(&tvnow, NULL);
+		tvdiff = 1000000LL * (tvnow.tv_sec - c->req.tvrstart.tv_sec)
+				 + (tvnow.tv_usec - c->req.tvrstart.tv_usec);
+		if(tvdiff >= 1000000LL * ksr_tcp_msg_read_timeout) {
+			LM_DBG("reactor: message read timeout for %p after %lld us\n", c,
+					tvdiff);
+			TCP_STATS_CON_TIMEOUT();
+			goto reap;
+		}
 	}
 	/* if time out due to write, add it to the blocklist */
 	if(tcp_async && _wbufq_non_empty(c) && TICKS_GE(t, c->wbuf_q.wr_timeout)) {
@@ -5160,6 +5354,9 @@ static ticks_t tcpconn_main_timeout(ticks_t t, struct timer_ln *tl, void *data)
 	/* idle timeout */
 	TCP_EV_IDLE_CONN_CLOSED(0, &c->rcv);
 	TCP_STATS_CON_TIMEOUT();
+#endif /* TCP_ASYNC */
+#ifdef TCP_ASYNC
+reap:
 #endif /* TCP_ASYNC */
 	LM_DBG("timeout for %p\n", c);
 	/* The connection timed out and is torn down here.
@@ -5304,6 +5501,10 @@ void tcp_main_loop()
 			goto error;
 		}
 		LM_INFO("tcp main processing threads prepared\n");
+		/* mode 2: the reactor dispatch socketpair is created in the main
+		 * process by tcp_init_children() before any TCP child is forked, so it
+		 * is inherited here (and by every worker). Nothing to do at this point;
+		 * tcp_main uses ksr_tcp_reactor_get_dispatch_wfd() to ship tasks. */
 	} else {
 		LM_INFO("tcp main processing threads not enabled\n");
 	}
@@ -5359,6 +5560,25 @@ void tcp_main_loop()
 			}
 	}
 
+
+	/* mode 2: start the reactor thread pool (notify pipe + worker threads).
+	 * io_h is already initialized; the threads spawn and block in
+	 * tcp_cond_wait until reads/writes are routed to them.
+	 * tcp_reactor_pool_init() (tcp_reactor.c) creates the notify pipe but does
+	 * not watch it - only the io_wait thread may touch io_h, so that
+	 * registration happens here. */
+	if(ksr_tcp_main_threads == 2) {
+		if(tcp_reactor_pool_init() < 0) {
+			LM_CRIT("failed to start the tcp reactor thread pool\n");
+			goto error;
+		}
+		if(io_watch_add(&io_h, tcp_rpool.notify_pipe[0], POLLIN,
+				   F_TCP_REACTOR_NOTIFY, NULL)
+				< 0) {
+			LM_CRIT("failed to watch the reactor notify pipe\n");
+			goto error;
+		}
+	}
 
 	/* initialize the cfg framework */
 	if(cfg_child_init())
@@ -5433,6 +5653,8 @@ void tcp_main_loop()
 			goto error;
 	}
 error:
+	if(ksr_tcp_main_threads == 2)
+		tcp_reactor_pool_destroy(); /* stop + join pool threads */
 #ifdef SEND_FD_QUEUE
 	destroy_send_fd_queues();
 #endif
@@ -5686,6 +5908,12 @@ int tcp_init_children(int *woneinit)
 
 	/* create the tcp sock_info structures */
 	/* copy the sockets --moved to main_loop*/
+
+	/* mode 2: create the reactor dispatch socketpair before forking, so the
+	 * workers (below) and PROC_TCP_MAIN (forked by the caller right after) all
+	 * inherit the shared fds */
+	if(tcp_reactor_dsock_init() < 0)
+		goto error;
 
 	/* fork children & create the socket pairs*/
 	for(r = 0; r < tcp_children_no; r++) {

--- a/src/core/tcp_mtops.c
+++ b/src/core/tcp_mtops.c
@@ -39,6 +39,9 @@
 #include "dprint.h"
 #include "pt.h"
 #include "mem/shm.h"
+#include "globals.h"
+#include "pass_fd.h" /* send_all(), receive_fd() - mode 2 unix_tcp_sock relay */
+#include "tcp_conn.h" /* conn_cmds_t: CONN_TCPX_TASK_REQ/_DONE */
 
 #include "tcp_mtops.h"
 
@@ -65,6 +68,17 @@ static ksr_tcpx_proc_t *_ksr_tcpx_proc_list = NULL;
  *
  */
 static int _ksr_tcpx_proc_list_size = 0;
+
+/* mode 2: tcp_main-local write buffer and synchronous result slot.
+ * Used by the direct-call path (KSR_TCPX_MAIN_PIDX) instead of the
+ * per-process socketpair relay used in mode 1.
+ *
+ * Provide a scratch buffer for TLS per thread.
+ */
+
+extern int is_tcp_main(void);
+static _Thread_local unsigned char ksr_tcp_main_wrbuf[TLS_WR_MBUF_SZ];
+static _Thread_local tcpx_task_result_t *ksr_tcp_main_eresult = NULL;
 
 /**
  * Set a unique id per thread
@@ -110,6 +124,32 @@ static void *ksr_tcpx_thread_etask(void *param)
 int ksr_tcpx_thread_eresult(tcpx_task_result_t *rtask, int pidx)
 {
 	int len;
+	long resp[2];
+
+	if(pidx == KSR_TCPX_MAIN_PIDX) {
+		/* mode 2 + mtops:  direct-call path */
+		ksr_tcp_main_eresult = rtask;
+		return 0;
+	}
+
+	if(ksr_tcp_main_threads == 2) {
+		/* mode 2 + mtops: send response */
+		if(unlikely(pidx < 0 || pidx >= get_max_procs()
+					|| pt[pidx].unix_sock <= 0)) {
+			LM_ERR("invalid pidx %d for tcpx task result %p\n", pidx,
+					(void *)rtask);
+			return -1;
+		}
+		resp[0] = (long)rtask;
+		resp[1] = CONN_TCPX_TASK_DONE;
+		if(unlikely(send_all(pt[pidx].unix_sock, resp, sizeof(resp)) <= 0)) {
+			LM_ERR("failed to send tcpx task result [%p] to pidx [%d]\n",
+					(void *)rtask, pidx);
+			return -1;
+		}
+		return 0;
+	}
+
 	len = write(_ksr_tcpx_proc_list[pidx].rcvsock[1], &rtask,
 			sizeof(tcpx_task_result_t *));
 	if(len <= 0) {
@@ -127,6 +167,27 @@ int ksr_tcpx_thread_eresult(tcpx_task_result_t *rtask, int pidx)
 int ksr_tcpx_task_send(tcpx_task_t *task, int pidx)
 {
 	int len;
+	long req[2];
+
+	if(ksr_tcp_main_threads == 2) {
+		if(is_tcp_main()) {
+			/* already in PROC_TCP_MAIN: call exec() directly, no relay
+			 * needed */
+			if(task->exec)
+				task->exec(task->param, KSR_TCPX_MAIN_PIDX);
+			return 0;
+		}
+		/* mode 2 + mtops: send task over own unix_tcp_sock */
+		req[0] = (long)task;
+		req[1] = CONN_TCPX_TASK_REQ;
+		if(unlikely(send_all(unix_tcp_sock, req, sizeof(req)) <= 0)) {
+			LM_ERR("failed to send tcpx task [%p] to PROC_TCP_MAIN: %s (%d)\n",
+					(void *)task, strerror(errno), errno);
+			return -1;
+		}
+		return 0;
+	}
+
 	len = write(
 			_ksr_tcpx_proc_list[pidx].sndsock[1], &task, sizeof(tcpx_task_t *));
 	if(len <= 0) {
@@ -143,6 +204,29 @@ int ksr_tcpx_task_send(tcpx_task_t *task, int pidx)
 int ksr_tcpx_task_result_recv(tcpx_task_result_t **rtask, int pidx)
 {
 	int received;
+	long resp[2];
+	int fd_unused = -1;
+
+	if(ksr_tcp_main_threads == 2) {
+		if(is_tcp_main()) {
+			/* mode 2 direct-call path */
+			*rtask = ksr_tcp_main_eresult;
+			ksr_tcp_main_eresult = NULL;
+			return 0;
+		}
+		/* mode 2 + mtops: block for response */
+		received = receive_fd(
+				unix_tcp_sock, resp, sizeof(resp), &fd_unused, MSG_WAITALL);
+		if(received != (int)sizeof(resp) || resp[1] != CONN_TCPX_TASK_DONE) {
+			LM_ERR("failed/invalid tcpx task result recv from PROC_TCP_MAIN"
+				   " (n=%d)\n",
+					received);
+			return -1;
+		}
+		*rtask = (tcpx_task_result_t *)resp[0];
+		return 0;
+	}
+
 	if((received = recvfrom(_ksr_tcpx_proc_list[pidx].rcvsock[0], rtask,
 				sizeof(tcpx_task_result_t *), 0, NULL, 0))
 			< 0) {
@@ -166,6 +250,11 @@ int ksr_tcpx_proc_list_init(void)
 	int i;
 
 	if(_ksr_tcpx_proc_list != NULL) {
+		return 0;
+	}
+
+	if(ksr_tcp_main_threads == 2) {
+		/* mode 2: no per-process trampoline threads or socketpairs needed */
 		return 0;
 	}
 
@@ -215,6 +304,11 @@ int ksr_tcpx_proc_list_prepare(void)
 {
 	int i;
 
+	if(ksr_tcp_main_threads == 2) {
+		/* mode 2: direct-call path replaces per-process threads */
+		return 0;
+	}
+
 	for(i = 0; i < _ksr_tcpx_proc_list_size; i++) {
 		if(pthread_create(&_ksr_tcpx_proc_list[i].ethread, NULL,
 				   ksr_tcpx_thread_etask, (void *)(long)i)) {
@@ -237,6 +331,12 @@ error:
  */
 unsigned char *ksr_tcpx_thread_wrbuf(int pidx)
 {
+	/* mode 2: the encode trampoline passes pidx == process_no (a single value
+	 * for PROC_TCP_MAIN), but the work runs on many threads. Return the
+	 * thread-local buffer for every mode-2 caller, regardless of pidx, so
+	 * concurrent pool-thread TLS encodes do not share one buffer. */
+	if(ksr_tcp_main_threads == 2 || pidx == KSR_TCPX_MAIN_PIDX)
+		return ksr_tcp_main_wrbuf;
 	if(_ksr_tcpx_proc_list == NULL)
 		return NULL;
 	if(pidx >= _ksr_tcpx_proc_list_size)

--- a/src/core/tcp_mtops.h
+++ b/src/core/tcp_mtops.h
@@ -26,6 +26,10 @@
 #define TLS_RD_MBUF_SZ 65536
 #define TLS_WR_MBUF_SZ 65536
 
+/* pidx sentinel used in mode 2: identifies the tcp_main thread context.
+ * No per-process trampoline thread exists; exec() is called directly. */
+#define KSR_TCPX_MAIN_PIDX (-1)
+
 typedef void (*tcpx_cbe_f)(void *p, int pidx);
 
 typedef struct tcpx_task

--- a/src/core/tcp_reactor.c
+++ b/src/core/tcp_reactor.c
@@ -1,0 +1,1534 @@
+/*
+ * Copyright (C) 2026 S-P Chan
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * @brief mode 2 (full tcp reactor, ksr_tcp_main_threads == 2) - pool, dispatch
+ * socket, and PROC_TCP_MAIN-side job/event handling.
+ *
+ * This file is a leaf module: it owns all mode-2-exclusive state (the
+ * dispatch socketpair, the reactor thread pool, per-connection shield/job
+ * bookkeeping) and exposes a small entry-point API (tcp_reactor.h) to
+ * tcp_main.c and tcp_read.c. It does not touch tcp_main.c's private io_wait
+ * set (io_h) or local timer (tcp_main_ltimer) directly - see the tcpmain_*
+ * wrapper prototypes and the long comment next to them in tcp_conn.h for why.
+ */
+
+/* pthread_setname_np() needs _GNU_SOURCE on glibc; must be set before any
+ * include (same requirement as tcp_cond.c). */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <poll.h>
+#include <signal.h> /* sigfillset/pthread_sigmask - pool threads */
+#include <pthread.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "dprint.h"
+#include "ip_addr.h"
+#include "globals.h"
+#include "locking.h"
+#include "mem/mem.h"
+#include "mem/shm_mem.h"
+#include "mem/pkg.h"
+#include "pass_fd.h"  /* send_all() */
+#include "tcp_conn.h" /* struct tcp_connection, tcpconn_ref/put, F_TCP_REQ_*,
+						 * tcpconn_try_unhash()/_put_destroy()/etc. and the
+						 * tcpmain_* io_h/timer wrappers */
+#include "tcp_reactor.h"
+#include "tcp_reactor_mem.h" /* tcp_reactor_pkg_lock_install() */
+#include "tcp_mtops.h"		 /* tcpx_task_t, KSR_TCPX_MAIN_PIDX */
+#include "tcp_server.h"		 /* ksr_tcp_reactor_get_dispatch_wfd() */
+#include "tcp_read.h"		 /* tcp_read_req(), rd_conn_flags_t, RD_CONN_* */
+#include "tcp_options.h"	 /* tcp_cfg */
+#include "cfg/cfg_struct.h"	 /* cfg_get() */
+#include "timer.h"
+#include "timer_ticks.h"
+#include "local_timer.h"
+#ifdef CORE_TLS
+#include "tls/tls_server.h" /* tls_encode() */
+#else
+#include "tls_hooks.h" /* tls_encode() via TLS_HOOKS */
+#endif
+
+/* mode 2 reactor: shared AF_UNIX SOCK_DGRAM socketpair.
+ * [0] = read end (all workers recvfrom this fd after fork)
+ * [1] = write end (tcp_main sends task pointers here) */
+static int ksr_tcp_reactor_dsock[2] = {-1, -1};
+
+int ksr_tcp_reactor_get_dispatch_rfd(void)
+{
+	return ksr_tcp_reactor_dsock[0];
+}
+
+int ksr_tcp_reactor_get_dispatch_wfd(void)
+{
+	return ksr_tcp_reactor_dsock[1];
+}
+
+/* mode 2 reactor pool wakeup condvar (shm) */
+struct tcp_reactor_wake *tcp_reactor_wake = NULL;
+struct tcp_reactor_pool tcp_rpool;
+
+/* number of reactor pool threads; configurable via the tcp_reactor_threads
+ * cfg.y directive (assigns through the extern in globals.h), default 8. */
+int ksr_tcp_reactor_threads = 8;
+
+/* per-pool-thread index (0..N-1); -1 in the io_wait/main thread and any other
+ * thread. Set at pool-thread start (tcp_reactor_thread_routine()). Two uses:
+ * selecting the per-thread TLS encode scratch buffer (see tcp_mtops.c) so
+ * concurrent pool encodes never collide, and letting tcp_reactor_send_put()/
+ * tcpconn_send_unsafe() tell a pool thread from the io_wait thread (both
+ * satisfy is_tcp_main()) via tcp_reactor_pool_thread_idx(). */
+static _Thread_local int tcp_reactor_thread_idx = -1;
+
+int tcp_reactor_pool_thread_idx(void)
+{
+	return tcp_reactor_thread_idx;
+}
+
+/* The dispatch socket carries one task pointer per datagram. A write of at
+ * most PIPE_BUF bytes is guaranteed atomic, so the pointer is never torn
+ * across concurrent worker recvs (see the _Static_assert below). */
+_Static_assert(sizeof(uintptr_t) <= PIPE_BUF,
+		"task pointer too wide for atomic dispatch write");
+
+/* Hand a task pointer to the workers over the dispatch socketpair.
+ *
+ * The socket is non-blocking: poll briefly for the buffer to drain
+ * and retry, giving up only on a hard error or if the workers
+ * stay wedged past the bounded wait.
+ * Returns 0 on success, -1 on failure
+ * (task not sent - the caller must free it). */
+#define TCP_REACTOR_DISPATCH_POLL_MS 100
+#define TCP_REACTOR_DISPATCH_POLL_TRIES 5
+static int tcp_reactor_dispatch_send(uintptr_t ptr)
+{
+	int wfd = ksr_tcp_reactor_get_dispatch_wfd();
+	int tries = 0;
+	ssize_t sent;
+	struct pollfd pfd;
+
+	for(;;) {
+		sent = send(wfd, &ptr, sizeof(ptr), 0);
+		if(sent == (ssize_t)sizeof(ptr))
+			return 0;
+		if(sent < 0 && errno == EINTR)
+			continue; /* interrupted before anything was sent - retry */
+		if(sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+			if(tries++ >= TCP_REACTOR_DISPATCH_POLL_TRIES) {
+				LM_WARN("dispatch socket full: workers not draining after"
+						" %d x %dms - dropping task\n",
+						TCP_REACTOR_DISPATCH_POLL_TRIES,
+						TCP_REACTOR_DISPATCH_POLL_MS);
+				return -1;
+			}
+			pfd.fd = wfd;
+			pfd.events = POLLOUT;
+			pfd.revents = 0;
+			poll(&pfd, 1, TCP_REACTOR_DISPATCH_POLL_MS); /* wait for drain */
+			continue;
+		}
+		LM_ERR("dispatch send failed (%s)\n",
+				(sent < 0) ? strerror(errno) : "short write");
+		return -1;
+	}
+}
+
+/*
+ * Allocate a tcp_reactor_task_t in shm, copy the reassembled SIP message
+ * and receive_info into it, then send the pointer to the workers via the
+ * dispatch socketpair write end.
+ *
+ * Called on a PROC_TCP_MAIN reactor pool thread - the read/reassembly runs in
+ * the TCP_R_READ job, not on the io_wait thread - at the point where
+ * receive_tcp_msg() would be called inline in modes 0/1. WS delivers here too
+ * (ws_deliver_sip), likewise from a pool thread.
+ *
+ * The receiving worker dispatches on task->flags (plain SIP -> receive_msg(),
+ * F_TCP_REQ_HEP3 -> hep3_process_msg()) then shm_free()s the task.
+ */
+int tcp_reactor_dispatch_msg(char *buf, unsigned int len, unsigned int flags,
+		struct receive_info *rcv)
+{
+	tcp_reactor_task_t *task;
+	uintptr_t ptr;
+
+	task = shm_malloc(sizeof(tcp_reactor_task_t) + len + 1);
+	if(task == NULL) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+	task->rcv = *rcv;
+	task->msg_len = len;
+	task->flags = flags;
+	memcpy(task->msg_buf, buf, len);
+	task->msg_buf[len] = '\0';
+
+	ptr = (uintptr_t)task;
+	if(tcp_reactor_dispatch_send(ptr) < 0) {
+		shm_free(task);
+		return -1;
+	}
+	return 0;
+}
+
+int tcp_reactor_dispatch_tls_event(struct tcp_connection *c)
+{
+	tcp_reactor_task_t *task;
+	uintptr_t ptr;
+
+	/* Keep c alive for the hop to the worker: it reads c's cached TLS metadata
+	 * and hands the refcnt back via CONN_TLS_EVENT_DONE. The read job that
+	 * reached us already holds a ref, so this extra one is never the last -
+	 * the error-path tcpconn_put() below can't free c. */
+	tcpconn_ref(c);
+
+	task = shm_malloc(sizeof(tcp_reactor_task_t) + 1);
+	if(task == NULL) {
+		SHM_MEM_ERROR;
+		tcpconn_put(c);
+		return -1;
+	}
+	task->rcv = c->rcv;
+	task->con = c;
+	task->msg_len = 0;
+	task->flags = F_TCP_REQ_TLS_EVENT;
+	task->msg_buf[0] = '\0';
+
+	ptr = (uintptr_t)task;
+	if(tcp_reactor_dispatch_send(ptr) < 0) {
+		shm_free(task);
+		tcpconn_put(c);
+		return -1;
+	}
+	return 0;
+}
+
+/* ===========================================================================
+ * Write-queue staging, shield/unshield, and per-connection reactor helpers.
+ * ========================================================================= */
+
+
+/* mode 2: append an outgoing payload to c's write queue (wbuf_q), encrypting it
+ * first for TLS/WSS (tls_encode) or copying it verbatim for plain TCP.
+ **/
+static int tcp_reactor_wbuf_add_locked(struct tcp_connection *c, char *buf,
+		unsigned len, snd_flags_t send_flags)
+{
+#ifdef USE_TLS
+	const char *t_buf, *rest_buf;
+	unsigned t_len, rest_len;
+	snd_flags_t t_send_flags;
+	int wn;
+
+	if(unlikely(c->type == PROTO_TLS || c->type == PROTO_WSS)) {
+		t_buf = buf;
+		t_len = len;
+		do {
+			t_send_flags = send_flags;
+			wn = tls_encode(
+					c, &t_buf, &t_len, &rest_buf, &rest_len, &t_send_flags);
+			if(unlikely((wn < 0)
+						|| (t_len && (_wbufq_add(c, t_buf, t_len) < 0)))) {
+				c->state = S_CONN_BAD;
+				c->timeout = get_ticks_raw(); /* force timeout */
+				return -1;
+			}
+			t_buf = rest_buf;
+			t_len = rest_len;
+		} while(unlikely(rest_len && wn > 0));
+		return 0;
+	}
+#endif /* USE_TLS */
+	if(unlikely(len && (_wbufq_add(c, buf, len) < 0))) {
+		c->state = S_CONN_BAD;
+		c->timeout = get_ticks_raw(); /* force timeout */
+		return -1;
+	}
+	tcpconn_set_send_flags(c, send_flags);
+	return 0;
+}
+
+/* mode 2: the locking wrapper around tcp_reactor_wbuf_add_locked() for callers
+ * that do NOT already hold c->write_lock - it takes the lock, appends (encoding
+ * for TLS), and releases it. Same 0/-1 return. Mirrors the TLS branch of the
+ * legacy tcpconn_send_put(). */
+static int tcp_reactor_wbuf_enqueue(struct tcp_connection *c, char *buf,
+		unsigned len, snd_flags_t send_flags)
+{
+	int ret;
+
+	lock_get(&c->write_lock);
+	ret = tcp_reactor_wbuf_add_locked(c, buf, len, send_flags);
+	lock_release(&c->write_lock);
+	return ret;
+}
+
+/* mode 2: enable POLLOUT watching on an already-hashed connection (mirrors the
+ * CONN_QUEUED_WRITE logic). Non-destructive: on io_watch failure it clears the
+ * write-watch flag and returns -1 WITHOUT freeing c, so callers that keep using
+ * c afterwards (e.g. the TLS read path) stay safe. Returns 0 on success. */
+int tcp_reactor_enable_write_watch(struct tcp_connection *c)
+{
+	ticks_t t;
+
+	/* mode 2: if the conn is currently owned by a pool job
+	 * (F_CONN_POOL_BUSY) it is in neither io_h nor the local timer, and is
+	 * being touched by a pool thread. Return immediately WITHOUT touching
+	 * c->flags or io_h - a pool thread (this may be called from its TLS /
+	 * CRLF-pong write-back) must not race the io_wait thread on c->flags. The
+	 * data is already in wbuf_q and the job completion re-arms POLLOUT from it.
+	 * This check MUST come before any c->flags write below. */
+	if(c->flags & F_CONN_POOL_BUSY)
+		return 0;
+	if(c->flags & F_CONN_WANTS_WR)
+		return 0;
+	c->flags |= F_CONN_WANTS_WR;
+	t = get_ticks_raw();
+	if(likely((c->flags & F_CONN_MAIN_TIMER)
+			   && (TICKS_LT(c->wbuf_q.wr_timeout, c->timeout))
+			   && TICKS_LT(t, c->wbuf_q.wr_timeout))) {
+		tcpmain_local_timer_del(&c->timer);
+		local_timer_reinit(&c->timer);
+		tcpmain_local_timer_add(&c->timer, c->wbuf_q.wr_timeout - t, t);
+	}
+	if(!(c->flags & F_CONN_WRITE_W)) {
+		c->flags |= F_CONN_WRITE_W;
+		if(!(c->flags & F_CONN_READ_W)) {
+			if(unlikely(tcpmain_io_watch_add_conn(c->s, POLLOUT, c) < 0)) {
+				LM_CRIT("failed to enable write watch (reactor)\n");
+				c->flags &= ~F_CONN_WRITE_W;
+				return -1;
+			}
+		} else {
+			if(unlikely(tcpmain_io_watch_chg(c->s, POLLIN | POLLOUT, -1) < 0)) {
+				LM_CRIT("failed to change socket watch events (reactor)\n");
+				c->flags &= ~F_CONN_WRITE_W;
+				return -1;
+			}
+		}
+	}
+	return 0;
+}
+
+/* mode 2: enable POLLOUT watching, destroying the connection on io_watch
+ * failure. Used by the IPC write/connect handlers, which do not touch c after
+ * this returns. Returns 0 on success, -1 on error (c unhashed and destroyed). */
+static int tcp_reactor_watch_write(struct tcp_connection *c)
+{
+	if(unlikely(tcp_reactor_enable_write_watch(c) < 0)) {
+		if(likely(tcpconn_try_unhash(c))) {
+			if((c->flags & F_CONN_READ_W) && (c->s != -1)) {
+				tcpmain_io_watch_del(c->s, -1, 1);
+				c->flags &= ~F_CONN_READ_W;
+			}
+			tcpconn_put_destroy(c);
+		} else {
+			BUG("unhashed connection watched for IO\n");
+		}
+		return -1;
+	}
+	return 0;
+}
+
+/* mode 2: modifies the existing per-connection timer:
+ * - allows PROC_TCP_MAIN to reap a partial read, instead of
+ *   waiting for the slower cross-process tcp_timer_check_connections() sca
+ * - pulls c->timeout in to the partial-read deadline (message start +
+ *   ksr_tcp_msg_read_timeout) and re-arms c->timer to fire there
+ * Caller passes t = current tick.
+ */
+static void tcp_reactor_arm_read_timeout(struct tcp_connection *c, ticks_t t)
+{
+	struct timeval tvnow;
+	long long elapsed_us, remaining_ms;
+	ticks_t deadline;
+
+	if(likely(ksr_tcp_msg_read_timeout <= 0 || c->state != S_CONN_OK
+			   || c->req.tvrstart.tv_sec == 0))
+		return;
+	gettimeofday(&tvnow, NULL);
+	elapsed_us = 1000000LL * (tvnow.tv_sec - c->req.tvrstart.tv_sec)
+				 + (tvnow.tv_usec - c->req.tvrstart.tv_usec);
+	remaining_ms = (1000000LL * ksr_tcp_msg_read_timeout - elapsed_us) / 1000LL;
+	if(remaining_ms < 0)
+		remaining_ms = 0;
+	deadline = t + MS_TO_TICKS((ticks_t)remaining_ms);
+	if(TICKS_LT(deadline, c->timeout))
+		c->timeout = deadline;
+	/* re-arm the local timer to (possibly) fire earlier at the read deadline */
+	if(likely(c->flags & F_CONN_MAIN_TIMER)) {
+		tcpmain_local_timer_del(&c->timer);
+		local_timer_reinit(&c->timer);
+		tcpmain_local_timer_add(&c->timer, c->timeout - t, t);
+	}
+}
+
+/* mode 2: enqueue a read/write job for c onto the pool task queue. Caller
+ * (io_wait thread) has already shielded the conn. Returns 0/-1. */
+static int tcp_reactor_enqueue_job(
+		struct tcp_connection *c, enum tcp_reactor_op op)
+{
+	struct tcp_reactor_job *job;
+
+	job = pkg_malloc(sizeof(*job));
+	if(unlikely(job == NULL)) {
+		PKG_MEM_ERROR;
+		return -1;
+	}
+	memset(job, 0, sizeof(*job));
+	job->conn = c;
+	job->op = op;
+	tcp_cond_lock(&tcp_reactor_wake->cond);
+	job->next = NULL;
+	if(tcp_rpool.task_tail != NULL)
+		tcp_rpool.task_tail->next = job;
+	else
+		tcp_rpool.task_head = job;
+	tcp_rpool.task_tail = job;
+	tcp_cond_signal(&tcp_reactor_wake->cond);
+	tcp_cond_unlock(&tcp_reactor_wake->cond);
+	return 0;
+}
+
+/* mode 2: enqueue a connectionless TCP_R_RUN job carrying task onto the pool
+ * queue. No shield/refcount dance concerns. Returns 0/-1. */
+static int tcp_reactor_enqueue_run(tcpx_task_t *task)
+{
+	struct tcp_reactor_job *job;
+
+	job = pkg_malloc(sizeof(*job));
+	if(unlikely(job == NULL)) {
+		PKG_MEM_ERROR;
+		return -1;
+	}
+	memset(job, 0, sizeof(*job));
+	job->op = TCP_R_RUN;
+	job->task = task;
+	tcp_cond_lock(&tcp_reactor_wake->cond);
+	job->next = NULL;
+	if(tcp_rpool.task_tail != NULL)
+		tcp_rpool.task_tail->next = job;
+	else
+		tcp_rpool.task_head = job;
+	tcp_rpool.task_tail = job;
+	tcp_cond_signal(&tcp_reactor_wake->cond);
+	tcp_cond_unlock(&tcp_reactor_wake->cond);
+	return 0;
+}
+
+/* mode 2 + mtops: used to send tasks to the thread pool from external
+ * processes like jsonrpc with tls.reload
+ */
+void tcp_reactor_handle_tcpx_task_req(tcpx_task_t *task)
+{
+	if(unlikely(tcp_reactor_enqueue_run(task) < 0)) {
+		/* Enqueue failed (pkg OOM) - the sender is blocked in
+		 * ksr_tcpx_task_result_recv() so dropping
+		 * the task here would hang it forever. Run it inline instead. */
+		LM_ERR("failed to enqueue tcpx task %p - running inline\n",
+				(void *)task);
+		if(task->exec)
+			task->exec(task->param, KSR_TCPX_MAIN_PIDX);
+	}
+}
+
+/* mode 2: take exclusive pool ownership of a connection. Runs in the
+ * io_wait thread. Removes the conn from io_h and the local timer, clears its
+ * watch flags, sets F_CONN_POOL_BUSY, and takes the single "in-pool" refcount
+ * that is held until the conn is unshielded or closed (it spans chained jobs).
+ * No-op (returns 0) if already busy. Returns -1 on io_watch error. */
+static int tcp_reactor_shield(struct tcp_connection *c, int fd_i)
+{
+	if(c->flags & F_CONN_POOL_BUSY)
+		return 0;
+	if((c->flags & (F_CONN_READ_W | F_CONN_WRITE_W)) && (c->s != -1)) {
+		if(unlikely(tcpmain_io_watch_del(c->s, fd_i, 0) < 0)) {
+			LM_ERR("reactor: io_watch_del (shield) failed for %p fd %d\n", c,
+					c->s);
+			return -1;
+		}
+	}
+	if(c->flags & F_CONN_MAIN_TIMER) {
+		tcpmain_local_timer_del(&c->timer);
+		c->flags &= ~F_CONN_MAIN_TIMER;
+	}
+	c->flags &= ~(
+			F_CONN_READ_W | F_CONN_WRITE_W | F_CONN_WANTS_RD | F_CONN_WANTS_WR);
+	c->flags |= F_CONN_POOL_BUSY;
+	tcpconn_ref(c); /* in-pool ref: released at unshield/close */
+	return 0;
+}
+
+/* mode 2: stage a plaintext write chunk onto c's per-connection
+ * write staging list (shm). Taken by a pool TCP_R_WRITE job. Safe to call from
+ * the io_wait thread (CONN_WRITE_REQ handler). Returns 0/-1. */
+static int tcp_reactor_wsq_add(struct tcp_connection *c, const char *buf,
+		unsigned len, snd_flags_t send_flags)
+{
+	struct tcp_wchunk *ch;
+
+	ch = shm_malloc(sizeof(*ch));
+	if(unlikely(ch == NULL)) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+	ch->buf = shm_malloc(len ? len : 1);
+	if(unlikely(ch->buf == NULL)) {
+		SHM_MEM_ERROR;
+		shm_free(ch);
+		return -1;
+	}
+	if(len)
+		memcpy(ch->buf, buf, len);
+	ch->len = len;
+	ch->send_flags = send_flags;
+	ch->next = NULL;
+	lock_get(&c->write_lock);
+	if(c->wsq_tail != NULL)
+		c->wsq_tail->next = ch;
+	else
+		c->wsq_head = ch;
+	c->wsq_tail = ch;
+	lock_release(&c->write_lock);
+	return 0;
+}
+
+/* mode 2: re-arm a connection in the reactor after its pool job(s)
+ * finished (unshield). Runs in the io_wait thread. Clears F_CONN_POOL_BUSY,
+ * adds POLLIN plus POLLOUT if a write accumulated, and re-arms the local timer
+ * the shield removed. Returns 0 on success, -1 on io_watch error (caller
+ * should then close the connection). */
+static int tcp_reactor_read_rearm(struct tcp_connection *c)
+{
+	short events = POLLIN;
+	ticks_t t;
+
+	c->flags &= ~F_CONN_POOL_BUSY;
+	c->flags |= F_CONN_READ_W | F_CONN_WANTS_RD;
+	if(_wbufq_non_empty(c)) {
+		events |= POLLOUT;
+		c->flags |= F_CONN_WRITE_W | F_CONN_WANTS_WR;
+	}
+	if(unlikely(tcpmain_io_watch_add_conn(c->s, events, c) < 0)) {
+		LM_ERR("reactor: failed to re-arm read watch for %p fd %d\n", c, c->s);
+		c->flags &= ~(F_CONN_READ_W | F_CONN_WRITE_W);
+		return -1;
+	}
+	t = get_ticks_raw();
+	c->timeout = t + cfg_get(tcp, tcp_cfg, con_lifetime);
+	/* re-arm the local timer disarmed by the shield (it was removed from the
+	 * timer list, so reinit + add - no del). arm_read_timeout() below may then
+	 * shorten it to the partial-read deadline if a message is mid-read. */
+	if(!(c->flags & F_CONN_MAIN_TIMER)) {
+		local_timer_reinit(&c->timer);
+		tcpmain_local_timer_add(&c->timer, c->timeout - t, t);
+		c->flags |= F_CONN_MAIN_TIMER;
+	}
+	tcp_reactor_arm_read_timeout(c, t);
+	return 0;
+}
+
+/* mode 2: tear down a connection owned by a pool job (EOF/error). The conn
+ * is shielded (out of io_h + timer already); runs on the io_wait thread.
+ *
+ * Both callers (handle_done on resp < 0, unshield_or_chain's close/re-arm-
+ * failure paths) enter with the in-pool ref still held. read_close drops the
+ * hash ref first, then the in-pool ref last - so if a transient ref is still
+ * outstanding (e.g. the tls:connection-out dispatch ref), tcpconn_put_destroy()
+ * lands above zero and that holder does the final free, instead of this call
+ * freeing a still-referenced conn. */
+static void tcp_reactor_read_close(struct tcp_connection *c)
+{
+	if(tcpconn_try_unhash(c))
+		tcpconn_put(c);
+	c->flags &= ~(F_CONN_POOL_BUSY | F_CONN_WANTS_RD | F_CONN_WANTS_WR);
+
+	tcp_emit_closed_event(c);
+	tcpconn_put_destroy(c);
+}
+
+/* mode 2: pool job completion on a healthy conn (io_wait thread).
+ * If a write was staged during the job, chain a TCP_R_WRITE job and keep
+ * ownership (POOL_BUSY + in-pool ref stay). Otherwise release the in-pool ref
+ * and hand the conn back to the reactor (un-shield: re-arm io_h + timer). */
+static void tcp_reactor_unshield_or_chain(struct tcp_connection *c)
+{
+	if(c->wsq_head != NULL && (c->flags & F_CONN_HASHED)
+			&& c->state != S_CONN_BAD) {
+		if(likely(tcp_reactor_enqueue_job(c, TCP_R_WRITE) == 0))
+			return; /* keep POOL_BUSY + in-pool ref; the write job completes */
+		/* enqueue failed: fall through to un-shield; the staged data waits in
+		 * wsq until the next write trigger */
+	}
+	/* Close paths: hand the still-held in-pool ref to read_close(), which drops
+	 * it last (see its comment) - safe even if a transient ref (e.g. the
+	 * tls:connection-out dispatch ref) is still outstanding. */
+	if(unlikely(!(c->flags & F_CONN_HASHED) || (c->state == S_CONN_BAD))) {
+		tcp_reactor_read_close(c);
+		return;
+	}
+	if(unlikely(tcp_reactor_read_rearm(c) < 0)) {
+		tcp_reactor_read_close(c);
+		return;
+	}
+	/* healthy: re-armed into io_h + the local timer, so release the in-pool
+	 * ref. The hash ref (and any still-outstanding transient holder) keeps the
+	 * conn alive. */
+	if(unlikely(tcpconn_put(c)))
+		tcpconn_destroy(c); /* only if this was somehow the last ref */
+}
+
+/* mode 2 write dispatch entry points, called from tcp_send() (tcp_main.c). */
+
+/* mode 2: a TCP worker hands an outgoing payload to PROC_TCP_MAIN, which owns
+ * all writes. TLS is handled in PROC_TCP_MAIN and not at the worker.
+ *
+ * Ownership: the caller's refcnt on c is transferred into the write request and
+ * dropped by tcp_main once the request is handled (see the CONN_WRITE_REQ arm of
+ * handle_ser_child()); on any error here we drop it ourselves so c is not leaked.
+ *
+ * Returns len as soon as the payload is accepted for sending - NOT when it
+ * reaches the wire. The send is async (handed to PROC_TCP_MAIN, queued in
+ * wbuf_q, written on POLLOUT), so the SIP caller sees success immediately; a
+ * later send failure is handled by tearing down the connection, and never comes
+ * back through this return value.
+ *
+ * Fast path: if we are already inside PROC_TCP_MAIN (a core CRLF pong / HTTP 100
+ * sent via tcp_send() from the read path) there is no worker->main hop - queue
+ * on wbuf_q and arm POLLOUT directly, mirroring the CONN_WRITE_REQ handler. */
+int tcp_reactor_send_put(struct tcp_connection *c, const char *buf,
+		unsigned len, snd_flags_t send_flags)
+{
+	tcp_reactor_write_req_t *wreq;
+	long response[2];
+
+	if(unlikely(is_tcp_main())) {
+		/* Called from within PROC_TCP_MAIN itself - no unix_tcp_sock self-send.
+		 * BUT is_tcp_main() is true for the whole process, i.e. BOTH the io_wait
+		 * thread AND the reactor pool threads. Only the io_wait thread owns io_h,
+		 * so the two cases must be handled differently. Release the refcnt the
+		 * caller (tcp_send) took on c either way. */
+		if(unlikely(tcpconn_put(c))) {
+			tcpconn_destroy(c); /* was the last ref */
+			return -1;
+		}
+		if(unlikely((c->state == S_CONN_BAD) || !(c->flags & F_CONN_HASHED))) {
+			/* in the process of being destroyed => drop the write */
+			return -1;
+		}
+		if(tcp_reactor_thread_idx >= 0) {
+			/* On a POOL thread: e.g. WS ws_send_crlf()/pong/close issued inline
+			 * from the read path (ws_frame_receive) while this thread owns the
+			 * shielded conn. We must NOT touch io_h or c's watch flags here -
+			 * that races the io_wait thread and can re-arm the fd while a read
+			 * job owns it, letting a second thread run on the same con->req
+			 * (torn WS frames / double-unmask -> garbage to workers). Stage the
+			 * payload on the conn's wsq (shm, under write_lock); the read job's
+			 * completion (tcp_reactor_unshield_or_chain) drains it via a chained
+			 * write job. */
+			if(unlikely(tcp_reactor_wsq_add(c, buf, len, send_flags) < 0))
+				return -1;
+			return (int)len;
+		}
+		/* io_wait thread (e.g. a core CRLF keepalive pong or HTTP/1.1
+		 * 100-continue sent via tcp_send() from the reactor's own read path):
+		 * safe to queue the payload and arm POLLOUT directly, mirroring the
+		 * CONN_WRITE_REQ handler. */
+		if(unlikely(tcp_reactor_wbuf_enqueue(c, (char *)buf, len, send_flags)
+					< 0)) {
+			return -1;
+		}
+		tcp_reactor_watch_write(c);
+		return (int)len;
+	}
+
+	wreq = shm_malloc(sizeof(tcp_reactor_write_req_t));
+	if(unlikely(wreq == NULL)) {
+		SHM_MEM_ERROR;
+		tcpconn_chld_put(c);
+		return -1;
+	}
+	wreq->buf = shm_malloc(len);
+	if(unlikely(wreq->buf == NULL)) {
+		SHM_MEM_ERROR;
+		shm_free(wreq);
+		tcpconn_chld_put(c);
+		return -1;
+	}
+	memcpy(wreq->buf, buf, len);
+	wreq->len = len;
+	wreq->conn = c; /* refcnt transferred to tcp_main */
+	wreq->send_flags = send_flags;
+
+	response[0] = (long)(uintptr_t)wreq;
+	response[1] = CONN_WRITE_REQ;
+	if(unlikely(send_all(unix_tcp_sock, response, sizeof(response)) <= 0)) {
+		LM_ERR("failed to send write request to tcp main: %s (%d)\n",
+				strerror(errno), errno);
+		shm_free(wreq->buf);
+		shm_free(wreq);
+		tcpconn_chld_put(c);
+		return -1;
+	}
+	return (int)len;
+}
+
+/* mode 2: no usable connection exists - ask PROC_TCP_MAIN to open a new
+ * outbound connection and send on it. The worker opens no socket and creates no
+ * tcp_connection. Returns len on success (optimistic), -1 on error. */
+int tcp_reactor_connect_put(struct dest_info *dst, union sockaddr_union *from,
+		const char *buf, unsigned len)
+{
+	tcp_reactor_connect_req_t *creq;
+	long response[2];
+
+	if(unlikely(is_tcp_main())) {
+		/* A new outbound connection requested by code running inside
+		 * PROC_TCP_MAIN itself. The unix_tcp_sock self-send below is invalid
+		 * here. The known in-tcp_main senders (core read-path CRLF pong /
+		 * HTTP 100-continue) always target an already-established connection
+		 * (handled by tcp_reactor_send_put), so this path is not expected to be
+		 * reached; fail loudly rather than emit a confusing "send on 0" error. */
+		LM_ERR("outbound connect requested from within PROC_TCP_MAIN to %s -"
+			   " not supported in mode 2, dropping\n",
+				su2a(&dst->to, sizeof(dst->to)));
+		return -1;
+	}
+
+	creq = shm_malloc(sizeof(tcp_reactor_connect_req_t));
+	if(unlikely(creq == NULL)) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+	creq->buf = shm_malloc(len);
+	if(unlikely(creq->buf == NULL)) {
+		SHM_MEM_ERROR;
+		shm_free(creq);
+		return -1;
+	}
+	memcpy(creq->buf, buf, len);
+	creq->len = len;
+	creq->dst = dst->to;
+	if(from != NULL) {
+		creq->from = *from;
+		creq->have_from = 1;
+	} else {
+		creq->have_from = 0;
+	}
+	creq->proto = dst->proto;
+	creq->id = dst->id;
+	creq->try_local_port = (dst->send_sock) ? dst->send_sock->port_no : 0;
+	creq->send_flags = dst->send_flags;
+
+	response[0] = (long)(uintptr_t)creq;
+	response[1] = CONN_CONNECT_REQ;
+	if(unlikely(send_all(unix_tcp_sock, response, sizeof(response)) <= 0)) {
+		LM_ERR("failed to send connect request to tcp main: %s (%d)\n",
+				strerror(errno), errno);
+		shm_free(creq->buf);
+		shm_free(creq);
+		return -1;
+	}
+	return (int)len;
+}
+
+/* mode 2 handle_ser_child() case bodies (CONN_TLS_EVENT_DONE/CONN_SCRIPT_CLOSE/
+ * CONN_WRITE_REQ/CONN_CONNECT_REQ), called from tcp_main.c. */
+
+/* mode 2: a worker finished a dispatched tls:connection-out event
+ * (tcp_reactor_dispatch_tls_event). tcpconn is the connection; drop the
+ * dispatch refcnt taken there. Doing it here, in PROC_TCP_MAIN, keeps
+ * connection destruction on the owner. Runs on the io_wait thread
+ * (handle_ser_child's CONN_TLS_EVENT_DONE arm). */
+void tcp_reactor_handle_tls_event_done(struct tcp_connection *tcpconn)
+{
+	if(unlikely(tcpconn_put(tcpconn)))
+		tcpconn_destroy(tcpconn);
+}
+
+/* mode 2: close connection on core errors (used with tcp_script_mode=0).
+ * scid is the connection id (rcv->proto_reserved1) - the worker never has a
+ * tcp_connection pointer for a dispatched task. Runs on the io_wait thread
+ * (handle_ser_child's CONN_SCRIPT_CLOSE arm). */
+void tcp_reactor_handle_script_close(int scid)
+{
+	struct tcp_connection *tcpconn;
+
+	tcpconn = tcpconn_get(scid, 0, 0, 0, 0); /* takes a ref */
+	if(tcpconn == NULL) {
+		LM_DBG("mode2: script-close for conn id %d: already gone\n", scid);
+		return;
+	}
+	/* if a pool job currently owns it,
+	 * do not unhash/free here - mark it bad and let the job completion
+	 * close it */
+	if(unlikely(tcpconn->flags & F_CONN_POOL_BUSY)) {
+		tcpconn->state = S_CONN_BAD;
+		tcpconn->timeout = get_ticks_raw();
+		if(unlikely(tcpconn_put(tcpconn)))
+			tcpconn_destroy(tcpconn); /* can't happen while busy */
+		return;
+	}
+	if(tcpconn_try_unhash(tcpconn))
+		tcpconn_put(tcpconn);
+	if(((tcpconn->flags & (F_CONN_WRITE_W | F_CONN_READ_W)))
+			&& (tcpconn->s != -1)) {
+		tcpmain_io_watch_del(tcpconn->s, -1, 1);
+		tcpconn->flags &= ~(F_CONN_WRITE_W | F_CONN_READ_W);
+	}
+	/* reason stays unset -> reports tcp:closed (EOF), same as the
+	 * mode 0/1 script-error close. */
+	tcp_emit_closed_event(tcpconn);
+	tcpconn_put_destroy(tcpconn); /* release the lookup ref */
+}
+
+/* mode 2: worker queued a write; wreq is the write request (shm-allocated by
+ * the worker in tcp_reactor_send_put()). Queues the payload into the wbuf_q
+ * (encrypting it first for TLS) and enables write watching, or (PROTO_TCP/
+ * TLS/WSS) stages it on wsq and shields+enqueues a TCP_R_WRITE pool job.
+ * Runs on the io_wait thread (handle_ser_child's CONN_WRITE_REQ arm). Frees
+ * wreq and wreq->buf on every path. */
+void tcp_reactor_handle_write_req(tcp_reactor_write_req_t *wreq)
+{
+	struct tcp_connection *tcpconn;
+
+	tcpconn = wreq->conn;
+	/* release the worker's refcnt; if it was the last, conn is gone */
+	if(unlikely(tcpconn_put(tcpconn))) {
+		tcpconn_destroy(tcpconn);
+		shm_free(wreq->buf);
+		shm_free(wreq);
+		return;
+	}
+	if(unlikely((tcpconn->state == S_CONN_BAD)
+				|| !(tcpconn->flags & F_CONN_HASHED))) {
+		/* in the process of being destroyed => drop the write */
+		shm_free(wreq->buf);
+		shm_free(wreq);
+		return;
+	}
+	/* Writes are offloaded to a pool thread. Stage the plaintext, then -
+	 * if the conn is not already owned by a pool job - shield it and
+	 * enqueue a write job; for TLS the job tls_encode()s each staged chunk
+	 * before flushing wbuf_q (the conn is shielded, so that pool thread
+	 * owns the SSL object exclusively). If the conn is busy, the data
+	 * waits in wsq and the running job's completion chains a write job.
+	 * Plain WS keeps the inline copy+watch path below (no TLS); WSS is
+	 * staged here too so its tls_encode runs on the owning pool thread. */
+	if(likely(tcpconn->type == PROTO_TCP || tcpconn->type == PROTO_TLS
+			   || tcpconn->type == PROTO_WSS)) {
+		if(unlikely(tcp_reactor_wsq_add(
+							tcpconn, wreq->buf, wreq->len, wreq->send_flags)
+					< 0)) {
+			tcpconn->state = S_CONN_BAD;
+			tcpconn->timeout = get_ticks_raw(); /* force reaper */
+			shm_free(wreq->buf);
+			shm_free(wreq);
+			return;
+		}
+		shm_free(wreq->buf);
+		shm_free(wreq);
+		if(!(tcpconn->flags & F_CONN_POOL_BUSY)) {
+			if(unlikely(tcp_reactor_shield(tcpconn, -1) < 0)) {
+				tcpconn->state = S_CONN_BAD;
+				tcpconn->timeout = get_ticks_raw();
+				return;
+			}
+			if(unlikely(tcp_reactor_enqueue_job(tcpconn, TCP_R_WRITE) < 0)) {
+				/* release the in-pool ref + un-shield; data waits in wsq */
+				tcp_reactor_unshield_or_chain(tcpconn);
+			}
+		}
+		return;
+	}
+	if(unlikely(tcp_reactor_wbuf_enqueue(
+						tcpconn, wreq->buf, wreq->len, wreq->send_flags)
+				< 0)) {
+		shm_free(wreq->buf);
+		shm_free(wreq);
+		return;
+	}
+	shm_free(wreq->buf);
+	shm_free(wreq);
+	tcp_reactor_watch_write(tcpconn);
+}
+
+/* mode 2: worker has no usable connection - open a new outbound one here in
+ * PROC_TCP_MAIN, or reuse a matching one another worker created meanwhile.
+ * creq is the connect request (shm-allocated by the worker in
+ * tcp_reactor_connect_put()). Runs on the io_wait thread (handle_ser_child's
+ * CONN_CONNECT_REQ arm). Frees creq and creq->buf on every path. */
+void tcp_reactor_handle_connect_req(tcp_reactor_connect_req_t *creq)
+{
+	struct tcp_connection *cc;
+	union sockaddr_union *cfrom;
+	struct ip_addr cip;
+	int cport;
+	ticks_t t;
+	ticks_t con_lifetime;
+
+	cfrom = creq->have_from ? &creq->from : NULL;
+	su2ip_addr(&cip, &creq->dst);
+	cport = su_getport(&creq->dst);
+	con_lifetime = cfg_get(tcp, tcp_cfg, con_lifetime);
+	/* dedup: another worker may have created a matching connection
+	 * since this worker's lookup missed => reuse it if so */
+	if(tcp_connection_match == TCPCONN_MATCH_STRICT
+			|| (creq->send_flags.f & SND_F_FORCE_PROTO)) {
+		cc = tcpconn_lookup(creq->id, &cip, cport, cfrom, creq->try_local_port,
+				con_lifetime, creq->proto);
+	} else {
+		cc = tcpconn_get(creq->id, &cip, cport, cfrom, con_lifetime);
+	}
+	if(cc != NULL) {
+		/* reuse: queue the payload onto the existing connection. The
+		 * reused conn may already be owned by a pool job (mid-read):
+		 * PROTO_TCP/TLS - stage the plaintext on wsq and let a pool write
+		 *     job do the TLS encode + flush
+		 * WS/WSS - keep the inline encode+watch path. */
+		if(unlikely(tcpconn_put(cc))) {
+			tcpconn_destroy(cc);
+			shm_free(creq->buf);
+			shm_free(creq);
+			return;
+		}
+		if(unlikely(
+				   (cc->state == S_CONN_BAD) || !(cc->flags & F_CONN_HASHED))) {
+			shm_free(creq->buf);
+			shm_free(creq);
+			return;
+		}
+		if(likely(cc->type == PROTO_TCP || cc->type == PROTO_TLS
+				   || cc->type == PROTO_WSS)) {
+			if(unlikely(tcp_reactor_wsq_add(
+								cc, creq->buf, creq->len, creq->send_flags)
+						< 0)) {
+				cc->state = S_CONN_BAD;
+				cc->timeout = get_ticks_raw(); /* force reaper */
+				shm_free(creq->buf);
+				shm_free(creq);
+				return;
+			}
+			shm_free(creq->buf);
+			shm_free(creq);
+			if(!(cc->flags & F_CONN_POOL_BUSY)) {
+				if(unlikely(tcp_reactor_shield(cc, -1) < 0)) {
+					cc->state = S_CONN_BAD;
+					cc->timeout = get_ticks_raw();
+					return;
+				}
+				if(unlikely(tcp_reactor_enqueue_job(cc, TCP_R_WRITE) < 0)) {
+					/* release in-pool ref + un-shield; data waits in wsq */
+					tcp_reactor_unshield_or_chain(cc);
+				}
+			}
+			return;
+		}
+		if(likely(tcp_reactor_wbuf_enqueue(
+						  cc, creq->buf, creq->len, creq->send_flags)
+				   == 0))
+			tcp_reactor_watch_write(cc);
+		shm_free(creq->buf);
+		shm_free(creq);
+		return;
+	}
+	/* open the connection (socket + non-blocking connect) here */
+	cc = tcpconn_connect(&creq->dst, cfrom, creq->proto, &creq->send_flags);
+	if(unlikely(cc == NULL)) {
+		LM_ERR("failed to open outbound connection to %s\n",
+				su2a(&creq->dst, sizeof(creq->dst)));
+		shm_free(creq->buf);
+		shm_free(creq);
+		return;
+	}
+	atomic_set(&cc->refcnt, 1); /* owned solely by tcp_main (hash) */
+	if(unlikely(tcpconn_add(cc) == 0)) {
+		LM_ERR("failed to hash outbound connection %p\n", cc);
+		tcp_safe_close(cc->s);
+		cc->flags |= F_CONN_FD_CLOSED;
+		_tcpconn_free(cc);
+		shm_free(creq->buf);
+		shm_free(creq);
+		return;
+	}
+	tcpmain_note_new_conn(cc->type == PROTO_TLS);
+	/* queue the payload; for TLS, tls_encode() buffers it until the
+	 * handshake completes (the handshake is driven on the read/write
+	 * events registered just below). */
+	if(unlikely(tcp_reactor_wbuf_enqueue(
+						cc, creq->buf, creq->len, creq->send_flags)
+				< 0)) {
+		tcpconn_try_unhash(cc);
+		tcpconn_put_destroy(cc);
+		shm_free(creq->buf);
+		shm_free(creq);
+		return;
+	}
+	shm_free(creq->buf);
+	shm_free(creq);
+	/* register in the reactor: watch read + write. The POLLOUT event
+	 * completes the connect and drains the wbuf_q. */
+	t = get_ticks_raw();
+	cc->timeout = t + con_lifetime;
+	tcpmain_local_timer_add(&cc->timer, con_lifetime, t);
+	cc->flags |= F_CONN_MAIN_TIMER | F_CONN_READ_W | F_CONN_WANTS_RD
+				 | F_CONN_WRITE_W | F_CONN_WANTS_WR;
+	cc->flags &= ~F_CONN_FD_CLOSED;
+	if(unlikely(tcpmain_io_watch_add_conn(cc->s, POLLIN | POLLOUT, cc) < 0)) {
+		LM_CRIT("failed to add outbound connection to the fd list\n");
+		cc->flags &= ~(F_CONN_WRITE_W | F_CONN_READ_W);
+		tcpconn_try_unhash(cc);
+		tcpconn_put_destroy(cc);
+	}
+}
+
+/* mode 2: full read/write handling for a connection's io event, called from
+ * handle_tcpconn_ev() as its very first action when ksr_tcp_main_threads==2 -
+ * tcp_main.c owns the fd permanently there (no fd-passing, no send2child), so
+ * this is effectively a second implementation of handle_tcpconn_ev() for that
+ * mode, kept here because the shield/enqueue/unshield dance and its io_h/timer
+ * bookkeeping is reactor-exclusive. Runs on the io_wait thread. Same return
+ * convention as handle_tcpconn_ev()/handle_io(). */
+int tcp_reactor_handle_tcpconn_ev(
+		struct tcp_connection *tcpconn, short ev, int fd_i)
+{
+	/* mode 2: tcp_main owns the fd permanently, reads and
+	 * assembles SIP messages (no fd-passing, no send2child).
+	 *
+	 * Worker busy-tracking (tcp_children[].busy) is skipped: use
+	 * kernel socket load balancing like udp_receiver_mode = 1
+	 */
+	rd_conn_flags_t read_flags;
+	int n;
+	int resp;
+
+	/* Defensive: a shielded conn (F_CONN_POOL_BUSY) should already be out of
+	 * io_h, so this event shouldn't fire. It can if the fd stayed armed while
+	 * busy (e.g. a WS handshake con->type flip in the worker outrunning the
+	 * shield's io_watch_del). Enqueuing a second read job would race two pool
+	 * threads on the same con->req buffer, so just drop the fd from the watch
+	 * set; the in-flight job's completion re-adds it, and level-triggered
+	 * epoll re-fires for any buffered data. */
+	if(unlikely(tcpconn->flags & F_CONN_POOL_BUSY)) {
+		if(tcpconn->s != -1) {
+			if(unlikely(tcpmain_io_watch_del(tcpconn->s, fd_i, 0) < 0))
+				LM_ERR("reactor: io_watch_del (busy re-arm) failed for %p "
+					   "fd %d\n",
+						tcpconn, tcpconn->s);
+		}
+		tcpconn->flags &= ~(F_CONN_READ_W | F_CONN_WRITE_W);
+		return 0;
+	}
+
+#ifdef TCP_ASYNC
+	/* drain pending writes first if the fd is write-watched */
+	if((ev & (POLLOUT | POLLERR | POLLHUP))
+			&& (tcpconn->flags & F_CONN_WRITE_W)) {
+		int wempty_q = 0;
+		if(unlikely((ev & (POLLERR | POLLHUP))
+					|| (wbufq_run(tcpconn->s, tcpconn, &wempty_q) < 0))) {
+			/* write error or peer gone: tear the connection down */
+			goto reactor_close;
+		}
+		if(wempty_q) {
+			tcpconn->flags &= ~F_CONN_WANTS_WR;
+			if(!(tcpconn->flags & F_CONN_READ_W)) {
+				if(unlikely(tcpmain_io_watch_chg(tcpconn->s, POLLIN, fd_i)
+							== -1)) {
+					LM_ERR("io_watch_chg (reactor wr) failed for %p fd "
+						   "%d\n",
+							tcpconn, tcpconn->s);
+					goto reactor_close;
+				}
+			}
+			tcpconn->flags &= ~F_CONN_WRITE_W;
+			if(tcpconn_close_after_send(tcpconn))
+				goto reactor_close;
+		}
+	}
+#endif /* TCP_ASYNC */
+
+	if(ev & (POLLIN | POLLERR | POLLHUP)) {
+#ifdef TCP_ASYNC
+		/* All four transports read on a pool thread. The shield gives that
+		 * thread exclusive ownership of the conn (F_CONN_POOL_BUSY), so the
+		 * SSL object and the WS codec are each touched by one thread at a
+		 * time (tls_encode()'s trampoline scratch buffer is per-thread too,
+		 * see tcp_mtops.c). The pre-upgrade handshake runs as PROTO_TCP/
+		 * PROTO_TLS, already covered, and stays covered after the con->type
+		 * flip to WS/WSS. */
+		if(likely(tcpconn->type == PROTO_TCP || tcpconn->type == PROTO_TLS
+				   || tcpconn->type == PROTO_WS
+				   || tcpconn->type == PROTO_WSS)) {
+			/* shield the conn from the (level-triggered) reactor + timer so
+			 * a pool thread can own it exclusively, then enqueue the read */
+			if(ev
+					& (POLLHUP | POLLERR
+#ifdef POLLRDHUP
+							| POLLRDHUP
+#endif /* POLLRDHUP */
+							))
+				tcpconn->flags |= F_CONN_FORCE_EOF;
+			if(unlikely(tcp_reactor_shield(tcpconn, fd_i) < 0))
+				goto reactor_close;
+			if(unlikely(tcp_reactor_enqueue_job(tcpconn, TCP_R_READ) < 0)) {
+				/* could not enqueue: release the in-pool ref and un-shield */
+				tcp_reactor_unshield_or_chain(tcpconn);
+			}
+			return 0;
+		}
+#endif /* TCP_ASYNC */
+		/* !TCP_ASYNC only: under TCP_ASYNC the four-transport offload above
+		 * returns, so this synchronous-read fall-through is the non-async
+		 * build's live path (unreachable in a normal TCP_ASYNC build). */
+		/* fold any error/EOF event into a forced EOF so a final buffered
+		 * message is still drained before the connection is closed */
+		read_flags = ((
+#ifdef POLLRDHUP
+							  (ev & POLLRDHUP) |
+#endif /* POLLRDHUP */
+							  (ev & (POLLHUP | POLLERR))
+							  | (tcpconn->flags
+									  & (F_CONN_EOF_SEEN | F_CONN_FORCE_EOF)))
+							 && !(ev & POLLPRI))
+							 ? RD_CONN_FORCE_EOF
+							 : 0;
+	repeat_read:
+		resp = tcp_read_req(tcpconn, &n, &read_flags);
+		/* tcp_read_req() dispatches complete messages to workers via
+		 * tcp_reactor_dispatch_msg(); for TLS it may run OpenSSL through
+		 * the direct-call trampoline (KSR_TCPX_MAIN_PIDX). */
+		if(unlikely(resp < 0)) {
+			if(resp != CONN_EOF)
+				tcpconn->state = S_CONN_BAD;
+			goto reactor_close;
+		}
+		if(unlikely(read_flags & RD_CONN_REPEAT_READ))
+			goto repeat_read;
+		/* partial or complete read: keep the fd, refresh the idle timeout.
+		 * If a message is still mid-read, also bound the timeout to the
+		 * message-read deadline so a stalled partial read is reaped. */
+		{
+			ticks_t tnow = get_ticks_raw();
+			tcpconn->timeout = tnow + cfg_get(tcp, tcp_cfg, con_lifetime);
+#ifdef TCP_ASYNC
+			tcp_reactor_arm_read_timeout(tcpconn, tnow);
+#endif /* TCP_ASYNC */
+		}
+	}
+	return 0;
+
+reactor_close:
+	/* unhash first, while F_CONN_MAIN_TIMER is still set, so the local
+	 * timer is removed before the connection is freed (try_unhash only
+	 * deletes the timer when the flag is set). Then stop watching the fd. */
+	if(tcpconn_try_unhash(tcpconn))
+		tcpconn_put(tcpconn);
+	if((tcpconn->flags & (F_CONN_WRITE_W | F_CONN_READ_W))
+			&& (tcpconn->s != -1)) {
+		if(unlikely(tcpmain_io_watch_del(tcpconn->s, fd_i, 1) < 0)) {
+			LM_ERR("io_watch_del (reactor) failed for %p fd %d\n", tcpconn,
+					tcpconn->s);
+		}
+		tcpconn->flags &= ~(F_CONN_WRITE_W | F_CONN_READ_W);
+	}
+	tcpconn->flags &= ~(F_CONN_WANTS_RD | F_CONN_WANTS_WR);
+	/* mode 2 inline read teardown (shield/enqueue not taken): same as
+	 * tcp_reactor_read_close - the reader detected an EOF/error/reset, so
+	 * emit the tcpops close event here too. Fire-once guarded. */
+	tcp_emit_closed_event(tcpconn);
+	tcpconn_put_destroy(tcpconn);
+	return -1;
+}
+
+/* ========================================================================
+ * mode 2: reactor thread pool inside PROC_TCP_MAIN - all reads on the pool;
+ * all writes except plain-WS on the pool
+ *
+ * Threads: one io_wait thread (this process's main thread) + N pool threads.
+ *
+ * Ownership / serialization:
+ *  - epoll (io_h) and the local timer (tcp_main_ltimer): io_wait thread ONLY.
+ *    Pool threads never call io_watch_*() or local_timer_*().
+ *  - F_CONN_POOL_BUSY = "a pool job owns this conn": set by the io_wait thread
+ *    when it shields the conn (removes it from io_h + the timer) and enqueues a
+ *    read/write job; cleared by the io_wait completion. While set, the conn has
+ *    at most ONE owner (one read OR write job at a time; chained jobs are
+ *    sequential), so its read/write callbacks never run concurrently with each
+ *    other or with the reactor.
+ *  - A single "in-pool" refcount is taken at shield and released at
+ *    unshield/close; it spans chained jobs and pins the conn so it cannot be
+ *    freed while a pool thread uses it.
+ *
+ * Per-field synchronization:
+ *  - c->flags        : io_wait thread ONLY (pool jobs never write c->flags;
+ *                      reads/buffers/state only). No race.
+ *  - c->req          : the read job exclusively while it runs (conn shielded).
+ *  - c->wbuf_q,c->wsq: c->write_lock (gen_lock). The completion's unlocked
+ *                      peeks (_wbufq_non_empty / wsq_head) are safe via the
+ *                      done_lock happens-before edge.
+ *  - c->refcnt       : atomic.
+ *  - handoff pool->io_wait: push to done_head under done_lock + a notify byte;
+ *                      io_wait reads done_head under done_lock - a
+ *                      release/acquire barrier, so completion sees the job's
+ *                      final writes.
+ **/
+
+/* tcp_reactor_thread_idx is defined near the top (needed earlier by
+ * tcp_reactor_send_put's pool-thread detection). */
+
+/* runs in the io_wait thread on notify_pipe readiness: process all completed
+ * jobs (coalesced). Only the io_wait thread touches io_h, so all re-arm / close
+ * happens here, never in a pool thread. */
+static void tcp_reactor_handle_done(void)
+{
+	struct tcp_reactor_job *job, *next;
+	struct tcp_connection *conn;
+	int op, resp;
+
+	pthread_mutex_lock(&tcp_rpool.done_lock);
+	job = tcp_rpool.done_head;
+	tcp_rpool.done_head = tcp_rpool.done_tail = NULL;
+	pthread_mutex_unlock(&tcp_rpool.done_lock);
+
+	while(job != NULL) {
+		next = job->next;
+		conn = job->conn;
+		op = job->op;
+		resp = job->resp;
+		pkg_free(job);
+
+		switch(op) {
+#ifdef TCP_ASYNC
+			case TCP_R_READ:
+			case TCP_R_WRITE:
+				/* The conn carries the single in-pool refcount (taken at
+				 * shield, released by close / unshield - not per job).
+				 * resp < 0 => EOF/error/write-error => tear down; else either
+				 * chain a staged write or hand the conn back to the reactor. */
+				if(unlikely(resp < 0)) {
+					tcp_reactor_read_close(conn);
+				} else {
+					tcp_reactor_unshield_or_chain(conn);
+				}
+				break;
+#endif /* TCP_ASYNC */
+			default:
+				break;
+		}
+		job = next;
+	}
+}
+
+/* pool thread body. arg = thread index. */
+static void *tcp_reactor_thread_routine(void *arg)
+{
+	struct tcp_reactor_job *job;
+	struct tcp_connection *conn;
+	sigset_t set;
+	char wake = 'x';
+
+	tcp_reactor_thread_idx = (int)(long)arg;
+
+#if defined(HAVE_PTHREAD_SETNAME_NP_2ARG) \
+		|| defined(HAVE_PTHREAD_SETNAME_NP_1ARG)
+	{
+		/* label this pool thread (comm is capped at 16 bytes incl. NUL) so
+		 * profilers / top -H / gdb can tell the pool threads apart and from the
+		 * io_wait thread. OS thread name only - kamailio's process table
+		 * (kamcmd core.ps) is unaffected. Always names the calling thread, so
+		 * macOS's 1-arg self-only form is sufficient. */
+		char tname[16];
+		snprintf(tname, sizeof(tname), "tcpr-pool-%d", tcp_reactor_thread_idx);
+#if defined(HAVE_PTHREAD_SETNAME_NP_2ARG)
+		pthread_setname_np(pthread_self(), tname);
+#else
+		pthread_setname_np(tname);
+#endif
+	}
+#endif
+
+	/* block signals - PROC_TCP_MAIN's main thread is the signal handler */
+	sigfillset(&set);
+	pthread_sigmask(SIG_BLOCK, &set, NULL);
+
+	while(1) {
+		job = NULL;
+		tcp_cond_lock(&tcp_reactor_wake->cond);
+		while(!tcp_rpool.stop && tcp_rpool.task_head == NULL) {
+			tcp_cond_wait(&tcp_reactor_wake->cond);
+		}
+		if(tcp_rpool.stop && tcp_rpool.task_head == NULL) {
+			tcp_cond_unlock(&tcp_reactor_wake->cond);
+			break;
+		}
+		/* All read/write/run jobs are enqueued onto task_head by the io_wait
+		 * thread, which has already shielded the conn (F_CONN_POOL_BUSY) and
+		 * taken the in-pool refcount, so a pool thread only ever touches a
+		 * connection already out of the reactor's epoll and timer. */
+		job = tcp_rpool.task_head;
+		if(job != NULL) {
+			tcp_rpool.task_head = job->next;
+			if(tcp_rpool.task_head == NULL)
+				tcp_rpool.task_tail = NULL;
+		}
+		tcp_cond_unlock(&tcp_reactor_wake->cond);
+
+		if(job == NULL)
+			continue; /* spurious wakeup */
+
+		switch(job->op) {
+			case TCP_R_READ: {
+				/* read + reassemble on conn->s (all of PROTO_TCP/TLS/WS/WSS).
+				 * tcp_read_req() reads via _tconfd(conn)==conn->s; for WS the frame
+				 * codec runs here under the shield and dispatches the defragmented
+				 * payload to workers via tcp_reactor_dispatch_msg(). No io_watch /
+				 * no free here - the io_wait thread completes. */
+				rd_conn_flags_t read_flags;
+				int n, resp;
+				conn = job->conn;
+				read_flags =
+						(conn->flags & (F_CONN_EOF_SEEN | F_CONN_FORCE_EOF))
+								? RD_CONN_FORCE_EOF
+								: 0;
+				do {
+					resp = tcp_read_req(conn, &n, &read_flags);
+				} while(resp >= 0 && (read_flags & RD_CONN_REPEAT_READ));
+				if(resp < 0 && resp != CONN_EOF)
+					conn->state = S_CONN_BAD;
+				job->resp = resp;
+				break;
+			}
+			case TCP_R_WRITE: {
+				/* drain the connection's plaintext staging list into wbuf_q
+				 * (PROTO_TCP: plain copy; PROTO_TLS: tls_encode via the
+				 * direct-call trampoline on this pool thread) and flush wbuf_q to
+				 * the socket. No c->flags writes here (the io_wait completion owns
+				 * those); only buffers/state under write_lock. */
+				struct tcp_wchunk *ch;
+				int werr = 0, wempty = 0;
+				conn = job->conn;
+				lock_get(&conn->write_lock);
+				while((ch = conn->wsq_head) != NULL) {
+					conn->wsq_head = ch->next;
+					if(tcp_reactor_wbuf_add_locked(
+							   conn, ch->buf, ch->len, ch->send_flags)
+							< 0)
+						werr = 1;
+					shm_free(ch->buf);
+					shm_free(ch);
+				}
+				conn->wsq_tail = NULL;
+				lock_release(&conn->write_lock);
+				if(!werr && wbufq_run(conn->s, conn, &wempty) < 0)
+					werr = 1;
+				/* resp: <0 error; 1 = wbuf_q still has data (needs POLLOUT,
+				 * handled inline after un-shield); 0 = fully drained */
+				job->resp = werr ? -1 : (wempty ? 0 : 1);
+				break;
+			}
+			case TCP_R_RUN:
+				LM_WARN("tcpr-pool-%d: running tcpx task %p (exec=%p)\n",
+						tcp_reactor_thread_idx, (void *)job->task,
+						job->task ? (void *)job->task->exec : NULL);
+				if(job->task && job->task->exec)
+					job->task->exec(job->task->param, KSR_TCPX_MAIN_PIDX);
+				pkg_free(job);
+				continue;
+			default:
+				LM_ERR("unknown reactor job op %d\n", job->op);
+				break;
+		}
+
+		/* hand the completed job back to the reactor thread */
+		pthread_mutex_lock(&tcp_rpool.done_lock);
+		job->next = NULL;
+		if(tcp_rpool.done_tail != NULL)
+			tcp_rpool.done_tail->next = job;
+		else
+			tcp_rpool.done_head = job;
+		tcp_rpool.done_tail = job;
+		pthread_mutex_unlock(&tcp_rpool.done_lock);
+
+		if(write(tcp_rpool.notify_pipe[1], &wake, 1) < 0) {
+			if(errno != EAGAIN && errno != EWOULDBLOCK)
+				LM_ERR("failed to notify reactor of completion: %s\n",
+						strerror(errno));
+		}
+	}
+	return NULL;
+}
+
+/* create the notify pipe + spawn the pool. Runs in PROC_TCP_MAIN after io_h is
+ * initialized. Returns 0 on success, -1 on error. */
+int tcp_reactor_pool_init(void)
+{
+	int i;
+
+	LM_WARN("TCP reactor: using %d threads\n", ksr_tcp_reactor_threads);
+
+	/* pool_init() runs on PROC_TCP_MAIN's io_wait/main thread; name it here (pool
+	 * threads name themselves in tcp_reactor_thread_routine). OS thread comm only,
+	 * so kamcmd core.ps still reports the usual process description. */
+#if defined(HAVE_PTHREAD_SETNAME_NP_2ARG)
+	pthread_setname_np(pthread_self(), "tcpr-iowait");
+#elif defined(HAVE_PTHREAD_SETNAME_NP_1ARG)
+	pthread_setname_np("tcpr-iowait");
+#endif
+
+	if(pipe(tcp_rpool.notify_pipe) < 0) {
+		LM_ERR("reactor notify pipe: %s\n", strerror(errno));
+		return -1;
+	}
+	if(fcntl(tcp_rpool.notify_pipe[0], F_SETFL,
+			   fcntl(tcp_rpool.notify_pipe[0], F_GETFL) | O_NONBLOCK)
+					< 0
+			|| fcntl(tcp_rpool.notify_pipe[1], F_SETFL,
+					   fcntl(tcp_rpool.notify_pipe[1], F_GETFL) | O_NONBLOCK)
+					   < 0) {
+		LM_ERR("reactor notify pipe O_NONBLOCK: %s\n", strerror(errno));
+		return -1;
+	}
+	/* NOT registered in io_h here - tcp_reactor_pool_init() runs on
+	 * PROC_TCP_MAIN's io_wait thread, but io_h itself stays private to
+	 * tcp_main.c (see tcp_conn.h); the caller (tcp_main_loop()) does the
+	 * io_watch_add() for this pipe right after this function returns. */
+	if(pthread_mutex_init(&tcp_rpool.done_lock, NULL) != 0) {
+		LM_ERR("failed to init reactor done_lock\n");
+		return -1;
+	}
+	tcp_rpool.threads = pkg_malloc(sizeof(pthread_t) * ksr_tcp_reactor_threads);
+	if(tcp_rpool.threads == NULL) {
+		PKG_MEM_ERROR;
+		return -1;
+	}
+	tcp_rpool.threads_no = 0;
+	tcp_rpool.stop = 0;
+	/* serialize this process's pkg heap before any pool thread runs: from here
+	 * on the io_wait thread and the pool threads share pkg concurrently */
+	tcp_reactor_pkg_lock_install();
+	for(i = 0; i < ksr_tcp_reactor_threads; i++) {
+		if(pthread_create(&tcp_rpool.threads[i], NULL,
+				   tcp_reactor_thread_routine, (void *)(long)i)
+				!= 0) {
+			LM_ERR("failed to create reactor pool thread %d/%d\n", i,
+					ksr_tcp_reactor_threads);
+			return -1; /* threads_no counts started threads for destroy/join */
+		}
+		tcp_rpool.threads_no++;
+	}
+	LM_INFO("tcp reactor mode 2: started %d pool threads\n",
+			tcp_rpool.threads_no);
+	return 0;
+}
+
+/* stop + join the pool. Safe to call when the pool was never started. */
+void tcp_reactor_pool_destroy(void)
+{
+	int i;
+
+	if(tcp_rpool.threads == NULL)
+		return;
+	tcp_cond_lock(&tcp_reactor_wake->cond);
+	tcp_rpool.stop = 1;
+	tcp_cond_broadcast(&tcp_reactor_wake->cond);
+	tcp_cond_unlock(&tcp_reactor_wake->cond);
+	for(i = 0; i < tcp_rpool.threads_no; i++)
+		pthread_join(tcp_rpool.threads[i], NULL);
+	pkg_free(tcp_rpool.threads);
+	tcp_rpool.threads = NULL;
+	tcp_rpool.threads_no = 0;
+}
+
+/* mode 2: drain the notify pipe and process all completed jobs (coalesced).
+ * Called from tcp_main.c's handle_io() on F_TCP_REACTOR_NOTIFY readiness -
+ * runs on the io_wait thread. */
+void tcp_reactor_handle_notify(void)
+{
+	char nbuf[64];
+
+	while(read(tcp_rpool.notify_pipe[0], nbuf, sizeof(nbuf)) > 0) {
+	}
+	tcp_reactor_handle_done();
+}
+
+/* mode 2: create the reactor dispatch socketpair (AF_UNIX SOCK_DGRAM).
+ * MUST be called in the main process before any TCP child (workers AND
+ * PROC_TCP_MAIN) is forked, so all of them inherit the shared fds: workers
+ * recvfrom dsock[0] (the kernel load-balances across them) and PROC_TCP_MAIN
+ * sends reassembled SIP tasks on dsock[1]. Both ends are non-blocking.
+ * Returns 0 on success (or when not in mode 2), -1 on error. */
+int tcp_reactor_dsock_init(void)
+{
+	if(ksr_tcp_main_threads != 2)
+		return 0;
+	if(socketpair(AF_UNIX, SOCK_DGRAM, 0, ksr_tcp_reactor_dsock) < 0) {
+		LM_ERR("failed to create reactor dispatch socketpair: %s\n",
+				strerror(errno));
+		return -1;
+	}
+	if(fcntl(ksr_tcp_reactor_dsock[0], F_SETFL,
+			   fcntl(ksr_tcp_reactor_dsock[0], F_GETFL) | O_NONBLOCK)
+			< 0) {
+		LM_ERR("failed to set O_NONBLOCK on reactor dsock[0]: %s\n",
+				strerror(errno));
+		return -1;
+	}
+	if(fcntl(ksr_tcp_reactor_dsock[1], F_SETFL,
+			   fcntl(ksr_tcp_reactor_dsock[1], F_GETFL) | O_NONBLOCK)
+			< 0) {
+		LM_ERR("failed to set O_NONBLOCK on reactor dsock[1]: %s\n",
+				strerror(errno));
+		return -1;
+	}
+	LM_INFO("tcp reactor dispatch socketpair created (rfd=%d wfd=%d)\n",
+			ksr_tcp_reactor_dsock[0], ksr_tcp_reactor_dsock[1]);
+
+	/* reactor pool wakeup: its condvar must live in shm and be initialised
+	 * before fork so PROC_TCP_MAIN's io_wait thread and pool threads share the
+	 * same PROCESS_SHARED condvar. The pool threads + notify pipe (tcp_rpool)
+	 * are created later, inside PROC_TCP_MAIN. */
+	tcp_reactor_wake = shm_malloc(sizeof(*tcp_reactor_wake));
+	if(tcp_reactor_wake == NULL) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+	memset(tcp_reactor_wake, 0, sizeof(*tcp_reactor_wake));
+	if(tcp_cond_init(&tcp_reactor_wake->cond) != 0) {
+		LM_ERR("failed to init reactor pool condvar\n");
+		shm_free(tcp_reactor_wake);
+		tcp_reactor_wake = NULL;
+		return -1;
+	}
+	LM_INFO("tcp reactor pool wakeup initialized\n");
+	return 0;
+}

--- a/src/core/tcp_reactor.h
+++ b/src/core/tcp_reactor.h
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2026 S-P Chan
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _TCP_REACTOR_H_
+#define _TCP_REACTOR_H_
+
+#include "ip_addr.h" /* struct receive_info, snd_flags_t */
+#include "tcp_cond.h" /* tcp_cond_t (pulls in <pthread.h>) - mode 2 thread pool */
+#include "tcp_mtops.h" /* tcpx_task_t - carried by TCP_R_RUN jobs */
+
+struct tcp_connection;
+
+/*
+ * Task dispatched from PROC_TCP_MAIN to a TCP worker (mode 2).
+ *
+ * Allocated in shared memory with the message buffer inline:
+ *   shm_malloc(sizeof(tcp_reactor_task_t) + msg_len + 1)
+ *
+ * The pointer is written to ksr_tcp_reactor_dsock[1] as a uintptr_t.
+ * Workers recvfrom ksr_tcp_reactor_dsock[0], cast back, dispatch on
+ * flags (plain SIP -> receive_msg(), F_TCP_REQ_HEP3 -> hep3_process_msg()),
+ * then shm_free the task.
+ */
+typedef struct tcp_reactor_task
+{
+	struct receive_info rcv;	/* copied from con->rcv at reassembly time */
+	struct tcp_connection *con; /* F_TCP_REQ_TLS_EVENT only: the connection
+								 * whose tls:connection-out route the worker runs;
+								 * NULL for message tasks. A dispatch refcnt is
+								 * held on it until the worker hands it back via
+								 * CONN_TLS_EVENT_DONE. */
+	unsigned int msg_len;
+	unsigned int flags; /* framing discriminator (F_TCP_REQ_HEP3, ...); the
+						 * message buffer is self-describing, so this only
+						 * selects the worker entry point, it carries no state */
+	char msg_buf[0];	/* inline message buffer, null-terminated */
+} tcp_reactor_task_t;
+
+/*
+ * Write request sent from a TCP worker to PROC_TCP_MAIN (mode 2).
+ *
+ * Allocated in shared memory by the worker in tcp_send(); the pointer is
+ * passed to tcp_main via pt[process_no].unix_sock as response[0] with
+ * command CONN_WRITE_REQ. tcp_main queues buf into conn->wbuf_q, enables
+ * POLLOUT watching, releases the worker's connection refcnt, and frees
+ * both buf and the request struct.
+ */
+typedef struct tcp_reactor_write_req
+{
+	struct tcp_connection *conn; /* refcnt held by worker; tcp_main releases */
+	char *buf;					 /* shm-allocated payload */
+	unsigned int len;
+	snd_flags_t send_flags;
+} tcp_reactor_write_req_t;
+
+/*
+ * Connect request sent from a TCP worker to PROC_TCP_MAIN (mode 2) when no
+ * struct tcp_connection exists
+ * - the worker does not perform the connect.
+ * - tcp_main performs socket()/connect(), creates the struct tcp_connection,
+ *   queues the payload, and watches the fd
+ * - allocated in shm by the worker; passed as response[0] with command
+ * - tcp_main frees buf and the request struct.
+ */
+typedef struct tcp_reactor_connect_req
+{
+	union sockaddr_union dst;  /* destination (dst->to) */
+	union sockaddr_union from; /* bind source (valid only if have_from) */
+	int have_from;
+	int proto;			/* PROTO_TCP / PROTO_TLS / PROTO_WS / PROTO_WSS */
+	int id;				/* dst->id, for the dedup re-check */
+	int try_local_port; /* send_sock local port, for strict matching */
+	snd_flags_t send_flags;
+	char *buf; /* shm payload (plaintext for TLS) */
+	unsigned int len;
+} tcp_reactor_connect_req_t;
+
+/* Allocate a tcp_reactor_task_t in shm, copy buf+rcv+flags into it, and write
+ * the pointer to the dispatch socketpair write end. Called from
+ * PROC_TCP_MAIN in mode 2 wherever receive_tcp_msg() would be called. flags
+ * carries the framing discriminator (e.g. F_TCP_REQ_HEP3) the worker uses to
+ * pick the message entry point. */
+int tcp_reactor_dispatch_msg(char *buf, unsigned int len, unsigned int flags,
+		struct receive_info *rcv);
+
+/* Dispatch a tls:connection-out event to a TCP worker (mode 2).
+ * Takes a refcnt on c, allocates a F_TCP_REQ_TLS_EVENT
+ * task in shm carrying c, and writes the pointer to the dispatch socket.
+ * The worker runs the route and hands the refcnt back via CONN_TLS_EVENT_DONE.
+ *
+ * Returns 0 on success, -1 on error  */
+int tcp_reactor_dispatch_tls_event(struct tcp_connection *c);
+
+/* Reactor pool thread index of the calling thread: 0..N-1 on a PROC_TCP_MAIN
+ * pool thread, -1 otherwise (io_wait/main thread, or any other process/mode).
+ * Exposed so the pkg-allocator guard (tcp_reactor_mem.c) can flag pkg use on a
+ * pool thread without the reactor thread-local leaking outside core. */
+int tcp_reactor_pool_thread_idx(void);
+
+/* Mode-2 write entry points, called from tcp_send()/tcpconn_send_unsafe() in
+ * tcp_main.c. tcp_reactor_send_put()/_connect_put() ship a write/connect
+ * request from a worker to PROC_TCP_MAIN (or, when already running inside
+ * PROC_TCP_MAIN, stage the payload directly); tcp_reactor_enable_write_watch()
+ * arms POLLOUT on an already-hashed connection - also used directly by the
+ * tcpconn_send_unsafe() TLS handshake-flush path. */
+int tcp_reactor_send_put(struct tcp_connection *c, const char *buf,
+		unsigned len, snd_flags_t send_flags);
+int tcp_reactor_connect_put(struct dest_info *dst, union sockaddr_union *from,
+		const char *buf, unsigned len);
+int tcp_reactor_enable_write_watch(struct tcp_connection *c);
+
+/* Mode-2 entry points called from tcp_main.c - one per integration point in
+ * the io_wait dispatch (handle_tcpconn_ev(), handle_ser_child(),
+ * tcp_main_loop(), tcp_init_children()). All of tcp_reactor.c's own pool/job/
+ * shield machinery is file-static; these are the only doors into it. */
+int tcp_reactor_handle_tcpconn_ev(
+		struct tcp_connection *tcpconn, short ev, int fd_i);
+void tcp_reactor_handle_write_req(tcp_reactor_write_req_t *wreq);
+void tcp_reactor_handle_connect_req(tcp_reactor_connect_req_t *creq);
+void tcp_reactor_handle_tls_event_done(struct tcp_connection *tcpconn);
+void tcp_reactor_handle_script_close(int scid);
+void tcp_reactor_handle_tcpx_task_req(tcpx_task_t *task);
+void tcp_reactor_handle_notify(void);
+int tcp_reactor_pool_init(void);
+void tcp_reactor_pool_destroy(void);
+int tcp_reactor_dsock_init(void);
+
+/* =========================================================================
+ * tcp_main_threads == 2
+ *
+ * PROC_TCP_MAIN/io_wait owns all sockets. Pool threads only run read/write
+ * callbacks on connections handed to them, then signal completion over a
+ * notify pipe. The io_wait thread shields the conn and enqueues read/write
+ * jobs onto task_head; pool threads wait on the PROCESS_SHARED condvar. A
+ * write is triggered by a worker's CONN_WRITE_REQ, but it's the io_wait
+ * thread's handler that stages the plaintext and enqueues the job - the
+ * worker never touches the queue directly.
+ * ========================================================================= */
+
+/* job kinds */
+enum tcp_reactor_op
+{
+	TCP_R_READ = 1,	 /* run the read callback on conn (reactor-enqueued) */
+	TCP_R_WRITE = 2, /* drain conn's write staging (io_wait-enqueued) */
+	TCP_R_RUN = 3,	 /* run an arbitrary tcpx_task_t, no connection involved */
+};
+
+/* A read/write job references only the connection (+op); it never carries a
+ * payload - write data lives on the connection's wsq staging list. It holds a
+ * refcount on conn (taken at enqueue, released in completion). A TCP_R_RUN job
+ * carries a task instead of a conn (conn stays NULL) and is self-contained: the
+ * pool thread runs task->exec() and frees the job itself, no io_wait-side
+ * completion needed - see tcp_reactor_handle_tcpx_task_req(). All jobs are
+ * pkg-allocated by the enqueuing thread. */
+struct tcp_reactor_job
+{
+	struct tcp_connection *conn;
+	enum tcp_reactor_op op;
+	int resp; /* callback result (e.g. wbuf still pending); READ/WRITE only */
+	tcpx_task_t *task; /* TCP_R_RUN only */
+	struct tcp_reactor_job *next;
+};
+
+/* Wakeup condvar for the reactor pool: the io_wait thread signals it to hand
+ * jobs to pool threads, which wait on it. A PROCESS_SHARED + (possibly)ROBUST condvar in
+ * shm, allocated before fork; the sharing is only between the io_wait thread
+ * and the pool threads inside PROC_TCP_MAIN. */
+struct tcp_reactor_wake
+{
+	tcp_cond_t cond; /* PROCESS_SHARED + ROBUST mutex + cond */
+};
+extern struct tcp_reactor_wake *tcp_reactor_wake;
+
+/* thread pool state, local to PROC_TCP_MAIN (pkg / process-private memory) */
+struct tcp_reactor_pool
+{
+	pthread_t *threads;
+	int threads_no;
+	int stop;
+	struct tcp_reactor_job *task_head; /* read/run jobs (reactor-enqueued) */
+	struct tcp_reactor_job *task_tail;
+	pthread_mutex_t done_lock; /* plain mutex: same process only */
+	struct tcp_reactor_job *done_head;
+	struct tcp_reactor_job *done_tail;
+	int notify_pipe[2]; /* [0] watched by reactor, [1] written by threads */
+};
+extern struct tcp_reactor_pool tcp_rpool;
+
+#endif /* _TCP_REACTOR_H_ */

--- a/src/core/tcp_reactor_mem.c
+++ b/src/core/tcp_reactor_mem.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2025 S-P Chan
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * @brief Mutex-wrapped pkg allocator for PROC_TCP_MAIN (see tcp_reactor_mem.h).
+ */
+
+#include "dprint.h"
+#include "mem/pkg.h"
+#include "tcp_reactor_mem.h"
+
+#ifdef PKG_MALLOC
+/* PKG_MALLOC build: pkg_* is served by Kamailio's own lock-free per-process
+ * allocator via the _pkg_root vtable, which is what we must serialize. When
+ * PKG_MALLOC is NOT defined pkg_* expands straight to the (thread-safe) system
+ * malloc and _pkg_root is bypassed entirely, so there is nothing to lock - see
+ * the no-op install at the bottom of this file. */
+
+#include <pthread.h>
+
+/* The single mutex that serializes all pkg allocation in this process once the
+ * wrappers are installed, plus the saved originals we delegate to. Only ever
+ * touched in PROC_TCP_MAIN (mode 2). */
+static pthread_mutex_t _ksr_pkg_lock = PTHREAD_MUTEX_INITIALIZER;
+static sr_malloc_f _ksr_pkg_orig_xmalloc;
+static sr_malloc_f _ksr_pkg_orig_xmallocxz;
+static sr_realloc_f _ksr_pkg_orig_xrealloc;
+static sr_realloc_f _ksr_pkg_orig_xreallocxf;
+static sr_free_f _ksr_pkg_orig_xfree;
+
+/* The wrappers just take the mutex and delegate to the saved original. Two
+ * sets: the DBG_SR_MEMORY build carries (file, func, line, mname) through the
+ * allocator vtable, the normal build does not - match both signatures exactly. */
+#ifdef DBG_SR_MEMORY
+static void *_ksr_pkg_l_xmalloc(void *mbp, size_t size, const char *file,
+		const char *func, unsigned int line, const char *mname)
+{
+	void *p;
+	pthread_mutex_lock(&_ksr_pkg_lock);
+	p = _ksr_pkg_orig_xmalloc(mbp, size, file, func, line, mname);
+	pthread_mutex_unlock(&_ksr_pkg_lock);
+	return p;
+}
+static void *_ksr_pkg_l_xmallocxz(void *mbp, size_t size, const char *file,
+		const char *func, unsigned int line, const char *mname)
+{
+	void *p;
+	pthread_mutex_lock(&_ksr_pkg_lock);
+	p = _ksr_pkg_orig_xmallocxz(mbp, size, file, func, line, mname);
+	pthread_mutex_unlock(&_ksr_pkg_lock);
+	return p;
+}
+static void *_ksr_pkg_l_xrealloc(void *mbp, void *ptr, size_t size,
+		const char *file, const char *func, unsigned int line,
+		const char *mname)
+{
+	void *p;
+	pthread_mutex_lock(&_ksr_pkg_lock);
+	p = _ksr_pkg_orig_xrealloc(mbp, ptr, size, file, func, line, mname);
+	pthread_mutex_unlock(&_ksr_pkg_lock);
+	return p;
+}
+static void *_ksr_pkg_l_xreallocxf(void *mbp, void *ptr, size_t size,
+		const char *file, const char *func, unsigned int line,
+		const char *mname)
+{
+	void *p;
+	pthread_mutex_lock(&_ksr_pkg_lock);
+	p = _ksr_pkg_orig_xreallocxf(mbp, ptr, size, file, func, line, mname);
+	pthread_mutex_unlock(&_ksr_pkg_lock);
+	return p;
+}
+static void _ksr_pkg_l_xfree(void *mbp, void *ptr, const char *file,
+		const char *func, unsigned int line, const char *mname)
+{
+	pthread_mutex_lock(&_ksr_pkg_lock);
+	_ksr_pkg_orig_xfree(mbp, ptr, file, func, line, mname);
+	pthread_mutex_unlock(&_ksr_pkg_lock);
+}
+#else  /* !DBG_SR_MEMORY */
+static void *_ksr_pkg_l_xmalloc(void *mbp, size_t size)
+{
+	void *p;
+	pthread_mutex_lock(&_ksr_pkg_lock);
+	p = _ksr_pkg_orig_xmalloc(mbp, size);
+	pthread_mutex_unlock(&_ksr_pkg_lock);
+	return p;
+}
+static void *_ksr_pkg_l_xmallocxz(void *mbp, size_t size)
+{
+	void *p;
+	pthread_mutex_lock(&_ksr_pkg_lock);
+	p = _ksr_pkg_orig_xmallocxz(mbp, size);
+	pthread_mutex_unlock(&_ksr_pkg_lock);
+	return p;
+}
+static void *_ksr_pkg_l_xrealloc(void *mbp, void *ptr, size_t size)
+{
+	void *p;
+	pthread_mutex_lock(&_ksr_pkg_lock);
+	p = _ksr_pkg_orig_xrealloc(mbp, ptr, size);
+	pthread_mutex_unlock(&_ksr_pkg_lock);
+	return p;
+}
+static void *_ksr_pkg_l_xreallocxf(void *mbp, void *ptr, size_t size)
+{
+	void *p;
+	pthread_mutex_lock(&_ksr_pkg_lock);
+	p = _ksr_pkg_orig_xreallocxf(mbp, ptr, size);
+	pthread_mutex_unlock(&_ksr_pkg_lock);
+	return p;
+}
+static void _ksr_pkg_l_xfree(void *mbp, void *ptr)
+{
+	pthread_mutex_lock(&_ksr_pkg_lock);
+	_ksr_pkg_orig_xfree(mbp, ptr);
+	pthread_mutex_unlock(&_ksr_pkg_lock);
+}
+#endif /* DBG_SR_MEMORY */
+
+void tcp_reactor_pkg_lock_install(void)
+{
+	if(_ksr_pkg_orig_xmalloc != NULL)
+		return; /* already installed */
+	_ksr_pkg_orig_xmalloc = _pkg_root.xmalloc;
+	_ksr_pkg_orig_xmallocxz = _pkg_root.xmallocxz;
+	_ksr_pkg_orig_xrealloc = _pkg_root.xrealloc;
+	_ksr_pkg_orig_xreallocxf = _pkg_root.xreallocxf;
+	_ksr_pkg_orig_xfree = _pkg_root.xfree;
+
+	/* Only the alloc/free/realloc paths are wrapped - status/info/report are
+	 * diagnostic and not on the hot concurrent path. */
+	_pkg_root.xmalloc = _ksr_pkg_l_xmalloc;
+	_pkg_root.xmallocxz = _ksr_pkg_l_xmallocxz;
+	_pkg_root.xrealloc = _ksr_pkg_l_xrealloc;
+	_pkg_root.xreallocxf = _ksr_pkg_l_xreallocxf;
+	_pkg_root.xfree = _ksr_pkg_l_xfree;
+
+	LM_WARN("PROC_TCP_MAIN pkg allocator serialized for reactor threads\n");
+}
+
+#else /* !PKG_MALLOC */
+
+/* System-malloc build: pkg_malloc/pkg_free are the (thread-safe) libc
+ * allocator, so the reactor pool needs no pkg serialization - nothing to do. */
+void tcp_reactor_pkg_lock_install(void)
+{
+	LM_DBG("pkg uses the system allocator (no PKG_MALLOC); reactor pkg lock "
+		   "not needed\n");
+}
+
+#endif /* PKG_MALLOC */

--- a/src/core/tcp_reactor_mem.h
+++ b/src/core/tcp_reactor_mem.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 S-P Chan
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * @brief Serialize the per-process pkg allocator for the threaded TCP reactor.
+ *
+ * pkg_malloc/pkg_free are served by Kamailio's own per-process allocator
+ * (_pkg_root vtable), which is deliberately lock-free under Kamailio's
+ * classic one-thread-per-process model. The full reactor (tcp_main_threads
+ * == 2) breaks that model: PROC_TCP_MAIN runs an io_wait thread plus a pool
+ * of reader threads that all touch this process's pkg heap (reactor job
+ * alloc/free, WS frame encode, TLS/WSS, config/event routes on the pool).
+ * Unlocked concurrent pkg_malloc/pkg_free corrupts the heap freelist.
+ *
+ * Rather than locking every call site, this wraps the _pkg_root vtable
+ * (xmalloc/xmallocxz/xrealloc/xreallocxf/xfree) with one process-local mutex.
+ * _pkg_root is per-process, so installing the wrapper in PROC_TCP_MAIN leaves
+ * worker processes and the tcp_main_threads 0/1 paths untouched.
+ *
+ * Orthogonal to the reactor's other thread-safety measures (shared read
+ * buffers, io_h ownership, per-connection shields) - this covers pkg only.
+ */
+
+#ifndef _tcp_reactor_mem_h
+#define _tcp_reactor_mem_h
+
+/**
+ * @brief Install the mutex-wrapped pkg allocator into _pkg_root.
+ *
+ * Idempotent. Must be called from PROC_TCP_MAIN (mode 2 only), once, BEFORE any
+ * reactor pool thread is spawned, so the vtable swap itself cannot race. After
+ * this returns, every pkg_malloc/pkg_free in this process is serialized by a
+ * single mutex. No-op-safe to call more than once.
+ *
+ * In a build without PKG_MALLOC (pkg_* == thread-safe system malloc) this is a
+ * no-op: there is no lock-free allocator to protect.
+ */
+void tcp_reactor_pkg_lock_install(void);
+
+#endif /* _tcp_reactor_mem_h */

--- a/src/core/tcp_read.c
+++ b/src/core/tcp_read.c
@@ -41,6 +41,7 @@
 
 #include <unistd.h>
 #include <stdlib.h> /* for abort() */
+#include <stdint.h> /* for uintptr_t */
 
 #include "dprint.h"
 #include "tcp_conn.h"
@@ -49,6 +50,9 @@
 #include "tcp_ev.h"
 #include "pass_fd.h"
 #include "globals.h"
+#include "tcp_server.h"
+#include "tcp_reactor.h"
+#include "mem/shm_mem.h"
 #include "receive.h"
 #include "timer.h"
 #include "local_timer.h"
@@ -117,7 +121,8 @@ enum fd_types
 {
 	F_NONE,
 	F_TCPMAIN,
-	F_TCPCONN
+	F_TCPCONN,
+	F_TCP_REACTOR /* mode 2: shared dispatch socket carrying SIP task pointers */
 };
 
 /* list of tcp connections handled by this process */
@@ -461,7 +466,11 @@ int tcp_read(struct tcp_connection *c, rd_conn_flags_t *flags)
 	unsigned int len;
 
 	r = &c->req;
-	fd = c->fd;
+	/* mode 2: tcp_main owns and reads the connection, where the socket fd is
+	 * c->s (c->fd is the fd-passing copy, only valid in a worker). _tconfd()
+	 * selects c->s in tcp_main and c->fd in a worker, so modes 0/1 are
+	 * unchanged. Matches the TLS read path, which already uses _tconfd(c). */
+	fd = _tconfd(c);
 	bytes_free = r->b_size - (unsigned int)(r->pos - r->buf);
 
 	if(unlikely(bytes_free <= 0)) {
@@ -1611,8 +1620,14 @@ int receive_tcp_msg(char *tcpbuf, unsigned int len,
 {
 	int ret = 0;
 #ifdef TCP_CLONE_RCVBUF
-	static char *buf = NULL;
-	static unsigned int bsize = 0;
+	/* mode 2: PROC_TCP_MAIN runs a pool of reader threads that all execute
+	 * receive_tcp_msg(). A process-global static clone buffer would be shared
+	 * across those threads - two of them memcpy their frame in and (for WS)
+	 * unmask in place, clobbering each other (garbage dispatched to workers).
+	 * _Thread_local gives each pool thread its own clone buffer. Harmless for
+	 * modes 0/1, where each reader is a single-threaded process. */
+	static _Thread_local char *buf = NULL;
+	static _Thread_local unsigned int bsize = 0;
 	int blen;
 
 	/* cloning is disabled via parameter */
@@ -1854,17 +1869,27 @@ again:
 			// if (unlikely(req->flags&F_TCP_REQ_MSRP_FRAME)){
 			if(unlikely(req->state == H_MSRP_FINISH)) {
 				/* msrp frame */
-				ret = receive_tcp_msg(
-						req->start, req->parsed - req->start, &con->rcv, con);
+				if(ksr_tcp_main_threads == 2)
+					ret = tcp_reactor_dispatch_msg(req->start,
+							req->parsed - req->start,
+							req->flags & F_TCP_REQ_MSRP_FRAME, &con->rcv);
+				else
+					ret = receive_tcp_msg(req->start, req->parsed - req->start,
+							&con->rcv, con);
 			} else
 #endif
 #ifdef READ_HTTP11
 					if(unlikely(req->state == H_HTTP11_CHUNK_FINISH)) {
 				/* http chunked request */
 				req->body[req->content_len] = 0;
-				ret = receive_tcp_msg(req->start,
-						req->body + req->content_len - req->start, &con->rcv,
-						con);
+				if(ksr_tcp_main_threads == 2)
+					ret = tcp_reactor_dispatch_msg(req->start,
+							req->body + req->content_len - req->start, 0,
+							&con->rcv);
+				else
+					ret = receive_tcp_msg(req->start,
+							req->body + req->content_len - req->start,
+							&con->rcv, con);
 			} else
 #endif
 #ifdef READ_WS
@@ -1874,6 +1899,11 @@ again:
 						req->start, req->parsed - req->start, &con->rcv, con);
 			} else
 #endif
+					if(ksr_tcp_main_threads == 2)
+				ret = tcp_reactor_dispatch_msg(req->start,
+						req->parsed - req->start, req->flags & F_TCP_REQ_HEP3,
+						&con->rcv);
+			else
 				ret = receive_tcp_msg(
 						req->start, req->parsed - req->start, &con->rcv, con);
 
@@ -2110,6 +2140,101 @@ inline static int handle_io(struct fd_map *fm, short events, int idx)
 				goto con_error;
 			}
 			break;
+		case F_TCP_REACTOR: {
+			/* mode 2: PROC_TCP_MAIN dispatched a reassembled SIP message as a
+			 * shm task pointer over the shared dgram socket. Consume it, run
+			 * the message, and free the task. */
+			tcp_reactor_task_t *task;
+			uintptr_t task_ptr;
+		again_reactor:
+			ret = n = recv(fm->fd, &task_ptr, sizeof(task_ptr), MSG_DONTWAIT);
+			if(unlikely(n < 0)) {
+				if(errno == EWOULDBLOCK || errno == EAGAIN) {
+					ret = 0;
+					break;
+				} else if(errno == EINTR) {
+					goto again_reactor;
+				} else {
+					LM_CRIT("recv on reactor dispatch socket failed: %s [%d]\n",
+							strerror(errno), errno);
+					goto error;
+				}
+			}
+			if(unlikely(n == 0)) {
+				LM_ERR("EOF on reactor dispatch socket\n");
+				goto error;
+			}
+			if(unlikely(n != (int)sizeof(task_ptr))) {
+				LM_CRIT("short read on reactor dispatch socket: %d bytes\n", n);
+				goto error;
+			}
+			task = (tcp_reactor_task_t *)(uintptr_t)task_ptr;
+			if(unlikely(task == NULL)) {
+				LM_CRIT("null task pointer from tcp main\n");
+				break;
+			}
+			if(unlikely(task->flags & F_TCP_REQ_TLS_EVENT)) {
+				/* mode 2: run the dispatched tls:connection-out route here in
+				 * the worker - a single-threaded config context. The route
+				 * reads TLS metadata cached in shm (task->con->extra_data), so
+				 * no OpenSSL runs in the worker. Then hand the connection back
+				 * to PROC_TCP_MAIN, which drops the dispatch refcnt. */
+				long tls_resp[2];
+				if(likely(tls_hook.run_event_route != NULL))
+					tls_hook.run_event_route(task->con);
+				tls_resp[0] = (long)(uintptr_t)task->con;
+				tls_resp[1] = CONN_TLS_EVENT_DONE;
+				if(unlikely(tsend_stream(unix_tcp_sock, (char *)tls_resp,
+									sizeof(tls_resp), -1)
+							<= 0))
+					LM_ERR("failed to return tls-event conn to tcp main\n");
+				shm_free(task);
+				break;
+			}
+			/* The message buffer is self-describing; task->flags only picks
+			 * the entry point. HEP3/MSRP carry their own framing and go through
+			 * the same sr_event decoders as in modes 0/1. The worker has no
+			 * local tcp_connection, so con is NULL; the decoders that need the
+			 * connection id read it from rcv->proto_reserved1 (== con->id). */
+			{
+				int rmret;
+				if(unlikely(task->flags & F_TCP_REQ_HEP3))
+					rmret = hep3_process_msg(
+							task->msg_buf, task->msg_len, &task->rcv, NULL);
+#ifdef READ_MSRP
+				else if(unlikely(task->flags & F_TCP_REQ_MSRP_FRAME))
+					rmret = msrp_process_msg(
+							task->msg_buf, task->msg_len, &task->rcv, NULL);
+#endif
+				else {
+					rmret = receive_msg(
+							task->msg_buf, task->msg_len, &task->rcv);
+					/* SIP honours tcp_script_mode: CONTINUE masks a negative
+					 * script result so the connection stays up - same as
+					 * receive_tcp_msg() in modes 0/1. */
+					if(ksr_tcp_script_mode & TCP_SCRIPT_MODE_CONTINUE)
+						rmret = 0;
+				}
+				/* mode 2 parity with modes 0/1: a negative message-processing
+				 * result (e.g. request_route return(-1) with tcp_script_mode=0)
+				 * closes the connection. The worker holds no tcp_connection, so
+				 * ask PROC_TCP_MAIN to drop it by id (rcv.proto_reserved1 ==
+				 * con->id) via CONN_SCRIPT_CLOSE. */
+				if(unlikely(rmret < 0)) {
+					long clresp[2];
+					clresp[0] = (long)task->rcv.proto_reserved1;
+					clresp[1] = CONN_SCRIPT_CLOSE;
+					if(unlikely(tsend_stream(unix_tcp_sock, (char *)clresp,
+										sizeof(clresp), -1)
+								<= 0))
+						LM_ERR("mode2: failed to request script-close for "
+							   "conn id %ld\n",
+								(long)task->rcv.proto_reserved1);
+				}
+			}
+			shm_free(task);
+			break;
+		}
 		case F_TCPCONN:
 			con = (struct tcp_connection *)fm->data;
 			if(unlikely(con->state == S_CONN_BAD)) {
@@ -2220,9 +2345,22 @@ void tcp_receive_loop(int unix_sock)
 	if(init_local_timer(&tcp_reader_ltimer, get_ticks_raw()) != 0)
 		goto error;
 	/* add the unix socket */
-	if(io_watch_add(&io_w, tcpmain_sock, POLLIN, F_TCPMAIN, 0) < 0) {
-		LM_CRIT("failed to add tcp main socket to the fd list\n");
-		goto error;
+	if(ksr_tcp_main_threads == 2) {
+		/* mode 2: this worker is a pure SIP engine - it does not own tcp fds
+		 * and never receives them via fd-passing. Instead it consumes
+		 * reassembled SIP messages dispatched by PROC_TCP_MAIN over the shared
+		 * dgram socket. */
+		if(io_watch_add(&io_w, ksr_tcp_reactor_get_dispatch_rfd(), POLLIN,
+				   F_TCP_REACTOR, 0)
+				< 0) {
+			LM_CRIT("failed to add reactor dispatch socket to the fd list\n");
+			goto error;
+		}
+	} else {
+		if(io_watch_add(&io_w, tcpmain_sock, POLLIN, F_TCPMAIN, 0) < 0) {
+			LM_CRIT("failed to add tcp main socket to the fd list\n");
+			goto error;
+		}
 	}
 
 	/* initialize the config framework */

--- a/src/core/tcp_read.h
+++ b/src/core/tcp_read.h
@@ -40,6 +40,9 @@ int tcp_read_headers(
 int tcp_read_data(int fd, struct tcp_connection *c, char *buf, int b_size,
 		rd_conn_flags_t *flags);
 
+int tcp_read_req(struct tcp_connection *con, int *bytes_read,
+		rd_conn_flags_t *read_flags);
+
 
 #endif /*__tcp_read_h*/
 

--- a/src/core/tcp_server.h
+++ b/src/core/tcp_server.h
@@ -32,6 +32,12 @@
 int tcp_send(struct dest_info *dst, union sockaddr_union *from, const char *buf,
 		unsigned len);
 
+/* mode 2 reactor: dispatch socketpair accessors.
+ * rfd: read end — workers watch this fd (recvfrom task pointers).
+ * wfd: write end — tcp_main sends task pointers here. */
+int ksr_tcp_reactor_get_dispatch_rfd(void);
+int ksr_tcp_reactor_get_dispatch_wfd(void);
+
 int tcpconn_add_alias(int id, int port, int proto);
 
 

--- a/src/core/tls_hooks.h
+++ b/src/core/tls_hooks.h
@@ -85,6 +85,12 @@ typedef struct tls_hooks
 	 * see: _tcpconn_add_alias_unsafe */
 	int (*match_connections_domain)(
 			struct tcp_connection *l_c, struct tcp_connection *r_c);
+	/* mode 2: run the tls:connection-out event route for c in the calling
+	 * (worker) process - a single-threaded config context. Set by the tls
+	 * module to tls_run_event_routes. Invoked by the reactor worker when it
+	 * receives a F_TCP_REQ_TLS_EVENT dispatch task (the SSL metadata the route
+	 * reads is already cached in shm c->extra_data). */
+	int (*run_event_route)(struct tcp_connection *c);
 } tls_hooks_t;
 
 

--- a/src/modules/msrp/msrp_cmap.c
+++ b/src/modules/msrp/msrp_cmap.c
@@ -249,7 +249,12 @@ int msrp_cmap_save(msrp_frame_t *mf)
 	it->sock.s[it->sock.len] = '\0';
 
 	it->expires = time(NULL) + expires;
-	it->conid = mf->tcpinfo->con->id;
+	/* con is NULL under the tcp reactor (tcp_main_threads=2): the frame is
+	 * decoded in a worker with no local tcp_connection. The connection id is
+	 * carried in rcv->proto_reserved1 (set == con->id before dispatch), which
+	 * is what the reply path (init_dst_from_rcv) keys off anyway. */
+	it->conid = (mf->tcpinfo->con != NULL) ? mf->tcpinfo->con->id
+										   : mf->tcpinfo->rcv->proto_reserved1;
 
 	/* insert item in cmap */
 	lock_get(&_msrp_cmap_head->cslots[idx].lock);

--- a/src/modules/tls/tls_mod.c
+++ b/src/modules/tls/tls_mod.c
@@ -363,6 +363,7 @@ static struct tls_hooks tls_h = {
 	tls_h_mod_pre_init_f,
 	tls_h_match_domain_f,
 	tls_h_match_connections_domain_f,
+	tls_run_event_routes,
 };
 /* clang-format on */
 

--- a/src/modules/tls/tls_server.c
+++ b/src/modules/tls/tls_server.c
@@ -37,6 +37,7 @@
 #include "../../core/globals.h"
 #include "../../core/tcp_conn.h"
 #include "../../core/tcp_int_send.h"
+#include "../../core/tcp_reactor.h" /* tcp_reactor_dispatch_tls_event() - mode 2 */
 #include "../../core/tcp_read.h"
 #include "../../core/tcp_mtops.h"
 #include "../../core/cfg/cfg.h"
@@ -2113,7 +2114,7 @@ int tls_h_read_mt_f(struct tcp_connection *c, rd_conn_flags_t *flags)
 	 * tls_run_event_routes() ran in a PROC_TCP_MAIN thread and
 	 * deferred the event route - we are back in the worker
 	 * so run the route now */
-	{
+	if(!is_tcp_main()) {
 		struct tls_extra_data *tls_c = (struct tls_extra_data *)c->extra_data;
 		if(tls_c != NULL && tls_c->run_conn_out_pending) {
 			tls_c->run_conn_out_pending = 0;
@@ -2166,9 +2167,16 @@ int tls_run_event_routes(struct tcp_connection *c)
 	if(_tls_evrt_connection_out < 0 && sr_tls_event_callback.len <= 0)
 		return 0;
 
-	/* With tcp_main_threads > 0 - mtops - ensure the route function
-	 * runs in the worker and not PROC_TCP_MAIN; we flag this for
-	 * deferred execution. */
+	/* With tcp_main_threads = 2: we are on a PROC_TCP_MAIN reactor thread.
+	 * Dispatch the event to a TCP worker. */
+	if(is_tcp_main() && ksr_tcp_main_threads == 2) {
+		tcp_reactor_dispatch_tls_event(c);
+		return 0;
+	}
+
+	/* With tcp_main_threads == 1 - mtops - ensure the route function
+         * runs in the worker and not PROC_TCP_MAIN; we flag this for
+         * deferred execution. */
 	if(is_tcp_main()) {
 		struct tls_extra_data *tls_c = (struct tls_extra_data *)c->extra_data;
 		if(tls_c != NULL)
@@ -2179,6 +2187,11 @@ int tls_run_event_routes(struct tcp_connection *c)
 	if(faked_msg_init() < 0)
 		return -1;
 	fmsg = faked_msg_next();
+	/* expose the connection's endpoints to the route: for an outbound
+	 * connection rcv.src is the peer we connected to and rcv.dst is the local
+	 * side, so $si/$sp read the peer and $Ri/$Rp the local socket. Without this
+	 * the faked message carries only the placeholder rcv (127.0.0.1:5060). */
+	fmsg->rcv = c->rcv;
 
 	backup_rt = get_route_type();
 	set_route_type(LOCAL_ROUTE);

--- a/src/modules/tls/tls_server.h
+++ b/src/modules/tls/tls_server.h
@@ -124,6 +124,7 @@ int tls_connect(struct tcp_connection *c, int *error);
 int tls_accept(struct tcp_connection *c, int *error);
 
 void tls_lookup_event_routes(void);
+int tls_run_event_routes(struct tcp_connection *c);
 int ksr_tls_set_connect_server_id(str *srvid);
 
 #endif /* _TLS_SERVER_H */

--- a/src/modules/websocket/ws_conn.c
+++ b/src/modules/websocket/ws_conn.c
@@ -508,6 +508,14 @@ static void wsconn_run_close_callback(ws_connection_t *wsc)
 	sr_event_exec(SREV_TCP_WS_CLOSE, &evp);
 }
 
+/* wsconn_run_route() runs the websocket:closed event route. It needs no thread
+ * serialization: its only caller, wsconn_dtor(), is reached solely from the
+ * WebSocket connection reaper, which runs in the single-threaded WEBSOCKET
+ * TIMER process. Even in the full tcp reactor (tcp_main_threads == 2) the read
+ * path (a PROC_TCP_MAIN pool thread) only marks the connection WS_S_REMOVING via
+ * wsconn_put(); it never dtors, so it never runs this route. The faked sip_msg /
+ * route_type this touches are therefore never accessed concurrently, in any
+ * tcp_main_threads mode. */
 static void wsconn_run_route(ws_connection_t *wsc)
 {
 	int rt, backup_rt;

--- a/src/modules/websocket/ws_frame.c
+++ b/src/modules/websocket/ws_frame.c
@@ -40,7 +40,9 @@
 #include "../../core/ut.h"
 #include "../../core/tcp_conn.h"
 #include "../../core/tcp_read.h"
+#include "../../core/tcp_reactor.h"
 #include "../../core/tcp_server.h"
+#include "../../core/globals.h"
 #include "../../core/counters.h"
 #include "../../core/mem/mem.h"
 #include "../../core/rand/kam_rand.h"
@@ -602,6 +604,22 @@ static int handle_pong(ws_frame_t *frame)
 	return 0;
 }
 
+/* Deliver a decoded, defragmented WS SIP payload.
+ *
+ * mode 2 (tcp reactor): the frame codec runs on a PROC_TCP_MAIN pool thread
+ * (single-owner under the connection shield). Running config here would execute
+ * the SIP route on a pool thread, so instead the payload is handed to a worker
+ * over the reactor dispatch socket - exactly like plain SIP / HEP3 / MSRP. The
+ * dispatch copies the buffer into shm, so the caller may reset frag_buf right
+ * after. Modes 0/1 keep the inline receive_msg() (worker owns the fd there). */
+static inline int ws_deliver_sip(
+		char *buf, unsigned int len, struct receive_info *rcv)
+{
+	if(unlikely(ksr_tcp_main_threads == 2))
+		return tcp_reactor_dispatch_msg(buf, len, 0, rcv);
+	return receive_msg(buf, len, rcv);
+}
+
 int ws_frame_receive(sr_event_param_t *evp)
 {
 	ws_frame_t frame;
@@ -664,7 +682,7 @@ int ws_frame_receive(sr_event_param_t *evp)
 				frame.wsc->frag_buf.s[frame.wsc->frag_buf.len] = '\0';
 
 				if(frame.fin) {
-					ret = receive_msg(frame.wsc->frag_buf.s,
+					ret = ws_deliver_sip(frame.wsc->frag_buf.s,
 							frame.wsc->frag_buf.len, tcpinfo->rcv);
 					frame.wsc->frag_buf.len = 0;
 					frame.wsc->frag_progress = 0;
@@ -708,7 +726,7 @@ int ws_frame_receive(sr_event_param_t *evp)
 
 					wsconn_put(frame.wsc);
 
-					return receive_msg(frame.payload_data, frame.payload_len,
+					return ws_deliver_sip(frame.payload_data, frame.payload_len,
 							tcpinfo->rcv);
 				} else {
 					memcpy(frame.wsc->frag_buf.s, frame.payload_data,
@@ -723,6 +741,17 @@ int ws_frame_receive(sr_event_param_t *evp)
 				LM_DBG("Rx MSRP frame:\n%.*s\n", frame.payload_len,
 						frame.payload_data);
 				update_stat(ws_msrp_received_frames, 1);
+				/* mode 2: dispatch the MSRP payload to a worker tagged as an MSRP
+				 * frame, so it runs the SREV_TCP_MSRP_FRAME decode there - the
+				 * same worker path as native MSRP-over-TCP. The worker sources the
+				 * conn id from rcv->proto_reserved1. */
+				if(unlikely(ksr_tcp_main_threads == 2)) {
+					ret = tcp_reactor_dispatch_msg(frame.payload_data,
+							frame.payload_len, F_TCP_REQ_MSRP_FRAME,
+							tcpinfo->rcv);
+					wsconn_put(frame.wsc);
+					return ret;
+				}
 				if(likely(sr_event_enabled(SREV_TCP_MSRP_FRAME))) {
 					tcp_event_info_t tev;
 					memset(&tev, 0, sizeof(tcp_event_info_t));


### PR DESCRIPTION

#### Pre-Submission Checklist
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [] Each component has a single commit (if not, squash them into one commit)
- [X] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [X]Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
## Threaded TCP receiver (`tcp_main_threads = 2`)

This PR adds a threaded TCP receiver — the TCP counterpart to the UDP `udp_receiver_mode = 1` setting. Unlike UDP, this mode also confines TCP writes to a single process.

The mode is selected with `tcp_main_threads`:

- `0` — classic multi-process TCP network I/O and TLS (unchanged).
- `1` — multi-process TCP network I/O, but the read for TLS and all TLS run in a single process. This was previously `tcp_main_threads > 0`.
- `2` (new) — all TCP network I/O and all TLS run in `PROC_TCP_MAIN`.

### What changes in mode 2

Transport is separated from SIP message handling. `PROC_TCP_MAIN` is the only process that holds TCP sockets, and sockets are no longer passed between processes with `sendmsg`/`SCM_RIGHTS`. This removes the file descriptor book-keeping and the borrow/return ceremony around TCP sockets.

- all reads are done in `PROC_TCP_MAIN` and SIP messages (as shm pointers) are passed to the workers (as with `udp_receiver_mode = 1`)
- Writes are always asynchronous. A worker never writes to a socket; it hands the payload to `PROC_TCP_MAIN` via `CONN_WRITE_REQ`.
- Outbound connections with no existing `tcp_connection_t` are opened in `PROC_TCP_MAIN` (via `CONN_CONNECT_REQ`) instead of in a worker.
- `PROC_TCP_MAIN` runs a thread pool for socket reads and async writes. The pool size is set with `tcp_reactor_threads` (default 8).

In mode 2: conceptually a TCP worker is identical to a UDP async worker - it only deals with  SIP messages. The TCP worker `io_wait` loop simplifies to the `recvfrom`-loop of UDP; in this PR we keep `io_wait` to coexist with mode-0/1.

### Notes for reviewers

- update: during the development of this PR some bugs were found on master regarding event handling. This PR depends on commits that have landed in master so the original commits that contained workarounds have been cleaned-up.
- The `src/core` commits are not squashed, so each step is a smaller read.
- `pkg_malloc` is lock-free and assumes one thread per process, which mode 2 breaks. If Kamailio is built against the system `malloc` (glibc, musl, …) this is a non-issue, since those are thread-safe. With Kamailio's own allocators, the `pkg` path is serialized inside `PROC_TCP_MAIN`; that serialization is confined to `PROC_TCP_MAIN` and touches nothing else. This contention was exposed by the websocket module - by fluke TLS, HEP, MSRP did not use `pkg_malloc` in any way that resulted in multi-threaded contention. (I have ongoing work to see if websocket can use `pkg_malloc` in a thread safe manner - but that is incidental to the thrust of this PR.)
- Modes 0 and 1 are untouched. Every new code path is gated on `tcp_main_threads = 2`.
