### PR TITLE
Makefile.groups: re-add kjwt module group for libjwt < 3

### DIFF
--- a/src/Makefile.groups
+++ b/src/Makefile.groups
@@ -489,6 +489,9 @@ module_group_kuuid=$(mod_list_uuid)
 # pkg libev modules
 module_group_kev=$(mod_list_ev)
 
+# pkg jwt module
+module_group_kjwt=$(mod_list_jwt)
+
 # pkg jwt3 module
 module_group_kjwt3=$(mod_list_jwt3)
 


### PR DESCRIPTION
Building with `group_include="... kjwt ..."` does not compile the jwt module (libjwt < 3): `module_group_kjwt` was removed when `kjwt3` was added, so selecting the jwt module via module groups silently excludes it from the build.

Re-add `module_group_kjwt=$(mod_list_jwt)` so the jwt module is selectable again through module groups.

Fixes #4867

---

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] No commits to README files for modules

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)

#### Checklist
- [x] Tested changes locally
- [x] Related to issue #4867