### PR TITLE
permissions: refcount table objects

### DIFF
--- a/src/modules/permissions/address.c
+++ b/src/modules/permissions/address.c
@@ -30,6 +30,7 @@
 
 #include "permissions.h"
 #include "hash.h"
+#include "address.h"
 #include "../../core/config.h"
 #include "../../lib/srdb1/db.h"
 #include "../../lib/srdb1/db_ut.h"
@@ -44,23 +45,13 @@
 
 #define TABLE_VERSION 6
 
-struct addr_list ***perm_addr_table =
+static struct addr_table **perm_addr_table =
 		NULL; /* Ptr to current address hash table ptr */
-struct addr_list **perm_addr_table_1 =
-		NULL; /* Pointer to address hash table 1 */
-struct addr_list **perm_addr_table_2 =
-		NULL; /* Pointer to address hash table 2 */
-
-struct subnet **perm_subnet_table = NULL;  /* Ptr to current subnet table */
-struct subnet *perm_subnet_table_1 = NULL; /* Ptr to subnet table 1 */
-struct subnet *perm_subnet_table_2 = NULL; /* Ptr to subnet table 2 */
-
-struct domain_name_list ***perm_domain_table =
+static struct subnet_table **perm_subnet_table =
+		NULL; /* Ptr to current subnet table */
+static struct domain_name_table **perm_domain_table =
 		NULL; /* Ptr to current domain name table */
-static struct domain_name_list **perm_domain_table_1 =
-		NULL; /* Ptr to domain name table 1 */
-static struct domain_name_list **perm_domain_table_2 =
-		NULL; /* Ptr to domain name table 2 */
+static gen_lock_t *perm_addr_tables_lock;
 
 static db1_con_t *perm_db_handle = 0;
 static db_func_t perm_dbf;
@@ -69,9 +60,9 @@ extern str perm_address_file;
 
 typedef struct address_tables_group
 {
-	struct addr_list **address_table;
-	struct subnet *subnet_table;
-	struct domain_name_list **domain_table;
+	struct addr_table *address_table;
+	struct subnet_table *subnet_table;
+	struct domain_name_table *domain_table;
 
 } address_tables_group_t;
 
@@ -87,7 +78,21 @@ static inline ip_addr_t *strtoipX(str *ips)
 	}
 }
 
