### PR TITLE
SIP parsing enhancements (core, pua, sipcapture, sanity)

### DIFF
--- a/src/core/msg_translator.c
+++ b/src/core/msg_translator.c
@@ -2617,6 +2617,7 @@ char *build_res_buf_from_sip_req(unsigned int code, str *text, str *new_tag,
 	int httpreq;
 	char *pvia;
 	str xparams = STR_NULL;
+	hdr_flags_t copied_sip_quad_hf = 0;
 
 	body = 0;
 	buf = 0;
@@ -2676,6 +2677,8 @@ char *build_res_buf_from_sip_req(unsigned int code, str *text, str *new_tag,
 	for(hdr = msg->headers; hdr; hdr = hdr->next) {
 		switch(hdr->type) {
 			case HDR_TO_T:
+				if(hdr != msg->to)
+					break;
 				if(new_tag && new_tag->len) {
 					to_tag = get_to(msg)->tag_value;
 					if(to_tag.len && to_tag.s)
@@ -2695,10 +2698,21 @@ char *build_res_buf_from_sip_req(unsigned int code, str *text, str *new_tag,
 				/* RR only for 1xx and 2xx replies */
 				if(code < 180 || code >= 300)
 					break;
+				len += hdr->len;
+				break;
 			case HDR_FROM_T:
+				if(hdr != msg->from)
+					break;
+				len += hdr->len;
+				break;
 			case HDR_CALLID_T:
+				if(hdr != msg->callid)
+					break;
+				len += hdr->len;
+				break;
 			case HDR_CSEQ_T:
-				/* we keep the original termination for these headers*/
+				if(hdr != msg->cseq)
+					break;
 				len += hdr->len;
 				break;
 			default:
@@ -2827,6 +2841,9 @@ char *build_res_buf_from_sip_req(unsigned int code, str *text, str *new_tag,
 				append_str(p, hdr->name.s, hdr->len);
 				break;
 			case HDR_TO_T:
+				if(copied_sip_quad_hf & HDR_TO_F)
+					break;
+				copied_sip_quad_hf |= HDR_TO_F;
 				if(new_tag && new_tag->len) {
 					if(to_tag.len && to_tag.s) { /* replacement */
 						/* before to-tag */
@@ -2861,10 +2878,24 @@ char *build_res_buf_from_sip_req(unsigned int code, str *text, str *new_tag,
 					bmark->to_tag_val.s =
 							p + (hdr->body.s + hdr->body.len - hdr->name.s);
 				}
-				/* no break */
+				append_str(p, hdr->name.s, hdr->len);
+				break;
 			case HDR_FROM_T:
+				if(copied_sip_quad_hf & HDR_FROM_F)
+					break;
+				copied_sip_quad_hf |= HDR_FROM_F;
+				append_str(p, hdr->name.s, hdr->len);
+				break;
 			case HDR_CALLID_T:
+				if(copied_sip_quad_hf & HDR_CALLID_F)
+					break;
+				copied_sip_quad_hf |= HDR_CALLID_F;
+				append_str(p, hdr->name.s, hdr->len);
+				break;
 			case HDR_CSEQ_T:
+				if(copied_sip_quad_hf & HDR_CSEQ_F)
+					break;
+				copied_sip_quad_hf |= HDR_CSEQ_F;
 				append_str(p, hdr->name.s, hdr->len);
 				break;
 			default:

--- a/src/core/parser/msg_parser.c
+++ b/src/core/parser/msg_parser.c
@@ -69,12 +69,26 @@ msg_flags_t global_req_flags = 0;
 
 int ksr_sip_parser_mode = KSR_SIP_PARSER_MODE_STRICT;
 
-/* returns pointer to next header line, and fill hdr_f ;
- * if at end of header returns pointer to the last crlf  (always buf)*/
-char *get_hdr_field(
-		char *const buf, char *const end, struct hdr_field *const hdr)
-{
+/* advance _p to the next header, including folded continuation lines.
+ * _match is NULL if no '\n' is found. */
+#define GET_HDR_NEXT(_p, _end, _match)                                   \
+	do {                                                                 \
+		do {                                                             \
+			(_match) = q_memchr((_p), '\n', (_end) - (_p));              \
+			if((_match) == NULL)                                         \
+				break;                                                   \
+			(_match)++;                                                  \
+			(_p) = (_match);                                             \
+		} while(((_p) < (_end)) && ((*(_p) == ' ') || (*(_p) == '\t'))); \
+	} while(0)
 
+/* fill hdr and set *next to the following header line (or the EOH crlf).
+ * next may be NULL if the caller does not need that pointer.
+ * returns 0 on success, -1 on error. hdr->type is HDR_ERROR_T only when
+ * parse_hname failed; a body parse error keeps the name type. */
+int get_hdr_field(char *const buf, char *const end, struct hdr_field *const hdr,
+		char **next)
+{
 	char *tmp = 0;
 	char *match;
 	struct via_body *vb;
@@ -82,6 +96,9 @@ char *get_hdr_field(
 	struct to_body *to_b;
 	int integer, err;
 	unsigned uval;
+
+	if(next)
+		*next = NULL;
 
 	if(!buf) {
 		DBG("null buffer pointer\n");
@@ -92,7 +109,9 @@ char *get_hdr_field(
 		/* double crlf or lflf or crcr */
 		DBG("found end of header\n");
 		hdr->type = HDR_EOH_T;
-		return buf;
+		if(next)
+			*next = buf;
+		return 0;
 	}
 
 	tmp = parse_hname(buf, end, hdr);
@@ -120,6 +139,7 @@ char *get_hdr_field(
 			vb = pkg_malloc(sizeof(struct via_body));
 			if(vb == 0) {
 				PKG_MEM_ERROR;
+				ser_error = E_OUT_OF_MEM;
 				goto error;
 			}
 			memset(vb, 0, sizeof(struct via_body));
@@ -139,6 +159,7 @@ char *get_hdr_field(
 			cseq_b = pkg_malloc(sizeof(struct cseq_body));
 			if(cseq_b == 0) {
 				PKG_MEM_ERROR;
+				ser_error = E_OUT_OF_MEM;
 				goto error;
 			}
 			memset(cseq_b, 0, sizeof(struct cseq_body));
@@ -252,24 +273,15 @@ char *get_hdr_field(
 		case HDR_OTHER_T:
 			/* just skip over it */
 			hdr->body.s = tmp;
-			/* find end of header */
-			/* find lf */
-			do {
-				match = q_memchr(tmp, '\n', end - tmp);
-				if(match) {
-					match++;
-				} else {
-					ERR("no eol - bad body for <%.*s> (hdr type: %d) [%.*s]\n",
-							hdr->name.len, hdr->name.s, hdr->type,
-							((end - tmp) > 128) ? 128 : (int)(end - tmp), tmp);
-					/* abort(); */
-					tmp = end;
-					goto error;
-				}
-				tmp = match;
-			} while(match < end && ((*match == ' ') || (*match == '\t')));
-			tmp = match;
-			hdr->body.len = match - hdr->body.s;
+			GET_HDR_NEXT(tmp, end, match);
+			if(match == NULL) {
+				ERR("no eol - bad body for <%.*s> (hdr type: %d) [%.*s]\n",
+						hdr->name.len, hdr->name.s, hdr->type,
+						((end - tmp) > 128) ? 128 : (int)(end - tmp), tmp);
+				tmp = end;
+				goto error;
+			}
+			hdr->body.len = tmp - hdr->body.s;
 			break;
 		default:
 			BUG("unknown header type %d [%.*s]\n", hdr->type,
@@ -279,13 +291,32 @@ char *get_hdr_field(
 	/* jku: if \r covered by current length, shrink it */
 	trim_r(hdr->body);
 	hdr->len = tmp - hdr->name.s;
-	return tmp;
+	if(next)
+		*next = tmp;
+	return 0;
+
 error:
 	DBG("error exit\n");
 	STATS_BAD_MSG_HDR();
-	hdr->type = HDR_ERROR_T;
-	hdr->len = tmp - hdr->name.s;
-	return tmp;
+	/* tmp is not the next header here (often NULL or mid-body) */
+	if((buf == NULL) || (buf >= end)) {
+		hdr->len = 0;
+		if(next)
+			*next = NULL;
+		return -1;
+	}
+	tmp = buf;
+	GET_HDR_NEXT(tmp, end, match);
+	if(match == NULL) {
+		hdr->len = 0;
+		if(next)
+			*next = NULL;
+		return -1;
+	}
+	hdr->len = tmp - buf;
+	if(next)
+		*next = tmp;
+	return -1;
 }
 
 
@@ -326,7 +357,12 @@ int parse_headers(
 #ifdef EXTRA_DEBUG
 	DBG("flags=%llx\n", (unsigned long long)flags);
 #endif
-	while(tmp < end && (flags & msg->parsed_flag) != flags) {
+	/* strict: keep walking to EOH so later bad/duplicate headers are
+	 * seen on this call; non-strict: stop once the requested flags are set */
+	while(tmp < end
+			&& ((ksr_sip_parser_mode & KSR_SIP_PARSER_MODE_STRICT)
+							? ((msg->parsed_flag & HDR_EOH_F) == 0)
+							: ((flags & msg->parsed_flag) != flags))) {
 		prefetch_loc_r(tmp + 64, 1);
 		hf = pkg_malloc(sizeof(struct hdr_field));
 		if(unlikely(hf == 0)) {
@@ -336,12 +372,39 @@ int parse_headers(
 		}
 		memset(hf, 0, sizeof(struct hdr_field));
 		hf->type = HDR_ERROR_T;
-		rest = get_hdr_field(tmp, end, hf);
+		rest = NULL;
+		if(get_hdr_field(tmp, end, hf, &rest) < 0) {
+			LOG(cfg_get(core, core_cfg, sip_parser_log),
+					"bad header field [%.*s]\n",
+					(end - tmp > 100) ? 100 : (int)(end - tmp), tmp);
+
+			if((ksr_sip_parser_mode & KSR_SIP_PARSER_MODE_STRICT)
+					|| (ser_error == E_OUT_OF_MEM)) {
+				goto error;
+			}
+
+			if(rest == NULL) {
+				LOG(cfg_get(core, core_cfg, sip_parser_log),
+						"bad header field, no eol\n");
+				goto error;
+			}
+
+			LOG(cfg_get(core, core_cfg, sip_parser_log),
+					"skipping bad %.*s header field, type %d recorded as "
+					"flag\n",
+					hf->name.len, ZSW(hf->name.s), hf->type);
+
+			msg->errored_hdrs |=
+					(hf->type == HDR_ERROR_T || hf->type == HDR_EOH_T)
+							? HDR_OTHER_F
+							: HDR_T2F(hf->type);
+			clean_hdr_field(hf);
+			pkg_free(hf);
+			tmp = rest;
+			continue;
+		}
 		switch(hf->type) {
 			case HDR_ERROR_T:
-				LOG(cfg_get(core, core_cfg, sip_parser_log),
-						"bad header field [%.*s]\n",
-						(end - tmp > 100) ? 100 : (int)(end - tmp), tmp);
 				goto error;
 			case HDR_EOH_T:
 				msg->eoh = tmp; /* or rest?*/

--- a/src/core/parser/msg_parser.h
+++ b/src/core/parser/msg_parser.h
@@ -346,6 +346,7 @@ typedef struct sip_msg
 	struct hdr_field *headers;	   /*!< All the parsed headers*/
 	struct hdr_field *last_header; /*!< Pointer to the last parsed header*/
 	hdr_flags_t parsed_flag;	   /*!< Already parsed header field types */
+	hdr_flags_t errored_hdrs; /*!< Header types that failed parse (skipped) */
 
 	/* Via, To, CSeq, Call-Id, From, end of header*/
 	/* pointers to the first occurrences of these headers;
@@ -482,8 +483,8 @@ int parse_msg(
 int parse_headers(
 		struct sip_msg *const msg, const hdr_flags_t flags, const int next);
 
-char *get_hdr_field(
-		char *const buf, char *const end, struct hdr_field *const hdr);
+int get_hdr_field(char *const buf, char *const end, struct hdr_field *const hdr,
+		char **next);
 
 void free_sip_msg(struct sip_msg *const msg);
 

--- a/src/core/parser/parse_addr_spec.c
+++ b/src/core/parser/parse_addr_spec.c
@@ -305,6 +305,7 @@ static char *parse_to_param(char *const buffer, const char *const end,
 								sizeof(struct to_param));
 						if(!param) {
 							PKG_MEM_ERROR;
+							ser_error = E_OUT_OF_MEM;
 							goto error;
 						}
 						memset(param, 0, sizeof(struct to_param));

--- a/src/core/parser/parse_to.c
+++ b/src/core/parser/parse_to.c
@@ -47,6 +47,7 @@ char *parse_to_body(
 	to_b = pkg_malloc(sizeof(struct to_body));
 	if(to_b == 0) {
 		PKG_MEM_ERROR;
+		ser_error = E_OUT_OF_MEM;
 		goto error;
 	}
 	memset(to_b, 0, sizeof(struct to_body));

--- a/src/core/parser/parse_via.c
+++ b/src/core/parser/parse_via.c
@@ -165,7 +165,7 @@ enum
 	FIN_I,
 	FIN_ALIAS
 #ifdef USE_COMP
-	,
+			,
 	FIN_COMP
 #endif
 	/*GEN_PARAM,
@@ -2537,6 +2537,7 @@ main_via:
 						param = pkg_malloc(sizeof(struct via_param));
 						if(param == 0) {
 							PKG_MEM_ERROR;
+							ser_error = E_OUT_OF_MEM;
 							goto error;
 						}
 						memset(param, 0, sizeof(struct via_param));
@@ -2706,11 +2707,11 @@ endofpacket:
 	if(vb->params.s != NULL && vb->params.len == 0 && vb->last_param != NULL) {
 		if(vb->last_param->name.len > 0) {
 			if(vb->last_param->value.len > 0) {
-				vb->params.len = vb->last_param->value.s + vb->last_param->value.len
-					- vb->params.s;
+				vb->params.len = vb->last_param->value.s
+								 + vb->last_param->value.len - vb->params.s;
 			} else {
-				vb->params.len = vb->last_param->name.s + vb->last_param->name.len
-					- vb->params.s;
+				vb->params.len = vb->last_param->name.s
+								 + vb->last_param->name.len - vb->params.s;
 			}
 		}
 	}
@@ -2731,11 +2732,11 @@ nextvia:
 	if(vb->params.s != NULL && vb->params.len == 0 && vb->last_param != NULL) {
 		if(vb->last_param->name.len > 0) {
 			if(vb->last_param->value.len > 0) {
-				vb->params.len = vb->last_param->value.s + vb->last_param->value.len
-					- vb->params.s;
+				vb->params.len = vb->last_param->value.s
+								 + vb->last_param->value.len - vb->params.s;
 			} else {
-				vb->params.len = vb->last_param->name.s + vb->last_param->name.len
-					- vb->params.s;
+				vb->params.len = vb->last_param->name.s
+								 + vb->last_param->name.len - vb->params.s;
 			}
 		}
 	}
@@ -2743,6 +2744,7 @@ nextvia:
 	vb->next = pkg_malloc(sizeof(struct via_body));
 	if(vb->next == 0) {
 		PKG_MEM_ERROR;
+		ser_error = E_OUT_OF_MEM;
 		goto error;
 	}
 	vb = vb->next;

--- a/src/modules/pua/send_subscribe.c
+++ b/src/modules/pua/send_subscribe.c
@@ -313,8 +313,8 @@ void subs_cback_func(struct cell *t, int cb_type, struct tmcb_params *ps)
 			goto faked_error;
 		}
 		memset(callid, 0, sizeof(struct hdr_field));
-		get_hdr_field(
-				t->callid_hdr.s, t->callid_hdr.s + t->callid_hdr.len, callid);
+		get_hdr_field(t->callid_hdr.s, t->callid_hdr.s + t->callid_hdr.len,
+				callid, NULL);
 		hentity->call_id = callid->body;
 
 		from = (struct hdr_field *)pkg_malloc(sizeof(struct hdr_field));
@@ -323,7 +323,8 @@ void subs_cback_func(struct cell *t, int cb_type, struct tmcb_params *ps)
 			goto faked_error;
 		}
 		memset(from, 0, sizeof(struct hdr_field));
-		get_hdr_field(t->from_hdr.s, t->from_hdr.s + t->from_hdr.len, from);
+		get_hdr_field(
+				t->from_hdr.s, t->from_hdr.s + t->from_hdr.len, from, NULL);
 		parse_to(from->body.s, from->body.s + from->body.len + 1, &FROM);
 		if(FROM.uri.len <= 0) {
 			LM_ERR("'From' header NOT parsed\n");

--- a/src/modules/sanity/sanity.c
+++ b/src/modules/sanity/sanity.c
@@ -315,7 +315,7 @@ int check_ruri_scheme(sip_msg_t *msg)
 		if((_hf)->type == _hdr_type) {                                        \
 			if(_hdr_flags & _hdr_flag) {                                      \
 				LM_DBG("duplicated %s header\n", _hdr_name);                  \
-				return SANITY_CHECK_FAILED;                                   \
+				sanity_check_status = SANITY_CHECK_FAILED;                    \
 			}                                                                 \
 			_hdr_flags |= _hdr_flag;                                          \
 		}                                                                     \
@@ -326,6 +326,7 @@ int check_required_headers(sip_msg_t *msg)
 {
 	hdr_field_t *hf;
 	hdr_flags_t hdr_flags = 0;
+	int sanity_check_status = SANITY_CHECK_PASSED;
 
 	LM_DBG("check_required_headers entered\n");
 
@@ -342,11 +343,15 @@ int check_required_headers(sip_msg_t *msg)
 
 	if(parse_headers(msg, HDR_EOH_F, 0) != 0) {
 		LM_ERR("failed to parse headers\n");
-		if(sanity_reply(msg, 400, "Bad Headers") < 0) {
-			LM_WARN("failed to send 400 reply\n");
-		}
-		return SANITY_CHECK_FAILED;
+		sanity_check_status = SANITY_CHECK_FAILED;
 	}
+
+	if(msg->errored_hdrs
+			& (HDR_FROM_F | HDR_TO_F | HDR_CALLID_F | HDR_CSEQ_F)) {
+		LM_ERR("errored headers found\n");
+		sanity_check_status = SANITY_CHECK_FAILED;
+	}
+
 	for(hf = msg->headers; hf; hf = hf->next) {
 		SANITY_HDR_DUPCHECK(hf, hdr_flags, HDR_FROM_T, HDR_FROM_F, "From");
 		SANITY_HDR_DUPCHECK(hf, hdr_flags, HDR_TO_T, HDR_TO_F, "To");
@@ -355,10 +360,16 @@ int check_required_headers(sip_msg_t *msg)
 		SANITY_HDR_DUPCHECK(hf, hdr_flags, HDR_CSEQ_T, HDR_CSEQ_F, "CSeq");
 	}
 
-	/* TODO: check for other required headers according to request type */
-	LM_DBG("check_required_headers passed\n");
+	if(sanity_check_status == SANITY_CHECK_FAILED
+			&& sanity_reply(msg, 400, "Bad Headers") < 0) {
+		LM_WARN("failed to send 400 reply\n");
+	}
 
-	return SANITY_CHECK_PASSED;
+	/* TODO: check for other required headers according to request type */
+	LM_DBG("check_required_headers status: %s\n",
+			sanity_check_status ? "PASSED" : "FAILED");
+
+	return sanity_check_status;
 }
 
 /* check if the SIP version in the Via header is 2.0 */

--- a/src/modules/sipcapture/sipcapture.c
+++ b/src/modules/sipcapture/sipcapture.c
@@ -467,8 +467,8 @@ int force_capture_callid(struct sip_msg *msg, struct _sipcapture_object *sco)
 		}
 		memset(hdr, 0, sizeof(struct hdr_field));
 		hdr->type = HDR_ERROR_T;
-		get_hdr_field(tmp, end, hdr);
-		if(hdr->type != HDR_CALLID_T) {
+		if((get_hdr_field(tmp, end, hdr, NULL) < 0)
+				|| (hdr->type != HDR_CALLID_T)) {
 			LM_DBG("Bad msg callid error\n");
 			pkg_free(hdr);
 			EMPTY_STR(sco->callid);


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
This PR is to make the sip parsing more deterministic when in both strict and non strict mode.

**Strict mode changes**

When in strict parsing mode ie. `sip_parser_mode=1` when receiving a new message the Kamailio core will test for what it calls the transaction quadruple, which is the `To`, `From`, `Call-ID`, `CSeq` and fail to enter the route if the SIP messages does not contain those headers. The parsing of the message is deliberately lazy in nature as opposed to eager parsing but it can leave the core in an odd state when strict parsing is set on.

Example invalid message which with strict parsing on will fail to enter the route due to a duplicate quadruple(To in this case)

```
INVITE sip:user@domain.com SIP 2.0
To: <valid nameaddr>
To: <valid nameaddr>
From: <valid nameaddr>
Call-ID: valid-callid
CSeq: INVITE 1
X-Custom-Header: value
....
Content-Length: 0
```

Example of a request which will enter the route but result in undefined behaviour

```
INVITE sip:user@domain.com SIP 2.0
To: <valid nameaddr>
From: <valid nameaddr>
Call-ID: valid-callid
CSeq: INVITE 1
X-Custom-Header: value
To: <valid nameaddr>
....
Content-Length: 0
```

The reason why this happens is because the second To header is not parsed as the check_required_headers keeps going until it finds an instance of the quadruple and it will enter the route and depending on how you are using the route you could fail at another point where the rest of the headers would be parsed or when construct the SIP reply or request once the route finishes, given the expectation would be that strict parsing would fail straight away but in this case it would not. 

The change turns the strict parsing mode into an eager parser so it fails early, this shouldn't meaningfully change the behaviour of most configuration but it does in the case outlined above so it technically creates a backwards incompatible change.

**Non strict mode changes**

When the `sip_parser_mode=0` and there is a duplicate check it will only copy the first valid instance of the quadruple in the reply, the current behaviour is such that when constructing a reply eg. `400 Bad Request` both To headers are copied, this change ensures only one of them is copied which is the first instance of that header during parsing.

One other change is when in this mode if there is a message such as this

```
INVITE sip:user@domain.com SIP 2.0
To: <invalid nameaddr>
To: <valid nameaddr>
From: <valid nameaddr>
Call-ID: valid-callid
CSeq: INVITE 1
X-Custom-Header: value
....
Content-Length: 0
```

It will still parse the quadruple but will take into account the valid `To` header only which in this case is the second instance of the header but the first instance is tracked as an error so that when calling `sanity_check` in the `sanity` module it can behave correctly if the check for required headers is set in the modparam.

The reason for fixing this case is that if the request contains at least one valid instance of the quadruple then it can be used to generate a reply. In the above message case the core would drop the request.

However the below example would not drop and then the sanity check would fail at this point and due to how the check required headers works it means we would not be able to reply but we would do the sanity check.

```
INVITE sip:user@domain.com SIP 2.0
To: <valid nameaddr>
From: <valid nameaddr>
Call-ID: valid-callid
CSeq: INVITE 1
X-Custom-Header: value
To: <invalid nameaddr>
....
Content-Length: 0
```

This just once again tightens up the behaviour so that is deterministic and the script writer can reasonably infer how the parsing will behave based on their requirements.

#### Testing

I have a suite of SIPp tests that can verify this behaviour, what is the recommended project to do those tests in?