### PR TITLE
sanity: enforce CSeq < 2^31 per RFC 3261 via core str2int(), closes #4838

### DIFF
--- a/src/modules/sanity/sanity.c
+++ b/src/modules/sanity/sanity.c
@@ -403,7 +403,6 @@ int check_rfc3261_compliance(sip_msg_t *msg)
 		return SANITY_CHECK_FAILED;
 	}
 
-
 	if(msg->via1->branch->value.len < 7
 			|| memcmp(msg->via1->branch->value.s, "z9hG4bK", 7) != 0) {
 		LM_WARN("Via1 branch parameter does not start with the magic cookie\n");
@@ -672,9 +671,8 @@ int check_cseq_value(sip_msg_t *msg)
 			}
 			return SANITY_CHECK_FAILED;
 		}
-		if(str2valid_uint(
-				   &((struct cseq_body *)msg->cseq->parsed)->number, &cseq)
-				!= 0) {
+		if(str2int(&((struct cseq_body *)msg->cseq->parsed)->number, &cseq) != 0
+				|| cseq >= (1U << 31)) {
 			if(sanity_reply(msg, 400, "CSeq number is illegal") < 0) {
 				LM_WARN("failed to send 400 via sl reply 2\n");
 			}


### PR DESCRIPTION
## Related Issue

Closes #4838 - sanity: reject out-of-range CSeq values per RFC 3261.

## Expected vs Actual

RFC 3261 §8.1.1.5 requires the CSeq sequence number (for non-REGISTER
requests outside a dialog) to be expressible as a 32-bit unsigned integer
and strictly LESS THAN 2^31. Instead:

 - CSeq in [2^31, 2^32 - 1]: silently passed through sanity_check() and
   eventually returned 404 Not Found instead of 400 CSeq number is illegal.
 - CSeq exactly 4294967296 (2^32): the hand-written parser in sanity.c
   local str2valid_uint compared against the literal 4294967296 with
   equal semantics, accepted it, and UINT_MAX+1 wrapped back to 0.
   The request therefore also returned 404 rather than 400.

## Root cause

Both wrong paths came from the same root cause: the CSeq call site in
check_cseq_value() used the module-local str2valid_uint() which has two
independent flaws:

 1. Its accumulator is declared as a SIGNED 32-bit int result, so any
    value in [2^31, 2^32 - 1] triggers signed integer UB on the final
    assignment.
 2. The 10-digit upper-bound check uses manual string comparison against
    the literal string 4294967296. Because this boundary comparison treats
    equal as still within range, the exact boundary value 4294967296
    parses successfully and then wraps to 0 on the unsigned int store.

## Fix

Reuse the overflow-checked core helper str2int() already provided by
core/ut.h (which is already the default numeric parser for most other
fields in the code base). Add the RFC 3261 upper bound check cseq < 2^31
RIGHT NEXT TO the != 0 check so both overflow AND out-of-range sit in
the same conditional.

Notably, str2valid_uint() itself and the Expires call site in
check_expires_value() are INTENTIONALLY LEFT UNTOUCHED, so Expires
behaviour does not change at all, and this PR has the narrowest possible
blast radius.

## Boundary matrix verified locally

Verified against a local 6.1.3/master VM build (gcc 11, make sanity module)
for the six boundary cases a reviewer would want to see:

| Input CSeq        | Decimal             | Expected | This patch |
|-------------------|---------------------|----------|------------|
| 0                 | 0                   | pass     | 200        |
| 2147483647        | 2^31 - 1            | pass     | 200        |
| 2147483648        | 2^31                | 400      | 400        |
| 4294967295        | 2^32 - 1 (UINT_MAX) | 400      | 400        |
| 4294967296        | 2^32                | 400      | 400        |
| 4294967297        | 2^32 + 1            | 400      | 400        |

## Checklist

- [x] Commit message is descriptive and matches the coding guidelines (see https://www.kamailio.org/wikidocs/devel/codingstyle/)
- [x] Compile and unit tests: sanity module compiles cleanly locally; no other module changed
- [x] No documentation needed: this is a pure bug fix / conformance hardening for values the RFC already requires to be rejected
- [x] No new / removed config vars
- [x] Expires-value call site and str2valid_uint() body left untouched so unrelated Expires behaviour does not regress