-int reload_address_insert(address_tables_group_t *atg, unsigned int gid,
+static void get_addr_tables(address_tables_group_t *atg)
+{
+	atg->address_table = get_addr_hash_table();
+	atg->subnet_table = get_subnet_table();
+	atg->domain_table = get_domain_name_table();
+}
+
+static void put_addr_tables(address_tables_group_t *atg)
+{
+	put_addr_hash_table(atg->address_table);
+	put_subnet_table(atg->subnet_table);
+	put_domain_name_table(atg->domain_table);
+}
+
+static int reload_address_insert(address_tables_group_t *atg, unsigned int gid,
 		str *ips, unsigned int mask, unsigned int port, str *tagv)
 {
 	ip_addr_t *ipa;
@@ -119,7 +124,8 @@ int reload_address_insert(address_tables_group_t *atg, unsigned int gid,
 	if(ipa != NULL) {
 		if((ipa->af == AF_INET6 && mask == 128)
 				|| (ipa->af == AF_INET && mask == 32)) {
-			if(addr_hash_table_insert(atg->address_table, gid, ipa, port, tagv)
+			if(addr_hash_table_insert(
+					   atg->address_table->table, gid, ipa, port, tagv)
 					== -1) {
 				LM_ERR("hash table problem\n");
 				return -1;
@@ -127,8 +133,8 @@ int reload_address_insert(address_tables_group_t *atg, unsigned int gid,
 			LM_DBG("Tuple <%u, %.*s, %u> inserted into address hash table\n",
 					gid, ips->len, ips->s, port);
 		} else {
-			if(subnet_table_insert(
-					   atg->subnet_table, gid, ipa, mask, port, tagv)
+			if(subnet_table_insert(atg->subnet_table->table,
+					   &atg->subnet_table->count, gid, ipa, mask, port, tagv)
 					== -1) {
 				LM_ERR("subnet table problem\n");
 				return -1;
@@ -137,7 +143,8 @@ int reload_address_insert(address_tables_group_t *atg, unsigned int gid,
 					ips->len, ips->s, port, mask);
 		}
 	} else {
-		if(domain_name_table_insert(atg->domain_table, gid, ips, port, tagv)
+		if(domain_name_table_insert(
+				   atg->domain_table->table, gid, ips, port, tagv)
 				== -1) {
 			LM_ERR("domain name table problem\n");
 			return -1;
@@ -152,7 +159,7 @@ int reload_address_insert(address_tables_group_t *atg, unsigned int gid,
  * Reload addr table from database to new hash table and when done, make new hash table
  * current one.
  */
-int reload_address_db_table(address_tables_group_t *atg)
+static int reload_address_db_table(address_tables_group_t *atg)
 {
 	db_key_t cols[5];
 	db1_res_t *res = NULL;
@@ -373,7 +380,7 @@ dberror:
  * Reload addr table from file to new hash table and when done, make new hash table
  * current one.
  */
-int reload_address_file_table(address_tables_group_t *atg)
+static int reload_address_file_table(address_tables_group_t *atg)
 {
 	char line[1024], *p;
 	FILE *f = NULL;
@@ -463,34 +470,12 @@ error:
 int reload_address_table(void)
 {
 	int ret = 0;
-	address_tables_group_t atg;
+	address_tables_group_t atg, old_atg;
 
-	/* Choose new hash table and free its old contents */
-	if(*perm_addr_table == perm_addr_table_1) {
-		empty_addr_hash_table(perm_addr_table_2);
-		atg.address_table = perm_addr_table_2;
-	} else {
-		empty_addr_hash_table(perm_addr_table_1);
-		atg.address_table = perm_addr_table_1;
-	}
-
-	/* Choose new subnet table */
-	if(*perm_subnet_table == perm_subnet_table_1) {
-		empty_subnet_table(perm_subnet_table_2);
-		atg.subnet_table = perm_subnet_table_2;
-	} else {
-		empty_subnet_table(perm_subnet_table_1);
-		atg.subnet_table = perm_subnet_table_1;
-	}
-
-	/* Choose new domain name table */
-	if(*perm_domain_table == perm_domain_table_1) {
-		empty_domain_name_table(perm_domain_table_2);
-		atg.domain_table = perm_domain_table_2;
-	} else {
-		empty_domain_name_table(perm_domain_table_1);
-		atg.domain_table = perm_domain_table_1;
-	}
+	/* Create new set of tables */
+	atg.address_table = new_addr_hash_table();
+	atg.subnet_table = new_subnet_table();
+	atg.domain_table = new_domain_name_table();
 
 	if(perm_address_file.s == NULL) {
 		ret = reload_address_db_table(&atg);
@@ -501,9 +486,32 @@ int reload_address_table(void)
 		return ret;
 	}
 
+	/* switch out global pointers */
+
+	lock_get(perm_addr_tables_lock);
+
+	old_atg.address_table = *perm_addr_table;
+	old_atg.subnet_table = *perm_subnet_table;
+	old_atg.domain_table = *perm_domain_table;
+
 	*perm_addr_table = atg.address_table;
 	*perm_subnet_table = atg.subnet_table;
 	*perm_domain_table = atg.domain_table;
+
+	lock_release(perm_addr_tables_lock);
+
+	/* wait for all references to be dropped, then free old tables */
+
+	if(old_atg.address_table)
+		ref_cnt_wait_zero(&old_atg.address_table->ref, perm_addr_tables_lock);
+	if(old_atg.subnet_table)
+		ref_cnt_wait_zero(&old_atg.subnet_table->ref, perm_addr_tables_lock);
+	if(old_atg.domain_table)
+		ref_cnt_wait_zero(&old_atg.domain_table->ref, perm_addr_tables_lock);
+
+	free_addr_hash_table(old_atg.address_table);
+	free_subnet_table(old_atg.subnet_table);
+	free_domain_name_table(old_atg.domain_table);
 
 	LM_DBG("address table reloaded successfully.\n");
 
@@ -553,7 +561,6 @@ int reload_address_table_cmd(void)
  */
 int init_addresses(void)
 {
-	perm_addr_table_1 = perm_addr_table_2 = 0;
 	perm_addr_table = 0;
 
 	if(perm_address_file.s == NULL) {
@@ -589,56 +596,40 @@ int init_addresses(void)
 		}
 	}
 
-	perm_addr_table_1 = new_addr_hash_table();
-	if(!perm_addr_table_1)
-		return -1;
-
-	perm_addr_table_2 = new_addr_hash_table();
-	if(!perm_addr_table_2)
-		goto error;
-
 	perm_addr_table =
-			(struct addr_list ***)shm_malloc(sizeof(struct addr_list **));
+			(struct addr_table **)shm_malloc(sizeof(struct addr_table *));
 	if(!perm_addr_table) {
 		LM_ERR("no more shm memory for addr_hash_table\n");
 		goto error;
 	}
+	*perm_addr_table = NULL;
 
-	*perm_addr_table = perm_addr_table_1;
-
-	perm_subnet_table_1 = new_subnet_table();
-	if(!perm_subnet_table_1)
-		goto error;
-
-	perm_subnet_table_2 = new_subnet_table();
-	if(!perm_subnet_table_2)
-		goto error;
-
-	perm_subnet_table = (struct subnet **)shm_malloc(sizeof(struct subnet *));
+	perm_subnet_table =
+			(struct subnet_table **)shm_malloc(sizeof(struct subnet_table *));
 	if(!perm_subnet_table) {
 		LM_ERR("no more shm memory for subnet_table\n");
 		goto error;
 	}
+	*perm_subnet_table = NULL;
 
-	*perm_subnet_table = perm_subnet_table_1;
-
-	perm_domain_table_1 = new_domain_name_table();
-	if(!perm_domain_table_1)
-		goto error;
-
-	perm_domain_table_2 = new_domain_name_table();
-	if(!perm_domain_table_2)
-		goto error;
-
-	perm_domain_table = (struct domain_name_list ***)shm_malloc(
-			sizeof(struct domain_name_list **));
+	perm_domain_table = (struct domain_name_table **)shm_malloc(
+			sizeof(struct domain_name_table *));
 	if(!perm_domain_table) {
 		LM_ERR("no more shm memory for domain name table\n");
 		goto error;
 	}
+	*perm_domain_table = NULL;
 
-	*perm_domain_table = perm_domain_table_1;
+	perm_addr_tables_lock = lock_alloc();
+	if(!perm_addr_tables_lock) {
+		LM_ERR("no more shm memory for address tables lock\n");
+		goto error;
+	}
 
+	if(!lock_init(perm_addr_tables_lock)) {
+		LM_ERR("failed to init address tables lock\n");
+		goto error;
+	}
 
 	if(reload_address_table() == -1) {
 		LM_CRIT("reload of address table failed\n");
@@ -653,42 +644,25 @@ int init_addresses(void)
 	return 0;
 
 error:
-	if(perm_addr_table_1) {
-		free_addr_hash_table(perm_addr_table_1);
-		perm_addr_table_1 = 0;
-	}
-	if(perm_addr_table_2) {
-		free_addr_hash_table(perm_addr_table_2);
-		perm_addr_table_2 = 0;
-	}
 	if(perm_addr_table) {
+		free_addr_hash_table(*perm_addr_table);
 		shm_free(perm_addr_table);
 		perm_addr_table = 0;
 	}
-	if(perm_subnet_table_1) {
-		free_subnet_table(perm_subnet_table_1);
-		perm_subnet_table_1 = 0;
-	}
-	if(perm_subnet_table_2) {
-		free_subnet_table(perm_subnet_table_2);
-		perm_subnet_table_2 = 0;
-	}
 	if(perm_subnet_table) {
+		free_subnet_table(*perm_subnet_table);
 		shm_free(perm_subnet_table);
 		perm_subnet_table = 0;
 	}
-
-	if(perm_domain_table_1) {
-		free_domain_name_table(perm_domain_table_1);
-		perm_domain_table_1 = 0;
-	}
-	if(perm_domain_table_2) {
-		free_domain_name_table(perm_domain_table_2);
-		perm_domain_table_2 = 0;
-	}
 	if(perm_domain_table) {
+		free_domain_name_table(*perm_domain_table);
 		shm_free(perm_domain_table);
 		perm_domain_table = 0;
+	}
+	if(perm_addr_tables_lock) {
+		lock_destroy(perm_addr_tables_lock);
+		shm_free(perm_addr_tables_lock);
+		perm_addr_tables_lock = 0;
 	}
 
 	if(perm_address_file.s == NULL) {
@@ -704,52 +678,58 @@ error:
  */
 void clean_addresses(void)
 {
-	if(perm_addr_table_1)
-		free_addr_hash_table(perm_addr_table_1);
-	if(perm_addr_table_2)
-		free_addr_hash_table(perm_addr_table_2);
-	if(perm_addr_table)
+	if(perm_addr_table) {
+		free_addr_hash_table(*perm_addr_table);
 		shm_free(perm_addr_table);
-	if(perm_subnet_table_1)
-		free_subnet_table(perm_subnet_table_1);
-	if(perm_subnet_table_2)
-		free_subnet_table(perm_subnet_table_2);
-	if(perm_subnet_table)
+	}
+	if(perm_subnet_table) {
+		free_subnet_table(*perm_subnet_table);
 		shm_free(perm_subnet_table);
-	if(perm_domain_table_1)
-		free_domain_name_table(perm_domain_table_1);
-	if(perm_domain_table_2)
-		free_domain_name_table(perm_domain_table_2);
-	if(perm_domain_table)
+	}
+	if(perm_domain_table) {
+		free_domain_name_table(*perm_domain_table);
 		shm_free(perm_domain_table);
+	}
+	if(perm_addr_tables_lock) {
+		lock_destroy(perm_addr_tables_lock);
+		shm_free(perm_addr_tables_lock);
+	}
 }
 
 
 int allow_address(sip_msg_t *_msg, int addr_group, str *ips, int port)
 {
 	struct ip_addr *ipa;
+	address_tables_group_t atg;
+	int retval = -1;
+
+	get_addr_tables(&atg);
 
 	ipa = strtoipX(ips);
 
 	if(ipa) {
 		if(perm_addr_table
-				&& match_addr_hash_table(*perm_addr_table, addr_group, ipa,
-						   (unsigned int)port)
+				&& match_addr_hash_table(atg.address_table->table, addr_group,
+						   ipa, (unsigned int)port)
 						   == 1) {
-			return 1;
+			retval = 1;
 		} else {
 			if(perm_subnet_table) {
-				return match_subnet_table(*perm_subnet_table, addr_group, ipa,
+				retval = match_subnet_table(atg.subnet_table->table,
+						atg.subnet_table->count, addr_group, ipa,
 						(unsigned int)port);
 			}
 		}
 	} else {
 		if(perm_domain_table) {
-			return match_domain_name_table(
-					*perm_domain_table, addr_group, ips, (unsigned int)port);
+			retval = match_domain_name_table(atg.domain_table->table,
+					addr_group, ips, (unsigned int)port);
 		}
 	}
-	return -1;
+
+	put_addr_tables(&atg);
+
+	return retval;
 }
 
 /*
@@ -786,21 +766,30 @@ int w_allow_address(
 
 int allow_source_address(sip_msg_t *_msg, int addr_group)
 {
+	int retval = -1;
+	address_tables_group_t atg;
+
+	get_addr_tables(&atg);
+
 	LM_DBG("looking for <%u, %x, %u>\n", addr_group,
 			_msg->rcv.src_ip.u.addr32[0], _msg->rcv.src_port);
 
-	if(perm_addr_table
-			&& match_addr_hash_table(*perm_addr_table, addr_group,
+	if(atg.address_table
+			&& match_addr_hash_table(atg.address_table->table, addr_group,
 					   &_msg->rcv.src_ip, _msg->rcv.src_port)
 					   == 1) {
-		return 1;
+		retval = 1;
 	} else {
-		if(perm_subnet_table) {
-			return match_subnet_table(*perm_subnet_table, addr_group,
-					&_msg->rcv.src_ip, _msg->rcv.src_port);
+		if(atg.subnet_table) {
+			retval = match_subnet_table(atg.subnet_table->table,
+					atg.subnet_table->count, addr_group, &_msg->rcv.src_ip,
+					_msg->rcv.src_port);
 		}
 	}
-	return -1;
+
+	put_addr_tables(&atg);
+
+	return retval;
 }
 
 /*
@@ -829,25 +818,32 @@ int w_allow_source_address(struct sip_msg *_msg, char *_addr_group, char *_str2)
 int ki_allow_source_address_group(sip_msg_t *_msg)
 {
 	int group = -1;
+	address_tables_group_t atg;
+
+	get_addr_tables(&atg);
 
 	LM_DBG("looking for <%x, %u> in address table\n",
 			_msg->rcv.src_ip.u.addr32[0], _msg->rcv.src_port);
-	if(perm_addr_table) {
-		group = find_group_in_addr_hash_table(
-				*perm_addr_table, &_msg->rcv.src_ip, _msg->rcv.src_port);
+	if(atg.address_table) {
+		group = find_group_in_addr_hash_table(atg.address_table->table,
+				&_msg->rcv.src_ip, _msg->rcv.src_port);
 		LM_DBG("Found <%d>\n", group);
 
 		if(group != -1)
-			return group;
+			goto out;
 	}
 
 	LM_DBG("looking for <%x, %u> in subnet table\n",
 			_msg->rcv.src_ip.u.addr32[0], _msg->rcv.src_port);
-	if(perm_subnet_table) {
-		group = find_group_in_subnet_table(
-				*perm_subnet_table, &_msg->rcv.src_ip, _msg->rcv.src_port);
+	if(atg.subnet_table) {
+		group = find_group_in_subnet_table(atg.subnet_table->table,
+				atg.subnet_table->count, &_msg->rcv.src_ip, _msg->rcv.src_port);
 	}
 	LM_DBG("Found <%d>\n", group);
+
+out:
+	put_addr_tables(&atg);
+
 	return group;
 }
 
@@ -869,40 +865,46 @@ int allow_source_address_group(struct sip_msg *_msg, char *_str1, char *_str2)
 int ki_allow_address_group(sip_msg_t *_msg, str *_addr, int _port)
 {
 	int group = -1;
-
+	address_tables_group_t atg;
 	ip_addr_t *ipa;
+
+	get_addr_tables(&atg);
 
 	ipa = strtoipX(_addr);
 
 	if(ipa) {
 		LM_DBG("looking for <%.*s, %u> in address table\n", _addr->len,
 				_addr->s, (unsigned int)_port);
-		if(perm_addr_table) {
+		if(atg.address_table) {
 			group = find_group_in_addr_hash_table(
-					*perm_addr_table, ipa, (unsigned int)_port);
+					atg.address_table->table, ipa, (unsigned int)_port);
 			LM_DBG("Found address in group <%d>\n", group);
 
 			if(group != -1)
-				return group;
+				goto out;
 		}
-		if(perm_subnet_table) {
+		if(atg.subnet_table) {
 			LM_DBG("looking for <%.*s, %u> in subnet table\n", _addr->len,
 					_addr->s, _port);
-			group = find_group_in_subnet_table(
-					*perm_subnet_table, ipa, (unsigned int)_port);
+			group = find_group_in_subnet_table(atg.subnet_table->table,
+					atg.subnet_table->count, ipa, (unsigned int)_port);
 			LM_DBG("Found a match of subnet in group <%d>\n", group);
 		}
 	} else {
 		LM_DBG("looking for <%.*s, %u> in domain_name table\n", _addr->len,
 				_addr->s, (unsigned int)_port);
-		if(perm_domain_table) {
+		if(atg.domain_table) {
 			group = find_group_in_domain_name_table(
-					*perm_domain_table, _addr, (unsigned int)_port);
+					atg.domain_table->table, _addr, (unsigned int)_port);
 			LM_DBG("Found a match of domain_name in group <%d>\n", group);
 		}
 	}
 
 	LM_DBG("Found <%d>\n", group);
+
+out:
+	put_addr_tables(&atg);
+
 	return group;
 }
 
@@ -921,4 +923,56 @@ int allow_address_group(struct sip_msg *_msg, char *_addr, char *_port)
 	}
 
 	return ki_allow_address_group(_msg, &ips, port);
+}
+
+
+/*
+ * Obtain reference to global table
+ */
+struct addr_table *get_addr_hash_table(void)
+{
+	GENERIC_LOCK_REF_GET_RETURN(
+			struct addr_table, perm_addr_table, perm_addr_tables_lock);
+}
+
+/*
+ * Release reference after get_*()
+ */
+void put_addr_hash_table(struct addr_table *table)
+{
+	GENERIC_LOCK_REF_PUT(table, perm_addr_tables_lock);
+}
+
+/*
+ * Obtain reference to global table
+ */
+struct subnet_table *get_subnet_table(void)
+{
+	GENERIC_LOCK_REF_GET_RETURN(
+			struct subnet_table, perm_subnet_table, perm_addr_tables_lock);
+}
+
+/*
+ * Release reference after get_*()
+ */
+void put_subnet_table(struct subnet_table *table)
+{
+	GENERIC_LOCK_REF_PUT(table, perm_addr_tables_lock);
+}
+
+/*
+ * Obtain reference to global table
+ */
+struct domain_name_table *get_domain_name_table(void)
+{
+	GENERIC_LOCK_REF_GET_RETURN(
+			struct domain_name_table, perm_domain_table, perm_addr_tables_lock);
+}
+
+/*
+ * Release reference after get_*()
+ */
+void put_domain_name_table(struct domain_name_table *table)
+{
+	GENERIC_LOCK_REF_PUT(table, perm_addr_tables_lock);
 }

--- a/src/modules/permissions/address.h
+++ b/src/modules/permissions/address.h
@@ -28,16 +28,9 @@
 #include "../../core/parser/msg_parser.h"
 
 
-/* Pointer to current address hash table pointer */
-extern struct addr_list ***perm_addr_table;
-
-
-/* Pointer to current subnet table */
-extern struct subnet **perm_subnet_table;
-
-
-/* Pointer to current domain name table */
-extern struct domain_name_list ***perm_domain_table;
+struct addr_table;
+struct subnet_table;
+struct domain_name_table;
 
 /*
  * Initialize data structures
@@ -101,5 +94,37 @@ int ki_allow_source_address_group(sip_msg_t *_msg);
 int allow_address_group(struct sip_msg *_msg, char *_addr, char *_port);
 
 int ki_allow_address_group(sip_msg_t *_msg, str *_addr, int _port);
+
+
+/*
+ * Obtain reference to global table
+ */
+struct addr_table *get_addr_hash_table(void);
+
+/*
+ * Release reference after get_*()
+ */
+void put_addr_hash_table(struct addr_table *);
+
+/*
+ * Obtain reference to global table
+ */
+struct subnet_table *get_subnet_table(void);
+
+/*
+ * Release reference after get_*()
+ */
+void put_subnet_table(struct subnet_table *);
+
+/*
+ * Obtain reference to global table
+ */
+struct domain_name_table *get_domain_name_table(void);
+
+/*
+ * Release reference after get_*()
+ */
+void put_domain_name_table(struct domain_name_table *);
+
 
 #endif /* ADDRESS_H */

--- a/src/modules/permissions/doc/permissions_admin.xml
+++ b/src/modules/permissions/doc/permissions_admin.xml
@@ -902,18 +902,11 @@ modparam("permissions", "load_backends", 1)
 		<title><varname>reload_delta</varname> (int)</title>
 		<para>
 		The number of seconds that have to be waited before executing a new
-		RPC reload. By default there is a rate limiting of maximum one reload
-		in five seconds.
-		</para>
-		<para>
-		If set to 0, no rate limit is configured. Note carefully: use this
-		configuration only in tests environments because executing two RPC
-		reloads of the same table at the same time can cause &kamailio;
-		to crash.
+		RPC reload. By default there is a no rate limiting (zero).
 		</para>
 		<para>
 		<emphasis>
-			Default value is <quote>5</quote>.
+			Default value is <quote>0</quote>.
 		</emphasis>
 		</para>
 		<example>
@@ -921,27 +914,6 @@ modparam("permissions", "load_backends", 1)
 		<programlisting format="linespecific">
 ...
 modparam("permissions", "reload_delta", 1)
-...
-		</programlisting>
-		</example>
-	</section>
-	<section id ="permissions.p.trusted_cleanup_interval">
-		<title><varname>trusted_cleanup_interval</varname> (int)</title>
-		<para>
-		If module parameter <varname>db_mode</varname> is set to 1 a cleanup timer
-		is set to the trusted_cleanup_interval value in seconds.
-		This process will cleanup the previous values from memory after a RPC reload.
-		</para>
-		<para>
-		<emphasis>
-			Default value is <quote>60</quote>.
-		</emphasis>
-		</para>
-		<example>
-		<title>Set <varname>trusted_cleanup_interval</varname> parameter</title>
-		<programlisting format="linespecific">
-...
-modparam("permissions", "trusted_cleanup_interval", 120)
 ...
 		</programlisting>
 		</example>
@@ -1484,8 +1456,8 @@ if (allow_trusted("$si", "any", "$ai")) {
 			different tables:  address table and
 			subnet table depending on the value of
 			the mask field (IPv6: 64 or smaller, IPv4: 32 or smaller).
-			Note that there is a rate limiting defined by 'reload_delta'
-			parameter. By default is allowed maximum one reload in five seconds.
+			Note that there may be a rate limiting defined by 'reload_delta'
+			parameter.
 		</para>
 		<para>Parameters: <emphasis>none</emphasis></para>
 		<para>
@@ -1572,8 +1544,8 @@ if (allow_trusted("$si", "any", "$ai")) {
 		<para>
 			Causes the permissions module to re-read the contents of
 			the trusted database table into cache memory.
-			Note that there is a rate limiting defined by 'reload_delta'
-			parameter. By default is allowed maximum one reload in five seconds.
+			Note that there may be a rate limiting defined by 'reload_delta'
+			parameter.
 		</para>
 		<para>Parameters: <emphasis>none</emphasis></para>
 		<para>

--- a/src/modules/permissions/hash.c
+++ b/src/modules/permissions/hash.c
@@ -94,19 +94,18 @@ void get_tag_avp(int_str *tag_avp_p, int *tag_avp_type_p)
 /*
  * Create and initialize a hash table
  */
-struct trusted_list **new_hash_table(void)
+struct trusted_table *new_hash_table(void)
 {
-	struct trusted_list **ptr;
+	struct trusted_table *ptr;
 
 	/* Initializing hash tables and hash table variable */
-	ptr = (struct trusted_list **)shm_malloc(
-			sizeof(struct trusted_list *) * PERM_HASH_SIZE);
+	ptr = shm_malloc(sizeof(struct trusted_table));
 	if(!ptr) {
 		LM_ERR("no shm memory for hash table\n");
 		return 0;
 	}
 
-	memset(ptr, 0, sizeof(struct trusted_list *) * PERM_HASH_SIZE);
+	memset(ptr, 0, sizeof(*ptr));
 	return ptr;
 }
 
@@ -114,12 +113,32 @@ struct trusted_list **new_hash_table(void)
 /*
  * Release all memory allocated for a hash table
  */
-void free_hash_table(struct trusted_list **table)
+void free_hash_table(struct trusted_table *table)
 {
+	int i;
+	struct trusted_list *np, *next;
+
 	if(!table)
 		return;
 
-	empty_hash_table(table);
+	for(i = 0; i < PERM_HASH_SIZE; i++) {
+		np = table->table[i];
+		while(np) {
+			if(np->src_ip.s)
+				shm_free(np->src_ip.s);
+			if(np->pattern)
+				shm_free(np->pattern);
+			if(np->ruri_pattern)
+				shm_free(np->ruri_pattern);
+			if(np->tag.s)
+				shm_free(np->tag.s);
+			next = np->next;
+			shm_free(np);
+			np = next;
+		}
+		table->table[i] = 0;
+	}
+
 	shm_free(table);
 }
 
@@ -381,51 +400,22 @@ int hash_table_rpc_print(struct trusted_list **hash_table, rpc_t *rpc, void *c)
 	return 0;
 }
 
-/*
- * Free contents of hash table, it doesn't destroy the
- * hash table itself
- */
-void empty_hash_table(struct trusted_list **table)
-{
-	int i;
-	struct trusted_list *np, *next;
-
-	for(i = 0; i < PERM_HASH_SIZE; i++) {
-		np = table[i];
-		while(np) {
-			if(np->src_ip.s)
-				shm_free(np->src_ip.s);
-			if(np->pattern)
-				shm_free(np->pattern);
-			if(np->ruri_pattern)
-				shm_free(np->ruri_pattern);
-			if(np->tag.s)
-				shm_free(np->tag.s);
-			next = np->next;
-			shm_free(np);
-			np = next;
-		}
-		table[i] = 0;
-	}
-}
-
 
 /*
  * Create and initialize an address hash table
  */
-struct addr_list **new_addr_hash_table(void)
+struct addr_table *new_addr_hash_table(void)
 {
-	struct addr_list **ptr;
+	struct addr_table *ptr;
 
 	/* Initializing hash tables and hash table variable */
-	ptr = (struct addr_list **)shm_malloc(
-			sizeof(struct addr_list *) * PERM_HASH_SIZE);
+	ptr = shm_malloc(sizeof(struct addr_table));
 	if(!ptr) {
 		LM_ERR("no shm memory for hash table\n");
 		return 0;
 	}
 
-	memset(ptr, 0, sizeof(struct addr_list *) * PERM_HASH_SIZE);
+	memset(ptr, 0, sizeof(*ptr));
 	return ptr;
 }
 
@@ -433,12 +423,24 @@ struct addr_list **new_addr_hash_table(void)
 /*
  * Release all memory allocated for a hash table
  */
-void free_addr_hash_table(struct addr_list **table)
+void free_addr_hash_table(struct addr_table *table)
 {
+	int i;
+	struct addr_list *np, *next;
+
 	if(!table)
 		return;
 
-	empty_addr_hash_table(table);
+	for(i = 0; i < PERM_HASH_SIZE; i++) {
+		np = table->table[i];
+		while(np) {
+			next = np->next;
+			shm_free(np);
+			np = next;
+		}
+		table->table[i] = 0;
+	}
+
 	shm_free(table);
 }
 
@@ -600,42 +602,20 @@ int addr_hash_table_rpc_print(struct addr_list **table, rpc_t *rpc, void *c)
 
 
 /*
- * Free contents of hash table, it doesn't destroy the
- * hash table itself
- */
-void empty_addr_hash_table(struct addr_list **table)
-{
-	int i;
-	struct addr_list *np, *next;
-
-	for(i = 0; i < PERM_HASH_SIZE; i++) {
-		np = table[i];
-		while(np) {
-			next = np->next;
-			shm_free(np);
-			np = next;
-		}
-		table[i] = 0;
-	}
-}
-
-
-/*
  * Create and initialize a subnet table
  */
-struct subnet *new_subnet_table(void)
+struct subnet_table *new_subnet_table(void)
 {
-	struct subnet *ptr;
+	struct subnet_table *ptr;
 
-	/* subnet record [PERM_MAX_SUBNETS] contains in its grp field
-	 * the number of subnet records in the subnet table */
-	ptr = (struct subnet *)shm_malloc(
-			sizeof(struct subnet) * (PERM_MAX_SUBNETS + 1));
+	size_t alloc_size = sizeof(struct subnet_table)
+						+ sizeof(struct subnet) * PERM_MAX_SUBNETS;
+	ptr = shm_malloc(alloc_size);
 	if(!ptr) {
 		LM_ERR("no shm memory for subnet table\n");
 		return 0;
 	}
-	memset(ptr, 0, sizeof(struct subnet) * (PERM_MAX_SUBNETS + 1));
+	memset(ptr, 0, alloc_size);
 	return ptr;
 }
 
@@ -644,16 +624,14 @@ struct subnet *new_subnet_table(void)
  * Add <grp, subnet, mask, port, tag> into subnet table so that table is
  * kept in increasing ordered according to grp.
  */
-int subnet_table_insert(struct subnet *table, unsigned int grp,
-		ip_addr_t *subnet, unsigned int mask, unsigned int port, str *tagv)
+int subnet_table_insert(struct subnet *table, unsigned int *count,
+		unsigned int grp, ip_addr_t *subnet, unsigned int mask,
+		unsigned int port, str *tagv)
 {
 	int i;
-	unsigned int count;
 	str tags;
 
-	count = table[PERM_MAX_SUBNETS].grp;
-
-	if(count == PERM_MAX_SUBNETS) {
+	if(*count == PERM_MAX_SUBNETS) {
 		LM_CRIT("subnet table is full\n");
 		return 0;
 	}
@@ -672,7 +650,7 @@ int subnet_table_insert(struct subnet *table, unsigned int grp,
 		tags.s[tags.len] = '\0';
 	}
 
-	i = count - 1;
+	i = *count - 1;
 
 	while((i >= 0) && (table[i].grp > grp)) {
 		table[i + 1] = table[i];
@@ -685,7 +663,7 @@ int subnet_table_insert(struct subnet *table, unsigned int grp,
 	table[i + 1].mask = mask;
 	table[i + 1].tag = tags;
 
-	table[PERM_MAX_SUBNETS].grp = count + 1;
+	(*count)++;
 
 	return 1;
 }
@@ -695,15 +673,13 @@ int subnet_table_insert(struct subnet *table, unsigned int grp,
  * Check if an entry exists in subnet table that matches given group, ip_addr,
  * and port.  Port 0 in subnet table matches any port.
  */
-int match_subnet_table(struct subnet *table, unsigned int grp, ip_addr_t *addr,
-		unsigned int port)
+int match_subnet_table(struct subnet *table, unsigned int count,
+		unsigned int grp, ip_addr_t *addr, unsigned int port)
 {
-	unsigned int count, i;
+	unsigned int i;
 	avp_value_t val;
 	int best_idx = -1;
 	unsigned int best_mask = 0;
-
-	count = table[PERM_MAX_SUBNETS].grp;
 
 	i = 0;
 	while((i < count) && (table[i].grp < grp))
@@ -748,15 +724,13 @@ int match_subnet_table(struct subnet *table, unsigned int grp, ip_addr_t *addr,
  * and port.  Port 0 in subnet table matches any port.  Return group of
  * first match or -1 if no match is found.
  */
-int find_group_in_subnet_table(
-		struct subnet *table, ip_addr_t *addr, unsigned int port)
+int find_group_in_subnet_table(struct subnet *table, unsigned int count,
+		ip_addr_t *addr, unsigned int port)
 {
-	unsigned int count, i;
+	unsigned int i;
 	avp_value_t val;
 	int best_idx = -1;
 	unsigned int best_mask = 0;
-
-	count = table[PERM_MAX_SUBNETS].grp;
 
 	i = 0;
 	while(i < count) {
@@ -793,14 +767,12 @@ int find_group_in_subnet_table(
 /*! \brief
  * RPC interface :: Print subnet entries stored in hash table
  */
-int subnet_table_rpc_print(struct subnet *table, rpc_t *rpc, void *c)
+int subnet_table_rpc_print(
+		struct subnet *table, unsigned int count, rpc_t *rpc, void *c)
 {
 	int i;
-	int count;
 	void *th;
 	void *ih;
-
-	count = table[PERM_MAX_SUBNETS].grp;
 
 	for(i = 0; i < count; i++) {
 		if(rpc->add(c, "{", &th) < 0) {
@@ -832,35 +804,18 @@ int subnet_table_rpc_print(struct subnet *table, rpc_t *rpc, void *c)
 
 
 /*
- * Empty contents of subnet table
- */
-void empty_subnet_table(struct subnet *table)
-{
-	int i;
-	table[PERM_MAX_SUBNETS].grp = 0;
-	for(i = 0; i < PERM_MAX_SUBNETS; i++) {
-		if(table[i].tag.s != NULL) {
-			shm_free(table[i].tag.s);
-			table[i].tag.s = NULL;
-			table[i].tag.len = 0;
-		}
-	}
-}
-
-
-/*
  * Release memory allocated for a subnet table
  */
-void free_subnet_table(struct subnet *table)
+void free_subnet_table(struct subnet_table *table)
 {
 	int i;
 	if(!table)
 		return;
 	for(i = 0; i < PERM_MAX_SUBNETS; i++) {
-		if(table[i].tag.s != NULL) {
-			shm_free(table[i].tag.s);
-			table[i].tag.s = NULL;
-			table[i].tag.len = 0;
+		if(table->table[i].tag.s != NULL) {
+			shm_free(table->table[i].tag.s);
+			table->table[i].tag.s = NULL;
+			table->table[i].tag.len = 0;
 		}
 	}
 
@@ -870,52 +825,43 @@ void free_subnet_table(struct subnet *table)
 /*
  * Create and initialize a domain_name table
  */
-struct domain_name_list **new_domain_name_table(void)
+struct domain_name_table *new_domain_name_table(void)
 {
-	struct domain_name_list **ptr;
+	struct domain_name_table *ptr;
 
 	/* Initializing hash tables and hash table variable */
-	ptr = (struct domain_name_list **)shm_malloc(
-			sizeof(struct domain_name_list *) * PERM_HASH_SIZE);
+	ptr = (struct domain_name_table *)shm_malloc(
+			sizeof(struct domain_name_table));
 	if(!ptr) {
 		LM_ERR("no shm memory for hash table\n");
 		return 0;
 	}
 
-	memset(ptr, 0, sizeof(struct domain_name *) * PERM_HASH_SIZE);
+	memset(ptr, 0, sizeof(*ptr));
 	return ptr;
 }
 
 
 /*
- * Free contents of hash table, it doesn't destroy the
- * hash table itself
+ * Release all memory allocated for a hash table
  */
-void empty_domain_name_table(struct domain_name_list **table)
+void free_domain_name_table(struct domain_name_table *table)
 {
 	int i;
 	struct domain_name_list *np, *next;
 
+	if(!table)
+		return;
+
 	for(i = 0; i < PERM_HASH_SIZE; i++) {
-		np = table[i];
+		np = table->table[i];
 		while(np) {
 			next = np->next;
 			shm_free(np);
 			np = next;
 		}
-		table[i] = 0;
+		table->table[i] = 0;
 	}
-}
-
-/*
- * Release all memory allocated for a hash table
- */
-void free_domain_name_table(struct domain_name_list **table)
-{
-	if(!table)
-		return;
-
-	empty_domain_name_table(table);
 	shm_free(table);
 }
 
@@ -1062,4 +1008,24 @@ int domain_name_table_rpc_print(
 		}
 	}
 	return 0;
+}
+
+
+/*
+ * Sleeps until the given reference count, protected by the given lock, drops
+ * to zero
+ */
+void ref_cnt_wait_zero(unsigned int *ref, gen_lock_t *lock)
+{
+	unsigned int iter = 0;
+
+	lock_get(lock);
+	while(*ref != 0) {
+		lock_release(lock);
+		iter++;
+		LM_WARN("table is still in use after %u tries", iter);
+		sleep_us(iter * 10000);
+		lock_get(lock);
+	}
+	lock_release(lock);
 }

--- a/src/modules/permissions/hash.h
+++ b/src/modules/permissions/hash.h
@@ -49,6 +49,16 @@ struct trusted_list
 
 
 /*
+ * Wrapper structure for a trusted hash table with reference count
+ */
+struct trusted_table
+{
+	unsigned int ref;
+	struct trusted_list *table[PERM_HASH_SIZE];
+};
+
+
+/*
  * Parse and init tag avp specification
  */
 int init_tag_avp(str *tag_avp_param);
@@ -63,19 +73,13 @@ void get_tag_avp(int_str *tag_avp_p, int *tag_avp_type_p);
 /*
  * Create and initialize a hash table
  */
-struct trusted_list **new_hash_table(void);
+struct trusted_table *new_hash_table(void);
 
 
 /*
  * Release all memory allocated for a hash table
  */
-void free_hash_table(struct trusted_list **table);
-
-
-/*
- * Destroy a hash table
- */
-void destroy_hash_table(struct trusted_list **table);
+void free_hash_table(struct trusted_table *table);
 
 
 /*
@@ -98,13 +102,7 @@ int match_hash_table(struct trusted_list **table, struct sip_msg *msg,
 /*
  * Print entries stored in hash table
  */
-void hash_table_print(struct trusted_list **hash_table, FILE *reply_file);
 int hash_table_rpc_print(struct trusted_list **hash_table, rpc_t *rpc, void *c);
-
-/*
- * Empty hash table
- */
-void empty_hash_table(struct trusted_list **hash_table);
 
 
 /*
@@ -121,21 +119,25 @@ struct addr_list
 
 
 /*
+ * Wrapper structure for a address hash table with reference count
+ */
+struct addr_table
+{
+	unsigned int ref;
+	struct addr_list *table[PERM_HASH_SIZE];
+};
+
+
+/*
  * Create and initialize a hash table
  */
-struct addr_list **new_addr_hash_table(void);
+struct addr_table *new_addr_hash_table(void);
 
 
 /*
  * Release all memory allocated for a hash table
  */
-void free_addr_hash_table(struct addr_list **table);
-
-
-/*
- * Destroy a hash table
- */
-void destroy_addr_hash_table(struct addr_list **table);
+void free_addr_hash_table(struct addr_table *table);
 
 
 /*
@@ -165,14 +167,7 @@ int find_group_in_addr_hash_table(
 /*
  * Print addresses stored in hash table
  */
-void addr_hash_table_print(struct addr_list **hash_table, FILE *reply_file);
 int addr_hash_table_rpc_print(struct addr_list **table, rpc_t *rpc, void *c);
-
-
-/*
- * Empty hash table
- */
-void empty_addr_hash_table(struct addr_list **hash_table);
 
 
 /*
@@ -180,7 +175,7 @@ void empty_addr_hash_table(struct addr_list **hash_table);
  */
 struct subnet
 {
-	unsigned int grp; /* address group, subnet count in last record */
+	unsigned int grp; /* address group */
 	ip_addr_t
 			subnet; /* IP subnet in host byte order with host bits shifted out */
 	unsigned int port; /* port or 0 */
@@ -190,17 +185,29 @@ struct subnet
 
 
 /*
+ * Wrapper structure for a subnet table with reference count
+ */
+struct subnet_table
+{
+	unsigned int ref;
+	unsigned int count;
+	struct subnet
+			table[0]; // variable size at runtime, _perm_max_subnets elements
+};
+
+
+/*
  * Create a subnet table
  */
-struct subnet *new_subnet_table(void);
+struct subnet_table *new_subnet_table(void);
 
 
 /*
  * Check if an entry exists in subnet table that matches given group, ip_addr,
  * and port.  Port 0 in subnet table matches any port.
  */
-int match_subnet_table(struct subnet *table, unsigned int group,
-		ip_addr_t *addr, unsigned int port);
+int match_subnet_table(struct subnet *table, unsigned int count,
+		unsigned int group, ip_addr_t *addr, unsigned int port);
 
 
 /*
@@ -208,34 +215,29 @@ int match_subnet_table(struct subnet *table, unsigned int group,
  * and port.  Port 0 in subnet table matches any port.  Returns group of
  * the first match or -1 if no match is found.
  */
-int find_group_in_subnet_table(
-		struct subnet *table, ip_addr_t *addr, unsigned int port);
-
-/*
- * Empty contents of subnet table
- */
-void empty_subnet_table(struct subnet *table);
-
+int find_group_in_subnet_table(struct subnet *table, unsigned int count,
+		ip_addr_t *addr, unsigned int port);
 
 /*
  * Release memory allocated for a subnet table
  */
-void free_subnet_table(struct subnet *table);
+void free_subnet_table(struct subnet_table *table);
 
 
 /*
  * Add <grp, subnet, mask, port> into subnet table so that table is
  * kept ordered according to subnet, port, grp.
  */
-int subnet_table_insert(struct subnet *table, unsigned int grp,
-		ip_addr_t *subnet, unsigned int mask, unsigned int port, str *tagv);
+int subnet_table_insert(struct subnet *table, unsigned int *count,
+		unsigned int grp, ip_addr_t *subnet, unsigned int mask,
+		unsigned int port, str *tagv);
 
 
 /*
  * Print subnets stored in subnet table
  */
-void subnet_table_print(struct subnet *table, FILE *reply_file);
-int subnet_table_rpc_print(struct subnet *table, rpc_t *rpc, void *c);
+int subnet_table_rpc_print(
+		struct subnet *table, unsigned int count, rpc_t *rpc, void *c);
 
 
 /*
@@ -250,20 +252,27 @@ struct domain_name_list
 	struct domain_name_list *next;
 };
 
+
+/*
+ * Wrapper structure for a domain name table with reference count
+ */
+struct domain_name_table
+{
+	unsigned int ref;
+	struct domain_name_list *table[PERM_HASH_SIZE];
+};
+
+
 /*
  * Create a domain_name table
  */
-struct domain_name_list **new_domain_name_table(void);
+struct domain_name_table *new_domain_name_table(void);
 
 /*
  * Release memory allocated for a subnet table
  */
-void free_domain_name_table(struct domain_name_list **table);
+void free_domain_name_table(struct domain_name_table *table);
 
-/*
- * Empty contents of domain_name hash table
- */
-void empty_domain_name_table(struct domain_name_list **table);
 
 /*
  * Check if an entry exists in domain_name table that matches given group, domain_name,
@@ -289,8 +298,44 @@ int find_group_in_domain_name_table(
 /*! \brief
  * RPC: Print addresses stored in hash table
  */
-void domain_name_table_print(struct subnet *table, FILE *reply_file);
 int domain_name_table_rpc_print(
 		struct domain_name_list **table, rpc_t *rpc, void *c);
+
+
+/*
+ * Sleeps until the given reference count, protected by the given lock, drops
+ * to zero
+ */
+void ref_cnt_wait_zero(unsigned int *ref, gen_lock_t *lock);
+
+/*
+ * Generic helper macro to obtain reference to an object and return it
+ */
+#define GENERIC_LOCK_REF_GET_RETURN(type, global_ptr, lock) \
+	do {                                                    \
+		type *__ret = NULL;                                 \
+                                                            \
+		if(!(lock))                                         \
+			return NULL;                                    \
+                                                            \
+		lock_get(lock);                                     \
+		if(global_ptr)                                      \
+			__ret = *global_ptr;                            \
+		if(__ret)                                           \
+			__ret->ref++;                                   \
+		lock_release(lock);                                 \
+                                                            \
+		return __ret;                                       \
+	} while(0)
+
+
+#define GENERIC_LOCK_REF_PUT(object, lock) \
+	do {                                   \
+		if(object) {                       \
+			lock_get(lock);                \
+			(object)->ref--;               \
+			lock_release(lock);            \
+		}                                  \
+	} while(0)
 
 #endif /* _PERM_HASH_H_ */

--- a/src/modules/permissions/permissions.c
+++ b/src/modules/permissions/permissions.c
@@ -63,8 +63,7 @@ static char *perm_deny_suffix = ".deny";
 
 /* for allow_trusted and allow_address function */
 str perm_db_url = {NULL, 0}; /* Don't connect to the database by default */
-int perm_reload_delta = 5;
-int perm_trusted_table_interval = 60;
+int perm_reload_delta = 0;
 
 /* for allow_trusted function */
 int perm_db_mode = DISABLE_CACHE; /* Database usage mode: 0=no cache, 1=cache */
@@ -95,6 +94,7 @@ str perm_address_file = STR_NULL; /* Full path to file with address records */
 static int perm_check_all_branches = 1;
 
 time_t *perm_rpc_reload_time = NULL;
+gen_lock_t *perm_rpc_reload_time_lock = NULL;
 int _perm_max_subnets = 512;
 
 int _perm_load_backends = 0xFFFF;
@@ -203,7 +203,6 @@ static param_export_t params[] = {
 	{"subnet_match_mode", PARAM_INT, &_perm_subnet_match_mode},
 	{"load_backends", PARAM_INT, &_perm_load_backends},
 	{"reload_delta", PARAM_INT, &perm_reload_delta},
-	{"trusted_cleanup_interval", PARAM_INT, &perm_trusted_table_interval},
 	{0, 0, 0}
 };
 
@@ -643,8 +642,18 @@ static int mod_init(void)
 	}
 	*perm_rpc_reload_time = 0;
 
+	perm_rpc_reload_time_lock = lock_alloc();
+	if(!perm_rpc_reload_time_lock) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+	if(!lock_init(perm_rpc_reload_time_lock)) {
+		LM_ERR("failed to init reload time lock\n");
+		return -1;
+	}
+
 	if(perm_reload_delta < 0)
-		perm_reload_delta = 5;
+		perm_reload_delta = 0;
 
 	if(permissions_init_rpc() != 0) {
 		LM_ERR("failed to register RPC commands\n");
@@ -737,6 +746,12 @@ static void mod_exit(void)
 	if(perm_rpc_reload_time != NULL) {
 		shm_free(perm_rpc_reload_time);
 		perm_rpc_reload_time = 0;
+	}
+
+	if(perm_rpc_reload_time_lock != NULL) {
+		lock_destroy(perm_rpc_reload_time_lock);
+		shm_free(perm_rpc_reload_time_lock);
+		perm_rpc_reload_time_lock = 0;
 	}
 
 	for(i = 0; i < perm_rules_num; i++) {

--- a/src/modules/permissions/permissions.h
+++ b/src/modules/permissions/permissions.h
@@ -63,8 +63,6 @@ extern str perm_mask_col;	   /* Name of mask column */
 extern str perm_port_col;	   /* Name of port column */
 extern int perm_peer_tag_mode; /* Matching mode */
 extern int perm_reload_delta;  /* seconds between RPC reloads */
-extern int
-		perm_trusted_table_interval; /* interval of timer to clean old trusted data */
 
 /* backends to be loaded */
 #define PERM_LOAD_ADDRESSDB (1 << 0)
@@ -73,6 +71,7 @@ extern int
 #define PERM_LOAD_DENYFILE (1 << 3)
 extern int _perm_load_backends; /* */
 extern time_t *perm_rpc_reload_time;
+extern gen_lock_t *perm_rpc_reload_time_lock;
 
 typedef struct int_or_pvar
 {

--- a/src/modules/permissions/rpc.c
+++ b/src/modules/permissions/rpc.c
@@ -39,14 +39,18 @@ int rpc_check_reload(rpc_t *rpc, void *ctx)
 		rpc->fault(ctx, 500, "Not ready for reload");
 		return -1;
 	}
+
+	lock_get(perm_rpc_reload_time_lock);
+
 	if(*perm_rpc_reload_time != 0
 			&& *perm_rpc_reload_time > time(NULL) - perm_reload_delta) {
+		lock_release(perm_rpc_reload_time_lock);
 		LM_ERR("ongoing reload\n");
 		rpc->fault(ctx, 500, "ongoing reload");
 		return -1;
 	}
-	// we are reloading, don't allow new reloads
-	*perm_rpc_reload_time = time(NULL) + 86400;
+	*perm_rpc_reload_time = time(NULL);
+	lock_release(perm_rpc_reload_time_lock);
 	return 0;
 }
 
@@ -64,7 +68,7 @@ void rpc_trusted_reload(rpc_t *rpc, void *c)
 	if(perm_db_mode == ENABLE_CACHE) {
 		if(reload_trusted_table_cmd() != 1) {
 			rpc->fault(c, 500, "Reload failed.");
-			goto done;
+			return;
 		}
 		rpc->rpl_printf(c, "Reload OK");
 	} else {
@@ -72,11 +76,6 @@ void rpc_trusted_reload(rpc_t *rpc, void *c)
 			   "disabled.\n");
 		rpc->fault(c, 500, "Reload skipped (disabled cache)");
 	}
-
-done:
-	// reloading is done
-	*perm_rpc_reload_time = time(NULL);
-	return;
 }
 
 
@@ -85,16 +84,18 @@ done:
  */
 void rpc_trusted_dump(rpc_t *rpc, void *c)
 {
+	struct trusted_table *table = get_trusted_table();
 
-	if(perm_trust_table == NULL) {
+	if(table == NULL) {
 		rpc->fault(c, 500, "No trusted table");
 		return;
 	}
 
-	if(hash_table_rpc_print(*perm_trust_table, rpc, c) < 0) {
+	if(hash_table_rpc_print(table->table, rpc, c) < 0) {
 		LM_DBG("failed to print a hash_table dump\n");
-		return;
 	}
+
+	put_trusted_table(table);
 
 	return;
 }
@@ -112,14 +113,10 @@ void rpc_address_reload(rpc_t *rpc, void *c)
 
 	if(reload_address_table_cmd() != 1) {
 		rpc->fault(c, 500, "Reload failed.");
-		goto done;
+		return;
 	}
 
 	rpc->rpl_printf(c, "Reload OK");
-done:
-	// reloading is done
-	*perm_rpc_reload_time = time(NULL);
-	return;
 }
 
 
@@ -128,14 +125,18 @@ done:
  */
 void rpc_address_dump(rpc_t *rpc, void *c)
 {
+	struct addr_table *table = get_addr_hash_table();
 
-	if(perm_addr_table == NULL) {
+	if(table == NULL) {
 		rpc->fault(c, 500, "No address table");
 		return;
 	}
-	if(addr_hash_table_rpc_print(*perm_addr_table, rpc, c) < 0) {
+	if(addr_hash_table_rpc_print(table->table, rpc, c) < 0) {
 		LM_DBG("failed to print address table dump\n");
 	}
+
+	put_addr_hash_table(table);
+
 	return;
 }
 
@@ -145,13 +146,17 @@ void rpc_address_dump(rpc_t *rpc, void *c)
  */
 void rpc_subnet_dump(rpc_t *rpc, void *c)
 {
-	if(perm_subnet_table == NULL) {
+	struct subnet_table *table = get_subnet_table();
+
+	if(table == NULL) {
 		rpc->fault(c, 500, "No subnet table");
 		return;
 	}
-	if(subnet_table_rpc_print(*perm_subnet_table, rpc, c) < 0) {
+	if(subnet_table_rpc_print(table->table, table->count, rpc, c) < 0) {
 		LM_DBG("failed to print subnet table dump\n");
 	}
+
+	put_subnet_table(table);
 
 	return;
 }
@@ -162,14 +167,18 @@ void rpc_subnet_dump(rpc_t *rpc, void *c)
  */
 void rpc_domain_name_dump(rpc_t *rpc, void *c)
 {
+	struct domain_name_table *table = get_domain_name_table();
 
-	if(perm_domain_table == NULL) {
+	if(table == NULL) {
 		rpc->fault(c, 500, "No domain list table");
 		return;
 	}
-	if(domain_name_table_rpc_print(*perm_domain_table, rpc, c) < 0) {
+	if(domain_name_table_rpc_print(table->table, rpc, c) < 0) {
 		LM_DBG("failed to print domain table dump\n");
 	}
+
+	put_domain_name_table(table);
+
 	return;
 }
 

--- a/src/modules/permissions/trusted.c
+++ b/src/modules/permissions/trusted.c
@@ -30,6 +30,7 @@
 #include "permissions.h"
 #include "hash.h"
 #include "../../core/config.h"
+#include "../../core/locking.h"
 #include "../../lib/srdb1/db.h"
 #include "../../core/ip_addr.h"
 #include "../../core/mod_fix.h"
@@ -40,10 +41,9 @@
 
 #define TABLE_VERSION 6
 
-struct trusted_list ***perm_trust_table =
+static struct trusted_table **perm_trust_table =
 		0; /* Pointer to current hash table pointer */
-struct trusted_list **perm_trust_table_1 = 0; /* Pointer to hash table 1 */
-struct trusted_list **perm_trust_table_2 = 0; /* Pointer to hash table 2 */
+static gen_lock_t *perm_trust_table_lock;
 
 
 static db1_con_t *perm_db_handle = 0;
@@ -61,7 +61,7 @@ int reload_trusted_table(void)
 	db_row_t *row;
 	db_val_t *val;
 
-	struct trusted_list **new_hash_table;
+	struct trusted_table *new_table, *old_table;
 	int i;
 	int priority;
 	int ret;
@@ -97,13 +97,11 @@ int reload_trusted_table(void)
 		return -1;
 	}
 
-	/* Choose new hash table and free its old contents */
-	if(*perm_trust_table == perm_trust_table_1) {
-		new_hash_table = perm_trust_table_2;
-	} else {
-		new_hash_table = perm_trust_table_1;
+	new_table = new_hash_table();
+	if(!new_table) {
+		perm_dbf.free_result(perm_db_handle, res);
+		return -1;
 	}
-	empty_hash_table(new_hash_table);
 
 	row = RES_ROWS(res);
 
@@ -251,13 +249,13 @@ int reload_trusted_table(void)
 		} else {
 			priority = (int)VAL_INT(val + 5);
 		}
-		if(hash_table_insert(new_hash_table, (char *)VAL_STRING(val),
+		if(hash_table_insert(new_table->table, (char *)VAL_STRING(val),
 				   (char *)VAL_STRING(val + 1), pattern, ruri_pattern, tag,
 				   priority)
 				== -1) {
 			LM_ERR("hash table problem\n");
 			perm_dbf.free_result(perm_db_handle, res);
-			empty_hash_table(new_hash_table);
+			free_hash_table(new_table);
 			return -1;
 		}
 		LM_DBG("tuple <%s, %s, %s, %s, %s> inserted into trusted hash "
@@ -268,7 +266,17 @@ int reload_trusted_table(void)
 
 	perm_dbf.free_result(perm_db_handle, res);
 
-	*perm_trust_table = new_hash_table;
+	lock_get(perm_trust_table_lock);
+
+	old_table = *perm_trust_table;
+	*perm_trust_table = new_table;
+
+	lock_release(perm_trust_table_lock);
+
+	if(old_table)
+		ref_cnt_wait_zero(&old_table->ref, perm_trust_table_lock);
+
+	free_hash_table(old_table);
 
 	LM_DBG("trusted table reloaded successfully.\n");
 
@@ -277,7 +285,7 @@ int reload_trusted_table(void)
 dberror:
 	LM_ERR("database problem - invalid record\n");
 	perm_dbf.free_result(perm_db_handle, res);
-	empty_hash_table(new_hash_table);
+	free_hash_table(new_table);
 	return -1;
 }
 
@@ -305,7 +313,6 @@ int init_trusted(void)
 		}
 	}
 
-	perm_trust_table_1 = perm_trust_table_2 = 0;
 	perm_trust_table = 0;
 
 	if(perm_db_mode == ENABLE_CACHE) {
@@ -324,28 +331,28 @@ int init_trusted(void)
 			return -1;
 		}
 
-		perm_trust_table_1 = new_hash_table();
-		if(!perm_trust_table_1)
-			return -1;
-
-		perm_trust_table_2 = new_hash_table();
-		if(!perm_trust_table_2)
+		perm_trust_table = shm_malloc(sizeof(struct trusted_table *));
+		if(!perm_trust_table) {
+			SHM_MEM_ERROR;
 			goto error;
+		}
+		*perm_trust_table = NULL;
 
-		perm_trust_table = (struct trusted_list ***)shm_malloc(
-				sizeof(struct trusted_list **));
-		if(!perm_trust_table)
+		perm_trust_table_lock = lock_alloc();
+		if(!perm_trust_table_lock) {
+			SHM_MEM_ERROR;
 			goto error;
+		}
 
-		*perm_trust_table = perm_trust_table_1;
+		if(!lock_init(perm_trust_table_lock)) {
+			LM_ERR("failed to init trusted table lock\n");
+			goto error;
+		}
 
 		if(reload_trusted_table() == -1) {
 			LM_CRIT("reload of trusted table failed\n");
 			goto error;
 		}
-
-		if(register_timer(perm_ht_timer, NULL, perm_trusted_table_interval) < 0)
-			goto error;
 
 		perm_dbf.close(perm_db_handle);
 		perm_db_handle = 0;
@@ -353,17 +360,14 @@ int init_trusted(void)
 	return 0;
 
 error:
-	if(perm_trust_table_1) {
-		free_hash_table(perm_trust_table_1);
-		perm_trust_table_1 = 0;
-	}
-	if(perm_trust_table_2) {
-		free_hash_table(perm_trust_table_2);
-		perm_trust_table_2 = 0;
-	}
 	if(perm_trust_table) {
 		shm_free(perm_trust_table);
 		perm_trust_table = 0;
+	}
+	if(perm_trust_table_lock) {
+		lock_destroy(perm_trust_table_lock);
+		shm_free(perm_trust_table_lock);
+		perm_trust_table_lock = 0;
 	}
 	perm_dbf.close(perm_db_handle);
 	perm_db_handle = 0;
@@ -404,32 +408,30 @@ int init_child_trusted(int rank)
 }
 
 
-void perm_ht_timer(unsigned int ticks, void *param)
+/*
+ * Get pointer to the current table and increase reference count
+ */
+struct trusted_table *get_trusted_table(void)
 {
-	if(perm_rpc_reload_time == NULL)
-		return;
-
-	if(*perm_rpc_reload_time != 0
-			&& *perm_rpc_reload_time > time(NULL) - perm_trusted_table_interval)
-		return;
-
-	LM_DBG("cleaning old trusted table\n");
-	if(*perm_trust_table == perm_trust_table_1) {
-		empty_hash_table(perm_trust_table_2);
-	} else {
-		empty_hash_table(perm_trust_table_1);
-	}
+	GENERIC_LOCK_REF_GET_RETURN(
+			struct trusted_table, perm_trust_table, perm_trust_table_lock);
 }
+
+/*
+ * Release the reference obtained by get_trusted_table().
+ * Must be called when done with the table, and invalidates the pointer.
+ */
+void put_trusted_table(struct trusted_table *table)
+{
+	GENERIC_LOCK_REF_PUT(table, perm_trust_table_lock);
+}
+
 
 /*
  * Close connections and release memory
  */
 void clean_trusted(void)
 {
-	if(perm_trust_table_1)
-		free_hash_table(perm_trust_table_1);
-	if(perm_trust_table_2)
-		free_hash_table(perm_trust_table_2);
 	if(perm_trust_table)
 		shm_free(perm_trust_table);
 }
@@ -642,8 +644,12 @@ int allow_trusted(struct sip_msg *msg, char *src_ip, int proto, char *from_uri)
 		perm_dbf.free_result(perm_db_handle, res);
 		return result;
 	} else {
-		return match_hash_table(
-				*perm_trust_table, msg, src_ip, proto, from_uri);
+		struct trusted_table *table = get_trusted_table();
+		int ret = -1;
+		if(table)
+			ret = match_hash_table(table->table, msg, src_ip, proto, from_uri);
+		put_trusted_table(table);
+		return ret;
 	}
 }
 

--- a/src/modules/permissions/trusted.h
+++ b/src/modules/permissions/trusted.h
@@ -28,14 +28,6 @@
 #include "../../core/parser/msg_parser.h"
 
 
-extern struct trusted_list **
-		*perm_trust_table; /* Pointer to current trusted hash table pointer */
-extern struct trusted_list *
-		*perm_trust_table_1; /* Pointer to trusted hash table 1 */
-extern struct trusted_list *
-		*perm_trust_table_2; /* Pointer to trusted hash table 2 */
-
-
 /*
  * Initialize data structures
  */
@@ -46,6 +38,18 @@ int init_trusted(void);
  * Open database connections if necessary
  */
 int init_child_trusted(int rank);
+
+
+/*
+ * Get pointer to the current table and increase reference count
+ */
+struct trusted_table *get_trusted_table(void);
+
+/*
+ * Release the reference obtained by get_trusted_table().
+ * Must be called when done with the table, and invalidates the pointer.
+ */
+void put_trusted_table(struct trusted_table *);
 
 
 /*


### PR DESCRIPTION
- similar approach to 1f1cbcb022 (dispatcher)
- all existing table objects are encapsulated in higher-level struct which includes a reference count (e.g. `struct addr_list *` is encapsulated in `struct addr_table`, etc)
- reference counts are protected by a mutex (one for `struct trusted_table` and a second one for the tables in `address.c`)
- access to all table objects is only allowed through a call to the respective `get_*()` function, which returns a pointer to the table and increases the reference count
- every call to `get_*()` must be paired with a matching call to `put_*()` to release the reference
- the only write operation to all tables is a complete reload, which rebuilds brand new table objects and the swaps out the global pointers
- after swapping out the pointers, the reload process waits until all reference counts to the old table objects drops to zero, and only then frees the old tables
- with all this, concurrent read access is possible and safe while allowing for concurrent safe reloads
- the standalone `empty_*()` functions have become obsolete and have been integrated into the `free_*()` functions
- functions in address.c generally need access to all 3 tables, so we use the existing `address_tables_group_t` together with matching get/put functions to facilitate this
- the subnet table previously used an extra element to keep track of the number of subnets - this count was integrated into the higher-level struct, therefore obsoleting the need for the extra element
- the subnet table has a runtime-configurable (but not runtime-mutable) size: we use the empty-array syntax (`[0]`) in the struct together with an adjusted malloc size for that
- all `get_*()` and `put_*()` functions follow the same schema, so a generic macro is used for the body of these functions
- the cleanup function scheduled at regular intervals is not needed any more, therefore `trusted_cleanup_interval` has been removed
- the `reload_delta` option is kept, but now defaults to zero (no limit) as all concurrent reloads and read accesses are safe
- the `perm_rpc_reload_time` value is protected by an additional mutex, which is needed to eliminate a small race condition between reading and writing the value


#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [X] Commit message has the format required by CONTRIBUTING guide
- [X] Commits are split per component (core, individual modules, libs, utils, ...)
- [X] Each component has a single commit (if not, squash them into one commit)
- [ ] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [X] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [X] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [X] Tested changes locally
- [X] Related to issue #4809

#### Description

Eliminates race conditions between concurrent reloads and read accesses.

The previous double-buffering approach is now obsolete and has been replaced with proper reference-counting