### PR TITLE
db_redis: reshuffle sentinel code to cleanly build redis cluster/ sentinel

### DIFF
--- a/src/modules/db_redis/CMakeLists.txt
+++ b/src/modules/db_redis/CMakeLists.txt
@@ -1,5 +1,16 @@
 file(GLOB MODULE_SOURCES "*.c")
 
+option(WITH_SENTINELS "Build db_redis with Redis Sentinel support" OFF)
+option(WITH_HIREDIS_CLUSTER "Build db_redis with hiredis cluster support" OFF)
+
+if(WITH_SENTINELS AND WITH_HIREDIS_CLUSTER)
+  message(FATAL_ERROR "db_redis: WITH_SENTINELS and WITH_HIREDIS_CLUSTER are mutually exclusive")
+endif()
+
+if(NOT WITH_SENTINELS)
+  list(REMOVE_ITEM MODULE_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/redis_sentinels.c")
+endif()
+
 add_library(${module_name} SHARED ${MODULE_SOURCES})
 
 find_package(PkgConfig REQUIRED)
@@ -7,6 +18,17 @@ pkg_check_modules(hiredis REQUIRED IMPORTED_TARGET hiredis)
 add_library(hiredis::hiredis ALIAS PkgConfig::hiredis)
 
 target_link_libraries(${module_name} PRIVATE hiredis::hiredis)
+
+if(WITH_SENTINELS)
+  target_compile_definitions(${module_name} PRIVATE WITH_SENTINELS)
+endif()
+
+if(WITH_HIREDIS_CLUSTER)
+  pkg_check_modules(hiredis_cluster REQUIRED IMPORTED_TARGET hiredis_cluster)
+  add_library(hiredis::hiredis_cluster ALIAS PkgConfig::hiredis_cluster)
+  target_compile_definitions(${module_name} PRIVATE WITH_HIREDIS_CLUSTER)
+  target_link_libraries(${module_name} PRIVATE hiredis::hiredis_cluster)
+endif()
 
 # Check for hiredis SSL support
 pkg_check_modules(hiredis_ssl IMPORTED_TARGET hiredis_ssl)

--- a/src/modules/db_redis/Makefile
+++ b/src/modules/db_redis/Makefile
@@ -60,17 +60,33 @@ endif
 DEFS+=$(HIREDISDEFS)
 LIBS=$(HIREDISLIBS)
 
+# Mode switches:
+# - WITH_REDIS_CLUSTER=1 (default): enable cluster mode if hiredis_cluster exists
+# - WITH_REDIS_CLUSTER=0: force normal (non-cluster) mode
+# - WITH_SENTINELS=1: enable sentinel mode and disable cluster mode
+WITH_REDIS_CLUSTER ?= 1
+
+ifeq ($(WITH_SENTINELS),1)
+DEFS+=-DWITH_SENTINELS
+endif
+
 ifneq ($(HIREDIS_CLUSTER_BUILDER),)
-	HIREDISCLUSTERDEFS = $(shell $(HIREDIS_CLUSTER_BUILDER) --cflags)
-	HIREDISCLUSTERLIBS = $(shell $(HIREDIS_CLUSTER_BUILDER) --libs)
-	HIREDISCLUSTERLIBSPATH = $(shell $(HIREDIS_CLUSTER_BUILDER) --libs-only-L | cut -c 3-)
-	ifneq ($(shell ls $(HIREDISCLUSTERLIBSPATH) | grep libhiredis_cluster_ssl.so),)
-		HIREDISCLUSTERDEFS += -DWITH_SSL
-		HIREDISCLUSTERLIBS += -lhiredis_cluster_ssl
-	endif
-	DEFS+=-DWITH_HIREDIS_CLUSTER
-	DEFS+=$(HIREDISCLUSTERDEFS)
-	LIBS+=$(HIREDISCLUSTERLIBS)
+ifeq ($(WITH_SENTINELS),1)
+$(info db_redis: WITH_SENTINELS=1, skipping hiredis cluster mode)
+else ifeq ($(WITH_REDIS_CLUSTER),0)
+$(info db_redis: WITH_REDIS_CLUSTER=0, forcing normal (non-cluster) mode)
+else
+HIREDISCLUSTERDEFS = $(shell $(HIREDIS_CLUSTER_BUILDER) --cflags)
+HIREDISCLUSTERLIBS = $(shell $(HIREDIS_CLUSTER_BUILDER) --libs)
+HIREDISCLUSTERLIBSPATH = $(shell $(HIREDIS_CLUSTER_BUILDER) --libs-only-L | cut -c 3-)
+ifneq ($(shell ls $(HIREDISCLUSTERLIBSPATH) | grep libhiredis_cluster_ssl.so),)
+HIREDISCLUSTERDEFS += -DWITH_SSL
+HIREDISCLUSTERLIBS += -lhiredis_cluster_ssl
+endif
+DEFS+=-DWITH_HIREDIS_CLUSTER
+DEFS+=$(HIREDISCLUSTERDEFS)
+LIBS+=$(HIREDISCLUSTERLIBS)
+endif
 endif
 
 include ../../Makefile.modules

--- a/src/modules/db_redis/db_redis_mod.c
+++ b/src/modules/db_redis/db_redis_mod.c
@@ -30,7 +30,9 @@
 #include "db_redis_mod.h"
 #include "redis_dbase.h"
 #include "redis_table.h"
+#ifdef WITH_SENTINELS
 #include "redis_sentinels.h"
+#endif
 
 #ifdef WITH_SSL
 int db_redis_opt_tls = 0;
@@ -46,25 +48,15 @@ str redis_schema_path = str_init(SHARE_DIR "db_redis/kamailio");
 int db_redis_verbosity = 1;
 int mapping_struct_type = 0;
 str db_redis_hash_value = str_init("DUMMY");
-int db_redis_with_sentinels = 0;
-char *db_redis_master_name = "mymaster";
 
 int db_redis_hash_expires = 0;
 str db_redis_hash_expires_str = str_init("");
 char db_redis_hash_expires_buf[20] = {0};
 
-time_t *db_redis_shared_time = NULL;
-time_t last_seen_time = 0;
-int using_master_read_only = 0;
-
 static int db_redis_bind_api(db_func_t *dbb);
 static int mod_init(void);
 static void mod_destroy(void);
-int use_replicas = 0; // 0 master/RW, 1 replica/RO
 int keys_param(modparam_t type, void *val);
-int sentinels_param(modparam_t type, void *val);
-int recheck_replicas_interval = 120; // seconds
-int min_recheck_interval = 60;		 // seconds
 
 static cmd_export_t cmds[] = {
 		{"db_bind_api", (cmd_function)db_redis_bind_api, 0, 0, 0, 0},
@@ -82,12 +74,14 @@ static param_export_t params[] = {
 		{"max_key_length", PARAM_INT, &db_redis_max_key_len},
 		{"hash_value", PARAM_STRING, &db_redis_hash_value},
 		{"hash_expires", PARAM_INT, &db_redis_hash_expires},
+#ifdef WITH_SENTINELS
 		{"with_sentinels", PARAM_INT, &db_redis_with_sentinels},
 		{"sentinels_config", PARAM_STRING | PARAM_USE_FUNC,
 				(void *)sentinels_param},
 		{"use_replicas", PARAM_INT, &use_replicas}, // 0 master/RW, 1 replica/RO
 		{"redis_master_name", PARAM_STR, &db_redis_master_name},
 		{"recheck_replicas_interval", PARAM_INT, &recheck_replicas_interval},
+#endif
 #ifdef WITH_SSL
 		{"opt_tls", PARAM_INT, &db_redis_opt_tls},
 		{"ca_path", PARAM_STRING, &db_redis_ca_path},
@@ -138,23 +132,11 @@ int keys_param(modparam_t type, void *val)
 		return db_redis_keys_spec((char *)val);
 }
 
-int sentinels_param(modparam_t type, void *val)
-{
-	return parse_sentinel_config((char *)val);
-}
-
 int mod_register(char *path, int *dlflags, void *p1, void *p2)
 {
 	if(db_api_init() < 0)
 		return -1;
 	return 0;
-}
-
-static void db_redis_timer(unsigned int ticks, void *param)
-{
-	if(db_redis_shared_time) {
-		*db_redis_shared_time = time(NULL);
-	}
 }
 
 static int mod_init(void)
@@ -173,34 +155,11 @@ static int mod_init(void)
 				db_redis_hash_expires_str.s, 20, "%d", db_redis_hash_expires);
 	}
 
