### PR TITLE
ims_pcscf: fix sec-agree shared memory leak from repeated header params

### DIFF
--- a/src/modules/ims_ipsec_pcscf/cmd.c
+++ b/src/modules/ims_ipsec_pcscf/cmd.c
@@ -1013,12 +1013,23 @@ cleanup:
 	// stored on the contact. Free it here, otherwise it leaks on every
 	// re-registration. On the initial path ipsec_swapped==1 and data.ipsec is
 	// now owned by the contact - do NOT free it.
-	// sec_header is intentionally left alone (freed via the data_lump path).
 	if(req_sec_params && !ipsec_swapped && req_sec_params->data.ipsec) {
 		free_ipsec_data(req_sec_params->data.ipsec);
 		req_sec_params->data.ipsec = NULL;
 	}
-	// Do not free str* sec_header! It will be freed in data_lump.c -> free_lump()
+	// Free the security_t wrapper and its sec_header (a private shm copy of the
+	// request header name, never added to a lump). They are not stored on the
+	// contact, so without this they leak on every (re-)registration. data.ipsec
+	// is either freed just above (re-reg) or owned by the contact (initial swap)
+	// and must not be touched here.
+	if(req_sec_params) {
+		if(req_sec_params->sec_header.s) {
+			shm_free(req_sec_params->sec_header.s);
+			req_sec_params->sec_header.s = NULL;
+		}
+		shm_free(req_sec_params);
+		req_sec_params = NULL;
+	}
 	ul.unlock_udomain(d, &ci.via_host, ci.via_port, ci.via_prot);
 	pkg_free(ci.received_host.s);
 	pkg_free(ci.aor.s);

--- a/src/modules/ims_ipsec_pcscf/sec_agree.c
+++ b/src/modules/ims_ipsec_pcscf/sec_agree.c
@@ -69,7 +69,17 @@ static void trim_whitespaces(str *string)
 	}
 }
 
+/* Free any previous value before overwriting it. A Security-Client or
+ * Security-Verify header may carry several comma-separated ipsec-3gpp offers,
+ * so the same parameter (alg/ealg/prot/mod) can be parsed more than once;
+ * without this free the earlier shm allocation is orphaned on every
+ * (re-)registration. The last parsed value is kept, as before. */
 #define SEC_COPY_STR_PARAM(DST, SRC) \
+	if(DST.s != NULL) {              \
+		shm_free(DST.s);             \
+		DST.s = NULL;                \
+		DST.len = 0;                 \
+	}                                \
 	DST.s = shm_malloc(SRC.len);     \
 	if(DST.s == NULL) {              \
 		return -1;                   \

--- a/src/modules/ims_registrar_pcscf/sec_agree.c
+++ b/src/modules/ims_registrar_pcscf/sec_agree.c
@@ -67,7 +67,17 @@ static void trim_whitespaces(str *string)
 	}
 }
 
+/* Free any previous value before overwriting it. A Security-Client or
+ * Security-Verify header may carry several comma-separated ipsec-3gpp offers,
+ * so the same parameter (alg/ealg/prot/mod) can be parsed more than once;
+ * without this free the earlier shm allocation is orphaned on every
+ * (re-)registration. The last parsed value is kept, as before. */
 #define SEC_COPY_STR_PARAM(DST, SRC) \
+	if(DST.s != NULL) {              \
+		shm_free(DST.s);             \
+		DST.s = NULL;                \
+		DST.len = 0;                 \
+	}                                \
 	DST.s = shm_malloc(SRC.len);     \
 	if(DST.s == NULL) {              \
 		SHM_MEM_ERROR;               \


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format` from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Follow-up to #4764, addressing two remaining shared-memory leaks in the P-CSCF security-agreement (sec-agree) path.

During IMS (re-)registration the UE's `Security-Client` / `Security-Verify` header can list several comma-separated `ipsec-3gpp` mechanism offers, so `parse_sec_agree()` reads the `alg` / `ealg` / `prot` / `mod` parameters more than once. The `SEC_COPY_STR_PARAM` macro (present in both `ims_registrar_pcscf` and `ims_ipsec_pcscf`) `shm_malloc`'d a new buffer on each occurrence **without freeing the previous one**, orphaning several small shm allocations on every registration. Over time this fragments and exhausts the P-CSCF shared-memory pool (crash on busy nodes after a few days).

In addition, `ipsec_create()` in `ims_ipsec_pcscf` never freed the `security_t` returned by `cscf_get_security()`: only its `data.ipsec` was handled (freed on re-registration, or handed to the contact on initial registration), while the wrapper struct and its `sec_header` shm copy leaked on every call.

**Fixes**
- `ims_registrar_pcscf` / `ims_ipsec_pcscf`: `SEC_COPY_STR_PARAM` now frees the previous value before allocating the new one. The last parsed value is kept, so behavior is unchanged.
- `ims_ipsec_pcscf`: `ipsec_create()` now frees the `req_sec_params` wrapper and its `sec_header` on all paths (`data.ipsec` ownership is unchanged — freed on re-reg, retained by the contact on initial registration).

**Testing**
Verified with `kamcmd ... mod.stats all shm`: on a fresh start, `ims_registrar_pcscf` is `0` and `ims_ipsec_pcscf` holds only the fixed SPI pool. Before the fix, both grew on every re-registration cycle and never returned to baseline after UEs de-registered; with the fix, the totals plateau under load and return to baseline. Confirmed on a live P-CSCF with real UE devices over an extended period.