### PR TITLE
ims: remove unused sec_header from security_t

### DIFF
--- a/src/modules/ims_ipsec_pcscf/cmd.c
+++ b/src/modules/ims_ipsec_pcscf/cmd.c
@@ -1013,12 +1013,10 @@ cleanup:
 	// stored on the contact. Free it here, otherwise it leaks on every
 	// re-registration. On the initial path ipsec_swapped==1 and data.ipsec is
 	// now owned by the contact - do NOT free it.
-	// sec_header is intentionally left alone (freed via the data_lump path).
 	if(req_sec_params && !ipsec_swapped && req_sec_params->data.ipsec) {
 		free_ipsec_data(req_sec_params->data.ipsec);
 		req_sec_params->data.ipsec = NULL;
 	}
-	// Do not free str* sec_header! It will be freed in data_lump.c -> free_lump()
 	ul.unlock_udomain(d, &ci.via_host, ci.via_port, ci.via_prot);
 	pkg_free(ci.received_host.s);
 	pkg_free(ci.aor.s);

--- a/src/modules/ims_ipsec_pcscf/sec_agree.c
+++ b/src/modules/ims_ipsec_pcscf/sec_agree.c
@@ -179,14 +179,6 @@ static security_t *parse_sec_agree(struct hdr_field *h)
 	}
 	memset(params, 0, sizeof(security_t));
 
-	if((params->sec_header.s = shm_malloc(h->name.len)) == NULL) {
-		LM_ERR("Error allocating shm memory for security_t sec_header "
-			   "parameter during sec-agree parsing\n");
-		goto cleanup;
-	}
-	memcpy(params->sec_header.s, h->name.s, h->name.len);
-	params->sec_header.len = h->name.len;
-
 	// allocate memory for ipsec_t in security_t
 	params->data.ipsec = shm_malloc(sizeof(ipsec_t));
 	if(!params->data.ipsec) {
@@ -295,9 +287,6 @@ cleanup:
 	// Function - free_security()
 	// Keep them in sync!
 	if(params) {
-		if(params->sec_header.s)
-			shm_free(params->sec_header.s);
-
 		if(params->type == SECURITY_IPSEC && params->data.ipsec) {
 			if(params->data.ipsec->ealg.s)
 				shm_free(params->data.ipsec->ealg.s);

--- a/src/modules/ims_registrar_pcscf/sec_agree.c
+++ b/src/modules/ims_registrar_pcscf/sec_agree.c
@@ -115,10 +115,6 @@ void free_security_t(security_t *params)
 		return;
 	}
 
-	if(params->sec_header.s) {
-		shm_free(params->sec_header.s);
-	}
-
 	switch(params->type) {
 		case SECURITY_IPSEC:
 			if(params->data.ipsec) {
@@ -188,14 +184,6 @@ static security_t *parse_sec_agree(struct hdr_field *h)
 		return NULL;
 	}
 	memset(params, 0, sizeof(security_t));
-
-	if((params->sec_header.s = shm_malloc(h->name.len)) == NULL) {
-		SHM_MEM_ERROR_FMT("for security_t sec_header parameter during "
-						  "sec-agree parsing\n");
-		goto cleanup;
-	}
-	memcpy(params->sec_header.s, h->name.s, h->name.len);
-	params->sec_header.len = h->name.len;
 
 	// allocate memory for ipsec_t in security_t
 	params->data.ipsec = shm_malloc(sizeof(ipsec_t));

--- a/src/modules/ims_registrar_pcscf/sec_agree.h
+++ b/src/modules/ims_registrar_pcscf/sec_agree.h
@@ -44,7 +44,7 @@ security_t *cscf_get_security_verify(struct sip_msg *msg);
 
 /**
  * Free a security_t allocated by parse_sec_agree() / cscf_get_security[_verify]().
- * Safe to call with NULL. Frees the struct, its sec_header, the ipsec_t and all
+ * Safe to call with NULL. Frees the struct, the ipsec_t and all
  * of its parsed string fields. Mirrors free_security() in
  * ims_usrloc_pcscf/pcontact.c - keep the two in sync.
  * @param params - the security_t to free (may be NULL)

--- a/src/modules/ims_usrloc_pcscf/pcontact.c
+++ b/src/modules/ims_usrloc_pcscf/pcontact.c
@@ -122,10 +122,6 @@ void free_security(security_t *_p)
 		return;
 	}
 
-	if(_p->sec_header.s) {
-		shm_free(_p->sec_header.s);
-	}
-
 	switch(_p->type) {
 		case SECURITY_IPSEC:
 			if(_p->data.ipsec) {

--- a/src/modules/ims_usrloc_pcscf/usrloc.h
+++ b/src/modules/ims_usrloc_pcscf/usrloc.h
@@ -137,7 +137,6 @@ typedef enum sec_type
 
 typedef struct security
 {
-	str sec_header;		/**< Security Header value 				*/
 	security_type type; /**< Type of security in use			*/
 
 	union

--- a/src/modules/ims_usrloc_scscf/usrloc.h
+++ b/src/modules/ims_usrloc_scscf/usrloc.h
@@ -314,7 +314,6 @@ typedef enum sec_type
 
 typedef struct security
 {
-	str sec_header;		/**< Security Header value 				*/
 	security_type type; /**< Type of security in use			*/
 
 	union


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #4841

#### Description
sec_header is reserved and stored but later there's no reference to any use of that value.
