### PR TITLE
xcap_client: fix stack buffer overflow in send_http_get()

### DIFF
--- a/src/modules/xcap_client/xcap_functions.c
+++ b/src/modules/xcap_client/xcap_functions.c
@@ -449,7 +449,6 @@ error:
 char *send_http_get(char *path, unsigned int xcap_port, char *match_etag,
 		int match_type, char **etag)
 {
-	int len;
 	char *stream = NULL;
 	CURLcode ret_code;
 	CURL *curl_handle = NULL;
@@ -465,9 +464,7 @@ char *send_http_get(char *path, unsigned int xcap_port, char *match_etag,
 
 		hdr_name = (match_type == IF_MATCH) ? "If-Match" : "If-None-Match";
 
-		len = sprintf(match_header, "%s: %s\n", hdr_name, match_etag);
-
-		match_header[len] = '\0';
+		snprintf(match_header, sizeof(buf), "%s: %s\n", hdr_name, match_etag);
 	}
 
 	curl_handle = curl_easy_init();


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] LLM/AI Coding Assistants were involved in creating the C code or other included content
- [x] Code is formatted with `clang-format` using the config file `.clang-format` from source code folder
- [x] No commits to README files for modules (changes must be done to docbook files in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
- [x] PR should be backported to stable branches
- [ ] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Replace `sprintf()` with `snprintf()` in `send_http_get()` to bound the copy into the 128-byte fixed buffer, preventing a stack buffer overflow when a long ETag value is supplied via the If-Match / If-None-Match header.

The removed `match_header[len] = '\0'` line was redundant (snprintf always NUL-terminates) and would have written out of bounds on truncation.