### PR TITLE
WIP: tls: emit 5-tuple metadata in keylog callback

### DIFF
--- a/src/modules/tls/tls_domain.c
+++ b/src/modules/tls/tls_domain.c
@@ -25,6 +25,8 @@
  */
 
 #include <stdlib.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 #include <openssl/ssl.h>
 #include <openssl/opensslv.h>
 #include <openssl/bn.h>
@@ -1164,6 +1166,130 @@ static int tls_server_name_cb(SSL *ssl, int *ad, void *private)
 }
 #endif
 
+/**
+ * Emit an NSS-format comment line describing the TCP 5-tuple of the SSL
+ * connection, so downstream consumers (e.g. voipmonitor) can build a full
+ * (tuple, session-key) mapping from a keylog file or UDP stream that would
+ * otherwise carry only the crypto material.
+ *
+ * Comments starting with '#' are ignored by standard NSS keylog readers
+ * (Wireshark, Chrome), so this addition is backwards-compatible.
+ *
+ * Emits nothing when the tls_extra_data back-pointer to tcp_connection is
+ * not populated (older callers) or the SSL has no app_data.
+ */
+static void ksr_tls_keylog_emit_tuple(const SSL *ssl)
+{
+	struct tls_extra_data *data;
+	struct tcp_connection *c;
+	const SSL_CIPHER *cipher;
+	char src_ip[IP_ADDR_MAX_STR_SIZE];
+	char dst_ip[IP_ADDR_MAX_STR_SIZE];
+	char srv_random_hex[SSL3_RANDOM_SIZE * 2 + 1];
+	char buf[512];
+	unsigned char srv_random[SSL3_RANDOM_SIZE];
+	unsigned int dst_port;
+	unsigned int cipher_id;
+	size_t srv_random_len;
+	size_t i;
+	int version;
+	int n;
+
+	data = (struct tls_extra_data *)SSL_get_app_data(ssl);
+	if(data == NULL) {
+		return;
+	}
+	c = data->tcp_conn;
+	if(c == NULL) {
+		return;
+	}
+	/* ip_addr2a() returns a pointer into a single static buffer, so calling
+	 * it twice in one snprintf gives the same string for both operands.
+	 * Use ip_addr2sbuf() into caller-owned buffers instead. */
+	n = ip_addr2sbuf(&c->rcv.src_ip, src_ip, sizeof(src_ip) - 1);
+	src_ip[n] = '\0';
+	n = ip_addr2sbuf(&c->rcv.dst_ip, dst_ip, sizeof(dst_ip) - 1);
+	dst_ip[n] = '\0';
+
+	/* Local port resolution depends on connection direction:
+	 *
+	 * - Accepted (server-role, F_CONN_PASSIVE): rcv.dst_port is our listen
+	 *   port; if 0 fall back to bind_address->port_no.
+	 *
+	 * - Connected (client-role, kamailio dialed out): rcv.dst_port is not
+	 *   the local wire port - it's the peer's port for this direction of
+	 *   accounting. The actual local ephemeral is only available via
+	 *   getsockname on whatever fd is valid in the current process (c->fd
+	 *   for worker children, c->s for tcp-main). Try both; take the first
+	 *   non-zero. Downstream consumers matching on 5-tuple need the wire
+	 *   ephemeral, not rcv.dst_port.
+	 */
+	dst_port = c->rcv.dst_port;
+	if(!(c->flags & F_CONN_PASSIVE)) {
+		struct sockaddr_storage sa;
+		socklen_t sa_len;
+		unsigned int wire_port = 0;
+		int fds[2];
+		int fi;
+		fds[0] = c->fd;
+		fds[1] = c->s;
+		for(fi = 0; fi < 2 && wire_port == 0; fi++) {
+			if(fds[fi] < 0) {
+				continue;
+			}
+			sa_len = sizeof(sa);
+			if(getsockname(fds[fi], (struct sockaddr *)&sa, &sa_len)
+					!= 0) {
+				continue;
+			}
+			if(sa.ss_family == AF_INET) {
+				wire_port = ntohs(
+						((struct sockaddr_in *)&sa)->sin_port);
+			} else if(sa.ss_family == AF_INET6) {
+				wire_port = ntohs(
+						((struct sockaddr_in6 *)&sa)->sin6_port);
+			}
+		}
+		if(wire_port != 0) {
+			dst_port = wire_port;
+		}
+	} else if(dst_port == 0 && c->rcv.bind_address != NULL) {
+		dst_port = c->rcv.bind_address->port_no;
+	}
+
+	/* server_random, cipher, version - needed by consumers that build a full
+	 * ssl_sessions row from the file. NSS keylog format does not carry
+	 * server_random or cipher; include them here so consumers can populate
+	 * ssl_sessions-style rows (version, cipher_suite, client_random,
+	 * server_random, master_secret / traffic_secrets). */
+	srv_random_len = SSL_get_server_random(ssl, srv_random, sizeof(srv_random));
+	for(i = 0; i < srv_random_len && i < SSL3_RANDOM_SIZE; i++) {
+		snprintf(srv_random_hex + i * 2, 3, "%02x", srv_random[i]);
+	}
+	srv_random_hex[srv_random_len * 2] = '\0';
+
+	cipher = SSL_get_current_cipher(ssl);
+	cipher_id = cipher
+			? (unsigned int)(SSL_CIPHER_get_id(cipher) & 0xFFFF)
+			: 0;
+	version = SSL_version(ssl);
+
+	n = snprintf(buf, sizeof(buf),
+			"# TUPLE src=%s:%u dst=%s:%u sr=%s cs=%u v=%d\n",
+			src_ip, (unsigned)c->rcv.src_port, dst_ip, dst_port,
+			srv_random_hex, cipher_id, version);
+	if(n <= 0 || (size_t)n >= sizeof(buf)) {
+		return;
+	}
+
+	if(ksr_tls_keylog_mode != NULL
+			&& (*ksr_tls_keylog_mode & KSR_TLS_KEYLOG_MODE_MLOG)) {
+		LM_NOTICE("tlskeylog: %s", buf);
+	}
+	ksr_tls_keylog_file_write(ssl, buf);
+	ksr_tls_keylog_peer_send(ssl, buf);
+}
+
 static void ksr_tls_keylog_callback(const SSL *ssl, const char *line)
 {
 	if(ksr_tls_keylog_mode == NULL) {
@@ -1177,6 +1303,11 @@ static void ksr_tls_keylog_callback(const SSL *ssl, const char *line)
 			return;
 		}
 	}