-	db_redis_shared_time = shm_malloc(sizeof(time_t));
-	if(db_redis_shared_time == NULL) {
-		SHM_MEM_ERROR;
+#ifdef WITH_SENTINELS
+	if(db_redis_sentinels_init_runtime() != 0) {
 		return -1;
 	}
-
-	*db_redis_shared_time = 0;
-
-	if(db_redis_with_sentinels) {
-		if(db_redis_sc.sentinel_list == NULL) {
-			LM_ERR("sentinels_config parameter is required when using "
-				   "sentinels\n");
-			return -1;
-		}
-
-		if(recheck_replicas_interval <= 0) {
-			LM_WARN("Considering replica recheck is not desired.\n");
-			return 0;
-		} else {
-			min_recheck_interval = recheck_replicas_interval / 2;
-			if(register_timer(db_redis_timer, 0, recheck_replicas_interval)
-					< 0) {
-				LM_ERR("Failed to register timer for rechecking replica "
-					   "availability\n");
-				return -1;
-			}
-		}
-	}
+#endif
 	return 0;
 }
 

--- a/src/modules/db_redis/db_redis_mod.h
+++ b/src/modules/db_redis/db_redis_mod.h
@@ -25,6 +25,10 @@
 #ifndef _DB_REDIS_MOD_H
 #define _DB_REDIS_MOD_H
 
