### PR TITLE
rtpengine: new modparam stats_reply_pv

### DIFF
--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -804,6 +804,42 @@ modparam("rtpengine", "media_duration", "$avp(MEDIA_DURATION)")
 	</section>
 
 
+	<section id="rtpengine.p.stats_reply_pv">
+		<title><varname>stats_reply_pv</varname> (string)</title>
+		<para>
+			The name of a pseudovariable (AVP or script variable) to store the
+			complete reply of the commands returning call statistics,
+			serialized as JSON. This gives access to all the data returned by
+			RTPEngine (e.g., the full call statistics), not only the values
+			extracted into the mos_*_pv parameters.
+		</para>
+		<para>
+			The variable is set after invoking <quote>rtpengine_delete</quote>,
+			<quote>rtpengine_query</quote> or <quote>rtpengine_connect</quote>.
+			It is also set by <quote>rtpengine_manage</quote>, but only if the
+			command resulted in a deletion of the call (or call branch), e.g.
+			when processing a BYE or CANCEL.
+		</para>
+		<para>
+			Each of these commands writes the variable again on a successful
+			reply, so read it right after the command of interest. The
+			variable is not written by <quote>rtpengine_query_v</quote>, which
+			stores its reply in the variable given as its own parameter.
+		</para>
+		<para>
+			By default, this parameter is not set.
+		</para>
+		<example>
+		<title>Set <varname>stats_reply_pv</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpengine", "stats_reply_pv", "$avp(RTPENGINE_STATS_REPLY)")
+...
+</programlisting>
+		</example>
+	</section>
+
+
 	<section id="rtpengine.p.mos_min_pv">
 		<title><varname>mos_min_pv</varname> (string)</title>
 		<para>

--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -233,6 +233,7 @@ static void rtpengine_ping_check_timer(unsigned int ticks, void *);
 static int w_rtpengine_query_v(sip_msg_t *msg, char *pfmt, char *pvar);
 static int fixup_rtpengine_query_v(void **param, int param_no);
 static int fixup_free_rtpengine_query_v(void **param, int param_no);
+static int rtpengine_query_v_print(bencode_item_t *dict, str *fmt, str *bout);
 
 static int rtpengine_subscribe_request_wrap_f(struct sip_msg *msg, char *str1,
 		char *str2, char *str3, char *str4, char *str5);
@@ -364,6 +365,9 @@ static pv_spec_t *read_sdp_pvar = NULL;
 
 static str media_duration_pvar_str = {NULL, 0};
 static pv_spec_t *media_duration_pvar = NULL;
+
+static str stats_reply_pvar_str = {NULL, 0};
+static pv_spec_t *stats_reply_pvar = NULL;
 
 static str dtmf_event_callid_pvar_str = {NULL, 0};
 static pv_spec_t *dtmf_event_callid_pvar = NULL;
@@ -581,6 +585,7 @@ static param_export_t params[] = {
 	{"hash_table_size", PARAM_INT, &hash_table_size},
 	{"setid_default", PARAM_INT, &setid_default},
 	{"media_duration", PARAM_STR, &media_duration_pvar_str},
+	{"stats_reply_pv", PARAM_STR, &stats_reply_pvar_str},
 	{"hash_algo", PARAM_INT, &hash_algo},
 	{"dtmf_events_sock", PARAM_STRING | PARAM_USE_FUNC,
 			(void *)rtpengine_set_dtmf_events_sock},
@@ -2575,6 +2580,18 @@ static int mod_init(void)
 			LM_ERR("media_duration_pv: not a valid AVP or VAR definition "
 				   "<%.*s>\n",
 					media_duration_pvar_str.len, media_duration_pvar_str.s);
+			return -1;
+		}
+	}
+
+	if(stats_reply_pvar_str.len > 0) {
+		stats_reply_pvar = pv_cache_get(&stats_reply_pvar_str);
+		if(stats_reply_pvar == NULL
+				|| (stats_reply_pvar->type != PVT_AVP
+						&& stats_reply_pvar->type != PVT_SCRIPTVAR)) {
+			LM_ERR("stats_reply_pv: not a valid AVP or VAR definition "
+				   "<%.*s>\n",
+					stats_reply_pvar_str.len, stats_reply_pvar_str.s);
 			return -1;
 		}
 	}
@@ -5246,8 +5263,34 @@ static void parse_call_stats_1(struct minmax_mos_label_stats *mmls,
 	avp_print_mos(&mmls->average, &average_vals, created, msg);
 }
 
+/* store the entire command reply, serialized as JSON, in the
+ * pseudovariable configured via the stats_reply_pv modparam */
+static void stats_reply_store(struct sip_msg *msg, bencode_item_t *dict)
+{
+	static str jfmt = str_init("j");
+	pv_value_t val = {0};
+
+	if(stats_reply_pvar == NULL)
+		return;
+
+	if(rtpengine_query_v_print(dict, &jfmt, &val.rs) < 0) {
+		LM_ERR("failed to serialize command reply\n");
+		return;
+	}
+
+	val.flags = PV_VAL_STR;
+	if(stats_reply_pvar->setf(msg, &stats_reply_pvar->pvp, (int)EQ_T, &val) < 0)
+		LM_ERR("failed to set stats_reply_pv <%.*s>\n",
+				stats_reply_pvar_str.len, stats_reply_pvar_str.s);
+
+	/* val.rs.s is allocated by srjson print */
+	free(val.rs.s);
+}
+
 static void parse_call_stats(bencode_item_t *dict, struct sip_msg *msg)
 {
+	stats_reply_store(msg, dict);
+
 	if(!got_any_mos_pvs)
 		return;
 


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Currently, when a command returning call statistics (`delete`, `query`,
`connect`) is sent to RTPEngine, the module only extracts a subset of the
reply data (the MOS values exposed via the `mos_*_pv` parameters) and
discards the rest of the statistics returned by RTPEngine.

This PR adds a new module parameter, `stats_reply_pv`, naming an AVP or
script variable where the complete command reply is stored, serialized as
JSON (reusing the JSON serializer already used by `rtpengine_query_v()`).
This gives config writers access to everything RTPEngine returns — full
per-SSRC stats, totals, tags, etc. — for CDR enrichment, logging or
accounting purposes.

The store is hooked into `parse_call_stats()`, so the variable is set after
`rtpengine_delete()`, `rtpengine_query()` or `rtpengine_connect()`; it is
also set by `rtpengine_manage()`, but only if the command resulted in a
deletion of the call (or call branch), e.g. when processing a BYE or
CANCEL. When the parameter is not set, the code path is a no-op (single
NULL pointer check), so there is no overhead for existing deployments.

Usage:

```
modparam("rtpengine", "stats_reply_pv", "$avp(RTPENGINE_STATS_REPLY)")
```

Tested locally:
- module builds cleanly with gcc (no warnings), changed code verified with
  clang-format 18
- invalid PV specs (non-AVP/VAR) are rejected at startup in `mod_init()`
- end-to-end test against a simulated RTPEngine ng-protocol endpoint:
  after `rtpengine_query()` and `rtpengine_delete()`, the full reply of the
  respective command is available as JSON in the configured AVP, while the
  existing MOS PV behavior is unchanged
