### PR TITLE
dispatcher: trigger event_routes for disabled/inactive destinations on init/reload in mode 2

### DIFF
--- a/src/modules/dispatcher/dispatch.c
+++ b/src/modules/dispatcher/dispatch.c
@@ -4202,11 +4202,11 @@ int ds_update_state(sip_msg_t *msg, int group, str *address, str *iuid,
 
 
 			if((ds_event_callback_mode == DS_EVRTMODE_RUNTIME)
-					|| (ds_event_callback_mode == DS_EVRTMODE_INIT)
+					|| ((ds_event_callback_mode & DS_EVRTMODE_OPTIONS) == 0)
 					|| ((mode & DS_STATE_MODE_FUNC) == 0)) {
 				was_down = ds_skip_dst(old_state);
 				is_down = ds_skip_dst(idx->dlist[i].flags);
-				if(ds_event_callback_mode == DS_EVRTMODE_INIT) {
+				if(ds_event_callback_mode & DS_EVRTMODE_INIT) {
 					if((!was_down && is_down) || (old_state == 0 && is_down)) {
 						ds_run_route(msg, address, "dispatcher:dst-down", rctx);
 					} else if((was_down && !is_down)
@@ -4495,6 +4495,47 @@ int ds_reinit_state_all(int group, int state)
 					old_state, idx->dlist[i].flags, idx);
 		}
 	}
+	ds_put_list(list);
+	return 0;
+}
+
+/**
+ * Callback for iterating over destinations to trigger init event routes
+ * for disabled and inactive nodes
+ */
+static void ds_run_init_dst_cb(ds_set_t *node, int i, void *arg)
+{
+	ds_rctx_t rctx;
+
+	if(!ds_skip_dst(node->dlist[i].flags)) {
+		return;
+	}
+
+	memset(&rctx, 0, sizeof(ds_rctx_t));
+	rctx.flags = node->dlist[i].flags;
+	rctx.setid = node->id;
+	rctx.uri = node->dlist[i].uri;
+	rctx.code = 0;
+
+	ds_run_route(NULL, &node->dlist[i].uri, "dispatcher:dst-down", &rctx);
+}
+
+/**
+ * Execute event routes for disabled/inactive destinations when DS_EVRTMODE_LOAD is enabled
+ */
+int ds_run_init_event_routes(void)
+{
+	ds_list_t *list;
+
+	if((ds_event_callback_mode & DS_EVRTMODE_LOAD) == 0)
+		return 0;
+
+	list = ds_get_list();
+	if(list == NULL || list->head == NULL)
+		return 0;
+
+	LM_DBG("executing init event routes for disabled/inactive destinations\n");
+	ds_iter_set(list->head, &ds_run_init_dst_cb, NULL);
 	ds_put_list(list);
 	return 0;
 }

--- a/src/modules/dispatcher/dispatch.h
+++ b/src/modules/dispatcher/dispatch.h
@@ -91,8 +91,9 @@
 #define DS_STATE_MODE_FUNC (1<<1)
 
 #define DS_EVRTMODE_RUNTIME 0
-#define DS_EVRTMODE_OPTIONS 1
-#define DS_EVRTMODE_INIT 2
+#define DS_EVRTMODE_OPTIONS (1 << 0)
+#define DS_EVRTMODE_INIT    (1 << 1)
+#define DS_EVRTMODE_LOAD    (1 << 2)
 
 #define DS_SELRES_FAILED (ds_selres_t){0}
 
@@ -181,6 +182,7 @@ int ds_update_state(sip_msg_t *msg, int group, str *address, str *iuid,
 		int state, int mode, ds_rctx_t *rctx);
 int ds_reinit_state(int group, str *address, str *iuid, int state);
 int ds_reinit_state_all(int group, int state);
+int ds_run_init_event_routes(void);
 int ds_reinit_duid_state(int group, str *vduid, int state);
 int ds_mark_dst(struct sip_msg *msg, int state);
 int ds_mark_dst_mode(struct sip_msg *msg, int state, int mode);

--- a/src/modules/dispatcher/dispatcher.c
+++ b/src/modules/dispatcher/dispatcher.c
@@ -582,6 +582,9 @@ static int mod_init(void)
  */
 static int child_init(int rank)
 {
+	if(rank == PROC_SIPINIT) {
+		ds_run_init_event_routes();
+	}
 	return 0;
 }
 
@@ -1931,6 +1934,7 @@ static void dispatcher_rpc_reload(rpc_t *rpc, void *ctx)
 			return;
 		}
 	}