+#if defined(WITH_HIREDIS_CLUSTER) && defined(WITH_SENTINELS)
+#error "db_redis: WITH_HIREDIS_CLUSTER and WITH_SENTINELS are mutually exclusive"
+#endif
+
 #include "../../lib/srdb1/db.h"
 #include "../../lib/srdb1/db_ut.h"
 #include "../../lib/srdb1/db_query.h"
@@ -51,9 +55,6 @@
 
 extern str redis_keys;
 extern str redis_schema_path;
-extern int db_redis_with_sentinels;
-extern int use_replicas;
-extern char *db_redis_master_name;
 extern char *db_redis_db_pass;
 typedef enum
 {

--- a/src/modules/db_redis/redis_connection.c
+++ b/src/modules/db_redis/redis_connection.c
@@ -24,7 +24,9 @@
 
 #include "db_redis_mod.h"
 #include "redis_connection.h"
+#ifdef WITH_SENTINELS
 #include "redis_sentinels.h"
+#endif
 #include "redis_table.h"
 #include "redis_dbase.h"
 
@@ -129,12 +131,47 @@ static inline int redis_supports_expires(int major, int minor, int patch)
 	return 1;
 }
 
+int db_redis_authenticate(void *ctx, const char *password)
+{
+	redisReply *reply = NULL;
+#ifdef WITH_HIREDIS_CLUSTER
+	redisClusterContext *casted_ctx = (redisClusterContext *)ctx;
+#else
+	redisContext *casted_ctx = (redisContext *)ctx;
+#endif
+	if(!ctx) {
+		LM_ERR("No Redis context\n");
+		return -1;
+	}
+
+	if(!password) {
+		password = db_redis_db_pass;
+	}
+	if(!password) {
+		return 0;
+	}
+
+	reply = redisCommand(casted_ctx, "AUTH %s", password);
+
+	if(!reply) {
+		LM_ERR("AUTH error: %s\n", casted_ctx->errstr);
+		return -1;
+	}
+
+	if(reply->type == REDIS_REPLY_ERROR) {
+		LM_ERR("AUTH failed: %s\n", reply->str);
+		freeReplyObject(reply);
+		return -1;
+	}
+
+	freeReplyObject(reply);
+	return 0;
+}
+
 int db_redis_connect(km_redis_con_t *con)
 {
 	struct timeval tv;
 	redisReply *reply;
-	redisContext *sentinel_ctx = NULL;
-	int try_replicas = use_replicas;
 
 #ifndef WITH_HIREDIS_CLUSTER
 	int db;
@@ -215,69 +252,13 @@ int db_redis_connect(km_redis_con_t *con)
 		goto err;
 	}
 #else
