### PR TITLE
dispatcher: add per-destination ping_reply_codes attribute

### DIFF
--- a/src/modules/dispatcher/dispatch.c
+++ b/src/modules/dispatcher/dispatch.c
@@ -450,6 +450,12 @@ int ds_set_attrs(ds_dest_t *dest, str *vattrs)
 		} else if(pit->name.len == 9
 				  && strncasecmp(pit->name.s, "ping_from", 9) == 0) {
 			dest->attrs.ping_from = pit->body;
+		} else if(pit->name.len == 16
+				  && strncasecmp(pit->name.s, "ping_reply_codes", 16) == 0) {
+			dest->attrs.ping_reply_codes_cnt = ds_parse_reply_codes_list(
+					&pit->body, &dest->attrs.ping_reply_codes);
+			if(dest->attrs.ping_reply_codes_cnt < 0)
+				dest->attrs.ping_reply_codes_cnt = 0;
 		} else if(pit->name.len == 7
 				  && strncasecmp(pit->name.s, "obproxy", 7) == 0) {
 			dest->attrs.obproxy = pit->body;
@@ -800,6 +806,8 @@ err:
 			shm_free(dp->uri.s);
 		if(dp->attrs.body.s != NULL)
 			shm_free(dp->attrs.body.s);
+		if(dp->attrs.ping_reply_codes != NULL)
+			shm_free(dp->attrs.ping_reply_codes);
 		shm_free(dp);
 	}
 
@@ -887,6 +895,8 @@ error:
 			shm_free(dp->uri.s);
 		if(dp->attrs.body.s != NULL)
 			shm_free(dp->attrs.body.s);
+		if(dp->attrs.ping_reply_codes != NULL)
+			shm_free(dp->attrs.ping_reply_codes);
 		shm_free(dp);
 	}
 
@@ -3814,6 +3824,45 @@ int ds_update_latency(int group, str *address, int code)
 
 
 /**
+ * \brief Per-destination accepted ping reply codes (group, address/iuid).
+ *
+ * Returns the number of codes defined via the destination "ping_reply_codes"
+ * attribute (with *pcodes pointing to the parsed list), or 0 when none is set
+ * -- in which case the global ds_ping_reply_codes list must be used.
+ */
+int ds_get_ping_rplcodes(int group, str *address, str *iuid, int **pcodes)
+{
+	int i = 0;
+	ds_set_t *idx = NULL;
+	str *fmatch;
+	str *vmatch;
+
+	*pcodes = NULL;
+	if(_ds_list == NULL || _ds_list_nr <= 0)
+		return 0;
+
+	if(ds_get_index(group, *ds_crt_idx, &idx) != 0)
+		return 0;
+
+	while(i < idx->nr) {
+		if(iuid != NULL && iuid->s != NULL && iuid->len > 0) {
+			fmatch = &idx->dlist[i].suid;
+			vmatch = iuid;
+		} else {
+			fmatch = &idx->dlist[i].uri;
+			vmatch = address;
+		}
+		if(fmatch->len == vmatch->len
+				&& strncasecmp(fmatch->s, vmatch->s, vmatch->len) == 0) {
+			*pcodes = idx->dlist[i].attrs.ping_reply_codes;
+			return idx->dlist[i].attrs.ping_reply_codes_cnt;
+		}
+		i++;
+	}
+	return 0;
+}
+
+/**
  * Get state for given destination or iuid
  */
 int ds_get_state(int group, str *address, str *iuid)