+	ds_run_init_event_routes();
 	rpc->rpl_printf(ctx, "Ok. Dispatcher successfully reloaded.");
 	return;
 }

--- a/src/modules/dispatcher/doc/dispatcher_admin.xml
+++ b/src/modules/dispatcher/doc/dispatcher_admin.xml
@@ -1076,14 +1076,53 @@ end
 		<title><varname>event_callback_mode</varname> (int)</title>
 		<para>
 			Controls when the event_route or the KEMI event callback function
-			are executed. If set to 0, they are executed when the destination
-			state changes based on OPTIONS keepalives or the use of config
-			functions to set the state (e.g., ds_mark_dst(...)). If set to 1,
-			they are executed only on state change due to OPTIONS keepalives.
-			If set to 2, the event routes will always be executed when a state
-			change occurs, even if no previous state exists (for example, on
-			startup or reload).
+			are executed.
 		</para>
+		<para>
+			If set to 0, they are executed when the destination state changes based on
+			OPTIONS keepalives or the use of config functions to set the state
+			(e.g., ds_mark_dst(...)).
+		</para>
+		<para>
+			The value can be a bitmask combining the following flags:
+		</para>
+		<itemizedlist>
+			<listitem>
+			<para>
+				<emphasis>1</emphasis> (<emphasis>1&lt;&lt;0</emphasis>) - executed only on state change due to OPTIONS keepalives (ignores state changes from config functions).
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				<emphasis>2</emphasis> (<emphasis>1&lt;&lt;1</emphasis>) - always executed when a state change occurs, even if no previous state exists (for example, on initial probe transition).
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				<emphasis>4</emphasis> (<emphasis>1&lt;&lt;2</emphasis>) - executed for the initial state of disabled and inactive destinations on startup and RPC reload.
+			</para>
+			</listitem>
+		</itemizedlist>
+		<para>
+			Modes can be combined by adding their values. For example:
+		</para>
+		<itemizedlist>
+			<listitem>
+			<para>
+				<emphasis>6</emphasis> (2 + 4) - executes event routes on state change even with no previous state, and also triggers initial routes for disabled/inactive destinations on startup and reload.
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				<emphasis>5</emphasis> (1 + 4) - executes event routes only on OPTIONS keepalives, plus triggers initial routes for disabled/inactive destinations on startup and reload.
+			</para>
+			</listitem>
+			<listitem>
+			<para>
+				<emphasis>7</emphasis> (1 + 2 + 4) - enables all above behaviors.
+			</para>
+			</listitem>
+		</itemizedlist>
 		<para>
 			Note that event routes are not executed on RPC commands setting
 			the destination state.
@@ -1097,7 +1136,8 @@ end
 		<title>Set <varname>event_callback_mode</varname> parameter</title>
 		<programlisting format="linespecific">
 ...
-modparam("dispatcher", "event_callback_mode", 1)
+# execute routes on state change without previous state and on startup/reload (2 + 4)
+modparam("dispatcher", "event_callback_mode", 6)
 ...
 -- event callback function implemented in Lua
 function ksr_dispatcher_event(evname)


### PR DESCRIPTION
### Description

When `event_callback_mode = 2` (`DS_EVRTMODE_INIT`) is enabled, event routes are executed for active destinations on the first probe reply (via `old_state == 0`). However, disabled (`flags = 4`) and inactive (`flags = 1`) destinations are intentionally skipped from OPTIONS keepalive probing in `ds_ping_set()`, and neither `child_init` nor `dispatcher_rpc_reload` invoked `ds_update_state()`.

Consequently, initial event routes (`dispatcher:dst-down`) were never fired for these destinations on startup or reload, leaving monitoring systems (e.g. Prometheus via `xhttp_prom` or Zabbix) without metrics for disabled gateways.

This patch adds `ds_run_init_event_routes()`, which iterates over `_ds_list` using `ds_iter_set()` to trigger `dispatcher:dst-down` for disabled and inactive destinations:
- On startup: in `child_init()` for `rank == PROC_SIPINIT` (first worker).
- On reload: in `dispatcher_rpc_reload()` right after lists are successfully loaded into shared memory.

Active destinations continue to be triggered by keepalive replies as originally introduced in #4460, avoiding duplicate events.

Closes #4906