+	/* Emit the 5-tuple comment immediately before each key line so a file
+	 * reader can pair them: (# TUPLE ..., <key line>). One comment per key
+	 * line is intentionally simple; consumers that only care about the tuple
+	 * once per session can dedupe by 5-tuple. */
+	ksr_tls_keylog_emit_tuple(ssl);
 	if(*ksr_tls_keylog_mode & KSR_TLS_KEYLOG_MODE_MLOG) {
 		LM_NOTICE("tlskeylog: %s\n", line);
 	}

--- a/src/modules/tls/tls_server.c
+++ b/src/modules/tls/tls_server.c
@@ -395,6 +395,9 @@ static int tls_complete_init(struct tcp_connection *c)
 	/* SSL_set_bio does not allocate memory and has no return value */
 	SSL_set_bio(data->ssl, data->rwbio, data->rwbio);
 	c->extra_data = data;
+	data->tcp_conn = c; /* used by ksr_tls_keylog_callback to emit the 5-tuple
+	                     * alongside the NSS key line; SSL_get_fd() cannot
+	                     * recover this because the BIO is memory-backed. */
 	return 0;
 
 error:

--- a/src/modules/tls/tls_server.h
+++ b/src/modules/tls/tls_server.h
@@ -69,6 +69,11 @@ typedef struct tls_extra_data
 	int run_conn_out_pending; /* tcp_main_threads>0: tls:connection-out should not
 							   * run on a PROC_TCP_MAIN mtops thread; this flag
 							   * marks deferred execution */
+	struct tcp_connection *tcp_conn; /* back-pointer for keylog callback so it
+	                                  * can read the peer 5-tuple; the SSL* has
+	                                  * no accessible fd because kamailio uses
+	                                  * a memory BIO (tls_BIO_new_mbuf), so
+	                                  * SSL_get_fd()/BIO_get_fd() both fail. */
 
 	char *ssl_servername;
 	char *ssl_cipher_name;


