### PR TITLE
misc/fuzz: Fix build for OSS-Fuzz build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,8 +152,8 @@ if(OBJCOPY)
   add_custom_command(
     TARGET kamailio-oss-fuzz
     POST_BUILD
-    COMMAND ${OBJCOPY} --strip-symbol=main $<TARGET_FILE:kamailio-oss-fuzz>
-    COMMENT "Stripping main symbol from kamailio-oss-fuzz library"
+    COMMAND ${OBJCOPY} --localize-symbol=main $<TARGET_FILE:kamailio-oss-fuzz>
+    COMMENT "Localizing main symbol in kamailio-oss-fuzz library"
   )
 endif()
 


### PR DESCRIPTION
This PR fixes the build for the oss-fuzz to accommodate the changes of build script in https://github.com/google/oss-fuzz/pull/14955 which has some errors locating the necessary object symbols.