+#ifdef WITH_SENTINELS
 	if(db_redis_with_sentinels) {
-		redis_sentinel_t *sentinel;
-		int select_status, srv_found = 0;
-
-	recheck_sentinels:
-		for(sentinel = db_redis_sc.sentinel_list; sentinel != NULL;
-				sentinel = sentinel->next) {
-			struct timeval timeout;
-			timeout.tv_sec = 0;
-			timeout.tv_usec = 500000;
-
-			LM_INFO("Connecting to sentinel %s:%d\n", sentinel->host,
-					sentinel->port);
-			sentinel_ctx = redisConnectWithTimeout(
-					sentinel->host, sentinel->port, timeout);
-
-			if(!sentinel_ctx || sentinel_ctx->err) {
-				LM_ERR("Failed to create Redis context for sentinel %s:%d\n",
-						sentinel->host, sentinel->port);
-				if(sentinel_ctx) {
-					redisFree(sentinel_ctx);
-					sentinel_ctx = NULL;
-				}
-				continue;
-			}
-
-			if(db_redis_authenticate(sentinel_ctx, db_redis_sc.password) != 0) {
-				LM_ERR("Authentication error\n");
-				if(sentinel_ctx) {
-					redisFree(sentinel_ctx);
-					sentinel_ctx = NULL;
-				}
-				continue;
-			}
-
-			select_status = try_replicas
-									? db_redis_select_replica(sentinel_ctx, con)
-									: db_redis_select_master(sentinel_ctx, con);
-
-			if(select_status != 0) { // Failed to select master/replica
-				continue;
-			}
-
-			srv_found = 1;
-			break; // Successfully selected a server, break out of the loop
-		}
-		if(!srv_found) {
-			if(try_replicas) {
-				LM_ERR("Could not connect to any redis replica via sentinel, "
-					   "now defaulting to checking for master\n");
-				replica_list_free(&replica_list);
-				if(sentinel_ctx) {
-					redisFree(sentinel_ctx);
-					sentinel_ctx = NULL;
-				}
-				try_replicas = 0; // now try to connect to master
-				goto recheck_sentinels;
-			} else {
-				LM_ERR("Could not connect to any redis servers via sentinel\n");
-				goto err;
-			}
+		if(db_redis_resolve_server_via_sentinels(con) != 0) {
+			goto err;
 		}
 	}
+#endif
 	LM_INFO("connecting to redis at %s:%d\n", con->id->host, con->id->port);
 
 #ifdef WITH_SSL
@@ -422,8 +403,6 @@ err:
 		redisFree(con->con);
 		con->con = NULL;
 	}
-	if(sentinel_ctx)
-		redisFree(sentinel_ctx);
 	return -1;
 }
 
