### PR TITLE
rtp_media_server: fix stack buffer overflow in SDP rtpmap parsing

### DIFF
--- a/src/modules/rtp_media_server/rms_sdp.c
+++ b/src/modules/rtp_media_server/rms_sdp.c
@@ -105,7 +105,7 @@ static char *rms_sdp_get_rtpmap(str body, int type_number)
 		int id;
 		int sampling_rate;
 		char codec[64];
-		sscanf(pos, "a=rtpmap:%d %s/%d", &id, codec, &sampling_rate);
+		sscanf(pos, "a=rtpmap:%d %63s/%d", &id, codec, &sampling_rate);
 		if(id == type_number) {
 			LM_INFO("[%d][%s/%d]\n", id, codec, sampling_rate);
 			return rms_char_dup(codec, 1);


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

`rms_sdp_get_rtpmap()` parses the rtpmap attribute with an unbounded `%s`
into a 64 byte stack buffer:

```c
char codec[64];
sscanf(pos, "a=rtpmap:%d %s/%d", &id, codec, &sampling_rate);
```

The value comes from the SDP body of an incoming SIP message, which is
controlled by the remote peer. A long codec name therefore writes past the
end of `codec`.

Use a field width matching the buffer size. The conversion still keeps the
`/rate/channels` part, which the caller `rms_sdp_check_payload_type()`
splits with `strtok()`, so well-formed SDP is parsed exactly as before.
