### PR TITLE
dialog: arm timer before realtime DB write on CONFIRMED_NA

### DIFF
--- a/src/modules/dialog/dlg_handlers.c
+++ b/src/modules/dialog/dlg_handlers.c
@@ -545,11 +545,13 @@ static void dlg_onreply(struct cell *t, int type, struct tmcb_params *param)
 
 		/* save the settings to the database,
 		 * if realtime saving mode configured- save dialog now
-		 * else: the next time the timer will fire the update*/
+		 * else: the next time the timer will fire the update
+		 *
+		 * Arm the dialog timer before the realtime DB write so the
+		 * persisted timeout is time(0)+lifetime. Writing first leaves
+		 * tl.timeout at 0 and stores an already-expired value (GH #4804).
+		 */
 		dlg->dflags |= DLG_FLAG_NEW;
-		if(dlg_db_mode == DB_MODE_REALTIME)
-			update_dialog_dbinfo(dlg);
-
 		if(0 != insert_dlg_timer(&dlg->tl, dlg->lifetime)) {
 			LM_CRIT("Unable to insert dlg %p [%u:%u] on event %d [%d->%d] "
 					"with clid '%.*s' and tags '%.*s' '%.*s'\n",
@@ -561,6 +563,9 @@ static void dlg_onreply(struct cell *t, int type, struct tmcb_params *param)
 			/* dialog pointer inserted in timer list */
 			dlg_ref(dlg, 1);
 		}
+
+		if(dlg_db_mode == DB_MODE_REALTIME)
+			update_dialog_dbinfo(dlg);
 
 		/* dialog confirmed (ACK pending) */
 		run_dlg_callbacks(


### PR DESCRIPTION
With db_mode=1, dlg_onreply() wrote the dialog row at 200 OK before insert_dlg_timer() assigned tl.timeout. update_dialog_dbinfo() then persisted time(0)+tl.timeout-get_ticks() with tl.timeout still 0, so the stored timeout was already in the past.

Another instance loading that row (or a restart before ACK) treated the dialog as expired, destroyed it and deleted the shared DB row while the call was still established.

Reorder so the timer is armed first; the DB write then stores time(0)+lifetime as intended.

Closes: #4804

<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [ ] Commit message has the format required by CONTRIBUTING guide
- [ ] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
- [ ] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [ ] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [ ] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
