### PR TITLE
core: fix case insensitivity and bounds in _strnistr

### DIFF
--- a/src/core/str.c
+++ b/src/core/str.c
@@ -24,6 +24,7 @@
  * Module: \ref core
  */
 
+#include <ctype.h>
 #include <string.h>
 #include "str.h"
 #include "mem/mem.h"
@@ -78,20 +79,35 @@ char *_strnstr(const char *s, const char *find, size_t slen)
  */
 char *_strnistr(const char *s, const char *find, size_t slen)
 {
-	char c, sc;
+	const char *p, *q;
 	size_t len;
+	const char *last;
 
-	if((c = *find++) != '\0') {
-		len = strlen(find);
-		do {
-			do {
-				if((sc = *s++) == '\0' || slen-- < 1)
-					return (NULL);
-			} while(sc != c);
-			if(len > slen)
-				return (NULL);
-		} while(strncasecmp(s, find, len) != 0);
-		s--;
+	if(s == NULL || find == NULL || slen == 0) {
+		return NULL;
 	}
-	return ((char *)s);
+
+	len = strlen(find);
+	if(len == 0) {
+		return (char *)s;
+	}
+
+	if(len > slen) {
+		return NULL;
+	}
+
+	last = s + slen - len + 1;
+	while(s < last) {
+		q = find;
+		p = s;
+		while(*q && tolower((unsigned char)*p) == tolower((unsigned char)*q)) {
+			p++;
+			q++;
+		}
+		if(!*q) {
+			return (char *)s;
+		}
+		s++;
+	}
+	return NULL;
 }


### PR DESCRIPTION
While reviewing the core string utility functions in src/core/str.c, I noticed two issues with the _strnistr implementation:

Case-Insensitivity Bug: The first character comparison sc != c was done case-sensitively. If the search substring and target buffer differed in case on the very first character (such as searching for "Alias" inside a contact parameter "alias="), it would fail to match and miss the substring entirely.
Buffer Overread: The bounds checking sequence in the inner loop (sc = *s++) == '\0' || slen-- < 1 was ordered incorrectly. The dereference *s++ occurred before checking if slen had reached zero, potentially reading one byte past the buffer's designated length constraint.
This patch refactors the function to:

Validate input parameters (s, find, and slen) to prevent NULL dereferences.
Calculate a safe sliding-window limit pointer (last) to avoid any out-of-bounds pointer increments.
Perform a fully case-insensitive comparison using tolower on both characters.
