### PR TITLE
core: fix case-insensitive search and buffer overread in _strnistr

### DIFF
--- a/src/core/str.c
+++ b/src/core/str.c
@@ -25,6 +25,7 @@
  */
 
 #include <string.h>
+#include <ctype.h>
 #include "str.h"
 #include "mem/mem.h"
 
@@ -80,14 +81,17 @@ char *_strnistr(const char *s, const char *find, size_t slen)
 {
 	char c, sc;
 	size_t len;
+	char c_lower, c_upper;
 
 	if((c = *find++) != '\0') {
 		len = strlen(find);
+		c_lower = tolower((unsigned char)c);
+		c_upper = toupper((unsigned char)c);
 		do {
 			do {
-				if((sc = *s++) == '\0' || slen-- < 1)
+				if(slen-- < 1 || (sc = *s++) == '\0')
 					return (NULL);
-			} while(sc != c);
+			} while(sc != c_lower && sc != c_upper);
 			if(len > slen)
 				return (NULL);
 		} while(strncasecmp(s, find, len) != 0);


### PR DESCRIPTION
While checking _strnistr() in src/core/str.c, I noticed it performs a case-sensitive check on the first character of the search target, which breaks the case-insensitive search. Additionally, the boundary check evaluates after the pointer increment, leading to a 1-byte buffer overread on non-null-terminated strings. I've reordered the condition to prevent the overread and pre-computed the uppercase/lowercase characters for an efficient, case-insensitive match.

