### PR TITLE
topos: copy the Refer-To uri before handing it to the lump list

### DIFF
--- a/src/modules/topos/tps_msg.c
+++ b/src/modules/topos/tps_msg.c
@@ -319,6 +319,7 @@ static int tps_unmask_refer_to(
 	str *uri;
 	str nuri;
 	struct lump *l;
+	char *nbuf;
 	int ulen;
 	int ret;
 
@@ -384,8 +385,21 @@ static int tps_unmask_refer_to(
 		return -1;
 	}
 
-	if(insert_new_lump_after(l, nuri.s, nuri.len, 0) == 0) {
+	/* insert_new_lump_after() does not copy - the lump list takes ownership of
+	 * the buffer and free_lump() pkg_free()s it.  nuri points into the
+	 * stack-local rtsd, which is gone as soon as this function returns, so hand
+	 * over a pkg copy (same as tps_add_headers() and tps_mask_callid()). */
+	nbuf = (char *)pkg_malloc(nuri.len + 1);
+	if(nbuf == NULL) {
+		PKG_MEM_ERROR;
+		return -1;
+	}
+	memcpy(nbuf, nuri.s, nuri.len);
+	nbuf[nuri.len] = '\0';
+
+	if(insert_new_lump_after(l, nbuf, nuri.len, 0) == 0) {
 		LM_ERR("could not insert new Refer-To uri\n");
+		pkg_free(nbuf);
 		return -1;
 	}
 


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

`insert_new_lump_after()` does not copy: the lump list takes ownership of the buffer and `free_lump()` `pkg_free()`s it later. The uri handed over at `tps_msg.c:387` comes from `rtsd.a_contact` or `rtsd.b_contact`, and `rtsd` is a 16 KB `tps_data_t` stack local (`tps_msg.c:318`) filled by `tps_storage_load_dialog()`, whose appended `str` values all point into `rtsd.cbuf`. Once `tps_unmask_refer_to()` returns, the lump is left owning a stack address. `process_lumps()` copies out of the dead frame, and `free_lump()` hands that stack pointer to `pkg_free()`.

The other three `insert_new_lump_*` callers in topos pass pkg memory they allocated (`tps_msg.c:176`, `topos_mod.c:891`, `topos_mod.c:942`), and each frees it on the insert-failure path. This one call site looks like an oversight rather than a different ownership convention.

The patch hands over a pkg copy instead, and releases it if the insert fails.

Only `master` is affected. `tps_unmask_refer_to()` arrived in 78c94a2689 (2026-05-20), `git tag --contains 78c94a2689` is empty, and 6.1.4 has no such function, so no released version carries it and there is nothing to backport.

To reproduce it, one in-dialog REFER through a `topos` proxy is enough, with the `Refer-To` set to the masked Contact the proxy put in the 200 OK. All of it happens in the `SREV_NET_DATA_IN` handler, so the routing script is not involved.

Built with clang and `-fsanitize-address-use-after-return=always`, since gcc's ASan does not implement `detect_stack_use_after_return`. On `master` at c31fd77fe5:
```
==207586==ERROR: AddressSanitizer: stack-use-after-return on address 0x75e717574374
READ of size 22 at 0x75e717574374 thread T0
    #1 process_lumps src/core/msg_translator.c
    #2 build_req_buf_from_sip_req src/core/msg_translator.c
    #3 tps_msg_update src/modules/topos/tps_msg.c
    #4 tps_msg_received src/modules/topos/topos_mod.c
    #5 sr_event_exec src/core/events.c
    #6 receive_msg src/core/receive.c
    #7 udp_rcv_loop src/core/udp_server.c

Address 0x75e717574374 is located in stack of thread T0 at offset 17268 in frame
    #0 tps_unmask_refer_to src/modules/topos/tps_msg.c

  This frame has 10 object(s):
    [32, 16920) 'ltsd' (line 317)
    [17184, 34072) 'rtsd' (line 318) <== Memory access at offset 17268 is inside this variable
```

What explains this going unnoticed is that the REFER is still forwarded correctly without the patch. The UAS receives `Refer-To: <sip:bob@127.0.0.1:5070>`, properly unmasked, because nothing has overwritten the dead frame by the time `process_lumps()` reads it. The bug is silent in a normal run. The `pkg_free()` of a stack address is the more dangerous half.

With the patch applied, the same PoC unmasks the `Refer-To` exactly as before, and ASan reports nothing.

| build | ASan | Refer-To seen by UAS |
|---|---|---|
| master, unpatched | 1x stack-use-after-return | `<sip:bob@127.0.0.1:5070>` |
| with this patch | no report | `<sip:bob@127.0.0.1:5070>` |
