### PR TITLE
core: dns - keep the NAPTR failover state in the dns_srv_handle

### DIFF
--- a/src/core/dns_cache.c
+++ b/src/core/dns_cache.c
@@ -2760,10 +2760,6 @@ struct naptr_rdata *dns_naptr_sip_iterate(struct dns_rr *naptr_head,
 		}
 		LM_DBG("found a valid sip NAPTR rr %.*s, proto %d\n", naptr->repl_len,
 				naptr->repl, (int)naptr_proto);
-		if(naptr->skip_record) {
-			i++;
-			continue;
-		}
 		if((naptr_proto_supported(naptr_proto))) {
 			if(naptr_choose(&naptr_saved, &saved_proto, naptr, naptr_proto))
 				idx = i;
@@ -3330,65 +3326,6 @@ inline static int dns_srv_sip_resolve(struct dns_srv_handle *h, str *name,
 #ifdef USE_NAPTR
 
 
-static void mark_skip_current_naptr(
-		struct dns_rr *naptr_head, struct dns_hash_entry *srv)
-{
-	int i;
-	struct dns_rr *l;
-	struct naptr_rdata *naptr;
-
-	if(!naptr_head || !srv) {
-		return;
-	}
-
-	for(l = naptr_head, i = 0; l && (i < MAX_NAPTR_RRS); l = l->next, i++) {
-		naptr = (struct naptr_rdata *)l->rdata;
-		if(naptr == 0) {
-			break;
-		}
-		if(naptr->skip_record) {
-			continue;
-		}
-		if(srv->name_len == naptr->repl_len
-				&& !memcmp(srv->name, naptr->repl, srv->name_len)) {
-			naptr->skip_record = 1;
-			LM_NOTICE("Mark to skip %.*s NAPTR record due to all IPs are "
-					  "unreachable\n",
-					naptr->repl_len, naptr->repl);
-			break;
-		}
-	}
-}
-
-
-inline static int have_more_active_naptr(struct dns_rr *naptr_head)
-{
-	int i, res = 0;
-	struct dns_rr *l;
-	struct naptr_rdata *naptr;
-	char naptr_proto;
-
-	if(!naptr_head) {
-		return res;
-	}
-
-	for(l = naptr_head, i = 0; l && (i < MAX_NAPTR_RRS); l = l->next, i++) {
-		naptr = (struct naptr_rdata *)l->rdata;
-		if(naptr == 0) {
-			break;
-		}
-		if(naptr->skip_record) {
-			continue;
-		} else if((naptr_proto = naptr_get_sip_proto(naptr)) <= 0) {
-			continue;
-		} else if((naptr_proto_supported(naptr_proto))) {
-			res = 1;
-			break;
-		}
-	}
-	return res;
-}
-
 /* resolves a host name trying:
  * - NAPTR lookup if the address is not an ip and proto!=0, port!=0
  *    *port==0 and *proto=0 and if flags allow NAPTR lookups
@@ -3407,13 +3344,11 @@ inline static int dns_naptr_sip_resolve(struct dns_srv_handle *h, str *name,
 {
 	struct hostent *he;
 	struct ip_addr *tmp_ip;
-	naptr_bmp_t tried_bmp;
 	struct dns_hash_entry *e;
 	char n_proto, origproto;
 	str srv_name;
 	int ret;
-	int res;
-	int try_lookup_naptr = 0;
+	int continued;
 
 	ret = -E_DNS_NO_NAPTR;
 	if(proto)
@@ -3430,6 +3365,7 @@ inline static int dns_naptr_sip_resolve(struct dns_srv_handle *h, str *name,
 		}
 		return -E_DNS_NO_NAPTR;
 	}
+	continued = 0;
 	if(((h->srv == 0) && (h->a == 0) && (h->naptr == 0)) && /* first call */
 			proto && port && (*proto == 0) && (*port == 0)) {
 		*proto = PROTO_UDP; /* just in case we don't find another */
@@ -3454,51 +3390,52 @@ inline static int dns_naptr_sip_resolve(struct dns_srv_handle *h, str *name,
 		/* the handle takes over the reference returned by dns_get_entry(),
 		 * it is released by dns_srv_handle_put() */
 		h->naptr = e;
-		try_lookup_naptr = 1;
-	} else {
-		/* access old naptr lookup */
-		if((e = h->naptr) == 0)
-			goto naptr_not_found;
-	}
-	/* check if it's an ip address, dns_srv_sip_resolve will return the right failure */
-	if(str2ip(name) || str2ip6(name))
-		goto naptr_not_found;
-
-	if(!try_lookup_naptr) {
+		/* nothing tried yet by this handle */
+		naptr_iterate_init(&h->naptr_tried_rrs);
+	} else if((e = h->naptr) != 0) {
+		/* continue a naptr based resolution started by a previous call:
+		 * first try to get another ip for the naptr record in use */
+		continued = 1;
 		if(proto)
 			*proto = origproto;
-		res = dns_srv_sip_resolve(h, name, ip, port, proto, flags);
-		if(res) {
-			mark_skip_current_naptr(e->rr_lst, h->srv);
-			if(have_more_active_naptr(e->rr_lst)) {
-				// No more avaliable IP for current NAPTR record, let's try next one
-				try_lookup_naptr = 1;
-			}
-		} else {
-			return res;
-		}
+		ret = dns_srv_sip_resolve(h, name, ip, port, proto, flags);
+		if(ret >= 0)
+			return ret;
+		/* no more destinations for the current naptr record => fall through
+		 * and try the next naptr record not used yet by this handle */
+		LM_DBG("no more destinations for the current NAPTR record of %.*s"
+			   " (%d), trying the next one\n",
+				name->len, name->s, ret);
+	} else {
+		/* no naptr entry (previous fallback to srv/a) */
+		goto naptr_not_found;
 	}
 
-	if(try_lookup_naptr) {
-		naptr_iterate_init(&tried_bmp);
-		while(dns_naptr_sip_iterate(
-				e->rr_lst, &tried_bmp, &srv_name, &n_proto)) {
-			dns_srv_handle_reset(h); /* make sure h does not contain garbage
-									from previous dns_srv_sip_resolve calls */
-			if((ret = dns_srv_resolve_ip(h, &srv_name, ip, port, flags)) >= 0) {
-				LM_DBG("(%.*s, %d, %d), srv0, ret=%d\n", name->len, name->s,
-						h->srv_no, h->ip_no, ret);
-				if(proto)
-					*proto = n_proto;
-				h->proto = n_proto;
-				return ret;
-			}
-		}
-		/* no acceptable naptr record found, fallback to srv;
-		 * reset() releases the srv/a entries left by the failed attempts
-		 * above and keeps h->naptr, init() would leak them */
+	/* iterate only over the naptr records not tried yet by *this* handle:
+	 * h->naptr_tried_rrs is transaction local, it does not affect any other
+	 * dns_srv_handle resolving the same (cached) name */
+	while(dns_naptr_sip_iterate(
+			e->rr_lst, &h->naptr_tried_rrs, &srv_name, &n_proto)) {
+		/* drop the srv/a state of the previous naptr record, but keep
+		 * h->naptr and the list of the naptr records already tried */
 		dns_srv_handle_reset(h);
+		if((ret = dns_srv_resolve_ip(h, &srv_name, ip, port, flags)) >= 0) {
+			LM_DBG("(%.*s, %d, %d), srv0, ret=%d\n", name->len, name->s,
+					h->srv_no, h->ip_no, ret);
+			if(proto)
+				*proto = n_proto;
+			h->proto = n_proto;
+			return ret;
+		}
 	}
+	if(continued) {
+		/* all the naptr records of this handle are exhausted, report the
+		 * last error - do not restart the resolution from scratch */
+		return ret;
+	}
+	/* no acceptable naptr record found, fallback to srv
+	 * (make sure h does not contain garbage from the failed attempts above) */
+	dns_srv_handle_reset(h);
 naptr_not_found:
 	if(proto)
 		*proto = origproto;
@@ -3971,11 +3908,11 @@ int dns_cache_print_entry(rpc_t *rpc, void *ctx, struct dns_hash_entry *e)
 					rpc->fault(ctx, 500, "Internal error adding naptr order");
 					return -1;
 				}
-				if(rpc->struct_add(sh, "s", "rr_skip_record",
-						   ((struct naptr_rdata *)(rr->rdata))->skip_record
-								   ? "yes"
-								   : "no")
-						< 0) {
+				/* deprecated, kept for backward compatibility of the rpc
+				 * output: a naptr record is never skipped globally anymore,
+				 * the records already tried are tracked per dns_srv_handle
+				 * (i.e. per transaction), not in the shared dns cache */
+				if(rpc->struct_add(sh, "s", "rr_skip_record", "no") < 0) {
 					rpc->fault(ctx, 500,
 							"Internal error adding naptr rr_skip_record");
 					return -1;

--- a/src/core/dns_cache.c
+++ b/src/core/dns_cache.c
@@ -3451,6 +3451,8 @@ inline static int dns_naptr_sip_resolve(struct dns_srv_handle *h, str *name,
 		/* do naptr lookup */
 		if((e = dns_get_entry(name, T_NAPTR)) == 0)
 			goto naptr_not_found;
+		/* the handle takes over the reference returned by dns_get_entry(),
+		 * it is released by dns_srv_handle_put() */
 		h->naptr = e;
 		try_lookup_naptr = 1;
 	} else {
@@ -3486,17 +3488,16 @@ inline static int dns_naptr_sip_resolve(struct dns_srv_handle *h, str *name,
 			if((ret = dns_srv_resolve_ip(h, &srv_name, ip, port, flags)) >= 0) {
 				LM_DBG("(%.*s, %d, %d), srv0, ret=%d\n", name->len, name->s,
 						h->srv_no, h->ip_no, ret);
-				dns_hash_put(e);
 				if(proto)
 					*proto = n_proto;
 				h->proto = n_proto;
 				return ret;
 			}
 		}
-		/* no acceptable naptr record found, fallback to srv */
-		dns_hash_put(e);
-		dns_srv_handle_init(h); /* make sure h does not contain garbage
-								from previous dns_srv_sip_resolve calls */
+		/* no acceptable naptr record found, fallback to srv;
+		 * reset() releases the srv/a entries left by the failed attempts
+		 * above and keeps h->naptr, init() would leak them */
+		dns_srv_handle_reset(h);
 	}
 naptr_not_found:
 	if(proto)

--- a/src/core/dns_cache.h
+++ b/src/core/dns_cache.h
@@ -171,6 +171,13 @@ struct dns_srv_handle
 	struct dns_hash_entry *naptr; /**< naptr entry */
 	struct dns_hash_entry *srv;	  /**< srv entry */
 	struct dns_hash_entry *a;	  /**< a or aaaa current entry */
+#ifdef USE_NAPTR
+	/** @brief naptr records already used by this handle.
+	 * Handle (i.e. transaction) local state: it must never be stored in the
+	 * shared dns cache, else exhausting a naptr record in one transaction
+	 * would remove it from the candidate list of all the others */
+	naptr_bmp_t naptr_tried_rrs;
+#endif
 #ifdef DNS_SRV_LB
 	srv_flags_t srv_tried_rrs;
 #endif
@@ -289,6 +296,9 @@ inline static void dns_srv_handle_init(struct dns_srv_handle *h)
 	h->srv_no = h->ip_no = 0;
 	h->port = 0;
 	h->proto = 0;
+#ifdef USE_NAPTR
+	naptr_iterate_init(&h->naptr_tried_rrs);
+#endif
 #ifdef DNS_SRV_LB
 	h->srv_tried_rrs = 0;
 #endif
@@ -296,7 +306,9 @@ inline static void dns_srv_handle_init(struct dns_srv_handle *h)
 
 inline static void dns_srv_handle_reset(struct dns_srv_handle *h)
 {
-	/* do NOT put the naptr */
+	/* do NOT put the naptr and do NOT touch h->naptr_tried_rrs: reset() is
+	 * used while continuing the same naptr failover sequence, the list of
+	 * the naptr records already used by this handle must survive it */
 	if(h->srv) {
 		dns_hash_put(h->srv);
 		h->srv = 0;
@@ -311,6 +323,19 @@ inline static void dns_srv_handle_reset(struct dns_srv_handle *h)
 	h->proto = 0;
 #endif
 }
+
+#ifdef USE_NAPTR
+/** @brief iterates over the sip naptr records of a cached naptr entry
+ * Params:  naptr_head - naptr dns_rr list head
+ *          tried      - bitmap of the records already used by the caller
+ *                       (dns_srv_handle local, see naptr_tried_rrs)
+ *          srv_name   - result: srv name of the selected record
+ *          proto      - result: protocol of the selected record
+ * Returns: the selected naptr record or 0 if no more records are left
+ */
+struct naptr_rdata *dns_naptr_sip_iterate(struct dns_rr *naptr_head,
+		naptr_bmp_t *tried, str *srv_name, char *proto);
+#endif /* USE_NAPTR */
 
 /** @brief performes a srv query on name
  * Params:  name  - srv query target (e.g. _sip._udp.foo.bar)

--- a/src/core/resolve.c
+++ b/src/core/resolve.c
@@ -520,7 +520,6 @@ struct naptr_rdata *dns_naptr_parser(unsigned char *msg, unsigned char *end,
 		PKG_MEM_ERROR;
 		goto error;
 	}
-	naptr->skip_record = 0;
 	naptr->order = ntohs(order);
 	naptr->pref = ntohs(pref);
 

--- a/src/core/resolve.h
+++ b/src/core/resolve.h
@@ -130,7 +130,6 @@ struct naptr_rdata
 	unsigned char services_len;
 	unsigned char regexp_len;
 	unsigned char repl_len; /* not currently used */
-	unsigned char skip_record;
 
 	char str_table[1]; /* contains all the strings */
 };

--- a/test/misc/code/dns_naptr_iterate.c
+++ b/test/misc/code/dns_naptr_iterate.c
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2026 kamailio.org
+ *
+ * This file is part of Kamailio, a free SIP server.
+ *
+ * Kamailio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * Kamailio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/*!
+ * \file
+ * \brief Regression test for the NAPTR failover state ownership (GH #4911).
+ *
+ * The list of the NAPTR records already used while failing over must be
+ * local to the dns_srv_handle (i.e. to the SIP transaction) and must never
+ * be stored in the shared dns cache: a transaction which exhausts a NAPTR
+ * record must not remove that record from the candidate list of any other
+ * (concurrent or subsequent) transaction resolving the same name.
+ *
+ * The test drives dns_naptr_sip_iterate() - the NAPTR selection state
+ * machine - directly, with a hand built dns_rr list standing in for a cached
+ * NAPTR entry, so that neither a dns server nor the dns cache is needed.
+ *
+ * Build & run it with the helper script from the top of the source tree:
+ *
+ \verbatim
+   sh test/misc/code/dns_naptr_iterate.sh
+ \endverbatim
+ *
+ * Exits with 0 if all the checks pass, 1 otherwise.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../../src/core/dns_cache.h"
+#include "../../../src/core/resolve.h"
+#include "../../../src/core/ip_addr.h"
+
+static int tests_failed = 0;
+
+#define CHECK(cond, fmt, ...)                                           \
+	do {                                                                \
+		if(cond) {                                                      \
+			printf("ok   - " fmt "\n", ##__VA_ARGS__);                  \
+		} else {                                                        \
+			printf("FAIL - " fmt " (%s:%d)\n", ##__VA_ARGS__, __FILE__, \
+					__LINE__);                                          \
+			tests_failed++;                                             \
+		}                                                               \
+	} while(0)
+
+
+/** build a naptr_rdata as the dns cache would hold it */
+static struct naptr_rdata *mk_naptr(unsigned short order, unsigned short pref,
+		const char *flags, const char *services, const char *repl)
+{
+	struct naptr_rdata *n;
+	int flags_len, services_len, repl_len;
+
+	flags_len = strlen(flags);
+	services_len = strlen(services);
+	repl_len = strlen(repl);
+	n = malloc(sizeof(struct naptr_rdata) + flags_len + services_len + repl_len
+			   + 1);
+	if(n == 0) {
+		fprintf(stderr, "out of memory\n");
+		exit(1);
+	}
+	memset(n, 0, sizeof(struct naptr_rdata));
+	n->order = order;
+	n->pref = pref;
+	n->flags = &n->str_table[0];
+	n->flags_len = flags_len;
+	memcpy(n->flags, flags, flags_len);
+	n->services = &n->str_table[flags_len];
+	n->services_len = services_len;
+	memcpy(n->services, services, services_len);
+	/* no regexp - required for a valid sip naptr record */
+	n->regexp = &n->str_table[flags_len + services_len];
+	n->regexp_len = 0;
+	n->repl = &n->str_table[flags_len + services_len];
+	n->repl_len = repl_len;
+	memcpy(n->repl, repl, repl_len);
+	n->repl[repl_len] = 0;
+	return n;
+}
+
+
+static struct dns_rr *mk_naptr_rr_lst(void)
+{
+	struct dns_rr *head, *rr;
+	int i;
+	/* all of them udp, so that the selection depends only on order/pref and
+	 * not on the (config dependent) protocol preferences */
+	static const char *repl[3] = {"_sip._udp.edge1.example.net",
+			"_sip._udp.edge2.example.net", "_sip._udp.edge3.example.net"};
+
+	head = 0;
+	for(i = 2; i >= 0; i--) {
+		rr = malloc(sizeof(struct dns_rr));
+		if(rr == 0) {
+			fprintf(stderr, "out of memory\n");
+			exit(1);
+		}
+		memset(rr, 0, sizeof(struct dns_rr));
+		rr->rdata = mk_naptr(10 + i * 10, 100, "s", "SIP+D2U", repl[i]);
+		rr->expire = (ticks_t)-1;
+		rr->next = head;
+		head = rr;
+	}
+	return head;
+}
+
+
+static void free_naptr_rr_lst(struct dns_rr *head)
+{
+	struct dns_rr *rr, *nxt;
+
+	for(rr = head; rr; rr = nxt) {
+		nxt = rr->next;
+		free(rr->rdata);
+		free(rr);
+	}
+}
+
+
+/** returns the repl of the naptr record selected next by h, 0 if none left */
+static const char *next_naptr(struct dns_srv_handle *h, struct dns_rr *rr_lst)
+{
+	static char buf[MAX_DNS_NAME];
+	str srv_name;
+	char proto;
+
+	if(dns_naptr_sip_iterate(rr_lst, &h->naptr_tried_rrs, &srv_name, &proto)
+			== 0)
+		return 0;
+	if(srv_name.len >= (int)sizeof(buf))
+		return "<too long>";
+	memcpy(buf, srv_name.s, srv_name.len);
+	buf[srv_name.len] = 0;
+	return buf;
+}
+
+
+static int streq(const char *a, const char *b)
+{
+	return (a != 0) && (b != 0) && (strcmp(a, b) == 0);
+}
+
+
+/** snapshot of the rdata of every record, to check that the (shared) cached
+ * entry is never modified by the failover of a single transaction */
+static char *snap_naptr_rr_lst(struct dns_rr *head, int *len)
+{
+	struct dns_rr *rr;
+	char *buf;
+	int sz, off;
+
+	sz = 0;
+	for(rr = head; rr; rr = rr->next)
+		sz += (int)NAPTR_RDATA_SIZE(*(struct naptr_rdata *)rr->rdata);
+	buf = malloc(sz);
+	if(buf == 0) {
+		fprintf(stderr, "out of memory\n");
+		exit(1);
+	}
+	off = 0;
+	for(rr = head; rr; rr = rr->next) {
+		sz = (int)NAPTR_RDATA_SIZE(*(struct naptr_rdata *)rr->rdata);
+		memcpy(buf + off, rr->rdata, sz);
+		off += sz;
+	}
+	*len = off;
+	return buf;
+}
+
+
+int main(int argc, char **argv)
+{
+	struct dns_rr *rr_lst;
+	struct dns_srv_handle ha, hb;
+	const char *r;
+	char *snap, *snap2;
+	int snap_len, snap2_len;
+
+	rr_lst = mk_naptr_rr_lst();
+	snap = snap_naptr_rr_lst(rr_lst, &snap_len);
+
+	/* --- scenario 2: one handle walks through all the naptr records ---- */
+	dns_srv_handle_init(&ha);
+	CHECK(ha.naptr_tried_rrs == 0, "a fresh handle has no naptr record tried");
+
+	r = next_naptr(&ha, rr_lst);
+	CHECK(streq(r, "_sip._udp.edge1.example.net"),
+			"handle A selects the first naptr record (got '%s')", r ? r : "-");
+	CHECK(ha.naptr_tried_rrs != 0, "handle A recorded the record it used");
+
+	r = next_naptr(&ha, rr_lst);
+	CHECK(streq(r, "_sip._udp.edge2.example.net"),
+			"handle A continues with the next naptr record (got '%s')",
+			r ? r : "-");
+
+	/* the srv/ip state of the previous naptr record is dropped between two
+	 * naptr records, the naptr state must survive it */
+	dns_srv_handle_reset(&ha);
+	CHECK(ha.naptr_tried_rrs != 0,
+			"dns_srv_handle_reset() keeps the naptr records already tried");
+
+	r = next_naptr(&ha, rr_lst);
+	CHECK(streq(r, "_sip._udp.edge3.example.net"),
+			"handle A continues with the last naptr record (got '%s')",
+			r ? r : "-");
+
+	r = next_naptr(&ha, rr_lst);
+	CHECK(r == 0, "handle A has no naptr record left (got '%s')", r ? r : "-");
+
+	/* --- scenario 3/5/6: an independent handle is not affected ---------- */
+	dns_srv_handle_init(&hb);
+	CHECK(hb.naptr_tried_rrs == 0,
+			"a new handle starts with all the naptr records available");
+	r = next_naptr(&hb, rr_lst);
+	CHECK(streq(r, "_sip._udp.edge1.example.net"),
+			"handle B still selects the first naptr record, the one handle A"
+			" exhausted (got '%s')",
+			r ? r : "-");
+
+	/* --- the shared cached records were not modified at all ------------- */
+	snap2 = snap_naptr_rr_lst(rr_lst, &snap2_len);
+	CHECK((snap_len == snap2_len) && (memcmp(snap, snap2, snap_len) == 0),
+			"exhausting the naptr records of a handle leaves the cached"
+			" entry byte for byte unchanged");
+	free(snap2);
+
+	/* --- scenario 4: two interleaved handles ---------------------------- */
+	dns_srv_handle_init(&ha);
+	dns_srv_handle_init(&hb);
+	r = next_naptr(&ha, rr_lst);
+	CHECK(streq(r, "_sip._udp.edge1.example.net"),
+			"interleaved: A gets record 1 (got '%s')", r ? r : "-");
+	r = next_naptr(&hb, rr_lst);
+	CHECK(streq(r, "_sip._udp.edge1.example.net"),
+			"interleaved: B gets record 1 too (got '%s')", r ? r : "-");
+	r = next_naptr(&ha, rr_lst);
+	CHECK(streq(r, "_sip._udp.edge2.example.net"),
+			"interleaved: A gets record 2 (got '%s')", r ? r : "-");
+	r = next_naptr(&hb, rr_lst);
+	CHECK(streq(r, "_sip._udp.edge2.example.net"),
+			"interleaved: B gets record 2 (got '%s')", r ? r : "-");
+	r = next_naptr(&ha, rr_lst);
+	CHECK(streq(r, "_sip._udp.edge3.example.net"),
+			"interleaved: A gets record 3 (got '%s')", r ? r : "-");
+	r = next_naptr(&ha, rr_lst);
+	CHECK(r == 0, "interleaved: A is exhausted (got '%s')", r ? r : "-");
+	r = next_naptr(&hb, rr_lst);
+	CHECK(streq(r, "_sip._udp.edge3.example.net"),
+			"interleaved: B still gets record 3 after A gave up (got '%s')",
+			r ? r : "-");
+
+	/* --- a copied handle inherits the state of the original ------------- */
+	hb = ha; /* dns_srv_handle_cpy() without the refcnt update, the handles
+			  * hold no dns cache entry here */
+	CHECK(hb.naptr_tried_rrs == ha.naptr_tried_rrs,
+			"copying a handle carries over the naptr records already tried");
+
+	snap2 = snap_naptr_rr_lst(rr_lst, &snap2_len);
+	CHECK((snap_len == snap2_len) && (memcmp(snap, snap2, snap_len) == 0),
+			"the cached entry is still unchanged after the interleaved runs");
+	free(snap2);
+	free(snap);
+
+	free_naptr_rr_lst(rr_lst);
+	printf("%s\n", tests_failed ? "TESTS FAILED" : "all tests passed");
+	return tests_failed ? 1 : 0;
+}

--- a/test/misc/code/dns_naptr_iterate.sh
+++ b/test/misc/code/dns_naptr_iterate.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+#
+# Build and run the NAPTR failover state regression test (GH #4911).
+#
+# Kamailio has no unit test harness for the core, so the test is linked
+# against the core objects of a normal build.  Run it from the top of the
+# source tree:
+#
+#   sh test/misc/code/dns_naptr_iterate.sh
+#
+# It builds the tree first ("make all") if the objects are not there yet.
+
+set -e
+
+top=$(pwd)
+if [ ! -f "$top/src/core/dns_cache.c" ]; then
+	echo "run this script from the top of the kamailio source tree" >&2
+	exit 1
+fi
+
+CC=${CC:-cc}
+OBJCOPY=${OBJCOPY:-objcopy}
+
+if [ ! -f "$top/src/main.o" ] || [ ! -f "$top/src/core/dns_cache.o" ]; then
+	echo "* building the core objects ..."
+	make cfg >/dev/null
+	make all >/dev/null
+fi
+
+out=$(mktemp -d)
+trap 'rm -rf "$out"' EXIT
+
+defs=$(sed -n 's/^C_DEFS *= *//p' "$top/src/config.mak" | head -n 1)
+
+# main.o holds the core global variables (log_stderr, tcp_disable, ...) but
+# also main() - rename it out of the way
+$OBJCOPY --redefine-sym main=ksr_main_unused "$top/src/main.o" "$out/main.o"
+
+extra=""
+if [ -f "$top/src/cfg.tab.o" ] && [ -f "$top/src/lex.yy.o" ]; then
+	extra="$top/src/cfg.tab.o $top/src/lex.yy.o"
+else
+	# no bison/flex available: the config parser is not needed by the test,
+	# stub the few symbols it exports
+	cat >"$out/pp_stubs.c" <<'STUBS'
+#include <stdio.h>
+FILE *yyin = 0;
+int yyparse(void)
+{
+	return -1;
+}
+int pp_ifexp_state = 0;
+void ksr_cfg_print_initial_state(void) {}
+int pp_define(int len, const char *text)
+{
+	return -1;
+}
+int pp_define_set(int len, char *text, int mode)
+{
+	return -1;
+}
+int pp_define_set_type(int type)
+{
+	return -1;
+}
+int pp_define_get(int len, const char *text)
+{
+	return -1;
+}
+int pp_lookup(int len, const char *text)
+{
+	return -1;
+}
+char *pp_get_define_name(int idx)
+{
+	return 0;
+}
+int pp_get_define(int len, const char *text)
+{
+	return -1;
+}
+STUBS
+	eval $CC -c -o "$out/pp_stubs.o" $defs -I"$top/src" "$out/pp_stubs.c"
+	extra="$out/pp_stubs.o"
+fi
+
+objs=$(find "$top/src/core" "$top/src/lib" -name '*.o' | sort)
+
+eval $CC -o "$out/dns_naptr_iterate" -I"$top/src" $defs \
+	"$top/test/misc/code/dns_naptr_iterate.c" "$out/main.o" $extra \
+	$objs -lresolv -lpthread -ldl -lm
+
+"$out/dns_naptr_iterate"


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [ ] Each component has a single commit (if not, squash them into one commit)
  <!-- core is intentionally two commits, see below -->
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

> Note on the checklist: `core` is deliberately split in **two** commits, as
> requested in review, so that the refcounting fix is clearly identified and can
> be reviewed and backported on its own. Happy to squash them if preferred.

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [x] Related to issue #4911

#### Description

Fixes #4911.

Three commits:

1. `core: dns - fix the refcounting of the entries kept in dns_srv_handle`
2. `core: dns - keep the NAPTR failover state in the dns_srv_handle` (the #4911 fix)
3. `test: regression test for the NAPTR failover state ownership`

##### Problem

`use_dns_failover=yes` + `dns_try_naptr=yes`, a destination resolved through
NAPTR -> SRV -> several unreachable edge hosts. When one transaction has tried
every destination of a NAPTR record, kamailio logs:

```
mark_skip_current_naptr(): Mark to skip ... NAPTR record due to all IPs are unreachable
```

That transaction fails correctly (408), but every *unrelated* transaction to the
same name then fails immediately:

```
uri2dst2(): failed to resolve "<domain>" :unresolvable A or AAAA request (-7)
t_forward_nonack(): failure to add branches
```

and gets a 478, without retrying the NAPTR/SRV destinations at all — until the
NAPTR cache entry expires. It is especially bad when several public domains
CNAME to the same NAPTR target, since one failed call poisons all of them.
Reproducible on 5.8.x, 6.0.x, 6.1.x and master; 5.2.4 does not show it.

##### Root cause

`28049aafc8dd06c160ce5e7b8d5e4fc728441b0c` ("core: dns - use all NAPTR records",
#2290) added `unsigned char skip_record` to `struct naptr_rdata`. That struct
belongs to a `dns_hash_entry`, i.e. to the **shared** DNS cache.
`mark_skip_current_naptr()` sets `naptr->skip_record = 1` and
`dns_naptr_sip_iterate()` then skips the record — for every transaction and
every worker, until the entry expires:

```
transaction A exhausts NAPTR A
        |
        v
cached naptr_rdata.skip_record = 1
        |
        +---- transaction B sees it
        +---- transaction C sees it
        +---- other kamailio workers see it
```

So per-transaction failover state was being written into cross-transaction
shared state.

##### Fix

Keep the list of the NAPTR records already used in the resolution handle
instead, as `dns_srv_handle.naptr_tried_rrs`, next to the existing
`srv_tried_rrs`. `struct dns_srv_handle` already carries everything else needed
to continue a DNS failover across the successive attempts of one transaction.

Lifecycle:

* `dns_srv_handle_init()` clears it, so a new transaction always sees all the
  NAPTR records again;
* `dns_srv_handle_reset()` keeps it — exactly as it already keeps `h->naptr` —
  because it is only used to drop the srv/a state while continuing the *same*
  failover sequence;
* `dns_srv_handle_cpy()` carries it over to the branch of the next destination
  (plain struct copy);
* it disappears with the handle; nothing is ever written to the DNS cache.

`mark_skip_current_naptr()`, `have_more_active_naptr()` and
`naptr_rdata.skip_record` become unnecessary and are removed.

##### Marking names as unresolvable is not affected

Raised in review — detailing it here since it is the main risk to check.

Negative caching is a different mechanism and this PR does not touch it. An
unresolvable name is marked in `dns_get_entry()` / `dns_cache_do_request()`:
when the resolver returns nothing, `dns_cache_mk_bad_entry()` creates a
`DNS_FLAG_BAD_NAME` entry with `dns_neg_cache_ttl`, and every later lookup of
that name hits it (`dns_hash_get()` -> "negative cache => not resolvable") and
returns without querying the DNS. None of those functions, flags or config
variables are modified by this PR — the diff does not reference
`DNS_FLAG_BAD_NAME`, `dns_neg_cache_ttl`, `dns_cache_mk_bad_entry()` or
`dns_cache_do_request()` at all. So FQDNs the DNS does not answer for are still
queried once per `dns_neg_cache_ttl`, exactly as before.

`skip_record` was never driven by a DNS failure. `mark_skip_current_naptr()` was
called when `dns_srv_sip_resolve()` returned an error while *continuing* a
failover, i.e. when the handle had consumed all the SRV/A records of the current
NAPTR record after the destinations did not answer — its own log message says
"all IPs are unreachable". It recorded a *reachability* verdict in the DNS
cache, which is why it leaked across transactions and across the domains
CNAME-ing to the same target.

On the performance side, removing it does not add DNS traffic: when a second
transaction walks NAPTR A again, the SRV and A/AAAA records are served from the
DNS cache under their own TTLs (and from the negative cache when they do not
resolve), so this costs cache lookups, not queries.

What does legitimately change is that a second transaction will again *attempt*
destinations that a previous transaction found dead. Suppressing that is the job
of the destination blocklist, which is per destination (ip/port/proto) with its
own TTL and is consulted before sending a branch (`dst_is_blocklisted()` in
`t_fwd.c`, fed by `dst_blocklist_add()` on send error and on timeout in
`timer.c`) — unaffected by this PR. That is the right granularity for it: a
shared NAPTR flag cannot tell "this destination is dead" from "this destination
is perfectly fine for another customer domain that happens to CNAME to the same
NAPTR target", which is exactly the failure reported in #4911.

##### PR #2290 behaviour is preserved

`dns_naptr_sip_resolve()` still moves on to the next supported NAPTR record once
the current one has no destination left; it just asks `dns_naptr_sip_iterate()`
with the handle's own bitmap to know which records it has already used. NAPTR
order/preference selection (`naptr_choose()`), `MAX_NAPTR_RRS`, SRV load
balancing (`DNS_SRV_LB` — `h->srv_tried_rrs` is re-armed by
`dns_srv_resolve_nxt()` whenever `h->srv` is dropped), the IPv4/IPv6 flags and
the fallback to SRV then A/AAAA are unchanged.

##### Refcounting fix (first commit, independent)

Split out as its own commit so it can be reviewed and backported alone. It comes
from `34844f3b235235c9d44681f89098893967e3b408`, which started storing the NAPTR
entry in the handle:

* the handle keeps the reference returned by `dns_get_entry()`, but the success
  path also called `dns_hash_put(e)`, and `dns_srv_handle_put()` released it a
  second time later; on the calls continuing the same resolution `e` is
  `h->naptr` and no new reference is taken at all, so every one of them
  decremented it again;
* on the fallback path `dns_srv_handle_init()` only zeroed `h->srv` / `h->a`,
  leaking the entries left there by the failed `dns_srv_resolve_ip()` attempts;
  `dns_srv_handle_reset()` releases them and keeps `h->naptr`.

The second commit additionally makes a NAPTR record exhausted while continuing a
resolution report the last error instead of falling through and restarting
`dns_srv_sip_resolve()` from scratch.

The now-redundant second `str2ip()/str2ip6()` guard is dropped: the first-call
branch still returns early for IP literals *before* any `dns_get_entry()`, so
the fix from #2541 stays in place.

##### `rr_skip_record` compatibility (#4174)

`1f4e6795502626865d10c83b3880e2985eb94787` exposed the cached `skip_record`
through `dns_cache_print_entry()` as `rr_skip_record`. Rather than break the
`dns.view` output, the field is kept and now always reports `"no"`, with a
comment marking it deprecated: a cached NAPTR record is never skipped globally
anymore, the records already tried are tracked per `dns_srv_handle`. No RPC
consumer breaks, and the reported value is accurate. Happy to drop the field
entirely instead if that is preferred.

##### Tests

`test/misc/code/dns_naptr_iterate.c` drives `dns_naptr_sip_iterate()` with two
independent `dns_srv_handle` instances over the same hand-built cached NAPTR
record list, and checks that:

* one handle walks through every NAPTR record and then reports none left;
* `dns_srv_handle_reset()` does not lose the records already tried, while
  `dns_srv_handle_init()` does;
* a fresh handle still selects the record the first handle exhausted;
* two interleaved handles keep independent iteration state;
* the cached records are left byte for byte unchanged.

The core has no unit test harness, so the test links against the objects of a
normal build; `sh test/misc/code/dns_naptr_iterate.sh` builds and runs it
(19 checks, all passing). If a test outside `test/misc/code/` would be
preferred, or if it is not wanted at all, I am happy to move or drop that
commit.

Manual end-to-end check for the scenarios a unit test cannot cover: with
`use_dns_failover=yes` / `dns_try_naptr=yes` and a name with two NAPTR records
where the first one's SRV targets blackhole traffic, place a call (408 after
trying all of NAPTR A then NAPTR B), then immediately place a second call to the
same name or to another domain CNAME-ing to the same NAPTR target — before this
patch it fails instantly with a 478, after it the second call tries NAPTR A
normally. `kamcmd dns.view` shows the cached entry unchanged throughout.

##### Backporting

5.8, 6.0 and 6.1 do not have `34844f3b23`, so they have no `h->naptr` and still
call `dns_srv_handle_init(h)` inside the NAPTR loop, which would clear the new
bitmap. A backport needs either `34844f3b23` first, or that `init` replaced by a
reset that preserves `naptr_tried_rrs`. Glad to prepare the backport PRs once
the approach is agreed.