### PR DESCRIPTION
> **This is a draft / WIP.** Verified end-to-end in a downstream deployment
> (kamailio TLS trunk to a carrier, voipmonitor consuming the keylog file
> via an external tool that INSERTs `ssl_sessions` rows). Opening now to
> invite early feedback on the approach and framing before I clean up.

## The gap

The NSS keylog format (`CLIENT_RANDOM`, `SERVER_HANDSHAKE_TRAFFIC_SECRET`,
etc.) carries only crypto material and no association to the TCP connection
that produced it. That's sufficient for consumers that decrypt from a
wire-captured handshake — Wireshark reads the file and matches keys to
sessions by client_random. It is **not** sufficient for consumers that need
to bind a key to a connection they did not witness (a passive sniffer
restarted mid-session, needing to decrypt records on a reused TLS session).

`SSL_get_fd()` and `BIO_get_fd()` both return `-1` in the keylog callback
because the tls module uses a memory BIO (`tls_BIO_new_mbuf`), so the fd
cannot be recovered from OpenSSL alone.

## The change

Cache the `tcp_connection` back-pointer in `tls_extra_data` at SSL creation
time, then emit a `# TUPLE` comment line before each key line:

    # TUPLE src=<ip>:<port> dst=<ip>:<port> sr=<hex> cs=<u16> v=<version>
    CLIENT_RANDOM <hex> <hex>

Fields:

| Field   | Meaning                                                                                       |
|---------|-----------------------------------------------------------------------------------------------|
| `src` / `dst` | TCP 5-tuple. `dst_port` falls back to `rcv.bind_address->port_no` for accepted sockets (where `rcv.dst_port` is 0 by convention); connected sockets use `getsockname(c->fd)` / `getsockname(c->s)` to recover the true wire ephemeral port. |
| `sr`    | `server_random` hex (from `SSL_get_server_random`).                                           |
| `cs`    | Cipher suite id (`SSL_CIPHER_get_id & 0xFFFF`, IANA-assigned).                                |
| `v`     | TLS version (`0x0303` = TLS 1.2, `0x0304` = TLS 1.3).                                         |

NSS format treats `#` lines as comments, so Wireshark and other standard
readers ignore the addition — the file remains a valid keylog file.

Uses `ip_addr2sbuf()` with caller-owned buffers because `ip_addr2a()`
returns a pointer into a single static buffer and would yield the same
string for both operands in one `snprintf`.

## Why direction-aware `dst_port` resolution

- **Accepted (server-role, `F_CONN_PASSIVE`):** `rcv.dst_port` is our listen
  port; if 0 fall back to `bind_address->port_no`.
- **Connected (client-role, kamailio dialed out):** `rcv.dst_port` is not
  the local wire port — it's the peer's port for this direction of
  accounting. The actual local ephemeral is only available via
  `getsockname` on whatever fd is valid in the current process (`c->fd` for
  worker children, `c->s` for tcp-main). Try both; take the first non-zero.

Downstream consumers matching on 5-tuple need the wire ephemeral, not
`rcv.dst_port`, or their lookup will miss.

## Verification

Verified downstream 2026-08-31 on a kamailio 6.2 build with `keylog_mode=15`
armed against Telnyx TLS trunks. Both TLS 1.2 (cipher 49196) and TLS 1.3
(cipher 4866) sessions produce well-formed TUPLE lines with real ephemeral
ports in `dst_port` (getsockname fallback works). File is consumed by an
external tool that parses `# TUPLE` groups and populates `ssl_sessions`
rows in voipmonitor's DB; voipmonitor then decrypts sessions whose
handshake it did not witness, producing B-leg CDRs that were previously
missing.

## Open questions for reviewers

- Is emitting one TUPLE line before **every** key line the right choice, or
  should it be deduped per session? Cheap and simple as-is (consumers can
  dedupe by 5-tuple); TLS 1.3 produces multiple secrets per session so
  each key line already gets its own TUPLE.
- The `tcp_connection` back-pointer field lives in `tls_extra_data` — is
  that the right home, or would a smaller dedicated struct be cleaner?
- Fresh `getsockname` call in the callback for outbound sockets — I don't
  expect it to be hot, but happy to move the resolution earlier (once at
  handshake completion) if that's a concern.