### PR TITLE
topos: link outgoing processing via b-side uuid when stored a_uuid is empty

### DIFF
--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -1033,6 +1033,7 @@ int tps_request_received(sip_msg_t *msg, int dialog)
 	uint32_t direction = TPS_DIR_DOWNSTREAM;
 	int ret;
 	int use_branch = 0;
+	int dlg_found = 0;
 	unsigned int metid = 0;
 	uint32_t up_mode = 0;
 	rr_t *srr = NULL;
@@ -1067,9 +1068,11 @@ int tps_request_received(sip_msg_t *msg, int dialog)
 
 	tps_storage_lock_get(&lkey);
 
-	if(tps_storage_load_dialog(msg, &mtsd, &stsd) < 0) {
+	ret = tps_storage_load_dialog(msg, &mtsd, &stsd);
+	if(ret < 0) {
 		goto error;
 	}
+	dlg_found = (ret == 0) ? 1 : 0;
 	metid = get_cseq(msg)->method_id;
 	if((metid
 			   & (METHOD_BYE | METHOD_INFO | METHOD_PRACK | METHOD_UPDATE
@@ -1164,7 +1167,24 @@ int tps_request_received(sip_msg_t *msg, int dialog)
 		}
 	}
 	if(dialog != 0) {
-		tps_append_xuuid(msg, &stsd.a_uuid);
+		if(stsd.a_uuid.len > 0) {
+			tps_append_xuuid(msg, &stsd.a_uuid);
+		} else if(stsd.b_uuid.len > 0) {
+			/* stored record has no a-side uuid (e.g., dialog created without
+			 * a-side local contact) - link via the b-side uuid so outgoing
+			 * processing can still load the dialog record and detect the
+			 * direction; otherwise the no-x-uuid fallback in
+			 * tps_request_sent() assumes downstream and wrongly masks the
+			 * Call-ID of in-dialog ACKs relayed upstream */
+			tps_append_xuuid(msg, &stsd.b_uuid);
+		} else if(dlg_found && mtsd.a_uuid.len > 0) {
+			/* record found but carries no uuid values (e.g., branch record
+			 * loaded on the no-b-contact fallback path) - use the r-uri
+			 * token that keyed the dialog lookup; when no record was found,
+			 * append nothing so the outgoing side keeps the stateless
+			 * cover behavior for local ACK/CANCEL */
+			tps_append_xuuid(msg, &mtsd.a_uuid);
+		}
 		if(_tps_rr_update) {
 			if(tps_storage_update_dialog(
 					   msg, &mtsd, &stsd, TPS_DBU_RPLATTRS | TPS_DBU_BRR)
@@ -1345,7 +1365,10 @@ int tps_request_sent(sip_msg_t *msg, int dialog, int local)
 				tps_remove_headers(msg, HDR_CONTACT_T);
 				tps_remove_headers(msg, HDR_VIA_T);
 				tps_reinsert_via(msg, &mtsd, &mtsd.x_via1);
-				/* ACK and CANCEL go downstream so Call-ID mask required */
+				/* locally generated (hop-by-hop) ACK and CANCEL are assumed
+				 * to go downstream so Call-ID mask is applied - heuristic,
+				 * known-wrong for local ACKs to negative replies of b-side
+				 * requests, where server transactions match by via branch */
 				tps_mask_callid(msg);
 			}
 			return 0;
@@ -1395,7 +1418,16 @@ int tps_request_sent(sip_msg_t *msg, int dialog, int local)
 	}
 
 	tps_remove_headers(msg, HDR_RECORDROUTE_T);
-	tps_remove_headers(msg, HDR_CONTACT_T);
+	/* keep the original Contact when there is no stored surrogate contact
+	 * to reinsert (e.g., record created without that leg's local contact) -
+	 * a request without any Contact is worse than an unmasked one; still
+	 * strip it for the methods that do not use Contact at all */
+	if((get_cseq(msg)->method_id & _tps_methods_nocontact)
+			|| ((direction == TPS_DIR_UPSTREAM) ? ptsd->as_contact.len
+												: ptsd->bs_contact.len)
+					   > 0) {
+		tps_remove_headers(msg, HDR_CONTACT_T);
+	}
 	tps_remove_headers(msg, HDR_VIA_T);
 
 	tps_reinsert_via(msg, &mtsd, &mtsd.x_via1);
@@ -1499,6 +1531,14 @@ int tps_response_sent(sip_msg_t *msg)
 	if(contact_keep == 0 && msg->first_line.u.reply.statuscode >= 400
 			&& msg->first_line.u.reply.statuscode < 500
 			&& msg->contact == NULL) {
+		contact_keep = 1;
+	}
+	if(contact_keep == 0
+			&& ((direction == TPS_DIR_DOWNSTREAM) ? stsd.as_contact.len
+												  : stsd.bs_contact.len)
+					   <= 0) {
+		/* no stored surrogate contact to reinsert (e.g., record created
+		 * without that leg's local contact) - keep the original one */
 		contact_keep = 1;
 	}
 	if(contact_keep == 0) {

--- a/src/modules/topos/tps_storage.c
+++ b/src/modules/topos/tps_storage.c
@@ -764,6 +764,10 @@ int tps_storage_record(sip_msg_t *msg, tps_data_t *td, int dialog, int dir)
 		if(td->as_contact.len <= 0 && td->bs_contact.len <= 0) {
 			LM_WARN("no local address - do record routing for all initial "
 					"requests\n");
+		} else if(td->as_contact.len <= 0 || td->bs_contact.len <= 0) {
+			LM_DBG("one local contact missing (a: %d b: %d) - dialog record"
+				   " stored with an empty uuid on that side\n",
+					td->as_contact.len, td->bs_contact.len);
 		}
 		ret = _tps_storage_api.insert_dialog(td);
 		if(ret < 0)


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [ ] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder (matched surrounding style by hand; no clang-format in the build env — happy to reformat if CI flags it)
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

With `topos` + `mask_callid=1` (Call-ID codec via `topoh` `use_mode=1`), in-dialog **ACKs relayed upstream (b-side → a-side) are forwarded with the Call-ID still masked**, while BYEs on the same dialogs are delivered correctly decoded. Observed in a production deployment (kamailio 6.1.2, `topos_redis` storage) at a steady rate: the a-side proxy logs dialog-matching warnings for every carrier-side re-INVITE ACK, with the Route set correctly restored but the Call-ID still in `callid_prefix` form.

**Root cause.** Dialog records can be stored with an empty `a_uuid`: `tps_storage_fill_contact()` silently skips a leg whose local contact is not available at record time, and `insert_dialog()` accepts records with one empty uuid. For such dialogs `tps_request_received()` appended `P-SR-XUID` from the empty `stsd.a_uuid`, which `tps_add_headers()` silently drops. The outgoing side then hits the no-x-uuid fallback in `tps_request_sent()`, which assumes in-dialog ACK/CANCEL go downstream and unconditionally calls `tps_mask_callid()` — wrong for b-side-originated transactions whose ACK travels upstream (BYE is unaffected because the branch is ACK/CANCEL-only, matching the observed masked-ACK/clean-BYE signature).

**Fix.**
1. `tps_request_received()`: fall back to the stored b-side uuid — or to the r-uri tpsh token that keyed the dialog lookup when the loaded record carries no uuid values — so the outgoing side can always load the record and detect direction from the from-tag. When **no** record was found, nothing is appended, preserving the stateless local-ACK/CANCEL cover behavior bit-for-bit. Both storage backends already accept b-prefixed uuids (redis normalizes `b`→`a` in the key; the DB backend selects the column from the value's first char).
2. Since such dialogs now take full outgoing processing, keep the original Contact in requests (`tps_request_sent()`) and responses (`tps_response_sent()`) when the stored surrogate contact for that leg is empty — previously the Contact was removed with nothing reinserted, producing Contact-less re-INVITEs/2xx. Methods in `methods_nocontact` are still stripped unconditionally.
3. `tps_storage_record()`: debug log when a dialog record is stored with only one local contact (the silent producer of such records).

**Testing.** Compile-clean on master and 6.1.2. Functional lab (kamailio between two scripted UDP endpoints, topos+topos_redis, `mask_callid=1`, config equivalent to the production one), same matrix on patched and unpatched builds:
- healthy dialogs: patched output identical to unpatched (masking toward b-side, plain toward a-side, surrogate contacts both directions, BYE/reINVITE flows);
- defect record (blanked `a_uuid`/`as_contact` in redis mid-call): unpatched reproduces the bug on the wire (upstream ACK delivered with masked Call-ID); patched delivers it plain, keeps the original Contact on the upstream re-INVITE, and additionally delivers the 2xx-to-reINVITE and downstream BYE properly masked toward the b-side (unpatched leaked them unmasked);
- negative-reply flow: `tm`-generated local ACK to a 488 still leaves with the masked Call-ID (legacy fallback preserved).

**Note (pre-existing, not addressed here):** for records with empty `a_uuid`, the DB backend's `tps_db_update_dialog()`/`tps_db_end_dialog()` key the `a_uuid` column while falling back to the b_uuid value, so those updates match zero rows; the redis backend normalizes correctly. Can send a trivial follow-up mirroring `tps_db_load_dialog()`'s column selection if wanted.
