### PR TITLE
dialog: dmq few fixes for stats counting and dlg_cell free 

### DIFF
--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -227,7 +227,8 @@ int dlg_dmq_handle_msg(
 		d_entry = &(d_table->entries[dlg->h_entry]);
 		unref++;
 
-		if(lm > 0 && dlg->last_modified > lm && action != DLG_DMQ_SYNC) {
+		if(lm > 0 && dlg->last_modified > lm && action != DLG_DMQ_SYNC
+				&& action != DLG_DMQ_RM) {
 			/* LWW: skip if local dialog is newer */
 			LM_DBG("LWW: skipping stale action %d for dlg [%u:%u] "
 				   "local=%u incoming=%u\n",
@@ -369,7 +370,8 @@ int dlg_dmq_handle_msg(
 					}
 					break;
 				case DLG_STATE_DELETED:
-					if(dlg->state == DLG_STATE_CONFIRMED) {
+					if(dlg->state == DLG_STATE_CONFIRMED_NA
+							|| dlg->state == DLG_STATE_CONFIRMED) {
 						ret = remove_dialog_timer(&dlg->tl);
 						if(ret == 0) {
 							/* one extra unref due to removal from timer list */
@@ -389,9 +391,14 @@ int dlg_dmq_handle_msg(
 
 					/* prevent DB sync */
 					dlg->dflags |= DLG_FLAG_NEW;
+					/* mark as deleted by a dmq peer */
+					dlg->dflags |= DLG_FLAG_DMQ_DELETED;
 					/* keep dialog around for a bit, to prevent out-of-order
 					 * syncs to reestablish the dlg */
 					dlg->init_ts = ksr_time_uint(NULL, NULL);
+					/* ensure end_ts is set so dlg_clean_run can clean the dialog */
+					if(dlg->end_ts == 0)
+						dlg->end_ts = ksr_time_uint(NULL, NULL);
 
 					if(dlg->state != DLG_STATE_DELETED) {
 						run_dlg_callbacks(DLGCB_TERMINATED, dlg, NULL, NULL,
@@ -432,7 +439,8 @@ int dlg_dmq_handle_msg(
 			LM_DBG("Removed dlg [%u:%u] with callid [%.*s] int state [%u]\n",
 					iuid.h_entry, iuid.h_id, dlg->callid.len, dlg->callid.s,
 					dlg->state);
-			if(dlg->state == DLG_STATE_CONFIRMED
+			if(dlg->state == DLG_STATE_CONFIRMED_NA
+					|| dlg->state == DLG_STATE_CONFIRMED
 					|| dlg->state == DLG_STATE_EARLY) {
 				ret = remove_dialog_timer(&dlg->tl);
 				if(ret == 0) {
@@ -453,6 +461,15 @@ int dlg_dmq_handle_msg(
 			/* prevent DB sync */
 			dlg->dflags |= DLG_FLAG_NEW;
 			dlg->iflags &= ~DLG_IFLAG_DMQ_SYNC;
+			/* mark as deleted by a dmq peer */
+			dlg->dflags |= DLG_FLAG_DMQ_DELETED;
+
+			/* mark deleted if not already marked */
+			if(dlg->state != DLG_STATE_DELETED) {
+				dlg->state = DLG_STATE_DELETED;
+				if(dlg->end_ts == 0)
+					dlg->end_ts = ksr_time_uint(NULL, NULL);
+			}
 			unref++;
 			break;
 

--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -294,6 +294,9 @@ int dlg_dmq_handle_msg(
 
 			dlg->init_ts = init_ts;
 			dlg->start_ts = start_ts;
+			/* lifetime from UPDATE, needed for UNCONFIRMED state of the dialog */
+			if(lifetime > 0)
+				dlg->lifetime = lifetime;
 
 			vj = srjson_GetObjectItem(&jdoc, jdoc.root, "vars");
 			if(vj != NULL) {
@@ -336,7 +339,8 @@ int dlg_dmq_handle_msg(
 			switch(state) {
 				case DLG_STATE_EARLY:
 					dlg->start_ts = start_ts;
-					dlg->lifetime = lifetime;
+					if(lifetime > 0)
+						dlg->lifetime = lifetime;
 					/* apply leg info if it carries data */
 					if(tag1.len > 0) {
 						dlg_set_leg_info(
@@ -345,7 +349,8 @@ int dlg_dmq_handle_msg(
 					break;
 				case DLG_STATE_CONFIRMED:
 					dlg->start_ts = start_ts;
-					dlg->lifetime = lifetime;
+					if(lifetime > 0)
+						dlg->lifetime = lifetime;
 					/* apply leg info if it carries data */
 					if(tag1.len > 0) {
 						dlg_set_leg_info(
@@ -675,6 +680,9 @@ int dlg_dmq_replicate_action(dlg_dmq_action_t action, dlg_cell_t *dlg,
 					//dlg->iflags &= ~DLG_IFLAG_DMQ_SYNC;
 					break;
 				default:
+					/* lifetime on UPDATE fallthrough */
+					srjson_AddNumberToObject(
+							&jdoc, jdoc.root, "lifetime", dlg->lifetime);
 					LM_DBG("not syncing state %u\n", dlg->state);
 			}
 			break;

--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -399,12 +399,21 @@ int dlg_dmq_handle_msg(
 					dlg_unref(dlg, unref);
 					goto error;
 			}
-			if(newdlg == 1) {
-				if(state == DLG_STATE_CONFIRMED_NA
-						|| state == DLG_STATE_CONFIRMED) {
-					if_update_stat(dlg_enable_stats, active_dlgs, 1);
-				} else if(dlg->state == DLG_STATE_EARLY) {
+			/* update node-local stats for the dlg dmq synced state transition */
+			if(dlg->state != state) {
+				if(dlg->state == DLG_STATE_EARLY) {
+					if_update_stat(dlg_enable_stats, early_dlgs, -1);
+				}
+				if(state == DLG_STATE_EARLY) {
 					if_update_stat(dlg_enable_stats, early_dlgs, 1);
+				} else if((state == DLG_STATE_CONFIRMED_NA
+								  || state == DLG_STATE_CONFIRMED)
+						  && dlg->state < DLG_STATE_CONFIRMED_NA) {
+					if_update_stat(dlg_enable_stats, active_dlgs, 1);
+				} else if(state == DLG_STATE_DELETED
+						  && (dlg->state == DLG_STATE_CONFIRMED_NA
+								  || dlg->state == DLG_STATE_CONFIRMED)) {
+					if_update_stat(dlg_enable_stats, active_dlgs, -1);
 				}
 			}
 			dlg->state = state;
@@ -429,8 +438,9 @@ int dlg_dmq_handle_msg(
 							dlg, dlg->h_entry, dlg->h_id);
 				}
 			}
-			if(state == DLG_STATE_CONFIRMED_NA
-					|| state == DLG_STATE_CONFIRMED) {
+			/* update node-local stats for the dlg dmq synced removal */
+			if(dlg->state == DLG_STATE_CONFIRMED_NA
+					|| dlg->state == DLG_STATE_CONFIRMED) {
 				if_update_stat(dlg_enable_stats, active_dlgs, -1);
 			} else if(dlg->state == DLG_STATE_EARLY) {
 				if_update_stat(dlg_enable_stats, early_dlgs, -1);

--- a/src/modules/dialog/dlg_handlers.c
+++ b/src/modules/dialog/dlg_handlers.c
@@ -1464,6 +1464,16 @@ void dlg_onroute(struct sip_msg *req, str *route_params, void *param)
 	if(new_state == DLG_STATE_CONFIRMED && old_state != DLG_STATE_CONFIRMED)
 		dlg_ka_add(dlg);
 
+	/* for dmq replicated dlg: count CONFIRMED due to REQACK bump */
+	if(new_state == DLG_STATE_CONFIRMED && old_state < DLG_STATE_CONFIRMED_NA
+			&& (dlg->iflags & DLG_IFLAG_DMQ_SYNC)
+			&& !(dlg->dflags & DLG_FLAG_TM)) {
+		if(old_state == DLG_STATE_EARLY) {
+			if_update_stat(dlg_enable_stats, early_dlgs, -1);
+		}
+		if_update_stat(dlg_enable_stats, active_dlgs, 1);
+	}
+
 	/* run actions for the transition */
 	if(event == DLG_EVENT_REQBYE && new_state == DLG_STATE_DELETED
 			&& old_state != DLG_STATE_DELETED) {
@@ -1497,7 +1507,9 @@ void dlg_onroute(struct sip_msg *req, str *route_params, void *param)
 		_dlg_ctx.expect_t = 1;
 		dlg_set_ctx_iuid(dlg);
 
-		if_update_stat(dlg_enable_stats, active_dlgs, -1);
+		if(old_state == DLG_STATE_CONFIRMED_NA
+				|| old_state == DLG_STATE_CONFIRMED)
+			if_update_stat(dlg_enable_stats, active_dlgs, -1);
 		goto done;
 	}
 
@@ -1694,7 +1706,9 @@ void dlg_ontimeout(struct dlg_tl *tl)
 
 		unref++;
 		if_update_stat(dlg_enable_stats, expired_dlgs, 1);
-		if_update_stat(dlg_enable_stats, active_dlgs, -1);
+		if(old_state == DLG_STATE_CONFIRMED_NA
+				|| old_state == DLG_STATE_CONFIRMED)
+			if_update_stat(dlg_enable_stats, active_dlgs, -1);
 	} else {
 		unref = 1;
 	}

--- a/src/modules/dialog/dlg_hash.c
+++ b/src/modules/dialog/dlg_hash.c
@@ -1300,6 +1300,14 @@ void next_state_dlg(
 				case DLG_STATE_DELETED:
 					break;
 				default:
+					/* if dmq replicated dialog received BYE in unconfirmed state */
+					if((dlg->iflags & DLG_IFLAG_DMQ_SYNC)
+							&& !(dlg->dflags & DLG_FLAG_TM)) {
+						dlg->dflags |= DLG_FLAG_HASBYE;
+						dlg->state = DLG_STATE_DELETED;
+						*unref = 1;
+						break;
+					}
 					log_next_state_dlg(event, dlg);
 			}
 			break;

--- a/src/modules/dialog/dlg_hash.c
+++ b/src/modules/dialog/dlg_hash.c
@@ -1257,6 +1257,10 @@ void next_state_dlg(
 								dlg->tag[DLG_CALLEE_LEG].s);
 						break;
 					}
+					/* don't revive a dialog torn down by a dmq peer */
+					if(dlg->dflags & DLG_FLAG_DMQ_DELETED) {
+						break;
+					}
 					ref_dlg_unsafe(dlg, 1);
 				case DLG_STATE_UNCONFIRMED:
 				case DLG_STATE_EARLY:

--- a/src/modules/dialog/dlg_hash.h
+++ b/src/modules/dialog/dlg_hash.h
@@ -60,6 +60,7 @@
 #define DLG_FLAG_NEW (1 << 0)		   /*!< new dialog */
 #define DLG_FLAG_CHANGED (1 << 1)	   /*!< dialog was changed */
 #define DLG_FLAG_HASBYE (1 << 2)	   /*!< bye was received */
+#define DLG_FLAG_DMQ_DELETED (1 << 3)  /*!< deleted via dmq peer */
 #define DLG_FLAG_CALLERBYE (1 << 4)	   /*!< bye from caller */
 #define DLG_FLAG_CALLEEBYE (1 << 5)	   /*!< bye from callee */
 #define DLG_FLAG_LOCALDLG (1 << 6)	   /*!< local dialog, unused */

--- a/src/modules/dialog/dlg_req_within.c
+++ b/src/modules/dialog/dlg_req_within.c
@@ -231,7 +231,9 @@ void bye_reply_cb(struct cell *t, int type, struct tmcb_params *ps)
 		/* derefering the dialog */
 		dlg_unref(dlg, unref + 1);
 
-		if_update_stat(dlg_enable_stats, active_dlgs, -1);
+		if(old_state == DLG_STATE_CONFIRMED_NA
+				|| old_state == DLG_STATE_CONFIRMED)
+			if_update_stat(dlg_enable_stats, active_dlgs, -1);
 	}
 
 	if(new_state == DLG_STATE_DELETED && old_state == DLG_STATE_DELETED) {


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Few fixes for issues spotted during load test with dialog dmq, in active-active, and FQDN in-dialog roaming.