### PR TITLE
dialog: update CRITICAL dlg lifetime timer log logic

### DIFF
--- a/src/modules/dialog/dlg_db_handler.c
+++ b/src/modules/dialog/dlg_db_handler.c
@@ -281,6 +281,7 @@ int load_dialog_info_from_db(
 	db_val_t *values;
 	db_row_t *rows;
 	int i, nr_rows;
+	int ret;
 	struct dlg_cell *dlg;
 	str callid, from_uri, to_uri, from_tag, to_tag, req_uri;
 	str cseq1, cseq2, contact1, contact2, rroute1, rroute2;
@@ -495,7 +496,8 @@ int load_dialog_info_from_db(
 				dlg->end_ts = ksr_time_uint(NULL, NULL);
 			}
 			/*restore the timer values */
-			if(0 != insert_dlg_timer(&(dlg->tl), (int)dlg->tl.timeout)) {
+			ret = insert_dlg_timer(&(dlg->tl), (int)dlg->tl.timeout);
+			if(ret < 0) {
 				LM_CRIT("Unable to insert dlg %p [%u:%u] "
 						"with clid '%.*s' and tags '%.*s' '%.*s'\n",
 						dlg, dlg->h_entry, dlg->h_id, dlg->callid.len,
@@ -506,7 +508,8 @@ int load_dialog_info_from_db(
 				dlg_unref(dlg, 1);
 				continue;
 			}
-			dlg_ref(dlg, 1);
+			if(ret == 0)
+				dlg_ref(dlg, 1);
 			LM_DBG("current dialog timeout is %u (%u)\n", dlg->tl.timeout,
 					get_ticks());
 

--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -355,10 +355,11 @@ int dlg_dmq_handle_msg(
 						dlg_set_leg_info(
 								dlg, &tag2, &route_set2, &contact2, &cseq2, 1);
 					}
-					if(insert_dlg_timer(&dlg->tl, dlg->lifetime) != 0) {
+					ret = insert_dlg_timer(&dlg->tl, dlg->lifetime);
+					if(ret < 0) {
 						LM_CRIT("Unable to insert dlg timer %p [%u:%u]\n", dlg,
 								dlg->h_entry, dlg->h_id);
-					} else {
+					} else if(ret == 0) {
 						/* dialog pointer inserted in timer list */
 						dlg_ref(dlg, 1);
 					}

--- a/src/modules/dialog/dlg_handlers.c
+++ b/src/modules/dialog/dlg_handlers.c
@@ -450,6 +450,7 @@ static void dlg_onreply(struct cell *t, int type, struct tmcb_params *param)
 	dlg_cell_t *dlg = NULL;
 	dlg_iuid_t *iuid = NULL;
 	int new_state, old_state, unref, event;
+	int ret;
 	str tag;
 	sip_msg_t *req = param->req;
 	sip_msg_t *rpl = param->rpl;
@@ -550,14 +551,15 @@ static void dlg_onreply(struct cell *t, int type, struct tmcb_params *param)
 		if(dlg_db_mode == DB_MODE_REALTIME)
 			update_dialog_dbinfo(dlg);
 
-		if(0 != insert_dlg_timer(&dlg->tl, dlg->lifetime)) {
+		ret = insert_dlg_timer(&dlg->tl, dlg->lifetime);
+		if(ret < 0) {
 			LM_CRIT("Unable to insert dlg %p [%u:%u] on event %d [%d->%d] "
 					"with clid '%.*s' and tags '%.*s' '%.*s'\n",
 					dlg, dlg->h_entry, dlg->h_id, event, old_state, new_state,
 					dlg->callid.len, dlg->callid.s,
 					dlg->tag[DLG_CALLER_LEG].len, dlg->tag[DLG_CALLER_LEG].s,
 					dlg->tag[DLG_CALLEE_LEG].len, dlg->tag[DLG_CALLEE_LEG].s);
-		} else {
+		} else if(ret == 0) {
 			/* dialog pointer inserted in timer list */
 			dlg_ref(dlg, 1);
 		}
@@ -1515,9 +1517,24 @@ void dlg_onroute(struct sip_msg *req, str *route_params, void *param)
 
 		if((new_state != DLG_STATE_EARLY)
 				&& (old_state != DLG_STATE_CONFIRMED || reset)) {
-			if(update_dlg_timer(&dlg->tl, dlg->lifetime) == -1) {
+			ret = update_dlg_timer(&dlg->tl, dlg->lifetime);
+			if(ret < 0) {
 				LM_ERR("failed to update dialog lifetime\n");
 			} else {
+				if(ret == 1) {
+					/* for dmq replicated dlg: insert lifetime timer after REQACK bump */
+					if(new_state == DLG_STATE_CONFIRMED
+							&& old_state < DLG_STATE_CONFIRMED_NA
+							&& (dlg->iflags & DLG_IFLAG_DMQ_SYNC)
+							&& !(dlg->dflags & DLG_FLAG_TM)) {
+						LM_NOTICE("insert dlg timer on REQACK for replicated "
+								  "dlg %p [%u:%u]\n",
+								dlg, dlg->h_entry, dlg->h_id);
+						if(insert_dlg_timer(&dlg->tl, dlg->lifetime) == 0) {
+							dlg_ref(dlg, 1);
+						}
+					}
+				}
 				dlg->dflags |= DLG_FLAG_CHANGED;
 			}
 		}

--- a/src/modules/dialog/dlg_timer.c
+++ b/src/modules/dialog/dlg_timer.c
@@ -121,17 +121,24 @@ static inline void insert_dialog_timer_unsafe(struct dlg_tl *tl)
  * \brief Insert a dialog timer to the list
  * \param tl dialog timer list
  * \param interval timeout value in seconds
- * \return 0 on success, -1 when the input timer list is invalid
+ * \return 0 when inserted, 1 when already linked, -1 when the link is corrupt
  */
 int insert_dlg_timer(struct dlg_tl *tl, int interval)
 {
 	lock_get(d_timer->lock);
 
-	if(tl->next != 0 || tl->prev != 0) {
+	if((tl->next == 0) != (tl->prev == 0)) {
+		/* only one of next/prev set => genuinely corrupt link */
 		LM_CRIT("Trying to insert a bogus dlg tl=%p tl->next=%p tl->prev=%p\n",
 				tl, tl->next, tl->prev);
 		lock_release(d_timer->lock);
 		return -1;
+	}
+	if(tl->next != 0) {
+		/* already linked - nothing to insert */
+		lock_release(d_timer->lock);
+		LM_NOTICE("dlg timer already linked on insert - skipped tl=%p\n", tl);
+		return 1;
 	}
 	tl->timeout = get_ticks() + interval;
 	insert_dialog_timer_unsafe(tl);
@@ -190,18 +197,25 @@ int remove_dialog_timer(struct dlg_tl *tl)
  * \brief Update a dialog timer on the list
  * \param tl dialog timer
  * \param timeout new timeout value in seconds
- * \return 0 on success, -1 when the input list is invalid
+ * \return 0 when updated in place, 1 when not linked, -1 when the link is corrupt
  * \note the update is implemented as a remove, insert
  */
 int update_dlg_timer(struct dlg_tl *tl, int timeout)
 {
 	lock_get(d_timer->lock);
 
-	if(tl->next == 0 || tl->prev == 0) {
+	if((tl->next == 0) != (tl->prev == 0)) {
+		/* only one of next/prev set => genuinely corrupt link */
 		LM_CRIT("Trying to update a bogus dlg tl=%p tl->next=%p tl->prev=%p\n",
 				tl, tl->next, tl->prev);
 		lock_release(d_timer->lock);
 		return -1;
+	}
+	if(tl->next == 0) {
+		/* not linked - nothing to update */
+		lock_release(d_timer->lock);
+		LM_NOTICE("dlg timer not linked on update - skipped tl=%p\n", tl);
+		return 1;
 	}
 	remove_dialog_timer_unsafe(tl);
 	tl->timeout = get_ticks() + timeout;

--- a/src/modules/dialog/dlg_timer.h
+++ b/src/modules/dialog/dlg_timer.h
@@ -76,7 +76,7 @@ void destroy_dlg_timer(void);
  * \brief Insert a dialog timer to the list
  * \param tl dialog timer list
  * \param interval timeout value in seconds
- * \return 0 on success, -1 when the input timer list is invalid
+ * \return 0 when inserted, 1 when already linked (skipped, no reference), -1 when the link is corrupt
  */
 int insert_dlg_timer(struct dlg_tl *tl, int interval);
 
@@ -94,7 +94,7 @@ int remove_dialog_timer(struct dlg_tl *tl);
  * \brief Update a dialog timer on the list
  * \param tl dialog timer
  * \param timeout new timeout value in seconds
- * \return 0 on success, -1 when the input list is invalid
+ * \return 0 when updated in place, 1 when not linked, -1 when the link is corrupt
  * \note the update is implemented as a remove, insert
  */
 int update_dlg_timer(struct dlg_tl *tl, int timeout);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4774

#### Description
<!-- Describe your changes in detail -->
After #4774, we have noticed more CRITICAL logs in an active-active dialog DMQ cluster, as follows:
```
CRITICAL: dialog [dlg_timer.c:129]: insert_dlg_timer(): Trying to insert a bogus dlg tl=0xffff88832630 tl->next=0xffff78887e10 tl->prev=0xffff88eb9720
CRITICAL: dialog [dlg_dmq.c:375]: dlg_dmq_handle_msg(): Unable to insert dlg timer 0xffff888325d0 [3916:7561]
```

Decided to relax those logs a bit, in such a way:
1. for inserts: if timer is already there and timer links are ok => L_NOTICE and ignore, nothing more to insert
2. for updates: if timer is NOT already there => L_NOTICE and ignore, nothing to update
3. when ACK roams to different DMQ node, timer update got nothing to update on that new node  => insert it at this point

For point 3 specifically, reason is that the replicated dialog does not have the underlying transaction that can insert dialog's lifetime timer.