### PR TITLE
dmq: fix pkg leak on dmq_process_message

### DIFF
--- a/src/modules/dmq/message.c
+++ b/src/modules/dmq/message.c
@@ -148,6 +148,9 @@ int ki_dmq_process_message_rc(sip_msg_t *msg, int returnval)
 	dmq_node_t *dmq_node = NULL;
 	int ret;
 
+	/* zero early so error: can free peer_response.body */
+	memset(&peer_response, 0, sizeof(peer_response));
+
 	if(parse_headers(msg, HDR_EOH_F, 0) < 0) {
 		LM_ERR("failed to parse sip message headers\n");
 		goto error;
@@ -175,7 +178,6 @@ int ki_dmq_process_message_rc(sip_msg_t *msg, int returnval)
 	}
 	LM_DBG("dmq_handle_message peer found: %.*s\n", msg->parsed_uri.user.len,
 			msg->parsed_uri.user.s);
-	memset(&peer_response, 0, sizeof(peer_response));
 
 	if(parse_from_header(msg) < 0) {
 		LM_ERR("bad sip message or missing From hdr\n");
@@ -209,8 +211,13 @@ int ki_dmq_process_message_rc(sip_msg_t *msg, int returnval)
 		LM_WARN("no reply sent\n");
 	}
 
+	/* body was copied into the reply lump, free the original */
+	if(peer_response.body.s)
+		pkg_free(peer_response.body.s);
 	return returnval;
 error:
+	if(peer_response.body.s)
+		pkg_free(peer_response.body.s);
 	return -1;
 }
 


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
We have spotted pkg leaks on dmq_process_message(), due to notification body; pkg leaks slowly over time, depending how much dmq "ping_interval" is set (the lower is set, the faster leaks are noticed).