### PR TITLE
dispatcher: refcount ds_set_t table

### DIFF
--- a/src/modules/dispatcher/dispatch.c
+++ b/src/modules/dispatcher/dispatch.c
@@ -134,21 +134,16 @@ extern int ds_event_callback_mode;
 static db_func_t ds_dbf;
 static db1_con_t *ds_db_handle = NULL;
 
-static ds_set_t **ds_lists = NULL;
+static ds_list_t **ds_list = NULL; /* pointer to current list of sets */
 static gen_lock_t *ds_list_write_lock = NULL;
-
-static int *ds_list_nr = NULL;
-static int *ds_crt_idx = NULL;
-static int *ds_next_idx = NULL;
+static gen_lock_t *ds_list_read_lock = NULL;
+/* lock order for locking both: write lock first, read lock second */
 
 static ds_set_t *ds_strictest_node = NULL;
 static int ds_strictest_idx = 0;
 static int ds_strictest_match = 0;
 
 static sruid_t _ds_sruid = {0};
-
-#define _ds_list (ds_lists[*ds_crt_idx])
-#define _ds_list_nr (*ds_list_nr)
 
 void ds_rctx_set_uri(ds_rctx_t *rctx, str *uri);
 static void ds_run_route(
@@ -255,15 +250,15 @@ int ds_hash_load_destroy(void)
 /**
  *
  */
-static inline int ds_get_index(int group, int ds_list_idx, ds_set_t **index)
+static inline int ds_get_index(int group, ds_list_t *list, ds_set_t **index)
 {
 	ds_set_t *si = NULL;
 
-	if(index == NULL || group < 0 || ds_lists[ds_list_idx] == NULL)
+	if(index == NULL || group < 0 || list == NULL)
 		return -1;
 
 	/* get the index of the set */
-	si = ds_avl_find(ds_lists[ds_list_idx], group);
+	si = ds_avl_find(list->head, group);
 
 	if(si == NULL)
 		return -1;
@@ -306,7 +301,7 @@ void ds_log_dst_cb(ds_set_t *node, int i, void *arg)
 /**
  * Recursivly print ds_set
  */
-void ds_log_set(ds_set_t *node)
+static void ds_log_set(ds_set_t *node)
 {
 	ds_iter_set(node, &ds_log_dst_cb, NULL);
 
@@ -316,14 +311,59 @@ void ds_log_set(ds_set_t *node)
 /**
  *
  */
-int ds_log_sets(void)
+static int ds_log_sets(ds_list_t *list)
 {
-	if(_ds_list == NULL)
-		return -1;
-
-	ds_log_set(_ds_list);
+	ds_log_set(list->head);
 
 	return 0;
+}
+
+/**
+ * Construct a new list object in shared memory
+ */
+static ds_list_t *ds_new_list(void)
+{
+	ds_list_t *ret;
+
+	ret = shm_malloc(sizeof(ds_set_t *));
+	if(!ret)
+		return NULL;
+
+	memset(ret, 0, sizeof(*ret));
+	return ret;
+}
+
+/**
+ * Destroys the list object and the contained AVL tree
+ */
+static void ds_free_list(ds_list_t *list)
+{
+	if(!list)
+		return;
+	ds_avl_destroy(&list->head);
+	shm_free(list);
+}
+
+/**
+ * Wait for open references and then destroy the list
+ */
+static void ds_wait_free_list(ds_list_t *list)
+{
+	unsigned int iters;
+
+	if(!list)
+		return;
+
+	lock_get(ds_list_read_lock);
+	while(list->refs > 0) {
+		lock_release(ds_list_read_lock);
+		iters++;
+		sleep_us(iters * 10000);
+		lock_get(ds_list_read_lock);
+	}
+	lock_release(ds_list_read_lock);
+
+	ds_free_list(list);
 }
 
 /**
@@ -331,37 +371,30 @@ int ds_log_sets(void)
  */
 int ds_init_data(void)
 {
-	int *p;
-
-	ds_lists = (ds_set_t **)shm_malloc(2 * sizeof(ds_set_t *));
-	if(!ds_lists) {
+	ds_list = shm_malloc(sizeof(ds_set_t *));
+	if(!ds_list) {
 		SHM_MEM_ERROR;
 		return -1;
 	}
-	memset(ds_lists, 0, 2 * sizeof(ds_set_t *));
-
-
-	p = (int *)shm_malloc(3 * sizeof(int));
-	if(!p) {
-		shm_free(ds_lists);
-		SHM_MEM_ERROR;
-		return -1;
-	}
-	memset(p, 0, 3 * sizeof(int));
+	*ds_list = NULL;
 
 	ds_list_write_lock = lock_alloc();
 	if(!ds_list_write_lock) {
-		shm_free(ds_lists);
-		shm_free(p);
+		shm_free(ds_list);
 		SHM_MEM_ERROR;
 		return -1;
 	}
 	lock_init(ds_list_write_lock);
 
-	ds_crt_idx = p;
-	ds_next_idx = p + 1;
-	ds_list_nr = p + 2;
-	*ds_crt_idx = *ds_next_idx = 0;
+	ds_list_read_lock = lock_alloc();
+	if(!ds_list_read_lock) {
+		shm_free(ds_list);
+		lock_destroy(ds_list_write_lock);
+		lock_dealloc(ds_list_write_lock);
+		SHM_MEM_ERROR;
+		return -1;
+	}
+	lock_init(ds_list_read_lock);
 
 	return 0;
 }
@@ -517,14 +550,19 @@ int ds_oc_set_attrs(
 	ds_set_t *idx = NULL;
 	struct timeval tnow;
 	struct timeval tdiff;
+	ds_list_t *list;
 
-	if(_ds_list == NULL || _ds_list_nr <= 0) {
+	list = ds_get_list();
+
+	if(list == NULL || list->nr <= 0) {
+		ds_put_list(list);
 		LM_ERR("the list is null\n");
 		return -1;
 	}
 
 	/* get the index of the set */
-	if(ds_get_index(setid, *ds_crt_idx, &idx) != 0) {
+	if(ds_get_index(setid, list, &idx) != 0) {
+		ds_put_list(list);
 		LM_ERR("destination set [%d] not found\n", setid);
 		return -1;
 	}
@@ -560,6 +598,7 @@ int ds_oc_set_attrs(
 			LM_DBG("updated entry %d\n", i);
 		}
 	}
+	ds_put_list(list);
 	return ret;
 }
 
@@ -809,8 +848,9 @@ err:
 /**
  *
  */
-ds_dest_t *add_dest2list(int id, str uri, int flags, int priority, str *attrs,
-		int list_idx, int *setn, int dload, ds_latency_stats_t *latency_stats)
+static ds_dest_t *add_dest2list(int id, str uri, int flags, int priority,
+		str *attrs, ds_list_t *list, int dload,
+		ds_latency_stats_t *latency_stats)
 {
 	ds_dest_t *dp = NULL;
 	ds_set_t *sp = NULL;
@@ -843,7 +883,7 @@ ds_dest_t *add_dest2list(int id, str uri, int flags, int priority, str *attrs,
 		dp->latency_stats.timeout = latency_stats->timeout;
 	}
 
-	sp = ds_avl_insert(&ds_lists[list_idx], id, setn);
+	sp = ds_avl_insert(&list->head, id, &list->nr);
 	if(!sp) {
 		LM_ERR("no more memory.\n");
 		goto error;
@@ -1192,7 +1232,7 @@ int dp_init_priority_weights(ds_set_t *dset)
 }
 
 /*! \brief  compact destinations from sets for fast access */
-int reindex_dests(ds_set_t *node)
+static int reindex_dests(ds_set_t *node)
 {
 	int i = 0;
 	int j = 0;
@@ -1246,10 +1286,11 @@ int ds_load_list(char *lfile)
 {
 	char line[1024], *p;
 	FILE *f = NULL;
-	int id, setn, flags, priority;
+	int id, flags, priority;
 	str uri;
 	str attrs;
 	ds_latency_stats_t *latency_stats;
+	ds_list_t *old, *next;
 
 	lock_get(ds_list_write_lock);
 
@@ -1266,10 +1307,16 @@ int ds_load_list(char *lfile)
 		return -1;
 	}
 
-	id = setn = flags = priority = 0;
+	id = flags = priority = 0;
 
-	*ds_next_idx = (*ds_crt_idx + 1) % 2;
-	ds_avl_destroy(&ds_lists[*ds_next_idx]);
+	next = ds_new_list();
+	if(!next) {
+		SHM_MEM_ERROR;
+		lock_release(ds_list_write_lock);
+		fclose(f);
+		LM_ERR("out of memory");
+		return -1;
+	}
 
 	p = fgets(line, 1024, f);
 	while(p) {
@@ -1365,8 +1412,8 @@ int ds_load_list(char *lfile)
 		if(ds_ping_latency_stats && ds_retain_latency_stats) {
 			latency_stats = latency_stats_find(id, &uri);
 		}
-		if(add_dest2list(id, uri, flags, priority, &attrs, *ds_next_idx, &setn,
-				   0, latency_stats)
+		if(add_dest2list(
+				   id, uri, flags, priority, &attrs, next, 0, latency_stats)
 				== NULL) {
 			LM_WARN("unable to add destination %.*s to set %d -- skipping\n",
 					uri.len, uri.s, id);
@@ -1378,30 +1425,38 @@ int ds_load_list(char *lfile)
 		p = fgets(line, 1024, f);
 	}
 
-	if(reindex_dests(ds_lists[*ds_next_idx]) != 0) {
+	if(reindex_dests(next->head) != 0) {
 		LM_ERR("error on reindex\n");
 		goto error;
 	}
 
 	fclose(f);
 	f = NULL;
-	/* Update list - should it be sync'ed? */
-	_ds_list_nr = setn;
-	*ds_crt_idx = *ds_next_idx;
+
+	next->refs = 1; /* one reference for logging, below */
+
+	/* Swap new list with global one */
+	lock_get(ds_list_read_lock);
+	old = *ds_list;
+	*ds_list = next;
+	lock_release(ds_list_read_lock);
 
 	lock_release(ds_list_write_lock);
 
-	LM_DBG("found [%d] dest sets\n", _ds_list_nr);
+	LM_DBG("found [%d] dest sets\n", next->nr);
 
-	ds_log_sets();
+	ds_log_sets(next);
+	ds_put_list(next);
+
+	ds_wait_free_list(old);
+
 	return 0;
 
 error:
 	lock_release(ds_list_write_lock);
 	if(f != NULL)
 		fclose(f);
-	ds_avl_destroy(&ds_lists[*ds_next_idx]);
-	*ds_next_idx = *ds_crt_idx;
+	ds_free_list(next);
 	return -1;
 }
 
@@ -1500,7 +1555,7 @@ int ds_reload_db(void)
 /*! \brief load groups of destinations from DB*/
 int ds_load_db(void)
 {
-	int i, id, nr_rows, setn;
+	int i, id, nr_rows;
 	int flags;
 	int priority;
 	int nrcols;
@@ -1518,6 +1573,7 @@ int ds_load_db(void)
 #define DS_ATTRS_MAXSIZE 1024
 	char ds_attrs_buf[DS_ATTRS_MAXSIZE];
 	ds_latency_stats_t *latency_stats;
+	ds_list_t *old, *next;
 
 	query_cols[0] = &ds_set_id_col;
 	query_cols[1] = &ds_dest_uri_col;
@@ -1571,9 +1627,14 @@ int ds_load_db(void)
 		LM_WARN("no dispatching data in the db -- empty destination set\n");
 	}
 
-	setn = 0;
-	*ds_next_idx = (*ds_crt_idx + 1) % 2;
-	ds_avl_destroy(&ds_lists[*ds_next_idx]);
+	next = ds_new_list();
+	if(!next) {
+		SHM_MEM_ERROR;
+		lock_release(ds_list_write_lock);
+		ds_dbf.free_result(ds_db_handle, res);
+		LM_ERR("out of memory");
+		return -1;
+	}
 
 	for(i = 0; i < nr_rows; i++) {
 		values = ROW_VALUES(rows + i);
@@ -1698,8 +1759,8 @@ int ds_load_db(void)
 		if(ds_ping_latency_stats && ds_retain_latency_stats) {
 			latency_stats = latency_stats_find(id, &uri);
 		}
-		if(add_dest2list(id, uri, flags, priority, &attrs, *ds_next_idx, &setn,
-				   0, latency_stats)
+		if(add_dest2list(
+				   id, uri, flags, priority, &attrs, next, 0, latency_stats)
 				== NULL) {
 			dest_errs++;
 			LM_WARN("unable to add destination %.*s to set %d -- skipping\n",
@@ -1709,22 +1770,29 @@ int ds_load_db(void)
 			}
 		}
 	}
-	if(reindex_dests(ds_lists[*ds_next_idx]) != 0) {
+	if(reindex_dests(next->head) != 0) {
 		LM_ERR("error on reindex\n");
 		goto err2;
 	}
 
 	ds_dbf.free_result(ds_db_handle, res);
 
-	/* update data - should it be sync'ed? */
-	_ds_list_nr = setn;
-	*ds_crt_idx = *ds_next_idx;
+	next->refs = 1; /* one reference for logging, below */
+
+	/* Swap new list with global one */
+	lock_get(ds_list_read_lock);
+	old = *ds_list;
+	*ds_list = next;
+	lock_release(ds_list_read_lock);
 
 	lock_release(ds_list_write_lock);
 
-	LM_DBG("found [%d] dest sets\n", _ds_list_nr);
+	LM_DBG("found [%d] dest sets\n", next->nr);
 
-	ds_log_sets();
+	ds_log_sets(next);
+	ds_put_list(next);
+
+	ds_wait_free_list(old);
 
 	if(dest_errs > 0)
 		return -2;
@@ -1732,9 +1800,8 @@ int ds_load_db(void)
 
 err2:
 	lock_release(ds_list_write_lock);
-	ds_avl_destroy(&ds_lists[*ds_next_idx]);
 	ds_dbf.free_result(ds_db_handle, res);
-	*ds_next_idx = *ds_crt_idx;
+	ds_free_list(next);
 
 	return -1;
 }
@@ -1742,18 +1809,19 @@ err2:
 /*! \brief called from dispatcher.c: free all*/
 int ds_destroy_list(void)
 {
-	if(ds_lists) {
-		ds_avl_destroy(&ds_lists[0]);
-		ds_avl_destroy(&ds_lists[1]);
-		shm_free(ds_lists);
+	if(ds_list) {
+		ds_free_list(*ds_list);
+		shm_free(ds_list);
 	}
-
-	if(ds_crt_idx)
-		shm_free(ds_crt_idx);
 
 	if(ds_list_write_lock) {
 		lock_destroy(ds_list_write_lock);
 		lock_dealloc(ds_list_write_lock);
+	}
+
+	if(ds_list_read_lock) {
+		lock_destroy(ds_list_read_lock);
+		lock_dealloc(ds_list_read_lock);
 	}
 
 	return 0;
@@ -2088,11 +2156,19 @@ int ds_hash_pvar(struct sip_msg *msg, unsigned int *hash)
 int ds_list_exist(int set)
 {
 	ds_set_t *si = NULL;
+	ds_list_t *list;
+
 	LM_DBG("looking for destination set [%d]\n", set);
 
-	/* get the index of the set */
-	si = ds_avl_find(_ds_list, set);
+	list = ds_get_list();
 
+	if(list) {
+		/* get the index of the set */
+		si = ds_avl_find(list->head, set);
+		ds_put_list(list);
+	}
+
+	/* contents of `si` not valid here without reference, but pointer can be checked */
 	if(si == NULL) {
 		LM_DBG("destination set [%d] not found\n", set);
 		return -1; /* False */
@@ -2104,13 +2180,15 @@ int ds_list_exist(int set)
 /*
  * Return a destination set
  */
-ds_set_t *ds_list_lookup(int set)
+ds_set_t *ds_list_lookup(ds_list_t *list, int set)
 {
 	ds_set_t *si = NULL;
 	LM_DBG("looking for destination set [%d]\n", set);
 
-	/* get the index of the set */
-	si = ds_avl_find(_ds_list, set);
+	if(list) {
+		/* get the index of the set */
+		si = ds_avl_find(list->head, set);
+	}
 
 	if(si == NULL) {
 		LM_DBG("destination set [%d] not found\n", set);
@@ -2172,7 +2250,7 @@ int ds_load_add(struct sip_msg *msg, ds_set_t *dset, int setid, int dst)
 /**
  *
  */
-int ds_load_replace(struct sip_msg *msg, str *duid)
+static int ds_load_replace(struct sip_msg *msg, str *duid)
 {
 	ds_cell_t *it;
 	int set;
@@ -2180,6 +2258,7 @@ int ds_load_replace(struct sip_msg *msg, str *duid)
 	int newdst;
 	ds_set_t *idx = NULL;
 	int i;
+	ds_list_t *list;
 
 	if(duid->len <= 0) {
 		LM_ERR("invalid dst unique id not set for (%.*s)\n",
@@ -2187,15 +2266,23 @@ int ds_load_replace(struct sip_msg *msg, str *duid)
 		return -1;
 	}
 
+	list = ds_get_list();
+	if(!list) {
+		LM_ERR("no destination sets loaded");
+		return -1;
+	}
+
 	if((it = ds_get_cell(_dsht_load, &msg->callid->body)) == NULL) {
+		ds_put_list(list);
 		LM_ERR("cannot find load for (%.*s)\n", msg->callid->body.len,
 				msg->callid->body.s);
 		return -1;
 	}
 	set = it->dset;
 	/* get the index of the set */
-	if(ds_get_index(set, *ds_crt_idx, &idx) != 0) {
+	if(ds_get_index(set, list, &idx) != 0) {
 		ds_unlock_cell(_dsht_load, &msg->callid->body);
+		ds_put_list(list);
 		LM_ERR("destination set [%d] not found\n", set);
 		return -1;
 	}
@@ -2225,6 +2312,7 @@ int ds_load_replace(struct sip_msg *msg, str *duid)
 	}
 	if(newdst == -1) {
 		/* new destination has not been found: has been removed meanwhile? */
+		ds_put_list(list);
 		ds_unlock_cell(_dsht_load, &msg->callid->body);
 		LM_ERR("new destination address not found for [%d, %.*s]\n", set,
 				duid->len, duid->s);
@@ -2238,10 +2326,12 @@ int ds_load_replace(struct sip_msg *msg, str *duid)
 		DS_LOAD_DEC(idx, olddst);
 
 	if(ds_load_add(msg, idx, set, newdst) < 0) {
+		ds_put_list(list);
 		LM_ERR("unable to replace destination load [%.*s / %.*s]\n", duid->len,
 				duid->s, msg->callid->body.len, msg->callid->body.s);
 		return -1;
 	}
+	ds_put_list(list);
 	return 0;
 }
 
@@ -2253,9 +2343,17 @@ int ds_load_remove_byid(int set, str *duid)
 	int olddst;
 	ds_set_t *idx = NULL;
 	int i;
+	ds_list_t *list;
+
+	list = ds_get_list();
+	if(!list) {
+		LM_ERR("no destination sets loaded");
+		return -1;
+	}
 
 	/* get the index of the set */
-	if(ds_get_index(set, *ds_crt_idx, &idx) != 0) {
+	if(ds_get_index(set, list, &idx) != 0) {
+		ds_put_list(list);
 		LM_ERR("destination set [%d] not found\n", set);
 		return -1;
 	}
@@ -2269,6 +2367,7 @@ int ds_load_remove_byid(int set, str *duid)
 		}
 	}
 	if(olddst == -1) {
+		ds_put_list(list);
 		LM_ERR("old destination address not found for [%d, %.*s]\n", set,
 				duid->len, duid->s);
 		return -1;
@@ -2276,6 +2375,7 @@ int ds_load_remove_byid(int set, str *duid)
 
 	DS_LOAD_DEC(idx, olddst);
 
+	ds_put_list(list);
 	return 0;
 }
 
@@ -2999,29 +3099,32 @@ int ds_manage_routes(
 	int vlast = 0;
 	int valg = 0;
 	int xavp_filled = 0;
+	ds_list_t *list;
 
 	if(msg == NULL) {
 		LM_ERR("bad parameters\n");
 		return -1;
 	}
 
-	if(_ds_list == NULL || _ds_list_nr <= 0) {
+	list = ds_get_list();
+
+	if(list == NULL || list->nr <= 0) {
 		LM_ERR("no destination sets\n");
-		return -1;
+		goto error;
 	}
 
 	if((rstate->umode == DS_SETOP_DSTURI) && (ds_force_dst == 0)
 			&& (msg->dst_uri.s != NULL || msg->dst_uri.len > 0)) {
 		LM_ERR("destination already set [%.*s]\n", msg->dst_uri.len,
 				msg->dst_uri.s);
-		return -1;
+		goto error;
 	}
 
 
 	/* get the index of the set */
-	if(ds_get_index(rstate->setid, *ds_crt_idx, &idx) != 0) {
+	if(ds_get_index(rstate->setid, list, &idx) != 0) {
 		LM_ERR("destination set [%d] not found\n", rstate->setid);
-		return -1;
+		goto error;
 	}
 
 	if(rstate->alg == DS_ALG_RRSERIAL) {
@@ -3041,25 +3144,25 @@ int ds_manage_routes(
 		case DS_ALG_HASHCALLID: /* 0 - hash call-id */
 			if(ds_hash_callid(msg, &hash) != 0) {
 				LM_ERR("can't get callid hash\n");
-				return -1;
+				goto error;
 			}
 			break;
 		case DS_ALG_HASHFROMURI: /* 1 - hash from-uri */
 			if(ds_hash_fromuri(msg, &hash) != 0) {
 				LM_ERR("can't get From uri hash\n");
-				return -1;
+				goto error;
 			}
 			break;
 		case DS_ALG_HASHTOURI: /* 2 - hash to-uri */
 			if(ds_hash_touri(msg, &hash) != 0) {
 				LM_ERR("can't get To uri hash\n");
-				return -1;
+				goto error;
 			}
 			break;
 		case DS_ALG_HASHRURI: /* 3 - hash r-uri */
 			if(ds_hash_ruri(msg, &hash) != 0) {
 				LM_ERR("can't get ruri hash\n");
-				return -1;
+				goto error;
 			}
 			break;
 		case DS_ALG_ROUNDROBIN: /* 4 - round robin */
@@ -3087,7 +3190,7 @@ int ds_manage_routes(
 					break;
 				default:
 					LM_ERR("can't get authorization hash\n");
-					return -1;
+					goto error;
 			}
 			break;
 		case DS_ALG_RANDOM: /* 6 - random selection */
@@ -3096,7 +3199,7 @@ int ds_manage_routes(
 		case DS_ALG_HASHPV: /* 7 - hash on PV value */
 			if(ds_hash_pvar(msg, &hash) != 0) {
 				LM_ERR("can't get PV hash\n");
-				return -1;
+				goto error;
 			}
 			break;
 		case DS_ALG_SERIAL: /* 8 - use always first entry */
@@ -3125,7 +3228,7 @@ int ds_manage_routes(
 				i = ds_get_leastloaded(idx);
 				if(i < 0) {
 					/* no address selected */
-					return -1;
+					goto error;
 				}
 				hash = i;
 				if(ds_load_add(msg, idx, rstate->setid, hash) < 0) {
@@ -3149,7 +3252,7 @@ int ds_manage_routes(
 			hash = ds_manage_route_algo13(idx, rstate);
 			lock_release(&idx->lock);
 			if(hash == -1) {
-				return -1;
+				goto error;
 			}
 			xavp_filled = 1;
 			break;
@@ -3196,11 +3299,11 @@ int ds_manage_routes(
 				i = idx->nr - 1;
 				if(ds_skip_dst(idx->dlist[i].flags)
 						|| ds_oc_skip(idx, rstate->alg, i)) {
-					return -1;
+					goto error;
 				}
 				break;
 			}
-			return -1;
+			goto error;
 		}
 	}
 
@@ -3212,7 +3315,7 @@ int ds_manage_routes(
 				!= 0) {
 			LM_ERR("cannot set next hop address with: %.*s\n",
 					idx->dlist[hash].uri.len, idx->dlist[hash].uri.s);
-			return -1;
+			goto error;
 		}
 		rstate->emode = 1;
 	}
@@ -3236,11 +3339,13 @@ int ds_manage_routes(
 			if(sres != NULL) {
 				sres->hash = hash;
 			}
+			ds_put_list(list);
 			return 2;
 		}
 		if(sres != NULL) {
 			sres->hash = hash;
 		}
+		ds_put_list(list);
 		return 1;
 	}
 
@@ -3248,6 +3353,7 @@ int ds_manage_routes(
 		if(sres != NULL) {
 			sres->hash = hash;
 		}
+		ds_put_list(list);
 		return 1;
 	}
 
@@ -3256,12 +3362,13 @@ int ds_manage_routes(
 		if(sres != NULL) {
 			sres->hash = hash;
 		}
+		ds_put_list(list);
 		return 1;
 	}
 
 	if(!xavp_filled) {
 		if(ds_manage_routes_fill_xavp(hash, idx, rstate) == -1) {
-			return -1;
+			goto error;
 		}
 	}
 
@@ -3273,7 +3380,7 @@ int ds_manage_routes(
 				   idx, idx->nr - 1, rstate->setid, rstate->alg, &rstate->lxavp)
 				< 0) {
 			LM_ERR("failed to add default destination in the xavp\n");
-			return -1;
+			goto error;
 		}
 		rstate->cnt++;
 	}
@@ -3281,7 +3388,12 @@ int ds_manage_routes(
 	if(sres != NULL) {
 		sres->hash = hash;
 	}
+	ds_put_list(list);
 	return 1;
+
+error:
+	ds_put_list(list);
+	return -1;
 }
 
 int ds_update_dst(struct sip_msg *msg, int upos, int mode)
@@ -3366,12 +3478,12 @@ next_dst:
 /* callback for adding nodes based on index */
 void ds_add_dest_cb(ds_set_t *node, int i, void *arg)
 {
-	int setn;
 	ds_dest_t *ndst = NULL;
+	ds_list_t *next = arg;
 
 	ndst = add_dest2list(node->id, node->dlist[i].uri, node->dlist[i].flags,
-			node->dlist[i].priority, &node->dlist[i].attrs.body, *ds_next_idx,
-			&setn, node->dlist[i].dload, &node->dlist[i].latency_stats);
+			node->dlist[i].priority, &node->dlist[i].attrs.body, next,
+			node->dlist[i].dload, &node->dlist[i].latency_stats);
 	if(ndst == NULL) {
 		LM_WARN("failed to add destination in group %d - %.*s\n", node->id,
 				node->dlist[i].uri.len, node->dlist[i].uri.s);
@@ -3387,21 +3499,26 @@ void ds_add_dest_cb(ds_set_t *node, int i, void *arg)
 /* add dispatcher entry to in-memory dispatcher list */
 int ds_add_dst(int group, str *address, int flags, int priority, str *attrs)
 {
-	int setn;
+	ds_list_t *cur, *next;
+
+	next = ds_new_list();
+	if(!next) {
+		SHM_MEM_ERROR;
+		LM_ERR("out of memory");
+		return -1;
+	}
 
 	lock_get(ds_list_write_lock);
 
-	setn = _ds_list_nr;
+	cur = ds_get_list();
 
-	*ds_next_idx = (*ds_crt_idx + 1) % 2;
-	ds_avl_destroy(&ds_lists[*ds_next_idx]);
-
-	// add all existing destinations
-	ds_iter_set(_ds_list, &ds_add_dest_cb, NULL);
+	if(cur) {
+		// add all existing destinations
+		ds_iter_set(cur->head, &ds_add_dest_cb, next);
+	}
 
 	// add new destination
-	if(add_dest2list(group, *address, flags, priority, attrs, *ds_next_idx,
-			   &setn, 0, NULL)
+	if(add_dest2list(group, *address, flags, priority, attrs, next, 0, NULL)
 			== NULL) {
 		LM_WARN("unable to add destination %.*s to set %d", address->len,
 				address->s, group);
@@ -3410,23 +3527,31 @@ int ds_add_dst(int group, str *address, int flags, int priority, str *attrs)
 		}
 	}
 
-	if(reindex_dests(ds_lists[*ds_next_idx]) != 0) {
+	if(reindex_dests(next->head) != 0) {
 		LM_ERR("error on reindex\n");
 		goto error;
 	}
 
-	_ds_list_nr = setn;
-	*ds_crt_idx = *ds_next_idx;
+	next->refs = 1; /* one reference for logging, below */
+
+	/* Swap new list with global one */
+	lock_get(ds_list_read_lock);
+	*ds_list = next;
+	lock_release(ds_list_read_lock);
 
 	lock_release(ds_list_write_lock);
 
-	ds_log_sets();
+	ds_log_sets(next);
+	ds_put_list(next);
+
+	ds_put_list(cur);
+	ds_wait_free_list(cur);
+
 	return 0;
 
 error:
 	lock_release(ds_list_write_lock);
-	ds_avl_destroy(&ds_lists[*ds_next_idx]);
-	*ds_next_idx = *ds_crt_idx;
+	ds_free_list(next);
 	return -1;
 }
 
@@ -3446,8 +3571,8 @@ void ds_filter_dest_cb(ds_set_t *node, int i, void *arg)
 		return;
 
 	ndst = add_dest2list(node->id, node->dlist[i].uri, node->dlist[i].flags,
-			node->dlist[i].priority, &node->dlist[i].attrs.body, *ds_next_idx,
-			filter_arg->setn, node->dlist[i].dload,
+			node->dlist[i].priority, &node->dlist[i].attrs.body,
+			filter_arg->list, node->dlist[i].dload,
 			&node->dlist[i].latency_stats);
 
 	if(ndst == NULL) {
@@ -3462,47 +3587,62 @@ void ds_filter_dest_cb(ds_set_t *node, int i, void *arg)
 /* remove dispatcher entry from in-memory dispatcher list */
 int ds_remove_dst(int group, str *address)
 {
-	int setn;
+	ds_list_t *cur, *next;
 	struct ds_filter_dest_cb_arg filter_arg;
 	ds_dest_t *dp = NULL;
 
-	setn = 0;
+	next = ds_new_list();
+	if(!next) {
+		SHM_MEM_ERROR;
+		LM_ERR("out of memory");
+		return -1;
+	}
 
 	dp = pack_dest(*address, 0, 0, NULL, 0);
 	if(dp == NULL) {
+		ds_free_list(next);
 		LM_ERR("failed to pack address: %d %.*s\n", group, address->len,
 				address->s);
 		return -1;
 	}
 	filter_arg.setid = group;
 	filter_arg.dest = dp;
-	filter_arg.setn = &setn;
+	filter_arg.list = next;
 
 	lock_get(ds_list_write_lock);
 
-	*ds_next_idx = (*ds_crt_idx + 1) % 2;
-	ds_avl_destroy(&ds_lists[*ds_next_idx]);
+	cur = ds_get_list();
 
-	// add existing destinations except destination that matches group & address
-	ds_iter_set(_ds_list, &ds_filter_dest_cb, &filter_arg);
+	if(cur) {
+		// add existing destinations except destination that matches group & address
+		ds_iter_set(cur->head, &ds_filter_dest_cb, &filter_arg);
+	}
 
-	if(reindex_dests(ds_lists[*ds_next_idx]) != 0) {
+	if(reindex_dests(next->head) != 0) {
 		LM_ERR("error on reindex\n");
 		goto error;
 	}
 
-	_ds_list_nr = setn;
-	*ds_crt_idx = *ds_next_idx;
+	next->refs = 1; /* one reference for logging, below */
+
+	/* Swap new list with global one */
+	lock_get(ds_list_read_lock);
+	*ds_list = next;
+	lock_release(ds_list_read_lock);
 
 	lock_release(ds_list_write_lock);
 
-	ds_log_sets();
+	ds_log_sets(next);
+	ds_put_list(next);
+
+	ds_put_list(cur);
+	ds_wait_free_list(cur);
+
 	return 0;
 
 error:
 	lock_release(ds_list_write_lock);
-	ds_avl_destroy(&ds_lists[*ds_next_idx]);
-	*ds_next_idx = *ds_crt_idx;
+	ds_free_list(next);
 	return -1;
 }
 
@@ -3587,14 +3727,18 @@ ds_latency_stats_t *latency_stats_find(int group, str *address)
 
 	int i = 0;
 	ds_set_t *idx = NULL;
+	ds_list_t *list;
 
-	if(_ds_list == NULL || _ds_list_nr <= 0) {
+	list = ds_get_list();
+	if(list == NULL || list->nr <= 0) {
+		ds_put_list(list);
 		LM_DBG("the list is null\n");
 		return NULL;
 	}
 
 	/* get the index of the set */
-	if(ds_get_index(group, *ds_crt_idx, &idx) != 0) {
+	if(ds_get_index(group, list, &idx) != 0) {
+		ds_put_list(list);
 		LM_DBG("destination set [%d] not found\n", group);
 		return NULL;
 	}
@@ -3604,11 +3748,13 @@ ds_latency_stats_t *latency_stats_find(int group, str *address)
 				&& strncasecmp(idx->dlist[i].uri.s, address->s, address->len)
 						   == 0) {
 			/* destination address found - copy current stats */
+			ds_put_list(list);
 			return &idx->dlist[i].latency_stats;
 		}
 		i++;
 	}
 
+	ds_put_list(list);
 	return NULL;
 }
 
@@ -3704,16 +3850,20 @@ int ds_update_latency(int group, str *address, int code)
 	int i = 0;
 	int state = 0;
 	ds_set_t *idx = NULL;
+	ds_list_t *list;
 	congestion_control_state_t cc;
 	ds_init_congestion_control_state(&cc);
 
-	if(_ds_list == NULL || _ds_list_nr <= 0) {
+	list = ds_get_list();
+	if(list == NULL || list->nr <= 0) {
+		ds_put_list(list);
 		LM_ERR("the list is null\n");
 		return -1;
 	}
 
 	/* get the index of the set */
-	if(ds_get_index(group, *ds_crt_idx, &idx) != 0) {
+	if(ds_get_index(group, list, &idx) != 0) {
+		ds_put_list(list);
 		LM_ERR("destination set [%d] not found\n", group);
 		return -1;
 	}
@@ -3809,6 +3959,7 @@ int ds_update_latency(int group, str *address, int code)
 		dp_init_relative_weights(idx);
 		dp_init_priority_weights(idx);
 	}
+	ds_put_list(list);
 	return state;
 }
 
@@ -3822,14 +3973,18 @@ int ds_get_state(int group, str *address, str *iuid)
 	ds_set_t *idx = NULL;
 	str *fmatch;
 	str *vmatch;
+	ds_list_t *list;
 
-	if(_ds_list == NULL || _ds_list_nr <= 0) {
+	list = ds_get_list();
+	if(list == NULL || list->nr <= 0) {
+		ds_put_list(list);
 		LM_ERR("the list is null\n");
 		return -1;
 	}
 
 	/* get the index of the set */
-	if(ds_get_index(group, *ds_crt_idx, &idx) != 0) {
+	if(ds_get_index(group, list, &idx) != 0) {
+		ds_put_list(list);
 		LM_ERR("destination set [%d] not found\n", group);
 		return -1;
 	}
@@ -3845,10 +4000,12 @@ int ds_get_state(int group, str *address, str *iuid)
 		if(fmatch->len == vmatch->len
 				&& strncasecmp(fmatch->s, vmatch->s, vmatch->len) == 0) {
 			/* destination address found */
+			ds_put_list(list);
 			return idx->dlist[i].flags;
 		}
 		i++;
 	}
+	ds_put_list(list);
 	return 0;
 }
 
@@ -3866,14 +4023,18 @@ int ds_update_state(sip_msg_t *msg, int group, str *address, str *iuid,
 	str *vmatch;
 	int was_down = 0;
 	int is_down = 0;
+	ds_list_t *list;
 
-	if(_ds_list == NULL || _ds_list_nr <= 0) {
+	list = ds_get_list();
+	if(list == NULL || list->nr <= 0) {
+		ds_put_list(list);
 		LM_ERR("the list is null\n");
 		return -1;
 	}
 
 	/* get the index of the set */
-	if(ds_get_index(group, *ds_crt_idx, &idx) != 0) {
+	if(ds_get_index(group, list, &idx) != 0) {
+		ds_put_list(list);
 		LM_ERR("destination set [%d] not found\n", group);
 		return -1;
 	}
@@ -3982,6 +4143,7 @@ int ds_update_state(sip_msg_t *msg, int group, str *address, str *iuid,
 				ds_reinit_rweight_on_state_change(
 						old_state, idx->dlist[i].flags, idx);
 
+			ds_put_list(list);
 			LM_DBG("old state was %d, set new state to %d\n", old_state,
 					idx->dlist[i].flags);
 			return 0;
@@ -3989,6 +4151,7 @@ int ds_update_state(sip_msg_t *msg, int group, str *address, str *iuid,
 		i++;
 	}
 
+	ds_put_list(list);
 	return -1;
 }
 
@@ -4122,14 +4285,18 @@ int ds_reinit_state(int group, str *address, str *iuid, int state)
 	ds_set_t *idx = NULL;
 	str *fmatch;
 	str *vmatch;
+	ds_list_t *list;
 
-	if(_ds_list == NULL || _ds_list_nr <= 0) {
+	list = ds_get_list();
+	if(list == NULL || list->nr <= 0) {
+		ds_put_list(list);
 		LM_ERR("the list is null\n");
 		return -1;
 	}
 
 	/* get the index of the set */
-	if(ds_get_index(group, *ds_crt_idx, &idx) != 0) {
+	if(ds_get_index(group, list, &idx) != 0) {
+		ds_put_list(list);
 		LM_ERR("destination set [%d] not found\n", group);
 		return -1;
 	}
@@ -4154,11 +4321,13 @@ int ds_reinit_state(int group, str *address, str *iuid, int state)
 						old_state, idx->dlist[i].flags, idx);
 			}
 
+			ds_put_list(list);
 			return 0;
 		}
 	}
 	LM_ERR("destination address [%d : %.*s] not found\n", group, address->len,
 			address->s);
+	ds_put_list(list);
 	return -1;
 }
 
@@ -4169,14 +4338,18 @@ int ds_reinit_duid_state(int group, str *vduid, int state)
 {
 	int i = 0;
 	ds_set_t *idx = NULL;
+	ds_list_t *list;
 
-	if(_ds_list == NULL || _ds_list_nr <= 0) {
+	list = ds_get_list();
+	if(list == NULL || list->nr <= 0) {
+		ds_put_list(list);
 		LM_ERR("the list is null\n");
 		return -1;
 	}
 
 	/* get the index of the set */
-	if(ds_get_index(group, *ds_crt_idx, &idx) != 0) {
+	if(ds_get_index(group, list, &idx) != 0) {
+		ds_put_list(list);
 		LM_ERR("destination set [%d] not found\n", group);
 		return -1;
 	}
@@ -4195,11 +4368,13 @@ int ds_reinit_duid_state(int group, str *vduid, int state)
 						old_state, idx->dlist[i].flags, idx);
 			}
 
+			ds_put_list(list);
 			return 0;
 		}
 	}
 	LM_ERR("destination duid [%d : %.*s] not found\n", group, vduid->len,
 			vduid->s);
+	ds_put_list(list);
 	return -1;
 }
 
@@ -4210,14 +4385,18 @@ int ds_reinit_state_all(int group, int state)
 {
 	int i = 0;
 	ds_set_t *idx = NULL;
+	ds_list_t *list;
 
-	if(_ds_list == NULL || _ds_list_nr <= 0) {
+	list = ds_get_list();
+	if(list == NULL || list->nr <= 0) {
+		ds_put_list(list);
 		LM_ERR("the list is null\n");
 		return -1;
 	}
 
 	/* get the index of the set */
-	if(ds_get_index(group, *ds_crt_idx, &idx) != 0) {
+	if(ds_get_index(group, list, &idx) != 0) {
+		ds_put_list(list);
 		LM_ERR("destination set [%d] not found\n", group);
 		return -1;
 	}
@@ -4233,6 +4412,7 @@ int ds_reinit_state_all(int group, int state)
 					old_state, idx->dlist[i].flags, idx);
 		}
 	}
+	ds_put_list(list);
 	return 0;
 }
 
@@ -4284,15 +4464,20 @@ void ds_fprint_set(FILE *fout, ds_set_t *node)
  */
 int ds_fprint_list(FILE *fout)
 {
-	if(_ds_list == NULL || _ds_list_nr <= 0) {
+	ds_list_t *list;
+
+	list = ds_get_list();
+	if(list == NULL || list->nr <= 0) {
+		ds_put_list(list);
 		LM_ERR("no destination sets\n");
 		return -1;
 	}
 
-	fprintf(fout, "\nnumber of destination sets: %d\n", _ds_list_nr);
+	fprintf(fout, "\nnumber of destination sets: %d\n", list->nr);
 
-	ds_fprint_set(fout, _ds_list);
+	ds_fprint_set(fout, list->head);
 
+	ds_put_list(list);
 	return 0;
 }
 
@@ -4495,6 +4680,7 @@ int ds_is_addr_from_list(sip_msg_t *_m, int group, str *uri, int mode)
 	struct hostent *he = NULL;
 	int rc = -1;
 	int k, naddrs;
+	ds_list_t *g_list;
 
 	if(uri == NULL || uri->len <= 0) {
 		pipaddr = &_m->rcv.src_ip;
@@ -4561,15 +4747,21 @@ int ds_is_addr_from_list(sip_msg_t *_m, int group, str *uri, int mode)
 		ds_strictest_node = NULL;
 	}
 
+	g_list = ds_get_list();
+	if(!g_list) {
+		LM_DBG("no destination sets\n");
+		return -1;
+	}
+
 	if(naddrs > 1) {
 		for(k = 0; k < naddrs; k++) {
 			hostent2ip_addr(&aipaddr, he, k);
 			pipaddr = &aipaddr;
 			if(group == -1) {
 				rc = ds_is_addr_from_set_r(
-						_m, pipaddr, tport, tproto, _ds_list, mode, 1);
+						_m, pipaddr, tport, tproto, g_list->head, mode, 1);
 			} else {
-				list = ds_avl_find(_ds_list, group);
+				list = ds_avl_find(g_list->head, group);
 				if(list) {
 					rc = ds_is_addr_from_set(
 							_m, pipaddr, tport, tproto, list, mode, 0);
@@ -4582,9 +4774,9 @@ int ds_is_addr_from_list(sip_msg_t *_m, int group, str *uri, int mode)
 	} else {
 		if(group == -1) {
 			rc = ds_is_addr_from_set_r(
-					_m, pipaddr, tport, tproto, _ds_list, mode, 1);
+					_m, pipaddr, tport, tproto, g_list->head, mode, 1);
 		} else {
-			list = ds_avl_find(_ds_list, group);
+			list = ds_avl_find(g_list->head, group);
 			if(list) {
 				rc = ds_is_addr_from_set(
 						_m, pipaddr, tport, tproto, list, mode, 0);
@@ -4597,6 +4789,7 @@ int ds_is_addr_from_list(sip_msg_t *_m, int group, str *uri, int mode)
 				_m, ds_strictest_node, ds_strictest_idx, group == -1 ? 1 : 0);
 	}
 
+	ds_put_list(g_list);
 	return rc;
 }
 
@@ -4612,8 +4805,15 @@ int ds_is_active_uri(sip_msg_t *msg, int group, str *uri)
 {
 	ds_set_t *list;
 	int j;
+	ds_list_t *g_list;
 
-	list = ds_avl_find(_ds_list, group);
+	g_list = ds_get_list();
+	if(!g_list) {
+		LM_DBG("no destination sets\n");
+		return -1;
+	}
+
+	list = ds_avl_find(g_list->head, group);
 	if(list) {
 		for(j = 0; j < list->nr; j++) {
 			if(!ds_skip_dst(list->dlist[j].flags)) {
@@ -4633,6 +4833,7 @@ int ds_is_active_uri(sip_msg_t *msg, int group, str *uri)
 		}
 	}
 
+	ds_put_list(g_list);
 	return -1;
 }
 
@@ -4947,20 +5148,25 @@ void ds_ping_set(ds_set_t *node)
  */
 void ds_check_timer(unsigned int ticks, void *param)
 {
+	ds_list_t *list;
 
-
+	list = ds_get_list();
 	/* Check for the list. */
-	if(_ds_list == NULL || _ds_list_nr <= 0) {
+	if(list == NULL || list->nr <= 0) {
+		ds_put_list(list);
 		LM_DBG("no destination sets\n");
 		return;
 	}
 
 	if(_ds_ping_active != NULL && *_ds_ping_active == 0) {
+		ds_put_list(list);
 		LM_DBG("pinging destinations is inactive by admin\n");
 		return;
 	}
 
-	ds_ping_set(_ds_list);
+	ds_ping_set(list->head);
+
+	ds_put_list(list);
 }
 
 /*! \brief
@@ -5087,17 +5293,22 @@ void ds_dns_update_set(ds_set_t *node)
  */
 void ds_dns_timer(unsigned int ticks, void *param)
 {
+	ds_list_t *list;
+
 	if(!(ds_dns_mode & DS_DNS_MODE_TIMER)) {
 		return;
 	}
 
 	/* Check for the list. */
-	if(_ds_list == NULL || _ds_list_nr <= 0) {
+	list = ds_get_list();
+	if(list == NULL || list->nr <= 0) {
+		ds_put_list(list);
 		LM_DBG("no destination sets\n");
 		return;
 	}
 
-	ds_dns_update_set(_ds_list);
+	ds_dns_update_set(list->head);
+	ds_put_list(list);
 }
 
 int ds_next_dst_api(sip_msg_t *msg, int mode)
@@ -5119,14 +5330,41 @@ int bind_dispatcher(dispatcher_api_t *api)
 }
 
 
-ds_set_t *ds_get_list(void)
+ds_list_t *ds_get_list(void)
 {
-	return _ds_list;
+	ds_list_t *ret;
+
+	if(!ds_list_read_lock || !ds_list)
+		return NULL;
+
+	lock_get(ds_list_read_lock);
+	ret = *ds_list;
+	ret->refs++;
+	lock_release(ds_list_read_lock);
+
+	return ret;
+}
+
+void ds_put_list(ds_list_t *list)
+{
+	if(!list)
+		return;
+	lock_get(ds_list_read_lock);
+	list->refs--;
+	lock_release(ds_list_read_lock);
 }
 
 int ds_get_list_nr(void)
 {
-	return _ds_list_nr;
+	int ret;
+
+	ds_list_t *list = ds_get_list();
+	if(!list)
+		return 0;
+	ret = list->nr;
+	ds_put_list(list);
+
+	return ret;
 }
 
 ds_set_t *ds_avl_find(ds_set_t *node, int id)

--- a/src/modules/dispatcher/dispatch.h
+++ b/src/modules/dispatcher/dispatch.h
@@ -186,7 +186,6 @@ int ds_mark_dst(struct sip_msg *msg, int state);
 int ds_mark_dst_mode(struct sip_msg *msg, int state, int mode);
 int ds_mark_addr(sip_msg_t *msg, int state, int group, str *uri, int mode);
 int ds_print_list(FILE *fout);
-int ds_log_sets(void);
 int ds_list_exist(int set);
 int ds_is_active_uri(sip_msg_t *msg, int group, str *uri);
 
@@ -301,6 +300,12 @@ typedef struct _ds_set {
 	gen_lock_t lock;
 } ds_set_t;
 
+typedef struct _ds_list {
+	ds_set_t *head; /*!< top of AVL tree */
+	int nr; /*!< number of sets */
+	unsigned int refs;
+} ds_list_t;
+
 typedef struct _ds_select_state {
 	int setid;  /* dispatcher set id (group id) */
 	int alg;    /* algorithm to select destinations */
@@ -314,7 +319,7 @@ typedef struct _ds_select_state {
 struct ds_filter_dest_cb_arg {
 	int setid;
 	ds_dest_t *dest;
-	int *setn;
+	ds_list_t *list;
 };
 
 /* clang-format on */
@@ -324,10 +329,11 @@ struct ds_filter_dest_cb_arg {
 #define AVL_NEITHER -1
 #define AVL_BALANCED(n) (n->longer < 0)
 
-ds_set_t *ds_get_list(void);
+ds_list_t *ds_get_list(void);
+void ds_put_list(ds_list_t *);
 int ds_get_list_nr(void);
 
-ds_set_t *ds_list_lookup(int set);
+ds_set_t *ds_list_lookup(ds_list_t *list, int set);
 
 int ds_ping_active_init(void);
 int ds_ping_active_get(void);

--- a/src/modules/dispatcher/dispatcher.c
+++ b/src/modules/dispatcher/dispatcher.c
@@ -155,9 +155,6 @@ int ds_event_callback_mode = DS_EVRTMODE_RUNTIME;
 str ds_db_extra_attrs = STR_NULL;
 param_t *ds_db_extra_attrs_list = NULL;
 
-static int ds_reload_delta = 5;
-static time_t *ds_rpc_reload_time = NULL;
-
 /** module functions */
 static int mod_init(void);
 static int child_init(int);
@@ -330,7 +327,6 @@ static param_export_t params[]={
 	{"ds_attrs_none",      PARAM_INT, &ds_attrs_none},
 	{"ds_db_extra_attrs",  PARAM_STR, &ds_db_extra_attrs},
 	{"ds_load_mode",       PARAM_INT, &ds_load_mode},
-	{"reload_delta",       PARAM_INT, &ds_reload_delta },
 	{"ds_dns_mode",        PARAM_INT, &ds_dns_mode},
 	{"ds_dns_interval",    PARAM_INT, &ds_dns_interval},
 	{"ds_dns_ttl",         PARAM_INT, &ds_dns_ttl},
@@ -561,15 +557,6 @@ static int mod_init(void)
 				ds_latency_estimator_alpha);
 	}
 
-	ds_rpc_reload_time = shm_malloc(sizeof(time_t));
-	if(ds_rpc_reload_time == NULL) {
-		shm_free(ds_ping_reply_codes);
-		shm_free(ds_ping_reply_codes_cnt);
-		SHM_MEM_ERROR;
-		return -1;
-	}
-	*ds_rpc_reload_time = 0;
-
 	return 0;
 }
 
@@ -594,10 +581,6 @@ static void destroy(void)
 		shm_free(ds_ping_reply_codes);
 	if(ds_ping_reply_codes_cnt)
 		shm_free(ds_ping_reply_codes_cnt);
-	if(ds_rpc_reload_time != NULL) {
-		shm_free(ds_rpc_reload_time);
-		ds_rpc_reload_time = 0;
-	}
 }
 
 #define GET_VALUE(param_name, param, i_value, s_value, value_flags)        \
@@ -966,17 +949,6 @@ static int ds_warn_fixup(void **param, int param_no)
 
 static int ds_reload(sip_msg_t *msg)
 {
-	if(ds_rpc_reload_time == NULL) {
-		LM_ERR("not ready for reload\n");
-		return -1;
-	}
-	if(*ds_rpc_reload_time != 0
-			&& *ds_rpc_reload_time > time(NULL) - ds_reload_delta) {
-		LM_ERR("ongoing reload\n");
-		return -1;
-	}
-	*ds_rpc_reload_time = time(NULL);
-
 	if(!ds_db_url.s) {
 		if(ds_load_list(dslistfile) != 0) {
 			LM_ERR("failed reloading the list file\n");
@@ -1465,13 +1437,16 @@ static int pv_get_dsg(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 	int inactive = 0;
 	int j = 0;
 	ds_ocdata_t ocdata;
+	ds_list_t *list;
 
 	if(param == NULL) {
 		return -1;
 	}
-	dsg = ds_list_lookup(_pv_dsg_fetch_dg);
+	list = ds_get_list();
+	dsg = ds_list_lookup(list, _pv_dsg_fetch_dg);
 
 	if(dsg == NULL) {
+		ds_put_list(list);
 		return pv_get_null(msg, param, res);
 	}
 
@@ -1495,6 +1470,7 @@ static int pv_get_dsg(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 		}
 	}
 	lock_release(&dsg->lock);
+	ds_put_list(list);
 
 	switch(param->pvn.u.isname.name.n) {
 		case 0: /* count */
@@ -1839,19 +1815,6 @@ static const char *dispatcher_rpc_reload_doc[2] = {
 static void dispatcher_rpc_reload(rpc_t *rpc, void *ctx)
 {
 
-	if(ds_rpc_reload_time == NULL) {
-		LM_ERR("not ready for reload\n");
-		rpc->fault(ctx, 500, "Not ready for reload");
-		return;
-	}
-	if(*ds_rpc_reload_time != 0
-			&& *ds_rpc_reload_time > time(NULL) - ds_reload_delta) {
-		LM_ERR("ongoing reload\n");
-		rpc->fault(ctx, 500, "Ongoing reload");
-		return;
-	}
-	*ds_rpc_reload_time = time(NULL);
-
 	if(!ds_db_url.s) {
 		if(ds_load_list(dslistfile) != 0) {
 			rpc->fault(ctx, 500, "Reload Failed");
@@ -2043,7 +2006,7 @@ static void dispatcher_rpc_list(rpc_t *rpc, void *ctx)
 	int n;
 	str smode;
 	int vmode = DS_RPC_PRINT_NORMAL;
-	ds_set_t *dslist = NULL;
+	ds_list_t *dslist = NULL;
 	int dslistnr = 0;
 
 	n = rpc->scan(ctx, "*S", &smode);
@@ -2059,6 +2022,7 @@ static void dispatcher_rpc_list(rpc_t *rpc, void *ctx)
 	dslistnr = ds_get_list_nr();
 
 	if(dslist == NULL || dslistnr <= 0) {
+		ds_put_list(dslist);
 		LM_DBG("no destination sets\n");
 		rpc->fault(ctx, 500, "No Destination Sets");
 		return;
@@ -2066,15 +2030,18 @@ static void dispatcher_rpc_list(rpc_t *rpc, void *ctx)
 
 	/* add entry node */
 	if(rpc->add(ctx, "{", &th) < 0) {
+		ds_put_list(dslist);
 		rpc->fault(ctx, 500, "Internal error root reply");
 		return;
 	}
 	if(rpc->struct_add(th, "d[", "NRSETS", dslistnr, "RECORDS", &ih) < 0) {
+		ds_put_list(dslist);
 		rpc->fault(ctx, 500, "Internal error sets structure");
 		return;
 	}
 
-	ds_rpc_print_set(dslist, rpc, ctx, ih, vmode);
+	ds_rpc_print_set(dslist->head, rpc, ctx, ih, vmode);
+	ds_put_list(dslist);
 
 	return;
 }
@@ -2221,19 +2188,6 @@ static void dispatcher_rpc_add(rpc_t *rpc, void *ctx)
 	str dest;
 	str attrs = STR_NULL;
 
-	if(ds_rpc_reload_time == NULL) {
-		LM_ERR("Not ready for rebuilding destinations list\n");
-		rpc->fault(ctx, 500, "Not ready for reload");
-		return;
-	}
-	if(*ds_rpc_reload_time != 0
-			&& *ds_rpc_reload_time > time(NULL) - ds_reload_delta) {
-		LM_ERR("ongoing reload\n");
-		rpc->fault(ctx, 500, "Ongoing reload");
-		return;
-	}
-	*ds_rpc_reload_time = time(NULL);
-
 	flags = 0;
 	priority = 0;
 
@@ -2266,19 +2220,6 @@ static void dispatcher_rpc_remove(rpc_t *rpc, void *ctx)
 {
 	int group;
 	str dest;
-
-	if(ds_rpc_reload_time == NULL) {
-		LM_ERR("Not ready for rebuilding destinations list\n");
-		rpc->fault(ctx, 500, "Not ready for reload");
-		return;
-	}
-	if(*ds_rpc_reload_time != 0
-			&& *ds_rpc_reload_time > time(NULL) - ds_reload_delta) {
-		LM_ERR("ongoing reload\n");
-		rpc->fault(ctx, 500, "Ongoing reload");
-		return;
-	}
-	*ds_rpc_reload_time = time(NULL);
 
 	if(rpc->scan(ctx, "dS", &group, &dest) < 2) {
 		rpc->fault(ctx, 500, "Invalid Parameters");
@@ -2348,6 +2289,7 @@ static void dispatcher_rpc_oclist(rpc_t *rpc, void *ctx)
 	int i = 0;
 	ds_set_t *node = NULL;
 	void *th = NULL;
+	ds_list_t *list;
 
 	if(rpc->scan(ctx, "d", &group) != 1) {
 		rpc->fault(ctx, 500, "Invalid Parameters");
@@ -2355,8 +2297,10 @@ static void dispatcher_rpc_oclist(rpc_t *rpc, void *ctx)
 	}
 
 	/* get the index of the set */
-	node = ds_list_lookup(group);
+	list = ds_get_list();
+	node = ds_list_lookup(list, group);
 	if(node == NULL) {
+		ds_put_list(list);
 		LM_ERR("destination set [%d] not found\n", group);
 		rpc->fault(ctx, 404, "Destination Group Not Found");
 		return;
@@ -2365,6 +2309,7 @@ static void dispatcher_rpc_oclist(rpc_t *rpc, void *ctx)
 	for(i = 0; i < node->nr; i++) {
 		/* add entry node */
 		if(rpc->add(ctx, "{", &th) < 0) {
+			ds_put_list(list);
 			rpc->fault(ctx, 500, "Internal error root reply");
 			return;
 		}
@@ -2380,10 +2325,12 @@ static void dispatcher_rpc_oclist(rpc_t *rpc, void *ctx)
 				   node->dlist[i].ocdata.ocmin, "ocmax",
 				   node->dlist[i].ocdata.ocmax)
 				< 0) {
+			ds_put_list(list);
 			rpc->fault(ctx, 500, "Internal error main structure");
 			return;
 		}
 	}
+	ds_put_list(list);
 }
 
 /* clang-format off */

--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -1182,33 +1182,6 @@ modparam("dispatcher", "ds_load_mode", 1)
 		</example>
 	</section>
 
-	<section id="dispatcher.p.reload_delta">
-		<title><varname>reload_delta</varname> (int)</title>
-		<para>
-		The number of seconds that have to be waited before executing a new reload
-		of dispatcher records. By default there is a rate limiting of maximum
-		one reload in five seconds.
-		</para>
-		<para>
-		If set to 0, no rate limit is configured. Note carefully: use this
-		configuration only in tests environments because executing many RPC
-		reload commands at the same time can cause unexpected behavior.
-		</para>
-		<para>
-		<emphasis>
-			Default value is <quote>5</quote>.
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>reload_delta</varname> parameter</title>
-		<programlisting format="linespecific">
-...
-modparam("dispatcher", "reload_delta", 1)
-...
-		</programlisting>
-		</example>
-	</section>
-
 	<section id="dispatcher.p.ds_dns_mode">
 		<title><varname>ds_dns_mode</varname> (int)</title>
 		<para>


### PR DESCRIPTION
- refactor table object living in shared memory with a wrapper object (`ds_list_t` wrapping shared `ds_set_t` list)
- ds_list_t wrapper includes a reference count for thread safety
- reference count is protected by new global `ds_list_read_lock` mutex
- previously global `_ds_list_nr` count has been moved into the `ds_list_t` object
- read access to shared table must now happen through `ds_get_list()` or similar, which: obtains read lock, increases reference count, drops read lock, returns pointer to table with reference held
- calls to `ds_get_list()` must be paired with `ds_put_list()` to release the reference
- double-buffering of `ds_set_t` objects (via `ds_crt_idx` etc) is now obsolete: the global `ds_list` pointer always points to the single currently active list and is protected by the `ds_list_read_lock` mutex, and safe read access is guaranteed through the reference count even in case of a concurrent reload or write access
- write accesses continue to operate using copy-rewrite-replace and are therefore equivalent to full reloads
- write accesses are required to also obtain `ds_list_write_lock` in addition to `ds_list_read_lock`
- reloads or rewrites create a new `ds_list_t`, populate it, then swap out the global `ds_list` pointer
- after swapping out the pointer, the reload/rewrite thread waits until the old object's reference count drops to zero, and only then frees it, guaranteeing safety for readers in other threads
- `reload_delta` is now obsolete: reloads and rewrites are now safe at arbitrarily short intervals

Closes #4845
Closes #4807

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [ ] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [X] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #4845 and #4807

#### Description
Full thread safety for dispatcher with arbitrary reloads and concurrent read access

Possible caveat: Removal of `reload_delta` would throw an error after an upgrade for people who have it set