### PR TITLE
dlgs: add statistics for use with xhttp_prom

### DIFF
--- a/src/modules/dlgs/dlgs_mod.c
+++ b/src/modules/dlgs/dlgs_mod.c
@@ -35,6 +35,7 @@
 #include "../../core/timer_proc.h"
 
 #include "dlgs_records.h"
+#include "dlgs_stats.h"
 
 MODULE_VERSION
 
@@ -108,6 +109,10 @@ struct module_exports exports = {
  */
 static int mod_init(void)
 {
+	if(dlgs_stats_init() < 0) {
+		return -1;
+	}
+
 	if(dlgs_rpc_init() < 0) {
 		LM_ERR("failed to register RPC commands\n");
 		return -1;

--- a/src/modules/dlgs/dlgs_records.c
+++ b/src/modules/dlgs/dlgs_records.c
@@ -808,6 +808,37 @@ void dlgs_update_stats(dlgs_stats_t *stats, int state, int val)
 }
 
 /**
+ * Fill aggregated active and/or final stats from internal tracking.
+ */
+void dlgs_get_stats(dlgs_stats_t *astats, dlgs_stats_t *fstats)
+{
+	unsigned int i;
+
+	if(astats != NULL) {
+		memset(astats, 0, sizeof(dlgs_stats_t));
+	}
+	if(fstats != NULL) {
+		memset(fstats, 0, sizeof(dlgs_stats_t));
+	}
+	if(_dlgs_htb == NULL) {
+		return;
+	}
+	if(fstats != NULL) {
+		*fstats = _dlgs_htb->fstats;
+	}
+	if(astats != NULL) {
+		for(i = 0; i < _dlgs_htb->htsize; i++) {
+			astats->c_init += _dlgs_htb->slots[i].astats.c_init;
+			astats->c_progress += _dlgs_htb->slots[i].astats.c_progress;
+			astats->c_answered += _dlgs_htb->slots[i].astats.c_answered;
+			astats->c_confirmed += _dlgs_htb->slots[i].astats.c_confirmed;
+			astats->c_terminated += _dlgs_htb->slots[i].astats.c_terminated;
+			astats->c_notanswered += _dlgs_htb->slots[i].astats.c_notanswered;
+		}
+	}
+}
+
+/**
  *
  */
 int dlgs_update_item(sip_msg_t *msg)
@@ -1128,6 +1159,7 @@ static void dlgs_rpc_stats(rpc_t *rpc, void *ctx)
 	void *ti;
 	dlgs_stats_t *sti;
 	dlgs_stats_t sta;
+	dlgs_stats_t stf;
 	int i;
 
 	if(_dlgs_htb == NULL) {
@@ -1138,30 +1170,21 @@ static void dlgs_rpc_stats(rpc_t *rpc, void *ctx)
 		rpc->fault(ctx, 500, "Internal error creating rpc");
 		return;
 	}
+	dlgs_get_stats(&sta, &stf);
 	i = 0;
 	do {
 		if(i == 0) {
-			sti = &_dlgs_htb->fstats;
+			sti = &stf;
 			if(rpc->struct_add(th, "{", "final", &ti) < 0) {
 				rpc->fault(ctx, 500, "Internal error creating final stats");
 				return;
 			}
 		} else {
-			memset(&sta, 0, sizeof(dlgs_stats_t));
-			for(i = 0; i < _dlgs_htb->htsize; i++) {
-				sta.c_init += _dlgs_htb->slots[i].astats.c_init;
-				sta.c_progress += _dlgs_htb->slots[i].astats.c_progress;
-				sta.c_answered += _dlgs_htb->slots[i].astats.c_answered;
-				sta.c_confirmed += _dlgs_htb->slots[i].astats.c_confirmed;
-				sta.c_terminated += _dlgs_htb->slots[i].astats.c_terminated;
-				sta.c_notanswered += _dlgs_htb->slots[i].astats.c_notanswered;
-			}
 			sti = &sta;
 			if(rpc->struct_add(th, "{", "active", &ti) < 0) {
-				rpc->fault(ctx, 500, "Internal error creating final stats");
+				rpc->fault(ctx, 500, "Internal error creating active stats");
 				return;
 			}
-			i = 1;
 		}
 		if(rpc->struct_add(ti, "uuuuuu", "init", sti->c_init, "progress",
 				   sti->c_progress, "answered", sti->c_answered, "confirmed",

--- a/src/modules/dlgs/dlgs_records.h
+++ b/src/modules/dlgs/dlgs_records.h
@@ -48,6 +48,7 @@ typedef struct _dlgs_stats {
 } dlgs_stats_t;
 
 void dlgs_update_stats(dlgs_stats_t *stats, int state, int val);
+void dlgs_get_stats(dlgs_stats_t *astats, dlgs_stats_t *fstats);
 
 typedef struct _dlgs_tag {
 	unsigned int hashid;

--- a/src/modules/dlgs/dlgs_stats.c
+++ b/src/modules/dlgs/dlgs_stats.c
@@ -1,0 +1,161 @@
+/**
+ * Copyright (C) 2026 Justin LaVelle
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "../../core/counters.h"
+#include "../../core/dprint.h"
+#include "../../core/timer.h"
+
+#include "dlgs_records.h"
+#include "dlgs_stats.h"
+
+#ifdef STATISTICS
+
+unsigned long dlgs_stats_active_init(void);
+unsigned long dlgs_stats_active_progress(void);
+unsigned long dlgs_stats_active_answered(void);
+unsigned long dlgs_stats_active_confirmed(void);
+unsigned long dlgs_stats_active_terminated(void);
+unsigned long dlgs_stats_active_notanswered(void);
+unsigned long dlgs_stats_final_init(void);
+unsigned long dlgs_stats_final_progress(void);
+unsigned long dlgs_stats_final_answered(void);
+unsigned long dlgs_stats_final_confirmed(void);
+unsigned long dlgs_stats_final_terminated(void);
+unsigned long dlgs_stats_final_notanswered(void);
+
+/* clang-format off */
+static stat_export_t mod_stats[] = {
+	{"active_init",        STAT_IS_FUNC, (stat_var **)dlgs_stats_active_init},
+	{"active_progress",    STAT_IS_FUNC, (stat_var **)dlgs_stats_active_progress},
+	{"active_answered",    STAT_IS_FUNC, (stat_var **)dlgs_stats_active_answered},
+	{"active_confirmed",   STAT_IS_FUNC, (stat_var **)dlgs_stats_active_confirmed},
+	{"active_terminated",  STAT_IS_FUNC, (stat_var **)dlgs_stats_active_terminated},
+	{"active_notanswered", STAT_IS_FUNC, (stat_var **)dlgs_stats_active_notanswered},
+	{"final_init",         STAT_IS_FUNC, (stat_var **)dlgs_stats_final_init},
+	{"final_progress",     STAT_IS_FUNC, (stat_var **)dlgs_stats_final_progress},
+	{"final_answered",     STAT_IS_FUNC, (stat_var **)dlgs_stats_final_answered},
+	{"final_confirmed",    STAT_IS_FUNC, (stat_var **)dlgs_stats_final_confirmed},
+	{"final_terminated",   STAT_IS_FUNC, (stat_var **)dlgs_stats_final_terminated},
+	{"final_notanswered",  STAT_IS_FUNC, (stat_var **)dlgs_stats_final_notanswered},
+	{0, 0, 0}
+};
+/* clang-format on */
+
+static dlgs_stats_t _dlgs_stats_active;
+static dlgs_stats_t _dlgs_stats_final;
+static ticks_t _dlgs_stats_tm = 0;
+
+static void dlgs_stats_proc_update(void)
+{
+	ticks_t t;
+
+	t = get_ticks();
+	if(t > _dlgs_stats_tm) {
+		dlgs_get_stats(&_dlgs_stats_active, &_dlgs_stats_final);
+		_dlgs_stats_tm = t;
+	}
+}
+
+unsigned long dlgs_stats_active_init(void)
+{
+	dlgs_stats_proc_update();
+	return _dlgs_stats_active.c_init;
+}
+
+unsigned long dlgs_stats_active_progress(void)
+{
+	dlgs_stats_proc_update();
+	return _dlgs_stats_active.c_progress;
+}
+
+unsigned long dlgs_stats_active_answered(void)
+{
+	dlgs_stats_proc_update();
+	return _dlgs_stats_active.c_answered;
+}
+
+unsigned long dlgs_stats_active_confirmed(void)
+{
+	dlgs_stats_proc_update();
+	return _dlgs_stats_active.c_confirmed;
+}
+
+unsigned long dlgs_stats_active_terminated(void)
+{
+	dlgs_stats_proc_update();
+	return _dlgs_stats_active.c_terminated;
+}
+
+unsigned long dlgs_stats_active_notanswered(void)
+{
+	dlgs_stats_proc_update();
+	return _dlgs_stats_active.c_notanswered;
+}
+
+unsigned long dlgs_stats_final_init(void)
+{
+	dlgs_stats_proc_update();
+	return _dlgs_stats_final.c_init;
+}
+
+unsigned long dlgs_stats_final_progress(void)
+{
+	dlgs_stats_proc_update();
+	return _dlgs_stats_final.c_progress;
+}
+
+unsigned long dlgs_stats_final_answered(void)
+{
+	dlgs_stats_proc_update();
+	return _dlgs_stats_final.c_answered;
+}
+
+unsigned long dlgs_stats_final_confirmed(void)
+{
+	dlgs_stats_proc_update();
+	return _dlgs_stats_final.c_confirmed;
+}
+
+unsigned long dlgs_stats_final_terminated(void)
+{
+	dlgs_stats_proc_update();
+	return _dlgs_stats_final.c_terminated;
+}
+
+unsigned long dlgs_stats_final_notanswered(void)
+{
+	dlgs_stats_proc_update();
+	return _dlgs_stats_final.c_notanswered;
+}
+
+#endif /* STATISTICS */
+
+int dlgs_stats_init(void)
+{
+#ifdef STATISTICS
+	if(register_module_stats("dlgs", mod_stats) != 0) {
+		LM_ERR("failed to register statistics\n");
+		return -1;
+	}
+#endif
+	return 0;
+}

--- a/src/modules/dlgs/dlgs_stats.h
+++ b/src/modules/dlgs/dlgs_stats.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2026 Justin LaVelle
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef _DLGS_STATS_H_
+#define _DLGS_STATS_H_
+
+int dlgs_stats_init(void);
+
+#endif


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4879 

#### Description

Add statistics to `dlgs` module dialog state counters for use with `xhttp_prom` module. Using the `sl` module implementation as reference.

#### Output

```shell
$ curl -s http://127.0.0.1:9090/metrics |  grep dlgs
# TYPE kamailio_dlgs_active_answered gauge
kamailio_dlgs_active_answered 0 1787532399135
# TYPE kamailio_dlgs_active_confirmed gauge
kamailio_dlgs_active_confirmed 1 1787532399135
# TYPE kamailio_dlgs_active_init gauge
kamailio_dlgs_active_init 0 1787532399135
# TYPE kamailio_dlgs_active_notanswered gauge
kamailio_dlgs_active_notanswered 1 1787532399135
# TYPE kamailio_dlgs_active_progress gauge
kamailio_dlgs_active_progress 2 1787532399135
# TYPE kamailio_dlgs_active_terminated gauge
kamailio_dlgs_active_terminated 2 1787532399135
# TYPE kamailio_dlgs_final_answered gauge
kamailio_dlgs_final_answered 0 1787532399135
# TYPE kamailio_dlgs_final_confirmed gauge
kamailio_dlgs_final_confirmed 0 1787532399135
# TYPE kamailio_dlgs_final_init gauge
kamailio_dlgs_final_init 0 1787532399135
# TYPE kamailio_dlgs_final_notanswered gauge
kamailio_dlgs_final_notanswered 0 1787532399135
# TYPE kamailio_dlgs_final_progress gauge
kamailio_dlgs_final_progress 0 1787532399135
# TYPE kamailio_dlgs_final_terminated gauge
kamailio_dlgs_final_terminated 2 1787532399135
```