### PR TITLE
rtpengine: dmq startup sync action

### DIFF
--- a/src/modules/rtpengine/rtpengine_dmq.c
+++ b/src/modules/rtpengine/rtpengine_dmq.c
@@ -34,6 +34,7 @@ dmq_peer_t *rtpengine_dmq_peer = NULL;
 extern str rtpengine_dmq_peer_id;
 
 int rtpengine_dmq_request_sync(dmq_node_t *node);
+int rtpengine_dmq_send(str *body, dmq_node_t *node);
 
 /**
 * @brief add rtpengine notification peer
@@ -66,7 +67,42 @@ int rtpengine_dmq_init()
 
 int rtpengine_dmq_request_sync(dmq_node_t *node)
 {
+	srjson_doc_t jdoc;
+
+	LM_DBG("requesting sync from dmq peers\n");
+
+	srjson_InitDoc(&jdoc, NULL);
+
+	jdoc.root = srjson_CreateObject(&jdoc);
+	if(jdoc.root == NULL) {
+		LM_ERR("cannot create json root\n");
+		goto error;
+	}
+
+	srjson_AddNumberToObject(&jdoc, jdoc.root, "action", RTPENGINE_DMQ_SYNC);
+	jdoc.buf.s = srjson_PrintUnformatted(&jdoc, jdoc.root);
+	if(jdoc.buf.s == NULL) {
+		LM_ERR("unable to serialize data\n");
+		goto error;
+	}
+	jdoc.buf.len = strlen(jdoc.buf.s);
+	LM_DBG("sending serialized data %.*s\n", jdoc.buf.len, jdoc.buf.s);
+	if(rtpengine_dmq_send(&jdoc.buf, node) != 0) {
+		goto error;
+	}
+
+	jdoc.free_fn(jdoc.buf.s);
+	jdoc.buf.s = NULL;
+	srjson_DestroyDoc(&jdoc);
 	return 0;
+
+error:
+	if(jdoc.buf.s != NULL) {
+		jdoc.free_fn(jdoc.buf.s);
+		jdoc.buf.s = NULL;
+	}
+	srjson_DestroyDoc(&jdoc);
+	return -1;
 }
 
 int rtpengine_dmq_handle_msg(
@@ -197,6 +233,10 @@ int rtpengine_dmq_handle_msg(
 				goto error;
 			break;
 		case RTPENGINE_DMQ_SYNC:
+			if(rtpengine_dmq_replicate_sync(node) != 0) {
+				goto error;
+			}
+			break;
 		case RTPENGINE_DMQ_NONE:
 			break;
 	}
@@ -276,7 +316,7 @@ int rtpengine_dmq_replicate_action(rtpengine_dmq_action_t action, str callid,
 	if(jdoc.buf.s != NULL) {
 		jdoc.buf.len = strlen(jdoc.buf.s);
 		LM_DBG("sending serialized data %.*s\n", jdoc.buf.len, jdoc.buf.s);
-		if(rtpengine_dmq_send(&jdoc.buf, 0) != 0) {
+		if(rtpengine_dmq_send(&jdoc.buf, node) != 0) {
 			goto error;
 		}
 		jdoc.free_fn(jdoc.buf.s);
@@ -309,4 +349,52 @@ int rtpengine_dmq_replicate_remove(str callid, str viabranch)
 {
 	return rtpengine_dmq_replicate_action(
 			RTPENGINE_DMQ_REMOVE, callid, viabranch, NULL, NULL);
+}
+
+int rtpengine_dmq_replicate_sync(dmq_node_t *node)
+{
+	int i;
+	struct rtpengine_hash_entry *entry;
+	struct rtpengine_hash_table *hash_table;
+
+	LM_DBG("replicating all hash entries to dmq node\n");
+
+	if(!rtpengine_hash_table_sanity_checks()) {
+		LM_ERR("rtpengine_hash_table sanity checks failed\n");
+		return -1;
+	}
+	hash_table = rtpengine_hash_table_get();
+	if(!hash_table) {
+		LM_ERR("Can not get rtpengine_hash_table\n");
+		return -1;
+	}
+
+	for(i = 0; i < hash_table->size; i++) {
+		lock_get(&hash_table->row_locks[i]);
+
+		entry = hash_table->row_entry_list[i];
+
+		while(entry) {
+			if(entry->tout >= get_ticks()) {
+				LM_DBG("replicating hash entry callid=%.*s viabranch=%.*s\n",
+						entry->callid.len, entry->callid.s,
+						entry->viabranch.len, entry->viabranch.s);
+
+				if(rtpengine_dmq_replicate_action(RTPENGINE_DMQ_INSERT,
+						   entry->callid, entry->viabranch, entry->node, node)
+						!= 0) {
+					LM_ERR("failed to replicate hash entry callid=%.*s "
+						   "viabranch=%.*s\n",
+							entry->callid.len, entry->callid.s,
+							entry->viabranch.len, entry->viabranch.s);
+				}
+			}
+
+			entry = entry->next;
+		}
+
+		lock_release(&hash_table->row_locks[i]);
+	}
+
+	return 0;
 }

--- a/src/modules/rtpengine/rtpengine_dmq.h
+++ b/src/modules/rtpengine/rtpengine_dmq.h
@@ -48,5 +48,5 @@ int rtpengine_dmq_replicate_action(rtpengine_dmq_action_t action, str callid,
 int rtpengine_dmq_replicate_insert(
 		str callid, str viabranch, struct rtpp_node *rtpp_node);
 int rtpengine_dmq_replicate_remove(str callid, str viabranch);
-int rtpengine_dmq_replicate_sync();
+int rtpengine_dmq_replicate_sync(dmq_node_t *node);
 #endif

--- a/src/modules/rtpengine/rtpengine_hash.c
+++ b/src/modules/rtpengine/rtpengine_hash.c
@@ -156,6 +156,11 @@ int rtpengine_hash_table_destroy()
 	return 1;
 }
 
+struct rtpengine_hash_table *rtpengine_hash_table_get()
+{
+	return rtpengine_hash_table;
+}
+
 int rtpengine_hash_table_insert(
 		str callid, str viabranch, struct rtpengine_hash_entry *value)
 {

--- a/src/modules/rtpengine/rtpengine_hash.h
+++ b/src/modules/rtpengine/rtpengine_hash.h
@@ -30,6 +30,7 @@ struct rtpengine_hash_table
 
 int rtpengine_hash_table_init(int size);
 int rtpengine_hash_table_destroy();
+struct rtpengine_hash_table *rtpengine_hash_table_get();
 int rtpengine_hash_table_insert(
 		str callid, str viabranch, struct rtpengine_hash_entry *value);
 int rtpengine_hash_table_remove(str callid, str viabranch, enum rtpe_operation);


### PR DESCRIPTION
 rtpengine: sync DMQ hash table entries on node join

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
The rtpengine module replicates its callid/viabranch to rtpengine node mapping over DMQ, but only incrementally on insert/remove. A node that (re)joins the DMQ cluster starts with an empty hash table and never catches up with state already held by its nodes.
This PR adds a DMQ sync action, requested once at node registration (rtpengine_dmq_init()) via a broadcast RTPENGINE_DMQ_SYNC message. DMQ nodes receiving it reply by replicating their non-expired hash table entries directly to the requesting node, reusing the existing RTPENGINE_DMQ_INSERT action.