### PR TITLE
topos_redis: expire unconfirmed dialogs early

### DIFF
--- a/src/modules/topos/doc/topos_admin.xml
+++ b/src/modules/topos/doc/topos_admin.xml
@@ -191,6 +191,15 @@ modparam("topos", "sanity_checks", 1)
 			Interval in seconds after which the branch records are deleted.
 		</para>
 		<para>
+			This value also bounds the lifetime of a dialog record that has not
+			been confirmed yet: the record created for an initial request is
+			only kept for branch_expire, and is extended to dialog_expire when
+			the dialog is confirmed by a 2xx reply. Calls that are never
+			answered (negative reply, CANCEL or timeout) therefore do not
+			occupy storage for dialog_expire. Set this value above the longest
+			time you expect between the initial request and its final reply.
+		</para>
+		<para>
 		<emphasis>
 			Default value is 180 (3 min).
 		</emphasis>
@@ -215,6 +224,10 @@ modparam("topos", "branch_expire", 300)
 			This key is only relevant for INVITE dialog.
                         SUBSCRIBE dialog records lifetime are based on value set in expires
                         header. Moreover each re-SUBSCRIBEs update the dialog timestamp.
+		</para>
+		<para>
+			This interval starts when the dialog is confirmed. Until then the
+			record is kept for branch_expire only.
 		</para>
 		<para>
 		<emphasis>

--- a/src/modules/topos_redis/topos_redis_storage.c
+++ b/src/modules/topos_redis/topos_redis_storage.c
@@ -165,6 +165,7 @@ int tps_redis_insert_dialog(tps_data_t *td)
 	redisc_server_t *rsrv = NULL;
 	redisReply *rrpl = NULL;
 	unsigned long lval = 0;
