### PR TITLE
lcr: add continuous gateway ping mode

### DIFF
--- a/src/modules/lcr/doc/lcr.xml
+++ b/src/modules/lcr/doc/lcr.xml
@@ -27,6 +27,11 @@
 			<surname>Sas</surname>
 			<email>osas@voipembedded.com</email>
 		</editor>
+		<editor>
+			<firstname>Federico</firstname>
+			<surname>De Martin</surname>
+			<email>federico.demartin@eis.it</email>
+		</editor>
 	</authorgroup>
 	<copyright>
 		<year>2005-2014</year>

--- a/src/modules/lcr/doc/lcr_admin.xml
+++ b/src/modules/lcr/doc/lcr_admin.xml
@@ -1132,8 +1132,7 @@ modparam("lcr", "fetch_rows", 3000)
 		<title><varname>ping_interval</varname> (integer)</title>
 		<para>
 		  Interval in seconds for sending OPTIONS ping requests
-		  to gateways that, due to failures, have been marked
-		  as inactive by inactivate_gw() function call.
+		  to gateways selected according to <varname>ping_mode</varname>.
 		  If an inactive gateway later gives a valid response (see
 		  <varname>ping_valid_reply_codes</varname>) to a ping
 		  request, it is marked again as active.
@@ -1144,7 +1143,7 @@ modparam("lcr", "fetch_rows", 3000)
 		  parameters <varname>lcr_id_avp</varname> and
 		  <varname>defunct_gw_avp</varname> must have been defined.
 		  Value <quote>0</quote> disables sending of OPTIONS ping
-		  requests to failed gateways.
+		  requests to gateways.
 		</para>
 		<para>
 		<emphasis>
@@ -1163,11 +1162,57 @@ modparam("lcr", "ping_interval", 15)
 		</example>
 	</section>
 
+	<section id="lcr.p.ping_mode">
+		<title><varname>ping_mode</varname> (integer)</title>
+		<para>
+		  Controls which gateways are pinged and whether failed OPTIONS
+		  requests can inactivate them. This parameter has effect only when
+		  <varname>ping_interval</varname> is greater than zero.
+		</para>
+		<itemizedlist>
+		  <listitem>
+			<para>
+			  Value <quote>0</quote> preserves the existing behavior. Only
+			  gateways being inactivated or already inactive are pinged, and
+			  failed OPTIONS requests do not change their state.
+			</para>
+		  </listitem>
+		  <listitem>
+			<para>
+			  Value <quote>1</quote> continuously pings all gateways. A timeout
+			  or a reply that is neither a 2xx response nor listed in
+			  <varname>ping_valid_reply_codes</varname> counts as a failure.
+			  Once <varname>ping_inactivate_threshold</varname> is reached, the
+			  gateway is marked as inactive. A valid reply immediately marks it
+			  as active again. In this mode, calling
+			  <function>inactivate_gw()</function> is optional.
+			</para>
+		  </listitem>
+		</itemizedlist>
+		<para>
+		<emphasis>
+			Default value is <quote>0</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>
+		Set <varname>ping_mode</varname> parameter
+		</title>
+<programlisting format="linespecific">
+...
+modparam("lcr", "ping_mode", 1)
+...
+</programlisting>
+		</example>
+	</section>
+
 	<section id="lcr.p.ping_inactivate_threshold">
 		<title><varname>ping_inactivate_threshold</varname> (integer)</title>
 		<para>
-		  Tells after how many failures (= inactivate_gw() function
-		  calls) a gateway is marked as inactive.
+		  Tells after how many failures a gateway is marked as inactive.
+		  Calls to <function>inactivate_gw()</function> count as failures.
+		  When <varname>ping_mode</varname> is <quote>1</quote>, failed
+		  OPTIONS requests count towards the same threshold.
 		</para>
 		<para>
 		<emphasis>

--- a/src/modules/lcr/lcr_mod.c
+++ b/src/modules/lcr/lcr_mod.c
@@ -120,6 +120,9 @@ MODULE_VERSION
 #define DEF_LCR_GW_COUNT 128
 #define DEF_FETCH_ROWS 1024
 
+#define LCR_PING_MODE_INACTIVE 0
+#define LCR_PING_MODE_ALL 1
+
 /*
  * Database variables
  */
@@ -196,6 +199,7 @@ static int dont_strip_or_prefix_flag_param = -1;
 
 /* ping related params */
 unsigned int ping_interval_param = 0;
