### PR TITLE
lost: prevent crash on invalid findService response

### DIFF
--- a/src/modules/lost/functions.c
+++ b/src/modules/lost/functions.c
@@ -1118,6 +1118,10 @@ int lost_function(struct sip_msg *_m, char *_con, char *_uri, char *_name,
 	redirect = 1;
 	while(redirect) {
 		fsrdata = lost_parse_findServiceResponse(ret);
+		if(fsrdata == NULL) {
+			LM_ERR("findService response parsing failed\n");
+			goto err;
+		}
 		if(lost_verbose == 1) {
 			lost_print_findServiceResponse(fsrdata);
 		}


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [ ] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
If lost response cannot be parsed `lost_parse_findServiceResponse` functions return `NULL` pointer and this leading to Kamailio crash.
Added `NULL` pointer check.