+	unsigned long bval = 0;
 
 	if(td->a_uuid.len <= 0 && td->b_uuid.len <= 0) {
 		LM_INFO("no uuid for this message\n");
@@ -277,6 +278,14 @@ int tps_redis_insert_dialog(tps_data_t *td)
 		lval = (unsigned long)td->expires;
 	} else {
 		lval = (unsigned long)_tps_api.get_dialog_expire();
+		bval = (unsigned long)_tps_api.get_branch_expire();
+		if(lval != 0 && bval != 0) {
+			/* the dialog is not confirmed at this point - reserve only the
+			 * branch lifetime, extended to dialog_expire when a 2xx reply
+			 * confirms it in tps_redis_update_dialog(). A 0 value means
+			 * expiring is disabled - keep the longer lifetime then. */
+			lval = bval;
+		}
 	}
 
 	if(lval == 0) {
@@ -1280,6 +1289,7 @@ int tps_redis_update_dialog(
 	redisReply *rrpl = NULL;
 	int32_t liflags;
 	unsigned long lval = 0;
+	unsigned long dlgexp = 0;
 
 	if(sd->a_uuid.len <= 0 && sd->b_uuid.len <= 0) {
 		LM_INFO("no uuid for this message\n");
@@ -1357,6 +1367,13 @@ int tps_redis_update_dialog(
 			liflags = sd->iflags | TPS_IFLAG_DLGON;
 			TPS_REDIS_SET_ARGN(
 					liflags, rp, &rval, argc, &td_key_iflags, argv, argvlen);
+
+			/* confirmed - extend the branch lifetime reserved at insert time
+			 * to the full dialog lifetime. SUBSCRIBE is driven by the Expires
+			 * header, not dialog_expire (see tps_redis_insert_dialog()) */
+			if(md->s_method_id != METHOD_SUBSCRIBE) {
+				dlgexp = (unsigned long)_tps_api.get_dialog_expire();
+			}
 		}
 	}
 
@@ -1405,6 +1422,42 @@ int tps_redis_update_dialog(
 	LM_DBG("updated dialog record for [%.*s] with argc %d\n", rkey.len, rkey.s,
 			argc);
 	freeReplyObject(rrpl);
+
+	if(dlgexp != 0) {
+		argc = 0;
+
+		argv[argc] = "EXPIRE";
+		argvlen[argc] = 6;
+		argc++;
+
+		argv[argc] = rkey.s;
+		argvlen[argc] = rkey.len;
+		argc++;
+
+		TPS_REDIS_SET_ARGNV(dlgexp, rp, &rval, argc, argv, argvlen);
+
+		rrpl = _tps_redis_api.exec_argv(
+				rsrv, argc, (const char **)argv, argvlen);
+		if(rrpl == NULL || rrpl->type == REDIS_REPLY_ERROR) {
+			/* the record keeps the shorter branch lifetime and nothing
+			 * revisits it, so the dialog would be dropped while the call is
+			 * up - report it, but do not fail the reply of a confirmed
+			 * dialog over the expire alone */
+			LM_ERR("failed to extend expire of confirmed dialog record [%.*s]"
+				   " - it keeps the branch lifetime\n",
+					rkey.len, rkey.s);
+			if(rrpl != NULL) {
+				LM_ERR("redis replied: %s\n", rrpl->str);
+				freeReplyObject(rrpl);
+			} else if(rsrv->ctxRedis->err) {
+				LM_ERR("redis error: %s\n", rsrv->ctxRedis->errstr);
+			}
+		} else {
+			LM_DBG("expire %lu set on confirmed dialog record for [%.*s]\n",
+					dlgexp, rkey.len, rkey.s);
+			freeReplyObject(rrpl);
+		}
+	}
 
 	if(mode & TPS_DBU_TIME) {
 		/* reset expire for the key */


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #2012

#### Description

Fixes #2012.

In topos_redis, dialog records are inserted with the full dialog_expire lifetime before the call is confirmed. Unlike the DB backend (which has tps_db_clean_dialogs() to reap unconfirmed records after branch_expire), the Redis backend has no equivalent cleanup -- tps_redis_clean_dialogs() is a no-op.

This means every unanswered call attempt (CANCEL, negative reply, timeout) leaves its record in Redis for the entire dialog_expire duration, causing unnecessary keyspace growth.

Fix: insert dialog records with only branch_expire, then extend to dialog_expire on 2xx confirmation in tps_redis_update_dialog(). If either value is 0, disable expiry as before.

Note that `branch_expire` therefore bounds how long an unconfirmed dialog record is kept, so it must exceed the longest expected interval between the initial request and its final reply. This is the same rule the DB backend already enforces, and the `topos` documentation is updated to state it.

##### Testing

Kamailio 6.2.0-dev1 + Redis 7.4 + SIPp, `branch_expire=20` / `dialog_expire=300`, identical harness run against `master` and this branch.

| Test | master | this PR |
| --- | --- | --- |
| Rejected call (486) | ttl 300, record alive at +25s | ttl 20, gone by +25s |
| Cancelled call (CANCEL while ringing) | ttl 299, record alive at +25s | ttl 19, gone by +25s |
| No reply at all | ttl 298, record alive at +25s | ttl 18, gone by +25s |
| 50 rejected calls | 50 records alive at +27s | 0 records at +27s |
| Answered call, BYE 30s after answer | 1/1 ok, 0 routing failures | same |
| 200 answered calls, BYE past branch_expire | 200/200 ok | 200/200 ok |
| re-INVITE + BYE 25s into a call | n/a | routed in-dialog, 0 failures |
| SUBSCRIBE with `Expires: 600` | ttl 599 | ttl 599 (unaffected) |
| Redis rejects the confirming expire | n/a | call still connects, error logged |
| Ring 25s, i.e. longer than branch_expire | call fails, orphan record left | call fails the same way, no orphan |

Expire sequence observed on a single dialog record for one answered call:

```
tps_redis_insert_dialog():  expire 20 set on dialog record for [d:z:atpsh-...]
tps_redis_update_dialog():  expire 300 set on confirmed dialog record for [d:z:atpsh-...]
tps_redis_end_dialog():     expire 20 set on dialog record for [d:z:atpsh-...]
```
