### PR TITLE
cmake: Adjust kamailio.cfg and tls.cfg paths according to install prefix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -231,23 +231,35 @@ install(
 # Install the configuration file (kamailio.cfg) ${CFG_NAME} using a CODE block
 # to check  existence at install time instead of configure time
 # If(EXISTS ..) require full path
+add_custom_command(
+  OUTPUT kamailio.cfg.sample
+  COMMAND
+    sed -e "s#/usr/local/etc/kamailio#${CMAKE_INSTALL_FULL_SYSCONFDIR}/${MAIN_NAME}#g" -e
+    "s#/usr/local/lib/kamailio#${LIB_DIR}#g" < ${CMAKE_SOURCE_DIR}/etc/kamailio.cfg >
+    ${CMAKE_CURRENT_BINARY_DIR}/${MAIN_NAME}.cfg.sample
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(kamailio_cfg_sample ALL DEPENDS kamailio.cfg.sample)
+
 install(
   CODE "
     set(dir \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_SYSCONFDIR}/${MAIN_NAME}\")
+    set(sample_file \"${CFG_NAME}.cfg.sample\")
+    set(file \"${CFG_NAME}.cfg\")
 
     if(EXISTS \"\${dir}/${CFG_NAME}.cfg\")
         message(STATUS \"${CFG_NAME}.cfg already exists in \"
         \"\${dir}/${CFG_NAME}.cfg. Installing as ${CFG_NAME}.cfg.sample\")
-      file(INSTALL \"${CMAKE_SOURCE_DIR}/etc/kamailio.cfg\"
+        file(INSTALL \"${CMAKE_CURRENT_BINARY_DIR}/\${sample_file}\"
         DESTINATION \"$ENV{DESTDIR}${CMAKE_INSTALL_FULL_SYSCONFDIR}/${MAIN_NAME}\"
-        RENAME \"${CFG_NAME}.cfg.sample\"
         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
       )
     else()
-        file(INSTALL \"${CMAKE_SOURCE_DIR}/etc/kamailio.cfg\"
+        file(INSTALL \"${CMAKE_CURRENT_BINARY_DIR}/\${sample_file}\"
           DESTINATION \"$ENV{DESTDIR}${CMAKE_INSTALL_FULL_SYSCONFDIR}/${MAIN_NAME}\"
+          RENAME \"\${file}\"
           PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-          RENAME \"${CFG_NAME}.cfg\"
         )
     endif()
 "

--- a/src/modules/tls/CMakeLists.txt
+++ b/src/modules/tls/CMakeLists.txt
@@ -77,7 +77,9 @@ add_custom_target(tls_cfg_sample ALL DEPENDS tls.cfg.sample)
 
 add_custom_target(
   tls-install-cfg
-  COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component tls-cfg
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/tls.cfg.sample
+          $ENV{DESTDIR}${CMAKE_INSTALL_FULL_SYSCONFDIR}/${MAIN_NAME}/
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   COMMENT "Installing tls.cfg.sample to ${MAIN_NAME} config directory"
 )
 add_dependencies(tls-install-cfg tls_cfg_sample)

--- a/src/modules/tls/CMakeLists.txt
+++ b/src/modules/tls/CMakeLists.txt
@@ -42,18 +42,20 @@ endif()
 install(
   CODE "
     set(dir \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_SYSCONFDIR}/${MAIN_NAME}\")
+    set(sample_file \"tls.cfg.sample\")
     set(file \"tls.cfg\")
+
     if(EXISTS \"\${dir}/\${file}\")
         message(STATUS \"\${file} already exists in \${dir}/\${file}.
           Installing as \${file}.sample\")
-        file(INSTALL \"${CMAKE_CURRENT_SOURCE_DIR}/\${file}\"
+        file(INSTALL \"${CMAKE_CURRENT_BINARY_DIR}/\${sample_file}\"
           DESTINATION \"${CMAKE_INSTALL_FULL_SYSCONFDIR}/${MAIN_NAME}\"
-          RENAME \"\${file}.sample\"
           PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
         )
     else()
-        file(INSTALL \"${CMAKE_CURRENT_SOURCE_DIR}/\${file}\"
+        file(INSTALL \"${CMAKE_CURRENT_BINARY_DIR}/\${sample_file}\"
             DESTINATION \"${CMAKE_INSTALL_FULL_SYSCONFDIR}/${MAIN_NAME}\"
+            RENAME \"\${file}\"
             PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
     endif()
 "
@@ -63,7 +65,7 @@ install(
 add_custom_command(
   OUTPUT tls.cfg.sample
   COMMAND
-    sed -e "s#\/usr/local/etc/kamailio/#${CMAKE_INSTALL_FULL_SYSCONFDIR}#g" -e
+    sed -e "s#\/usr/local/etc/kamailio/#${CMAKE_INSTALL_FULL_SYSCONFDIR}/${MAIN_NAME}/#g" -e
     "s#kamailio-selfsigned#${MAIN_NAME}-selfsigned#g" < tls.cfg >
     ${CMAKE_CURRENT_BINARY_DIR}/tls.cfg.sample
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [ ] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4810 

#### Description
<!-- Describe your changes in detail -->
Adopted logic for kamailio.cfg and tls.cfg to adjust the default paths according to the install_prefix provided