@@ -573,27 +552,12 @@ void *db_redis_command_argv_to_node(
 
 #endif
 
-static inline int should_recheck_replicas(time_t crt_time)
-{
-	if(!using_master_read_only || !recheck_replicas_interval) {
-		return 0;
-	}
-
-	if(crt_time != last_seen_time
-			&& (crt_time - last_seen_time) > min_recheck_interval) {
-		last_seen_time = crt_time;
-		return 1;
-	}
-	return 0;
-}
-
 void *db_redis_command_argv(km_redis_con_t *con, redis_key_t *query)
 {
 	char **argv = NULL;
 	int argc;
 	redisReply *reply = NULL;
 	int reconnect_needed = 0;
-	time_t current_time;
 
 	print_query(query);
 
@@ -604,13 +568,10 @@ void *db_redis_command_argv(km_redis_con_t *con, redis_key_t *query)
 	}
 	LM_DBG("query has %d args\n", argc);
 
-	current_time = *db_redis_shared_time;
-	if(should_recheck_replicas(current_time)) {
-		LM_WARN("Reconnecting: redis master is being used for read-only "
-				"operations.\n");
-		last_seen_time = current_time;
-		reconnect_needed = 1;
-	} else {
+#ifdef WITH_SENTINELS
+	reconnect_needed = db_redis_should_reconnect_for_replica_recheck();
+#endif
+	if(!reconnect_needed) {
 		reply = redisCommandArgv(con->con, argc, (const char **)argv, NULL);
 		if(con->con->err != REDIS_OK) {
 			LM_WARN("redis connection is gone, try reconnect. (%d:%s)\n",
@@ -686,20 +647,16 @@ int db_redis_get_reply(km_redis_con_t *con, void **reply)
 	int ret;
 	redis_key_t *query;
 	int reconnect_needed = 0;
-	time_t current_time;
 
 	if(!con || !con->con) {
 		LM_ERR("Internal error passing null connection\n");
 		return -1;
 	}
 
-	current_time = *db_redis_shared_time;
-	if(should_recheck_replicas(current_time)) {
-		LM_WARN("Reconnecting: redis master is being used for read-only "
-				"operations.\n");
-		last_seen_time = current_time;
-		reconnect_needed = 1;
-	} else {
+#ifdef WITH_SENTINELS
+	reconnect_needed = db_redis_should_reconnect_for_replica_recheck();
+#endif
+	if(!reconnect_needed) {
 		*reply = NULL;
 		ret = redisGetReply(con->con, reply);
 		if(con->con->err != REDIS_OK) {

--- a/src/modules/db_redis/redis_connection.h
+++ b/src/modules/db_redis/redis_connection.h
@@ -46,7 +46,7 @@
 
 #include "db_redis_mod.h"
 
-#ifndef WITH_REDIS_CLUSTER
+#ifndef WITH_HIREDIS_CLUSTER
 #define db_redis_check_reply(con, reply, err)                                \
 	do {                                                                     \
 		if(!(reply) && !(con)->con) {                                        \
@@ -118,6 +118,7 @@ km_redis_con_t *db_redis_new_connection(const struct db_id *id);
 void db_redis_free_connection(struct pool_con *con);
 
 int db_redis_connect(km_redis_con_t *con);
+int db_redis_authenticate(void *ctx, const char *password);
 void *db_redis_command_argv(km_redis_con_t *con, redis_key_t *query);
 int db_redis_append_command_argv(
 		km_redis_con_t *con, redis_key_t *query, int queue);

--- a/src/modules/db_redis/redis_dbase.c
+++ b/src/modules/db_redis/redis_dbase.c
@@ -2714,7 +2714,7 @@ static int db_redis_perform_update(const db1_con_t *_h, km_redis_con_t *con,
 					LM_ERR("Failed to add key to delete query\n");
 					goto error;
 				}
-				if(db_redis_key_add_str(&query_v, key) != 0) {
+				if(db_redis_key_add_str(&query_v, &key->key) != 0) {
 					LM_ERR("Failed to add key to delete query\n");
 					goto error;
 				}

--- a/src/modules/db_redis/redis_sentinels.c
+++ b/src/modules/db_redis/redis_sentinels.c
@@ -21,10 +21,101 @@
 #include <stdlib.h>
 
 #include "redis_sentinels.h"
+
+#ifdef WITH_SENTINELS
 #include "db_redis_mod.h"
+
+int db_redis_with_sentinels = 0;
+char *db_redis_master_name = "mymaster";
+int use_replicas = 0;				 // 0 master/RW, 1 replica/RO
+int recheck_replicas_interval = 120; // seconds
+int min_recheck_interval = 60;		 // seconds
+time_t *db_redis_shared_time = NULL;
+time_t last_seen_time = 0;
+int using_master_read_only = 0;
 
 sentinel_config_t db_redis_sc;
 struct reply_list replica_list = {NULL, NULL, 0};
+
+int sentinels_param(modparam_t type, void *val)
+{
+	(void)type;
+	return parse_sentinel_config((char *)val);
+}
+
+void db_redis_timer(unsigned int ticks, void *param)
+{
+	(void)ticks;
+	(void)param;
+	if(db_redis_shared_time) {
+		*db_redis_shared_time = time(NULL);
+	}
+}
+
+int db_redis_sentinels_init_runtime(void)
+{
+	db_redis_shared_time = shm_malloc(sizeof(time_t));
+	if(db_redis_shared_time == NULL) {
+		SHM_MEM_ERROR;
+		return -1;
+	}
+
+	*db_redis_shared_time = 0;
+
+	if(db_redis_with_sentinels) {
+		if(db_redis_sc.sentinel_list == NULL) {
+			LM_ERR("sentinels_config parameter is required when using "
+				   "sentinels\n");
+			return -1;
+		}
+
+		if(recheck_replicas_interval <= 0) {
+			LM_WARN("Considering replica recheck is not desired.\n");
+			return 0;
+		}
+
+		min_recheck_interval = recheck_replicas_interval / 2;
+		if(register_timer(db_redis_timer, 0, recheck_replicas_interval) < 0) {
+			LM_ERR("Failed to register timer for rechecking replica "
+				   "availability\n");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+int should_recheck_replicas(time_t crt_time)
+{
+	if(!using_master_read_only || !recheck_replicas_interval) {
+		return 0;
+	}
+
+	if(crt_time != last_seen_time
+			&& (crt_time - last_seen_time) > min_recheck_interval) {
+		last_seen_time = crt_time;
+		return 1;
+	}
+	return 0;
+}
+
+int db_redis_should_reconnect_for_replica_recheck(void)
+{
+	time_t current_time;
+
+	if(!db_redis_shared_time) {
+		return 0;
+	}
+
+	current_time = *db_redis_shared_time;
+	if(should_recheck_replicas(current_time)) {
+		LM_WARN("Reconnecting: redis master is being used for read-only "
+				"operations.\n");
+		return 1;
+	}
+
+	return 0;
+}
 
 
 static int is_text(const redisReply *r)
@@ -391,40 +482,6 @@ error:
 	return -1;
 }
 
-/* Authenticate to Redis if a password was provided */
-int db_redis_authenticate(redisContext *ctx, const char *password)
-{
-	redisReply *reply = NULL;
-
-	if(!ctx) {
-		LM_ERR("No Redis context");
-		goto err;
-	}
-	if(!password) {
-		password = db_redis_db_pass;
-	}
-	if(!password) {
-		return 0;
-	}
-
-	reply = redisCommand(ctx, "AUTH %s", password);
-	if(!reply) {
-		LM_ERR("AUTH error: %s\n", ctx->errstr);
-		goto err;
-	}
-	if(reply->type == REDIS_REPLY_ERROR) {
-		LM_ERR("AUTH failed: %s\n", reply->str);
-		goto err;
-	}
-	freeReplyObject(reply);
-	return 0;
-
-err:
-	if(reply)
-		freeReplyObject(reply);
-	return -1;
-}
-
 int db_redis_select_master(redisContext *sentinel_ctx, km_redis_con_t *con)
 {
 	redisReply *reply = redisCommand(sentinel_ctx,
@@ -533,3 +590,73 @@ err:
 		freeReplyObject(reply);
 	return -1;
 }
+
+int db_redis_resolve_server_via_sentinels(km_redis_con_t *con)
+{
+	redisContext *sentinel_ctx = NULL;
+	redis_sentinel_t *sentinel;
+	int select_status;
+	int srv_found = 0;
+	int try_replicas = use_replicas;
+
+recheck_sentinels:
+	for(sentinel = db_redis_sc.sentinel_list; sentinel != NULL;
+			sentinel = sentinel->next) {
+		struct timeval timeout;
+		timeout.tv_sec = 0;
+		timeout.tv_usec = 500000;
+
+		LM_INFO("Connecting to sentinel %s:%d\n", sentinel->host,
+				sentinel->port);
+		sentinel_ctx = redisConnectWithTimeout(
+				sentinel->host, sentinel->port, timeout);
+
+		if(!sentinel_ctx || sentinel_ctx->err) {
+			LM_ERR("Failed to create Redis context for sentinel %s:%d\n",
+					sentinel->host, sentinel->port);
+			if(sentinel_ctx) {
+				redisFree(sentinel_ctx);
+				sentinel_ctx = NULL;
+			}
+			continue;
+		}
+
+		if(db_redis_authenticate(sentinel_ctx, db_redis_sc.password) != 0) {
+			LM_ERR("Authentication error\n");
+			redisFree(sentinel_ctx);
+			sentinel_ctx = NULL;
+			continue;
+		}
+
+		select_status = try_replicas
+								? db_redis_select_replica(sentinel_ctx, con)
+								: db_redis_select_master(sentinel_ctx, con);
+
+		redisFree(sentinel_ctx);
+		sentinel_ctx = NULL;
+
+		if(select_status != 0) {
+			continue;
+		}
+
+		srv_found = 1;
+		break;
+	}
+
+	if(!srv_found) {
+		if(try_replicas) {
+			LM_ERR("Could not connect to any redis replica via sentinel, "
+				   "now defaulting to checking for master\n");
+			replica_list_free(&replica_list);
+			try_replicas = 0;
+			goto recheck_sentinels;
+		}
+
+		LM_ERR("Could not connect to any redis servers via sentinel\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+#endif

--- a/src/modules/db_redis/redis_sentinels.h
+++ b/src/modules/db_redis/redis_sentinels.h
@@ -23,6 +23,8 @@
 #ifndef _REDIS_SENTINELS_H_
 #define _REDIS_SENTINELS_H_
 
+#ifdef WITH_SENTINELS
+
 #include <hiredis/hiredis.h>
 #include "db_redis_mod.h"
 #include "redis_connection.h"
@@ -68,6 +70,9 @@ typedef struct
 
 extern sentinel_config_t db_redis_sc;
 extern struct reply_list replica_list;
+extern int db_redis_with_sentinels;
+extern int use_replicas;
+extern char *db_redis_master_name;
 extern time_t last_seen_time;
 extern time_t *db_redis_shared_time;
 extern int using_master_read_only;
@@ -84,15 +89,25 @@ int replica_list_free(struct reply_list *list);
  */
 int parse_sentinel_config(char *spec);
 
+/* module param callback for sentinels_config */
+int sentinels_param(modparam_t type, void *val);
+
+/* timer callback used for replica recheck */
+void db_redis_timer(unsigned int ticks, void *param);
+
+/* initialize sentinel runtime state during module init */
+int db_redis_sentinels_init_runtime(void);
+
+/* decide when to refresh replica usage while on master */
+int should_recheck_replicas(time_t crt_time);
+
+/* decide if connection should reconnect to refresh replica usage */
+int db_redis_should_reconnect_for_replica_recheck(void);
+
 /*
  * Add sentinels in case of sentinel mode
  */
 int db_redis_add_sentinels(char *spec);
-
-/*
- * Authenticate to Redis if a password was provided
- */
-int db_redis_authenticate(redisContext *ctx, const char *password);
 
 /*
  * Select a master server using the Sentinel
@@ -103,5 +118,12 @@ int db_redis_select_master(redisContext *sentinel_ctx, km_redis_con_t *con);
  * Select a replica server using the Sentinel
  */
 int db_redis_select_replica(redisContext *sentinel_ctx, km_redis_con_t *con);
+
+/*
+ * Resolve redis host/port via configured sentinels.
+ */
+int db_redis_resolve_server_via_sentinels(km_redis_con_t *con);
+
+#endif
 
 #endif /* _REDIS_SENTINELS_H_ */


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
This better decouples the code that belongs to the redis cluster vs redis with sentinels (either export WITH_SENTINELS=1 or export WITH_HIREDIS_CLUSTER=1). This ensures that such builds work without problems.

I am not savvy in the Makefile and CMake part, I relied on AI.

Whoever is interested is welcome to test the cluster scenarios as I only have a sentinel setup.

Thank you
