### PR TITLE
dialog: add DMQ load callbacks option

### DIFF
--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -94,6 +94,7 @@ MODULE_VERSION
 static int mod_init(void);
 static int child_init(int rank);
 static void mod_destroy(void);
+static void warn_dmq_load_callback_modules(void);
 
 /* module parameter */
 static int dlg_hash_size = 4096;
@@ -120,6 +121,7 @@ int dlg_end_timeout = 300;
 int dlg_enable_dmq = 0;
 str dlg_dmq_peer_id = str_init("dialog");
 int dlg_enable_dmq_ka_iflags_sync = 0;
+int dlg_enable_dmq_load_callbacks = 0;
 
 int dlg_event_rt[DLG_EVENTRT_MAX];
 str dlg_event_callback = STR_NULL;
@@ -391,6 +393,7 @@ static param_export_t mod_params[]={
 	{ "ka_failed_limit",       PARAM_INT, &dlg_ka_failed_limit      },
 	{ "enable_dmq",            PARAM_INT, &dlg_enable_dmq           },
 	{ "enable_dmq_ka_iflags_sync",    PARAM_INT, &dlg_enable_dmq_ka_iflags_sync   },
+	{ "enable_dmq_load_callbacks", PARAM_INT, &dlg_enable_dmq_load_callbacks },
 	{ "event_callback",        PARAM_STR, &dlg_event_callback       },
 	{ "early_timeout",         PARAM_INT, &dlg_early_timeout        },
 	{ "noack_timeout",         PARAM_INT, &dlg_noack_timeout        },
@@ -557,10 +560,43 @@ static int pv_get_dlg_count(
 }
 
 
+static void warn_dmq_load_callback_modules(void)
+{
+	int acc_loaded;
+	int call_control_loaded;
+	int peerstate_loaded;
+	int pua_dialoginfo_loaded;
+	int uac_loaded;
+
+	if(dlg_enable_dmq_load_callbacks == 0)
+		return;
+
+	acc_loaded = module_loaded("acc");
+	call_control_loaded = module_loaded("call_control");
+	peerstate_loaded = module_loaded("peerstate");
+	pua_dialoginfo_loaded = module_loaded("pua_dialoginfo");
+	uac_loaded = module_loaded("uac");
+
+	if(acc_loaded || call_control_loaded || peerstate_loaded
+			|| pua_dialoginfo_loaded || uac_loaded) {
+		LM_WARN("enable_dmq_load_callbacks is enabled; loaded modules with "
+				"known DLGCB_LOADED behavior:%s%s%s%s%s. Review their effects "
+				"on dialogs created from DMQ\n",
+				acc_loaded ? " acc" : "",
+				call_control_loaded ? " call_control" : "",
+				peerstate_loaded ? " peerstate" : "",
+				pua_dialoginfo_loaded ? " pua_dialoginfo" : "",
+				uac_loaded ? " uac" : "");
+	}
+}
+
+
 static int mod_init(void)
 {
 	unsigned int n;
 	sr_cfgenv_t *cenv = NULL;
+
+	warn_dmq_load_callback_modules();
 
 	if(dlg_h_id_start == -1) {
 		dlg_h_id_start = server_id;

--- a/src/modules/dialog/dlg_dmq.c
+++ b/src/modules/dialog/dlg_dmq.c
@@ -41,6 +41,7 @@ int dlg_dmq_request_sync(dmq_node_t *dmq_node);
 extern int dlg_enable_stats;
 extern str dlg_dmq_peer_id;
 extern int dlg_enable_dmq_ka_iflags_sync;
+extern int dlg_enable_dmq_load_callbacks;
 
 /**
 * @brief add notification peer
@@ -342,6 +343,18 @@ int dlg_dmq_handle_msg(
 						dlg->state, state);
 				break;
 			}
+			if(action == DLG_DMQ_STATE) {
+				vj = srjson_GetObjectItem(&jdoc, jdoc.root, "vars");
+				if(vj != NULL) {
+					for(it = vj->child; it; it = it->next) {
+						k.s = it->string;
+						k.len = strlen(k.s);
+						v.s = it->valuestring;
+						v.len = strlen(v.s);
+						set_dlg_variable(dlg, &k, &v);
+					}
+				}
+			}
 			LM_DBG("State update dlg [%u:%u] with callid [%.*s] from state [%u]"
 				   " to state [%u]\n",
 					iuid.h_entry, iuid.h_id, dlg->callid.len, dlg->callid.s,
@@ -494,6 +507,10 @@ int dlg_dmq_handle_msg(
 
 		case DLG_DMQ_NONE:
 			break;
+	}
+	if(newdlg && dlg->state != DLG_STATE_DELETED
+			&& dlg_enable_dmq_load_callbacks != 0) {
+		run_dlg_load_callbacks(dlg);
 	}
 skip:
 	if(dlg) {
@@ -670,6 +687,16 @@ int dlg_dmq_replicate_action(dlg_dmq_action_t action, dlg_cell_t *dlg,
 
 		case DLG_DMQ_STATE:
 			srjson_AddNumberToObject(&jdoc, jdoc.root, "state", dlg->state);
+			if(action != DLG_DMQ_UPDATE && dlg_enable_dmq_load_callbacks != 0
+					&& dlg->vars != NULL) {
+				srjson_t *pj = NULL;
+				pj = srjson_CreateObject(&jdoc);
+				for(var = dlg->vars; var; var = var->next) {
+					srjson_AddStrToObject(&jdoc, pj, var->key.s, var->value.s,
+							var->value.len);
+				}
+				srjson_AddItemToObject(&jdoc, jdoc.root, "vars", pj);
+			}
 			switch(dlg->state) {
 				case DLG_STATE_EARLY:
 					srjson_AddNumberToObject(

--- a/src/modules/dialog/doc/dialog.xml
+++ b/src/modules/dialog/doc/dialog.xml
@@ -63,6 +63,11 @@
 			<surname>Klingenmeyer</surname>
 			<email>julien.klingenmeyer@corp.ovh.com</email>
 		</editor>
+		<editor>
+			<firstname>Simone</firstname>
+			<surname>de Blasiis</surname>
+			<email>simone.deblasiis@eis.it</email>
+		</editor>
 	</authorgroup>
 	<copyright>
 		<year>2006</year>

--- a/src/modules/dialog/doc/dialog_admin.xml
+++ b/src/modules/dialog/doc/dialog_admin.xml
@@ -1486,6 +1486,79 @@ modparam("dialog", "enable_dmq_ka_iflags_sync", 1)
 	</example>
     </section>
 
+	<section id="dialog.p.enable_dmq_load_callbacks">
+		<title><varname>enable_dmq_load_callbacks</varname> (int)</title>
+		<para>
+			If set to 1, active dialogs newly created from DMQ replication run the
+			<quote>DLGCB_LOADED</quote> callbacks after their replicated data has
+			been applied. This allows modules that register load callbacks, such as
+			the acc module with CDR generation enabled, to attach their per-dialog
+			callbacks to replicated dialogs.
+		</para>
+		<para>
+			While enabled, dialog variables are also included in subsequent DMQ
+			state messages. This keeps state used by the loaded callbacks, such as
+			the acc module's confirmed CDR start time, synchronized on the peer.
+		</para>
+		<para>
+			Enabling this parameter affects every module that registers a
+			<quote>DLGCB_LOADED</quote> callback. Verify the behavior of those
+			modules before enabling it.
+		</para>
+		<informaltable frame="all">
+			<tgroup cols="2">
+				<thead>
+					<row>
+						<entry>Module</entry>
+						<entry>Known effect</entry>
+					</row>
+				</thead>
+				<tbody>
+					<row>
+						<entry><varname>acc</varname></entry>
+						<entry>Restores CDR callbacks; expiry or split brain can
+						produce duplicate CDRs.</entry>
+					</row>
+					<row>
+						<entry><varname>call_control</varname></entry>
+						<entry>Can send duplicate or spurious stop commands from DMQ
+						peers.</entry>
+					</row>
+					<row>
+						<entry><varname>pua_dialoginfo</varname></entry>
+						<entry>Can send duplicate terminated PUBLISH requests.</entry>
+					</row>
+					<row>
+						<entry><varname>uac</varname></entry>
+						<entry>Restores From/To replacement callbacks for failover.</entry>
+					</row>
+					<row>
+						<entry><varname>peerstate</varname></entry>
+						<entry>Currently has no effect because load callbacks have no SIP
+						request.</entry>
+					</row>
+				</tbody>
+			</tgroup>
+		</informaltable>
+		<para>
+			Other modules registering <quote>DLGCB_LOADED</quote> are affected as
+			well.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>enable_dmq_load_callbacks</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("dialog", "enable_dmq_load_callbacks", 1)
+...
+</programlisting>
+		</example>
+	</section>
+
 	<section id="dialog.p.track_cseq_updates">
 		<title><varname>track_cseq_updates</varname> (int)</title>
 		<para>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #3254

#### Description
<!-- Describe your changes in detail -->
## Objective

Address #3254, where active calls replicated through DMQ may not produce a CDR after failover because the new active node has no accounting callbacks attached to the replicated dialogs.

This change adds the optional `enable_dmq_load_callbacks` dialog parameter. When enabled, dialogs created from DMQ replication run `DLGCB_LOADED` callbacks and synchronize dialog variables in state updates, allowing modules such as `acc` to restore the callbacks and state required for CDR generation.

The parameter defaults to `0`, preserving the dialog module’s existing behavior unless explicitly enabled. A startup warning and documentation describe the known impact on modules that register `DLGCB_LOADED`.