### PR TITLE
sipcapture: add bounds check for HEPv2 time header offset

### DIFF
--- a/src/modules/sipcapture/hep.c
+++ b/src/modules/sipcapture/hep.c
@@ -191,6 +191,12 @@ int hepv2_received(char *buf, unsigned int len, struct receive_info *ri)
 	/* timing */
 	if(heph->hp_v == 2) {
 		hep_offset += sizeof(struct hep_timehdr);
+		if(unlikely(buf + hep_offset > end)) {
+			LOG(L_ERR, "HEPv2 time header "
+					   "exceeds packet boundary\n");
+			return -1;
+		}
+
 		heptime_tmp = (struct hep_timehdr *)hep_payload;
 
 		heptime->tv_sec = to_le(heptime_tmp->tv_sec);
@@ -232,6 +238,10 @@ int hepv2_received(char *buf, unsigned int len, struct receive_info *ri)
 
 	hep_payload = buf + hep_offset;
 
+	if(unlikely(len < hep_offset)) {
+		LOG(L_ERR, "Calculated payload length underflow\n");
+		return -1;
+	}
 	receive_msg(hep_payload, (unsigned int)(len - hep_offset), ri);
 
 	return -1;


### PR DESCRIPTION
This PR fixes a potential crash in the sipcapture module when processing incoming HEPv2 packets with malformed or truncated payloads. 
**The Issue:** In the HEPv2 receive path (hep.c, under the hp_v == 2 branch), the code incremented hep_offset += sizeof(struct hep_timehdr) (12 bytes) without re-checking if the resulting offset exceeded the actual packet length
**The Fix.** Added checks to ensure that the calculated hep_offset does not exceed the packet length before proceeding