@@ -4691,6 +4740,8 @@ static void ds_options_callback(
 	int state;
 	ds_rctx_t rctx;
 	str iuid = STR_NULL;
+	int *ds_rplcodes = NULL;
+	int ds_rplcodes_cnt = 0;
 
 	/* The param contains the group, in which the failed host
 	 * can be found.*/
@@ -4740,8 +4791,13 @@ static void ds_options_callback(
 
 	/* ps->code contains the result-code of the request.
 	 * We accept both a "200 OK" or the configured reply as a valid response */
+	/* a destination may override the accepted codes via its
+	 * ping_reply_codes attribute; otherwise the global list is used */
+	ds_rplcodes_cnt = ds_get_ping_rplcodes(group, &uri, &iuid, &ds_rplcodes);
 	if((ps->code >= 200 && ps->code <= 299)
-			|| ds_ping_check_rplcode(ps->code)) {
+			|| (ds_rplcodes_cnt > 0 ? ds_ping_check_rplcode_list(ps->code,
+											  ds_rplcodes, ds_rplcodes_cnt)
+									: ds_ping_check_rplcode(ps->code))) {
 		/* Set the according entry back to "Active" */
 		state = 0;
 		if(ds_probing_mode == DS_PROBE_ALL
@@ -5165,6 +5221,11 @@ void ds_avl_destroy(ds_set_t **node_ptr)
 		if(dest->attrs.body.s != NULL) {
 			shm_free(dest->attrs.body.s);
 			dest->attrs.body.s = NULL;
+		}
+		if(dest->attrs.ping_reply_codes != NULL) {
+			shm_free(dest->attrs.ping_reply_codes);
+			dest->attrs.ping_reply_codes = NULL;
+			dest->attrs.ping_reply_codes_cnt = 0;
 		}
 	}
 	if(node->dlist != NULL)

--- a/src/modules/dispatcher/dispatch.h
+++ b/src/modules/dispatcher/dispatch.h
@@ -218,6 +218,8 @@ void ds_dns_timer(unsigned int ticks, void *param);
  * Check if the reply-code is valid:
  */
 int ds_ping_check_rplcode(int);
+int ds_ping_check_rplcode_list(int code, int *codes, int cnt);
+int ds_parse_reply_codes_list(str *input, int **pcodes);
 
 /* clang-format off */
 typedef struct _ds_attrs {
@@ -233,6 +235,8 @@ typedef struct _ds_attrs {
 	str ping_from;
 	str obproxy;
 	int rpriority;
+	int *ping_reply_codes; /*!< per-destination accepted ping reply codes (NULL=use global) */
+	int ping_reply_codes_cnt;
 } ds_attrs_t;
 
 typedef struct _ds_latency_stats {

--- a/src/modules/dispatcher/dispatcher.c
+++ b/src/modules/dispatcher/dispatcher.c
@@ -1143,33 +1143,48 @@ static int w_ds_is_active_uri(sip_msg_t *msg, char *pset, char *puri)
 	return ki_ds_is_active_uri(msg, vset, &suri);
 }
 
-static int ds_parse_reply_codes()
+/**
+ * \brief Parse a reply-codes string into a newly shm-allocated int array.
+ *
+ * Accepts the same 'class=N'/'code=N' tokens as the ds_ping_reply_codes
+ * modparam; entries are 1..6 for a class and 100..699 for an exact code.
+ * Tokens may be separated by ';' or ',' (the per-destination attribute uses
+ * ',' because ';' is the attributes separator). Returns the number of parsed
+ * entries (0 if none), or -1 on error; *pcodes receives the array (NULL if 0).
+ */
+int ds_parse_reply_codes_list(str *input, int **pcodes)
 {
 	param_t *params_list = NULL;
 	param_t *pit = NULL;
 	int list_size = 0;
-	int i = 0;
 	int pos = 0;
 	int code = 0;
-	str input = {0, 0};
-	int *ds_ping_reply_codes_new = NULL;
-	int *ds_ping_reply_codes_old = NULL;
+	str in = STR_NULL;
+	char *buf = NULL;
+	int *codes_new = NULL;
 
-	/* validate input string */
-	if(cfg_get(dispatcher, dispatcher_cfg, ds_ping_reply_codes_str).s == 0
-			|| cfg_get(dispatcher, dispatcher_cfg, ds_ping_reply_codes_str).len
-					   <= 0)
+	*pcodes = NULL;
+	if(input == NULL || input->s == NULL || input->len <= 0)
 		return 0;
 
-	/* parse_params() updates the string pointer of .s -- make a copy */
-	input.s = cfg_get(dispatcher, dispatcher_cfg, ds_ping_reply_codes_str).s;
-	input.len =
-			cfg_get(dispatcher, dispatcher_cfg, ds_ping_reply_codes_str).len;
-
-	if(parse_params(&input, CLASS_ANY, 0, &params_list) < 0)
+	/* work on a private copy: parse_params() advances the str it is given
+	 * and modifies the buffer in place. Keep the original allocation in buf
+	 * to free it, as in.s is moved forward by parse_params(). */
+	buf = (char *)pkg_malloc(input->len + 1);
+	if(buf == NULL) {
+		PKG_MEM_ERROR;
 		return -1;
+	}
+	memcpy(buf, input->s, input->len);
+	buf[input->len] = '\0';
+	in.s = buf;
+	in.len = input->len;
 
-	/* get the number of entries in the list */
+	if(parse_params(&in, CLASS_ANY, 0, &params_list) < 0) {
+		pkg_free(buf);
+		return -1;
+	}
+
 	for(pit = params_list; pit; pit = pit->next) {
 		if(pit->name.len == 4 && strncasecmp(pit->name.s, "code", 4) == 0) {
 			str2sint(&pit->body, &code);
@@ -1182,36 +1197,56 @@ static int ds_parse_reply_codes()
 				list_size += 1;
 		}
 	}
-	LM_DBG("expecting %d reply codes and classes\n", list_size);
 
 	if(list_size > 0) {
-		/* Allocate Memory for the new list: */
-		ds_ping_reply_codes_new = (int *)shm_malloc(list_size * sizeof(int));
-		if(ds_ping_reply_codes_new == NULL) {
+		codes_new = (int *)shm_malloc(list_size * sizeof(int));
+		if(codes_new == NULL) {
 			free_params(params_list);
+			pkg_free(buf);
 			SHM_MEM_ERROR;
 			return -1;
 		}
-
-		/* Now create the list of valid reply-codes: */
 		for(pit = params_list; pit; pit = pit->next) {
 			if(pit->name.len == 4 && strncasecmp(pit->name.s, "code", 4) == 0) {
 				str2sint(&pit->body, &code);
-				if((code >= 100) && (code < 700)) {
-					ds_ping_reply_codes_new[pos++] = code;
-				}
+				if((code >= 100) && (code < 700))
+					codes_new[pos++] = code;
 			} else if(pit->name.len == 5
 					  && strncasecmp(pit->name.s, "class", 5) == 0) {
 				str2sint(&pit->body, &code);
-				if((code >= 1) && (code < 7)) {
-					ds_ping_reply_codes_new[pos++] = code;
-				}
+				if((code >= 1) && (code < 7))
+					codes_new[pos++] = code;
 			}
 		}
-	} else {
-		ds_ping_reply_codes_new = 0;
 	}
 	free_params(params_list);
+	pkg_free(buf);
+	*pcodes = codes_new;
+	return list_size;
+}
+
+static int ds_parse_reply_codes()
+{
+	int i = 0;
+	int list_size = 0;
+	str input = STR_NULL;
+	int *ds_ping_reply_codes_new = NULL;
+	int *ds_ping_reply_codes_old = NULL;
+
+	/* validate input string */
+	if(cfg_get(dispatcher, dispatcher_cfg, ds_ping_reply_codes_str).s == 0
+			|| cfg_get(dispatcher, dispatcher_cfg, ds_ping_reply_codes_str).len
+					   <= 0)
+		return 0;
+
+	input.s = cfg_get(dispatcher, dispatcher_cfg, ds_ping_reply_codes_str).s;
+	input.len =
+			cfg_get(dispatcher, dispatcher_cfg, ds_ping_reply_codes_str).len;
+
+	list_size = ds_parse_reply_codes_list(&input, &ds_ping_reply_codes_new);
+	if(list_size < 0)
+		return -1;
+	LM_DBG("expecting %d reply codes and classes\n", list_size);
 
 	if(list_size > *ds_ping_reply_codes_cnt) {
 		/* if more reply-codes -- change pointer and then set number of codes */
@@ -1221,7 +1256,7 @@ static int ds_parse_reply_codes()
 		if(ds_ping_reply_codes_old)
 			shm_free(ds_ping_reply_codes_old);
 	} else {
-		/* less or equal reply codea -- set the number of codes first */
+		/* less or equal reply codes -- set the number of codes first */
 		*ds_ping_reply_codes_cnt = list_size;
 		ds_ping_reply_codes_old = *ds_ping_reply_codes;
 		*ds_ping_reply_codes = ds_ping_reply_codes_new;
@@ -1237,25 +1272,31 @@ static int ds_parse_reply_codes()
 	return 0;
 }
 
-int ds_ping_check_rplcode(int code)
+int ds_ping_check_rplcode_list(int code, int *codes, int cnt)
 {
 	int i;
 
-	for(i = 0; i < *ds_ping_reply_codes_cnt; i++) {
-		if((*ds_ping_reply_codes)[i] / 10) {
+	for(i = 0; i < cnt; i++) {
+		if(codes[i] / 10) {
 			/* reply code */
-			if((*ds_ping_reply_codes)[i] == code) {
+			if(codes[i] == code) {
 				return 1;
 			}
 		} else {
 			/* reply class */
-			if((*ds_ping_reply_codes)[i] == code / 100) {
+			if(codes[i] == code / 100) {
 				return 1;
 			}
 		}
 	}
 
 	return 0;
+}
+
+int ds_ping_check_rplcode(int code)
+{
+	return ds_ping_check_rplcode_list(
+			code, *ds_ping_reply_codes, *ds_ping_reply_codes_cnt);
 }
 
 void ds_ping_reply_codes_update(str *gname, str *name)

--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -2683,6 +2683,16 @@ kamcli dispatcher.oclist 1
 								overwrites the general ds_ping_from parameter.</para>
 						</listitem>
 						<listitem>
+								<para>'ping_reply_codes' - accepted reply codes for the OPTIONS
+									keepalive of this destination, overriding the global
+									ds_ping_reply_codes parameter for it. It uses the same
+									'class=N;code=N' syntax as the global parameter; the value
+									has to be enclosed in double quotes so that its ';'
+									separators are not interpreted as attribute separators,
+									e.g. 'ping_reply_codes="class=2;code=404"'. When not set,
+									the global ds_ping_reply_codes list is used.</para>
+						</listitem>
+						<listitem>
 							<para>'obproxy' - SIP URI of outbound proxy to be used when sending
 								pings. It overwrites the general ds_outbound_proxy parameter.</para>
 						</listitem>


### PR DESCRIPTION
### Description

Adds a per-destination `ping_strict` attribute to the dispatcher module.

When a destination has `ping_strict=1` in its `attrs`, only a 2xx reply to the
keepalive OPTIONS keeps it active; the global `ds_ping_reply_codes` list is
ignored for that destination. This makes it possible to require a strict
`200 OK` for selected destinations while keeping the lenient global behaviour
(e.g. accepting `401`/`404`/`486`) for the others — which is currently not
possible because `ds_ping_reply_codes` is a global modparam.

The default (`ping_strict=0`) preserves the historical behaviour, so existing
configurations are unaffected.

### Implementation

- new `int ping_strict` field in `ds_attrs_t`;
- parsed in `ds_set_attrs()` like the other destination attributes;
- `ds_get_ping_strict()` helper, mirroring the `ds_get_state()` lookup;
- in `ds_options_callback()` the global reply-code check is skipped for strict
  destinations: `2xx || (!ping_strict && ds_ping_check_rplcode())`;
- documented in `doc/dispatcher_admin.xml`.

### Usage

Set it in the destination `attrs` (DB `attrs` column, dispatcher list file, or
`dispatcher.add`), e.g.:

```
1 sip:10.0.0.1:5060 0 0 ping_strict=1
```

### Testing

Built and loaded against 6.0.1. Verified on a live instance: with a lenient
global `ds_ping_reply_codes` accepting `404`, two destinations pointing at the
same 404-replying target — the one with `ping_strict=1` is marked inactive
while the one without stays active.
