### PR TITLE
dispatcher - load unset callid

### DIFF
--- a/src/modules/dispatcher/dispatch.c
+++ b/src/modules/dispatcher/dispatch.c
@@ -2380,24 +2380,33 @@ int ds_load_remove_byid(int set, str *duid)
 /**
  *
  */
-int ds_load_remove(struct sip_msg *msg)
+static int ds_load_remove_bycallid(str *callid)
 {
 	ds_cell_t *it;
 
-	if((it = ds_get_cell(_dsht_load, &msg->callid->body)) == NULL) {
-		LM_ERR("cannot find load for (%.*s)\n", msg->callid->body.len,
-				msg->callid->body.s);
+	if((it = ds_get_cell(_dsht_load, callid)) == NULL) {
+		LM_ERR("cannot find load for (%.*s)\n", callid->len, callid->s);
 		return -1;
 	}
 
 	if(ds_load_remove_byid(it->dset, &it->duid) < 0) {
-		ds_unlock_cell(_dsht_load, &msg->callid->body);
+		ds_unlock_cell(_dsht_load, callid);
 		return -1;
 	}
-	ds_unlock_cell(_dsht_load, &msg->callid->body);
-	ds_del_cell(_dsht_load, &msg->callid->body);
+	ds_unlock_cell(_dsht_load, callid);
+	ds_del_cell(_dsht_load, callid);
 
 	return 0;
+}
+
+int ds_load_remove(struct sip_msg *msg)
+{
+	if(parse_headers(msg, HDR_CALLID_F, 0) != 0 || msg->callid == NULL
+			|| msg->callid->body.s == NULL || msg->callid->body.len <= 0) {
+		LM_ERR("cannot get Call-ID header\n");
+		return -1;
+	}
+	return ds_load_remove_bycallid(&msg->callid->body);
 }
 
 /**
@@ -2465,6 +2474,24 @@ int ds_load_unset(struct sip_msg *msg)
 			return 0;
 	}
 	return ds_load_remove(msg);
+}
+
+/**
+ * Off-load a call identified by an explicit Call-ID, independent of the
+ * current message. Useful where load must be released from a context that does
+ * not carry the original Call-ID (e.g. the dialog:failed event route, which may
+ * run with a synthetic message), by passing the dialog Call-ID instead.
+ */
+int ds_load_unset_callid(struct sip_msg *msg, str *callid)
+{
+	if(ds_xavp_dst.len <= 0)
+		return 0;
+
+	if(callid == NULL || callid->s == NULL || callid->len <= 0) {
+		LM_ERR("invalid Call-ID value\n");
+		return -1;
+	}
+	return ds_load_remove_bycallid(callid);
 }
 
 /**

--- a/src/modules/dispatcher/dispatch.h
+++ b/src/modules/dispatcher/dispatch.h
@@ -190,6 +190,7 @@ int ds_list_exist(int set);
 int ds_is_active_uri(sip_msg_t *msg, int group, str *uri);
 
 int ds_load_unset(struct sip_msg *msg);
+int ds_load_unset_callid(struct sip_msg *msg, str *callid);
 int ds_load_update(struct sip_msg *msg);
 
 int ds_hash_load_init(unsigned int htsize, int expire, int initexpire);

--- a/src/modules/dispatcher/dispatcher.c
+++ b/src/modules/dispatcher/dispatcher.c
@@ -182,6 +182,7 @@ static int w_ds_mark_dst1(struct sip_msg*, char*, char*);
 static int w_ds_mark_addr(struct sip_msg *msg, char *state, char *group,
 		char *uri);
 static int w_ds_load_unset(struct sip_msg*, char*, char*);
+static int w_ds_load_unset_cid(struct sip_msg*, char*, char*);
 static int w_ds_load_update(struct sip_msg*, char*, char*);
 
 static int w_ds_is_from_list0(struct sip_msg*, char*, char*);
@@ -265,6 +266,8 @@ static cmd_export_t cmds[]={
 		fixup_igp_null, fixup_free_igp_null, ANY_ROUTE},
 	{"ds_load_unset",    (cmd_function)w_ds_load_unset,   0,
 		0, 0, ANY_ROUTE},
+	{"ds_load_unset",    (cmd_function)w_ds_load_unset_cid, 1,
+		fixup_spve_null, fixup_free_spve_null, ANY_ROUTE},
 	{"ds_load_update",   (cmd_function)w_ds_load_update,  0,
 		0, 0, ANY_ROUTE},
 	{"ds_is_active",  (cmd_function)w_ds_is_active, 1,
@@ -939,6 +942,19 @@ static int w_ds_mark_addr(
 static int w_ds_load_unset(struct sip_msg *msg, char *str1, char *str2)
 {
 	if(ds_load_unset(msg) < 0)
+		return -1;
+	return 1;
+}
+
+static int w_ds_load_unset_cid(struct sip_msg *msg, char *pcid, char *str2)
+{
+	str scid = STR_NULL;
+
+	if(fixup_get_svalue(msg, (gparam_t *)pcid, &scid) < 0) {
+		LM_ERR("failed to get Call-ID parameter\n");
+		return -1;
+	}
+	if(ds_load_unset_callid(msg, &scid) < 0)
 		return -1;
 	return 1;
 }
@@ -1794,6 +1810,11 @@ static sr_kemi_t sr_kemi_dispatcher_exports[] = {
 	{ str_init("dispatcher"), str_init("ds_load_unset"),
 		SR_KEMIP_INT, ds_load_unset,
 		{ SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE,
+			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
+	},
+	{ str_init("dispatcher"), str_init("ds_load_unset_callid"),
+		SR_KEMIP_INT, ds_load_unset_callid,
+		{ SR_KEMIP_STR, SR_KEMIP_NONE, SR_KEMIP_NONE,
 			SR_KEMIP_NONE, SR_KEMIP_NONE, SR_KEMIP_NONE }
 	},
 	{ str_init("dispatcher"), str_init("ds_reload"),

--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -2118,14 +2118,25 @@ if(ds_is_active("10", "sip:127.0.0.1:5080")) {
 	</section>
 	<section>
 		<title>
-		<function moreinfo="none">ds_load_unset()</function>
+		<function moreinfo="none">ds_load_unset([callid])</function>
 		</title>
 		<para>
 		Remove the call load for the destination that routed the call.
 		</para>
 		<para>
+		Without a parameter, the call is identified by the Call-ID of the current
+		message. The optional <emphasis>callid</emphasis> parameter (which may
+		contain pseudo-variables) identifies the call by an explicit Call-ID
+		instead of the current message, so the load can be released from a context
+		that does not carry the original Call-ID - for example the
+		<function>dialog:failed</function> event route, which may run with a
+		synthetic message: passing <emphasis>$dlg(callid)</emphasis> there
+		releases the load reliably regardless of the message that triggered the
+		event.
+		</para>
+		<para>
 			This function can be used from REQUEST_ROUTE, FAILURE_ROUTE,
-			BRANCH_ROUTE and ONREPLY_ROUTE.
+			BRANCH_ROUTE, ONREPLY_ROUTE and EVENT_ROUTE.
 		</para>
 		<example>
 		<title><function>ds_load_unset</function> usage</title>
@@ -2150,6 +2161,12 @@ onreply_route {
             ds_load_unset();
     }
     ...
+}
+
+event_route[dialog:failed] {
+    # release the load by the dialog Call-ID, independent of the
+    # message that triggered the event
+    ds_load_unset("$dlg(callid)");
 }
 ...
 </programlisting>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This PR adds an optional `callid` argument to the dispatcher `ds_load_unset()` function (call-load algorithm, alg 10), so a call's gateway load can be released using an explicit Call-ID instead of the one on the current message.