### PR TITLE
rtpengine: zero pointer crash in rtpengine_dmq

### DIFF
--- a/src/modules/rtpengine/rtpengine.c
+++ b/src/modules/rtpengine/rtpengine.c
@@ -1217,6 +1217,7 @@ int get_rtpp_set_id_by_node(struct rtpp_node *node)
 {
 	struct rtpp_set *rtpp_list;
 	struct rtpp_node *crt_rtpp;
+	unsigned int res = 0;
 
 	lock_get(rtpp_set_list->rset_head_lock);
 	for(rtpp_list = rtpp_set_list->rset_first; rtpp_list != NULL;
@@ -1231,15 +1232,14 @@ int get_rtpp_set_id_by_node(struct rtpp_node *node)
 			}
 		}
 		lock_release(rtpp_list->rset_lock);
-		if(crt_rtpp != NULL)
+		if(crt_rtpp != NULL) {
+			res = rtpp_list->id_set;
 			break;
+		}
 	}
 	lock_release(rtpp_set_list->rset_head_lock);
 
-	if(crt_rtpp != NULL)
-		return rtpp_list->id_set;
-	else
-		return 0;
+	return res;
 }
 
 /**
@@ -3998,7 +3998,7 @@ select_node:
 					viabranch.s);
 			if(rtpengine_enable_dmq > 0)
 				rtpengine_dmq_replicate_insert(
-						ng_flags.call_id, viabranch, entry);
+						ng_flags.call_id, viabranch, node);
 		}
 	}
 

--- a/src/modules/rtpengine/rtpengine_dmq.c
+++ b/src/modules/rtpengine/rtpengine_dmq.c
@@ -242,7 +242,7 @@ int rtpengine_dmq_send(str *body, dmq_node_t *node)
 }
 
 int rtpengine_dmq_replicate_action(rtpengine_dmq_action_t action, str callid,
-		str viabranch, struct rtpengine_hash_entry *entry, dmq_node_t *node)
+		str viabranch, struct rtpp_node *rtpp_node, dmq_node_t *node)
 {
 	srjson_doc_t jdoc;
 	unsigned int setid = -1;
@@ -263,12 +263,12 @@ int rtpengine_dmq_replicate_action(rtpengine_dmq_action_t action, str callid,
 		srjson_AddStrToObject(
 				&jdoc, jdoc.root, "viabranch", viabranch.s, viabranch.len);
 	}
-	if(entry && entry->node) {
+	if(rtpp_node) {
 		srjson_AddStrToObject(&jdoc, jdoc.root, "rtpengine_url",
-				entry->node->rn_url.s, entry->node->rn_url.len);
+				rtpp_node->rn_url.s, rtpp_node->rn_url.len);
 
-		setid = get_rtpp_set_id_by_node(entry->node);
-		if(setid != -1)
+		setid = get_rtpp_set_id_by_node(rtpp_node);
+		if(setid)
 			srjson_AddNumberToObject(&jdoc, jdoc.root, "setid", setid);
 	}
 
@@ -299,10 +299,10 @@ error:
 }
 
 int rtpengine_dmq_replicate_insert(
-		str callid, str viabranch, struct rtpengine_hash_entry *entry)
+		str callid, str viabranch, struct rtpp_node *rtpp_node)
 {
 	return rtpengine_dmq_replicate_action(
-			RTPENGINE_DMQ_INSERT, callid, viabranch, entry, NULL);
+			RTPENGINE_DMQ_INSERT, callid, viabranch, rtpp_node, NULL);
 }
 
 int rtpengine_dmq_replicate_remove(str callid, str viabranch)

--- a/src/modules/rtpengine/rtpengine_dmq.h
+++ b/src/modules/rtpengine/rtpengine_dmq.h
@@ -44,9 +44,9 @@ int rtpengine_dmq_init();
 int rtpengine_dmq_handle_msg(
 		struct sip_msg *msg, peer_reponse_t *resp, dmq_node_t *node);
 int rtpengine_dmq_replicate_action(rtpengine_dmq_action_t action, str callid,
-		str viabranch, struct rtpengine_hash_entry *entry, dmq_node_t *node);
+		str viabranch, struct rtpp_node *rtpp_node, dmq_node_t *node);
 int rtpengine_dmq_replicate_insert(
-		str callid, str viabranch, struct rtpengine_hash_entry *entry);
+		str callid, str viabranch, struct rtpp_node *rtpp_node);
 int rtpengine_dmq_replicate_remove(str callid, str viabranch);
 int rtpengine_dmq_replicate_sync();
 #endif


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4893

#### Description
<!-- Describe your changes in detail -->

This is a fix for https://github.com/kamailio/kamailio/issues/4893 

Function rtpengine_dmq_replicate_action() changed to use rtpp_node instead of rtpengine_hash_entry to prevent such kind of crashes when hash_entry could be cleaned during kdmq message sending. 

This PR is changing same code as https://github.com/kamailio/kamailio/pull/4889 so one of it should be updated after other merged. 