### PR TITLE
cdp: reject undersized Diameter messages

### DIFF
--- a/src/modules/cdp/receiver.c
+++ b/src/modules/cdp/receiver.c
@@ -609,6 +609,12 @@ static inline int do_receive(serviced_peer_t *sp)
 			sp->buf_len += cnt;
 			if(sp->buf_len == DIAMETER_HEADER_LEN) {
 				sp->length = get_3bytes(sp->buf + 1);
+				if(sp->length < DIAMETER_HEADER_LEN) {
+					LM_ERR("[%.*s] Msg too short [%d] bytes\n",
+							sp->p ? sp->p->fqdn.len : 0,
+							sp->p ? sp->p->fqdn.s : 0, sp->length);
+					goto error_and_reset;
+				}
 				if(sp->length > DP_MAX_MSG_LENGTH) {
 					LM_ERR("[%.*s] Msg too big [%d] bytes\n",
 							sp->p ? sp->p->fqdn.len : 0,


### PR DESCRIPTION
#### Pre-Submission Checklist

- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format` from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change

- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist

- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4876

#### Description

Reject Diameter messages whose declared length is smaller than the fixed 20-byte header before allocating the receive buffer. Without this lower-bound check, the receiver can allocate an undersized shared-memory buffer and then copy the complete header into it.

Local verification:

- Built the complete `cdp` module successfully on macOS. The build only emitted existing semaphore deprecation warnings from unrelated files.
- An AddressSanitizer reproducer confirms that the prior sequence writes 20 bytes into a 5-byte allocation.
- The guarded path passes declared-length boundary cases 0, 5, 19, 20, 65536, and 65537 under AddressSanitizer and UndefinedBehaviorSanitizer.
- `clang-format --dry-run --Werror` and `git diff --check` pass.

Fixes #4876
