### PR TITLE
tm: initialize l_req.buf_size in prepare_new_uac

### DIFF
--- a/src/modules/tm/t_fwd.c
+++ b/src/modules/tm/t_fwd.c
@@ -368,6 +368,7 @@ static int prepare_new_uac(struct cell *t, struct sip_msg *i_req, int branch,
 	if(l_copy == 1) {
 		memset(&l_req, 0, sizeof(sip_msg_t));
 		l_req.buf = l_buf;
+		l_req.buf_size = sizeof(l_buf);
 		l_buf[0] = '\0';
 		if(sip_msg_copy(i_req, &l_req, 0) < 0) {
 			ret = E_OUT_OF_MEM;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
      from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
      in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4844

#### Description

In `prepare_new_uac()` (`src/modules/tm/t_fwd.c`), when `l_copy == 1` (serial forking / `msg_apply_changes_mode=1`), the local `sip_msg_t` was initialized with `memset` to zero, then `l_req.buf` was set to `l_buf` but `l_req.buf_size` was left at `0`.

`sip_msg_copy()` in `src/core/sip_msg_clone.c` checks:
```
if (imsg->buf_size > omsg->buf_size) {
    LM_ERR("invalid output buffer\n");
    return -1;
}
```
Since `l_req.buf_size == 0` and `i_req->buf_size > 0`, `sip_msg_copy` always returned `-1`, causing serial forking to fail with `E_OUT_OF_MEM`.

Fix: set `l_req.buf_size = sizeof(l_buf)` right after `l_req.buf = l_buf`.

Verified with a minimal C reproducer that mimics the `sip_msg_copy` size check - fails before the fix, passes after.