### PR TITLE
userblocklist: Add robust prefix length validation and fault handling

### DIFF
--- a/src/modules/userblocklist/userblocklist.c
+++ b/src/modules/userblocklist/userblocklist.c
@@ -1369,12 +1369,14 @@ static void check_list_rpc(rpc_t *rpc, void *ctx, int list_type)
 	/* Sanity checks */
 	if(rpc->scan(ctx, ".S", &prefix) < 1)
 		goto error_scan;
-	if(prefix.s == NULL || prefix.len == 0)
+	if(prefix.s == NULL || prefix.len <= 0)
 		goto error_scan;
+	if(prefix.len > MAXNUMBERLEN)
+		goto error_prefix;
 	if(rpc->add(ctx, "{", &out) < 0)
 		goto error;
 
-	strncpy(req_prefix, prefix.s, prefix.len);
+	memcpy(req_prefix, prefix.s, (size_t)prefix.len);
 	req_prefix[prefix.len] = '\0';
 
 	/* Check that global blocklist exists */
@@ -1444,6 +1446,11 @@ error_scan:
 	rpc->fault(ctx, 500, "Check failed: 1 argument needed (\"prefix\")");
 	return;
 
+error_prefix:
+	rpc->fault(ctx, 400, "Check failed: prefix exceeds %d characters",
+			MAXNUMBERLEN);
+	return;
+
 error:
 	rpc->fault(ctx, 500, "Check failed");
 	return;
@@ -1463,14 +1470,16 @@ static void check_userlist_rpc(rpc_t *rpc, void *ctx, int list_type)
 		domain.s = "";
 		domain.len = 0;
 	}
-	if(prefix.s == NULL || prefix.len == 0 || user.s == NULL || user.len == 0)
+	if(prefix.s == NULL || prefix.len <= 0 || user.s == NULL || user.len <= 0)
 		goto error_scan;
+	if(prefix.len > MAXNUMBERLEN)
+		goto error_prefix;
 	if(rpc->add(ctx, "{", &out) < 0)
 		goto error;
 	if(domain.s != NULL && domain.len != 0)
 		local_use_domain = 1;
 
-	strncpy(req_prefix, prefix.s, prefix.len);
+	memcpy(req_prefix, prefix.s, (size_t)prefix.len);
 	req_prefix[prefix.len] = '\0';
 
 	/* Check that global blocklist exists */
@@ -1552,6 +1561,10 @@ error_scan:
 	rpc->fault(ctx, 500,
 			"Check failed: 2 or 3 arguments needed (\"prefix\" \"user\" "
 			"\"domain\"(optional))");
+	return;
+error_prefix:
+	rpc->fault(ctx, 400, "Check failed: prefix exceeds %d characters",
+			MAXNUMBERLEN);
 	return;
 
 error:


### PR DESCRIPTION
This PR fixes a vulnerability that could allow an attacker with access to a  BinRPC listener to overwrite the stack and achieve remote code execution
**The fix:**
**Prefix Validation:** Added check to reject overlong prefixes (> MAXNUMBERLEN) 

**Fault Handling:** Introduced the error_prefix handler to return a  400 error ("Check failed: prefix exceeds %d characters")

**Memory Operations:** Replaced strncpy with  memcpy  for better handling of counted strings.

The above changes apply  in both check_list_rpc() and check_userlist_rpc()

Co-authored-by: Pedro J. Nunez-Cacho Fuentes <[tunelko@gmail.com](mailto:tunelko@gmail.com)>