### PR TITLE
sdpops: fix $sdp(m0:*) to use the first m-line

### DIFF
--- a/src/modules/sdpops/sdpops_mod.c
+++ b/src/modules/sdpops/sdpops_mod.c
@@ -2135,6 +2135,7 @@ int sdpops_attr_val(str *payload, str *attr, str *val)
 static int pv_get_sdp(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 {
 	sdp_info_t *sdp = NULL;
+	sdp_stream_cell_t *stream0 = NULL;
 	str sess_version = STR_NULL;
 	long sess_version_num = 0;
 	unsigned int uport = 0;
@@ -2213,35 +2214,27 @@ static int pv_get_sdp(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 			return pv_get_null(msg, param, res);
 		case 4:
 			/* m0:rtp:port */
-			if(sdp->sessions == NULL) {
+			/* streams are stored in reverse parsing order - use
+			 * get_sdp_stream_sdp() to fetch the first m-line (m0) */
+			stream0 = get_sdp_stream_sdp(sdp, 0, 0);
+			if(stream0 == NULL) {
 				return pv_get_null(msg, param, res);
 			}
-			if(sdp->sessions->streams == NULL) {
-				return pv_get_null(msg, param, res);
-			}
-			if(sdp->sessions->streams->port.s != NULL
-					&& sdp->sessions->streams->port.len > 0) {
-				return pv_get_strval(
-						msg, param, res, &sdp->sessions->streams->port);
+			if(stream0->port.s != NULL && stream0->port.len > 0) {
+				return pv_get_strval(msg, param, res, &stream0->port);
 			}
 			return pv_get_null(msg, param, res);
 		case 5:
 			/* m0:rtcp:port */
-			if(sdp->sessions == NULL) {
+			stream0 = get_sdp_stream_sdp(sdp, 0, 0);
+			if(stream0 == NULL) {
 				return pv_get_null(msg, param, res);
 			}
-			if(sdp->sessions->streams == NULL) {
-				return pv_get_null(msg, param, res);
+			if(stream0->rtcp_port.s != NULL && stream0->rtcp_port.len > 0) {
+				return pv_get_strval(msg, param, res, &stream0->rtcp_port);
 			}
-			if(sdp->sessions->streams->rtcp_port.s != NULL
-					&& sdp->sessions->streams->rtcp_port.len > 0) {
-				return pv_get_strval(
-						msg, param, res, &sdp->sessions->streams->rtcp_port);
-			}
-			if(sdp->sessions->streams->port.s != NULL
-					&& sdp->sessions->streams->port.len > 0) {
-				if(str2int(&sdp->sessions->streams->port, &uport) < 0
-						|| uport >= USHRT_MAX) {
+			if(stream0->port.s != NULL && stream0->port.len > 0) {
+				if(str2int(&stream0->port, &uport) < 0 || uport >= USHRT_MAX) {
 					return pv_get_null(msg, param, res);
 				}
 				uport++;
@@ -2278,33 +2271,24 @@ static int pv_get_sdp(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 			}
 		case 7:
 			/* m0:raw - all (raw) lines for m0 stream */
-			if(sdp->sessions == NULL) {
+			stream0 = get_sdp_stream_sdp(sdp, 0, 0);
+			if(stream0 == NULL) {
 				return pv_get_null(msg, param, res);
 			}
-			if(sdp->sessions->streams == NULL) {
-				return pv_get_null(msg, param, res);
-			}
-			if(sdp->sessions->streams->raw_stream.s != NULL
-					&& sdp->sessions->streams->raw_stream.len > 0) {
-				return pv_get_strval(
-						msg, param, res, &sdp->sessions->streams->raw_stream);
+			if(stream0->raw_stream.s != NULL && stream0->raw_stream.len > 0) {
+				return pv_get_strval(msg, param, res, &stream0->raw_stream);
 			}
 			return pv_get_null(msg, param, res);
 		case 8:
 			/* m0:b:AS */
-			if(sdp->sessions == NULL) {
+			stream0 = get_sdp_stream_sdp(sdp, 0, 0);
+			if(stream0 == NULL) {
 				return pv_get_null(msg, param, res);
 			}
-			if(sdp->sessions->streams == NULL) {
-				return pv_get_null(msg, param, res);
-			}
-			if(sdp->sessions->streams->raw_stream.s != NULL
-					&& sdp->sessions->streams->raw_stream.len > 0) {
+			if(stream0->raw_stream.s != NULL && stream0->raw_stream.len > 0) {
 				sattr.s = "b=AS:";
 				sattr.len = 5;
-				if(sdpops_attr_val(
-						   &sdp->sessions->streams->raw_stream, &sattr, &sval)
-						< 0) {
+				if(sdpops_attr_val(&stream0->raw_stream, &sattr, &sval) < 0) {
 					return pv_get_null(msg, param, res);
 				}
 				return pv_get_strval(msg, param, res, &sval);
@@ -2312,19 +2296,14 @@ static int pv_get_sdp(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 			return pv_get_null(msg, param, res);
 		case 9:
 			/* m0:b:RR */
-			if(sdp->sessions == NULL) {
+			stream0 = get_sdp_stream_sdp(sdp, 0, 0);
+			if(stream0 == NULL) {
 				return pv_get_null(msg, param, res);
 			}
-			if(sdp->sessions->streams == NULL) {
-				return pv_get_null(msg, param, res);
-			}
-			if(sdp->sessions->streams->raw_stream.s != NULL
-					&& sdp->sessions->streams->raw_stream.len > 0) {
+			if(stream0->raw_stream.s != NULL && stream0->raw_stream.len > 0) {
 				sattr.s = "b=RR:";
 				sattr.len = 5;
-				if(sdpops_attr_val(
-						   &sdp->sessions->streams->raw_stream, &sattr, &sval)
-						< 0) {
+				if(sdpops_attr_val(&stream0->raw_stream, &sattr, &sval) < 0) {
 					return pv_get_null(msg, param, res);
 				}
 				return pv_get_strval(msg, param, res, &sval);
@@ -2332,19 +2311,14 @@ static int pv_get_sdp(sip_msg_t *msg, pv_param_t *param, pv_value_t *res)
 			return pv_get_null(msg, param, res);
 		case 10:
 			/* m0:b:RS */
-			if(sdp->sessions == NULL) {
+			stream0 = get_sdp_stream_sdp(sdp, 0, 0);
+			if(stream0 == NULL) {
 				return pv_get_null(msg, param, res);
 			}
-			if(sdp->sessions->streams == NULL) {
-				return pv_get_null(msg, param, res);
-			}
-			if(sdp->sessions->streams->raw_stream.s != NULL
-					&& sdp->sessions->streams->raw_stream.len > 0) {
+			if(stream0->raw_stream.s != NULL && stream0->raw_stream.len > 0) {
 				sattr.s = "b=RS:";
 				sattr.len = 5;
-				if(sdpops_attr_val(
-						   &sdp->sessions->streams->raw_stream, &sattr, &sval)
-						< 0) {
+				if(sdpops_attr_val(&stream0->raw_stream, &sattr, &sval) < 0) {
 					return pv_get_null(msg, param, res);
 				}
 				return pv_get_strval(msg, param, res, &sval);


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format`
  from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files
  in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description

The `m0` variants of `$sdp(...)` return values taken from the **last** media stream of an SDP
body instead of the first, whenever the body carries more than one `m=` line.

The SDP parser prepends each parsed stream to the session list (`src/core/parser/sdp/sdp.c`,
"Insert the new stream": `stream->next = _session->streams; _session->streams = stream;`), so
`sdp->sessions->streams` points at the **last** m-line parsed. `pv_get_sdp()` dereferenced that
pointer directly for every `m0`-named case, so the returned value came from the wrong stream.
A body with a single stream is unaffected, which is why this is easy to miss.

The fix selects the stream with `get_sdp_stream_sdp(sdp, 0, 0)`, which matches on the
parse-ordered `stream_num`, so index 0 is the first `m=` line as the variable name implies.

Affected variables: `$sdp(m0:rtp:port)`, `$sdp(m0:rtcp:port)`, `$sdp(m0:raw)`, `$sdp(m0:b:AS)`,
`$sdp(m0:b:RR)`, `$sdp(m0:b:RS)`.

**Reproduction.** With a two-stream offer such as an IMS audio+video INVITE:

```
v=0
o=- 0 0 IN IP4 198.51.100.1
s=-
c=IN IP4 198.51.100.1
t=0 0
m=audio 49170 RTP/AVP 96
a=rtpmap:96 AMR-WB/16000
m=video 51372 RTP/AVP 97
a=rtpmap:97 H264/90000
```

`$sdp(m0:rtp:port)` yields `51372` (the video stream) where `49170` is expected. The same offset
applies to the other `m0` variants.

**Impact seen in practice.** Found in a 5G SA / IMS deployment where the P-CSCF reads
`$sdp(m0:...)` while building the media description for QoS authorisation. On audio-only calls
the values were correct; as soon as video was offered, the first-stream lookup silently returned
the video stream's values.

**Testing.** The change has been running in a production IMS deployment carrying VoNR and ViNR
traffic. Voice, video and SMS-over-IMS calls were exercised after the change with no regression,
and single-stream bodies behave exactly as before. Verified against current `master`;
`clang-format` clean using the in-tree `.clang-format` with clang-format 18, the version the
`pull_request` workflow pins.
