### PR TITLE
ndb_redis: inherit pass/tls attrs for dynamic cluster nodes

### DIFF
--- a/src/modules/ndb_redis/redis_client.c
+++ b/src/modules/ndb_redis/redis_client.c
@@ -1057,6 +1057,8 @@ int check_cluster_reply(redisReply *reply, redisc_server_t **rsrv)
 	str addr = {0, 0}, tmpstr = {0, 0}, name = {0, 0};
 	int server_len = 0;
 	char spec_new[512];
+	param_t *pit = NULL, *pnew = NULL;
+	str orig_pass = {0, 0}, orig_tls = {0, 0};
 
 	if(redis_cluster_param) {
 		LM_DBG("Redis replied: \"%.*s\"\n", (int)reply->len, reply->str);
@@ -1102,7 +1104,26 @@ int check_cluster_reply(redisReply *reply, redisc_server_t **rsrv)
 				char *server_new;
 
 				memset(spec_new, 0, sizeof(spec_new));
-				/* For now, also include db=0 to prepare attribute inheritance */
+				/* For now, also include db=0 to prepare attribute inheritance.
+				 * pass/tls are inherited too (below, once the node exists)
+				 * so a dynamically-created node for a TLS+auth-required
+				 * Redis Cluster (e.g. ElastiCache with transit encryption
+				 * and AUTH enabled) does not silently connect in plaintext
+				 * with no credentials and get refused. They are attached
+				 * directly to the new server's attrs rather than
+				 * interpolated into spec_new, so a password containing ';'
+				 * or '=' cannot inject or override another attribute here -
+				 * e.g. a password ending in ";tls=0" must not be able to
+				 * downgrade the redirect connection to plaintext. */
+				for(pit = (*rsrv)->attrs; pit; pit = pit->next) {
+					if(pit->name.len == 4
+							&& strncmp(pit->name.s, "pass", 4) == 0) {
+						orig_pass = pit->body;
+					} else if(pit->name.len == 3
+							  && strncmp(pit->name.s, "tls", 3) == 0) {
+						orig_tls = pit->body;
+					}
+				}
 				server_len = snprintf(spec_new, sizeof(spec_new) - 1,
 						"name=%.*s;addr=%.*s;port=%i;db=%d", name.len, name.s,
 						addr.len, addr.s, port, 0);
@@ -1125,6 +1146,36 @@ int check_cluster_reply(redisReply *reply, redisc_server_t **rsrv)
 					rsrv_new = redisc_get_server(&name);
 
 					if(rsrv_new) {
+						/* Attach pass/tls verbatim, bypassing parse_params()
+						 * entirely, so the raw values are never re-parsed
+						 * out of a ';'-delimited string (see the comment
+						 * above where orig_pass/orig_tls are captured). */
+						if(orig_pass.len > 0) {
+							pnew = (param_t *)pkg_malloc(sizeof(param_t));
+							if(pnew == NULL) {
+								PKG_MEM_ERROR;
+								return 0;
+							}
+							memset(pnew, 0, sizeof(param_t));
+							pnew->name.s = "pass";
+							pnew->name.len = 4;
+							pnew->body = orig_pass;
+							pnew->next = rsrv_new->attrs;
+							rsrv_new->attrs = pnew;
+						}
+						if(orig_tls.len > 0) {
+							pnew = (param_t *)pkg_malloc(sizeof(param_t));
+							if(pnew == NULL) {
+								PKG_MEM_ERROR;
+								return 0;
+							}
+							memset(pnew, 0, sizeof(param_t));
+							pnew->name.s = "tls";
+							pnew->name.len = 3;
+							pnew->body = orig_tls;
+							pnew->next = rsrv_new->attrs;
+							rsrv_new->attrs = pnew;
+						}
 						*rsrv = rsrv_new;
 						/* Need to connect to the new server now */
 						if(redisc_reconnect_server(rsrv_new) == 0) {


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [ ] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder (clang-format was not available in my environment; the
  patch was hand-matched to the surrounding function's existing style)
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [ ] Tested changes locally
- [x] Related to issue #4907

#### Description

Closes #4907.

`check_cluster_reply()` builds the spec for a dynamically-created cluster
node (created when a `-MOVED` reply points at a node not already
connected) with only `name`/`addr`/`port`/`db`. `pass`/`tls` are never
carried over from the server that received the redirect, so against a
Redis Cluster that requires AUTH and/or TLS (e.g. AWS ElastiCache with
transit encryption and an auth token), the new connection is refused and
every subsequent command against it fails with "Resource temporarily
unavailable".

GH #4433 / PR #4442 added `db=0` to the new spec explicitly "to prepare
attribute inheritance" but left `pass`/`tls`/timeouts as an unfinished
follow-up (see #4907 for the full repro and context). This PR finishes
the `pass`/`tls` half of that: once the new server node exists (after
`redisc_add_server()` succeeds), the original server's `pass`/`tls`
attrs are copied and prepended directly onto the new server's `attrs`
linked list, before `redisc_reconnect_server()` is called.

This is done as a direct attach of `param_t` nodes rather than by
interpolating `pass`/`tls` into `spec_new`'s `;`-delimited string,
because `spec_new` gets re-parsed by `redisc_add_server()` via the
generic, unescaped `parse_params()`. Interpolating a raw password into
that string would let a password containing `;` or `=` inject or
override another attribute in the new server's config (e.g. a password
crafted to end in `;tls=0` could silently downgrade the redirect
connection to plaintext). Attaching the attrs directly after the node
already exists avoids that entirely.

**Correctness/safety notes** (traced against current module code):
- `do_free_params()` only ever frees the `param_t` node itself, never
  `name.s`/`body.s`, so using a string literal for `name.s` and pointing
  `body` at the original server's already-allocated string is safe.
- Server attrs are only freed at module shutdown (`redisc_destroy()`),
  never while servers are in active use, so there's no dangling-pointer
  risk between the old and new server sharing that string memory.
- `redisc_reconnect_server()`'s attrs consumer matches by `name` string
  (`strncmp`), not by `ptype_t`, so leaving the manually-built nodes'
  `type` at the zero value (`P_OTHER`) is fine.

**Testing:** verified via `git apply --check`/build that the patch
applies cleanly and compiles against current master. The patched module
has also been running in a production-adjacent staging deployment for
several hours against a TLS+AUTH ElastiCache Redis Cluster with no
regressions (previously it logged a stale broken cluster-node connection
continuously). That deployment has not yet naturally hit a fresh `MOVED`
redirect since the patch was deployed, so the exact new-connection code
path added here has been verified by code review/tracing (see notes
above) but not yet observed end-to-end against a live redirect. Leaving
"Tested changes locally" unchecked above to reflect that honestly.
