### PR TITLE
xhttp_prom: emit TYPE lines for internal statistics

### DIFF
--- a/src/modules/xhttp_prom/prom.c
+++ b/src/modules/xhttp_prom/prom.c
@@ -222,6 +222,31 @@ static int metric_generate(
 			group->len, group->s, name->len, name->s, counter_val,
 			(uint64_t)ts);
 
+	/* Print TYPE line. The Prometheus exposition format makes it optional, but
+	 * strict parsers treat a sample with no declared type as untyped and drop
+	 * it, so statistics exported without one are invisible to those scrapers.
+	 * User defined metrics already emit HELP and TYPE (see
+	 * prom_metric_list_print); internal statistics did not.
+	 *
+	 * They are declared gauge rather than counter even though most of them only
+	 * increase: Prometheus reserves the _total suffix for counters, and these
+	 * names do not carry it, so declaring counter makes the output invalid for
+	 * the same strict parsers this is meant to satisfy. */
+	if(prom_body_printf(ctx, "# TYPE ") == -1) {
+		LM_ERR("Fail to print\n");
+		return -1;
+	}
+	if(prom_body_name_printf(ctx, "%.*s%.*s_%.*s", xhttp_prom_beginning.len,
+			   xhttp_prom_beginning.s, group->len, group->s, name->len, name->s)
+			== -1) {
+		LM_ERR("Fail to print\n");
+		return -1;
+	}
+	if(prom_body_printf(ctx, " gauge\n") == -1) {
+		LM_ERR("Fail to print\n");
+		return -1;
+	}
+
 	/* Print metric name. */
 	if(prom_body_name_printf(ctx, "%.*s%.*s_%.*s", xhttp_prom_beginning.len,
 			   xhttp_prom_beginning.s, group->len, group->s, name->len, name->s)


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

`metric_generate()` emits the internal Kamailio statistics without a `# TYPE`
line. The Prometheus exposition format makes `# TYPE` optional and treats such
a sample as untyped, but strict parsers drop untyped samples entirely, so the
internal statistics are invisible to those scrapers. User defined metrics are
unaffected — they already emit `HELP` and `TYPE` via `prom_metric_list_print()`.

This is the same problem reported in #3001, which was closed in 2022 because
the reporter had moved on to a workaround rather than because the approach was
rejected. In that thread @vhernando explained the original reasoning (the
module re-exports Kamailio's registered counters and cannot know which are
counters and which are gauges) and then proposed exactly the fix implemented
here:

> I am thinking on a workaround. Would asigning gauge type to Kamailio's
> metrics, even if they are actually counters, suit you?

`gauge` is the safe choice rather than `counter` even though most of these
statistics only increase: Prometheus reserves the `_total` suffix for counters
and these names do not carry it (e.g. `kamailio_sl_400_replies`), so declaring
them `counter` would make the output invalid for the same strict parsers this
change is meant to satisfy. A gauge accepts a monotonically increasing series
without complaint.

##### Reproduction and verification

The scraper in our case is the Datadog Agent's `openmetrics` check. Against an
unpatched module it reaches the endpoint and reports the instance healthy, but
collects zero samples — the failure is silent, which is what makes it awkward
to diagnose.

Verified against 6.0.3 by building the module and swapping it into the official
container image. After the change all 55 internal statistics carry a `TYPE`
line, and Datadog Agent 7.73.0 collects 55 samples where it previously
collected 0.

Before:

```
# Kamailio whole internal statistics
kamailio_core_bad_URIs_rcvd 0 1640265350616
kamailio_core_bad_msg_hdr 0 1640265350616
```

After:

```
# Kamailio whole internal statistics
# TYPE kamailio_core_bad_URIs_rcvd gauge
kamailio_core_bad_URIs_rcvd 0 1640265350616
# TYPE kamailio_core_bad_msg_hdr gauge
kamailio_core_bad_msg_hdr 0 1640265350616
```

I have left the backport checkbox unticked — happy to prepare a cherry-pick for
the stable branches if maintainers consider it appropriate.