+unsigned int ping_mode_param = LCR_PING_MODE_INACTIVE;
 unsigned int ping_inactivate_threshold_param = 1;
 str ping_valid_reply_codes_param = {"", 0};
 str ping_socket_param = {"", 0};
@@ -359,6 +363,7 @@ static param_export_t params[] = {
     {"priority_ordering",        PARAM_INT, &priority_ordering_param},
     {"fetch_rows",               PARAM_INT, &fetch_rows_param},
     {"ping_interval",            PARAM_INT, &ping_interval_param},
+    {"ping_mode",                PARAM_INT, &ping_mode_param},
     {"ping_inactivate_threshold",  PARAM_INT, &ping_inactivate_threshold_param},
     {"ping_valid_reply_codes",   PARAM_STR, &ping_valid_reply_codes_param},
     {"ping_from",                PARAM_STR, &ping_from_param},
@@ -583,6 +588,10 @@ static int mod_init(void)
 
 	if((ping_interval_param != 0) && (ping_interval_param < 10)) {
 		LM_ERR("invalid ping_interval value '%u'\n", ping_interval_param);
+		return -1;
+	}
+	if(ping_mode_param > LCR_PING_MODE_ALL) {
+		LM_ERR("invalid ping_mode value '%u'\n", ping_mode_param);
 		return -1;
 	}
 
@@ -2936,10 +2945,29 @@ static void ping_callback(struct cell *t, int type, struct tmcb_params *ps)
 			|| (check_extra_codes(ps->code) == 0)) {
 		if((uri.len == gw->uri_len)
 				&& (strncmp(uri.s, &(gw->uri[0]), uri.len) == 0)) {
-			LM_INFO("activating gw with uri %.*s\n", uri.len, uri.s);
+			if((ping_mode_param == LCR_PING_MODE_INACTIVE)
+					|| (gw->state != GW_ACTIVE)) {
+				LM_INFO("activating gw with uri %.*s\n", uri.len, uri.s);
+			}
 			gw->state = GW_ACTIVE;
 		} else {
 			LM_DBG("ignoring OPTIONS reply due to lcr.reload\n");
+		}
+	} else if(ping_mode_param == LCR_PING_MODE_ALL) {
+		if((uri.len != gw->uri_len)
+				|| (strncmp(uri.s, &(gw->uri[0]), uri.len) != 0)) {
+			return;
+		}
+		if(gw->state == GW_ACTIVE) {
+			gw->state = GW_PINGING + ping_inactivate_threshold_param;
+		} else if(gw->state > GW_INACTIVE) {
+			gw->state--;
+		} else {
+			return;
+		}
+		if(gw->state == GW_INACTIVE) {
+			LM_INFO("gw '%.*s' has been inactivated by OPTIONS failure\n",
+					gw->gw_name_len, gw->gw_name);
 		}
 	}
 
@@ -2947,7 +2975,7 @@ static void ping_callback(struct cell *t, int type, struct tmcb_params *ps)
 }
 
 
-/* Timer process for pinging inactive gateways */
+/* Timer process for pinging gateways */
 void ping_timer(unsigned int ticks, void *param)
 {
 	struct gw_info *gws;
@@ -2955,7 +2983,7 @@ void ping_timer(unsigned int ticks, void *param)
 	str uri;
 	unsigned int i, j;
 
-	/* Ping each gateway that is GW_PINGING state */
+	/* Ping all gateways in continuous mode, otherwise only GW_PINGING ones */
 
 	for(j = 1; j <= lcr_count_param; j++) {
 
@@ -2963,7 +2991,8 @@ void ping_timer(unsigned int ticks, void *param)
 
 		for(i = 1; i <= gws[0].ip_addr.u.addr32[0]; i++) {
 
-			if(gws[i].state >= GW_PINGING) {
+			if((ping_mode_param == LCR_PING_MODE_ALL)
+					|| (gws[i].state >= GW_PINGING)) {
 
 				uri.s = &(gws[i].uri[0]);
 				uri.len = gws[i].uri_len;


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

Add the `ping_mode` module parameter to control gateway probing behavior.

The default mode preserves the existing behavior and probes only gateways
already undergoing inactivation or marked inactive.

Continuous mode probes all gateways. Failed OPTIONS requests contribute to
`ping_inactivate_threshold` and mark a gateway inactive once the threshold is
reached. A valid 2xx response, or a code configured in
`ping_valid_reply_codes`, immediately marks the gateway active again.

The existing `inactivate_gw()` function remains available and contributes to
the same failure threshold.

The changes were built and tested on Debian.